### PR TITLE
Update extra_arguments schema example

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ post_apply:
 extra_arguments:
   - command_name: plan
     arguments:
-    - "-tfvars=myvars.tfvars"
+    - "-var-file=myvars.tfvars"
 ```
 
 When running the `pre_plan`, `post_plan`, `pre_apply`, and `post_apply` commands the following environment variables are available

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ post_apply:
 extra_arguments:
   - command_name: plan
     arguments:
-    - "-var-file=myvars.tfvars"
+    - "-var-file=terraform.tfvars"
 ```
 
 When running the `pre_plan`, `post_plan`, `pre_apply`, and `post_apply` commands the following environment variables are available

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ extra_arguments:
 When running the `pre_plan`, `post_plan`, `pre_apply`, and `post_apply` commands the following environment variables are available
 - `WORKSPACE`: if a workspace argument is supplied to `atlantis plan` or `atlantis apply`, ex `atlantis plan -w staging`, this will
 be the value of that argument. Else it will be `default`
-- `ATLANTIS_TERRAFORM_VERSION`: local version of `terraform` or the version from `terraform_version` if specified, ex. `0.10.0`
+- `ATLANTIS_TERRAFORM_VERSION`: local version of `terraform` or the version from `terraform_version` if specified, ex. `0.8.8`
 - `DIR`: absolute path to the root of the project on disk
 
 ## Locking


### PR DESCRIPTION
Within the README.md updated the following:
* Changed extra_arguments item to a valid argument.
* Rename `myvars.tfvars` to `terraform.tfvars`
* Updated the terraform version example value when referencing the env var `ATLANTIS_TERRAFORM_VERSION` to reflect the value of the var if the schema was run.