### PR TITLE
Make repo whitelist case insensitive.

### DIFF
--- a/server/events/repo_whitelist.go
+++ b/server/events/repo_whitelist.go
@@ -42,6 +42,10 @@ func (r *RepoWhitelist) IsWhitelisted(repoFullName string, vcsHostname string) b
 }
 
 func (r *RepoWhitelist) matchesRule(rule string, candidate string) bool {
+	// Case insensitive compare.
+	rule = strings.ToLower(rule)
+	candidate = strings.ToLower(candidate)
+
 	wildcardIdx := strings.Index(rule, Wildcard)
 	if wildcardIdx == -1 {
 		// No wildcard so can do a straight up match.

--- a/server/events/repo_whitelist_test.go
+++ b/server/events/repo_whitelist_test.go
@@ -133,6 +133,20 @@ func TestIsWhitelisted(t *testing.T) {
 			"github.com",
 			false,
 		},
+		{
+			"should be case insensitive",
+			"github.com/owner/repo",
+			"OwNeR/rEpO",
+			"github.com",
+			true,
+		},
+		{
+			"should be case insensitive for wildcards",
+			"github.com/owner/*",
+			"OwNeR/rEpO",
+			"github.com",
+			true,
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
This is okay to do because it's a better user experience and because
GitLab and GitHub project names are case insensitive as well.

Fixes #95