### PR TITLE
Add plugin cache. Don't run workspace if unneeded.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -163,7 +163,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	}
 	vcsClient := vcs.NewDefaultClientProxy(githubClient, gitlabClient)
 	commitStatusUpdater := &events.DefaultCommitStatusUpdater{Client: vcsClient}
-	terraformClient, err := terraform.NewClient()
+	terraformClient, err := terraform.NewClient(userConfig.DataDir)
 	// The flag.Lookup call is to detect if we're running in a unit test. If we
 	// are, then we don't error out because we don't have/want terraform
 	// installed on our CI system where the unit tests run.


### PR DESCRIPTION
Fixes #34

- run terraform with TF_PLUGIN_CACHE_DIR set so that terraform init will
be faster.
- check which workspace we're in and don't switch unless we need to.
- run terraform with TF_IN_AUTOMATION set so the plan output doesn't
have instructions that don't make sense. Ex.
```
This plan was saved to: /tmp/atlantis/data/repos/lkysow/atlantis-example/3/default/default.tfplan

To perform exactly these actions, run the following command to apply:
    terraform apply "/tmp/atlantis/data/repos/lkysow/atlantis-example/3/default/default.tfplan"
```