### PR TITLE
Allow specifying config values as environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,10 +442,10 @@ If you'd like to test out Atlantis before running it on your own repositories yo
 	- `atlantis apply` will run `terraform apply`. Since our pull request creates a `null_resource` (which does nothing) this is safe to do.
 
 ## Server Configuration
-Atlantis configuration can be specified via command line flags or a YAML config file.
-The `gh-token` and `gitlab-token` flags can also be specified via the `ATLANTIS_GH_TOKEN` and `ATLANTIS_GITLAB_TOKEN` environment variables respectively.
+Configuration for `atlantis server` can be specified via command line flags, environment variables or a YAML config file.
 Config file values are overridden by environment variables which in turn are overridden by flags.
 
+### YAML
 To use a yaml config file, run atlantis with `--config /path/to/config.yaml`.
 The keys of your config file should be the same as the flag, ex.
 ```yaml
@@ -453,6 +453,10 @@ The keys of your config file should be the same as the flag, ex.
 gh-token: ...
 log-level: ...
 ```
+
+### Environment Variables
+All flags can be specified as environment variables. You need to convert the flag's `-`'s to `_`'s, uppercase all the letters and prefix with `ATLANTIS_`.
+For example, `--gh-user` can be set via the environment variable `ATLANTIS_GH_USER`.
 
 To see a list of all flags and their descriptions run `atlantis server --help`
 

--- a/main.go
+++ b/main.go
@@ -17,18 +17,12 @@ package main
 import (
 	"github.com/runatlantis/atlantis/cmd"
 	"github.com/spf13/viper"
-	"strings"
 )
 
 const atlantisVersion = "0.3.3"
 
 func main() {
 	v := viper.New()
-	// Get environment variables with ATLANTIS prefix
-	v.SetEnvPrefix("ATLANTIS")
-	replacer := strings.NewReplacer("-","_")
-	v.SetEnvKeyReplacer(replacer)
-	v.AutomaticEnv()
 
 	// We're creating commands manually here rather than using init() functions
 	// (as recommended by cobra) because it makes testing easier.

--- a/main.go
+++ b/main.go
@@ -17,12 +17,18 @@ package main
 import (
 	"github.com/runatlantis/atlantis/cmd"
 	"github.com/spf13/viper"
+	"strings"
 )
 
 const atlantisVersion = "0.3.3"
 
 func main() {
 	v := viper.New()
+	// Get environment variables with ATLANTIS prefix
+	v.SetEnvPrefix("ATLANTIS")
+	replacer := strings.NewReplacer("-","_")
+	v.SetEnvKeyReplacer(replacer)
+	v.AutomaticEnv()
 
 	// We're creating commands manually here rather than using init() functions
 	// (as recommended by cobra) because it makes testing easier.


### PR DESCRIPTION
Fixes #38.

Builds off the great work by @psalaberria002 in #77.