### PR TITLE
Add newlines between flags in help output.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -76,7 +76,17 @@
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
   revision = "68e816d1c783414e79bc65b3994d9ab6b0a722ab"
 
 [[projects]]
@@ -160,7 +170,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/petergtz/pegomock"
-  packages = [".","internal/verify"]
+  packages = [
+    ".",
+    "internal/verify"
+  ]
   revision = "e34a58f05f9a8ea0cd71912e02a4b08e1128aa81"
 
 [[projects]]
@@ -172,7 +185,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
+  packages = [
+    ".",
+    "mem"
+  ]
   revision = "ee1bd8ee15a1306d1f9201acc41ef39cd9f99a1b"
 
 [[projects]]
@@ -232,13 +248,23 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows"
+  ]
   revision = "062cd7e4e68206d8bab9b18396626e855c992658"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = ["internal/gen","internal/triegen","internal/ucd","transform","unicode/cldr","unicode/norm"]
+  packages = [
+    "internal/gen",
+    "internal/triegen",
+    "internal/ucd",
+    "transform",
+    "unicode/cldr",
+    "unicode/norm"
+  ]
   revision = "1cbadb444a806fd9430d14ad08967ed91da4fa0a"
 
 [[projects]]
@@ -250,6 +276,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "88fa3a1b20bbf766eadeeef61d7199e61cb00896414ea6faeb7b25ff9b86451d"
+  inputs-digest = "00be02ec7fa459d29d2f8b3ab70a8fdf7e6c1085f4a6fd53ab6db452e0ade9da"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
- This will make the help output easier to read. To accomplish this, we
needed to not set defaults via cobra because then the default would be
printed on another line which looks bad. So now we set the defaults
ourselves.
- Also had to update spf13/pflag to the version that supports newlines
in flag descriptions.

Fixes #54 