### PR TITLE
Add checksum verification for Terraform binaries, upgrade Terraform to 0.11.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
-# v0.3.8 (Unreleased)
+# v0.3.8
+
+## Features
+* Terraform 0.11.7 in Docker image
+* Docker build now verifies terraform install via checksum
 
 ## Bugfixes
 * None
 
 ## Backwards Incompatibilities / Notes:
-* Docker image now contains latest Terraform 0.11.7
-* Docker image now does checksum verification for Terraform binaries during build
+* None
+
+## Downloads
+* [atlantis_darwin_amd64.zip](https://github.com/runatlantis/atlantis/releases/download/v0.3.8/atlantis_darwin_amd64.zip)
+* [atlantis_linux_386.zip](https://github.com/runatlantis/atlantis/releases/download/v0.3.8/atlantis_linux_386.zip)
+* [atlantis_linux_amd64.zip](https://github.com/runatlantis/atlantis/releases/download/v0.3.8/atlantis_linux_amd64.zip)
+* [atlantis_linux_arm.zip](https://github.com/runatlantis/atlantis/releases/download/v0.3.8/atlantis_linux_arm.zip)
 
 # v0.3.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v0.3.8 (Unreleased)
+
+## Bugfixes
+* None
+
+## Backwards Incompatibilities / Notes:
+* Docker image now contains latest Terraform 0.11.7
+* Docker image now does checksum verification for Terraform binaries during build
+
 # v0.3.7
 
 ## Bugfixes

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,10 +37,16 @@ ENV DEFAULT_TERRAFORM_VERSION=0.11.7
 
 # In the official Atlantis image we only have the latest of each Terrafrom version.
 RUN AVAILABLE_TERRAFORM_VERSIONS="0.8.8 0.9.11 0.10.8 ${DEFAULT_TERRAFORM_VERSION}" && \
-    for VERSION in ${AVAILABLE_TERRAFORM_VERSIONS}; do curl -LOk https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_linux_amd64.zip && \
-    mkdir -p /usr/local/bin/tf/versions/${VERSION} && \
-    unzip terraform_${VERSION}_linux_amd64.zip -d /usr/local/bin/tf/versions/${VERSION} && \
-    ln -s /usr/local/bin/tf/versions/${VERSION}/terraform /usr/local/bin/terraform${VERSION};rm terraform_${VERSION}_linux_amd64.zip;done && \
+    for VERSION in ${AVAILABLE_TERRAFORM_VERSIONS}; do \
+        curl -LOks https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_linux_amd64.zip && \
+        curl -LOks https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_SHA256SUMS && \
+        sed -n "/terraform_${VERSION}_linux_amd64.zip/p" terraform_${VERSION}_SHA256SUMS | sha256sum -c && \
+        mkdir -p /usr/local/bin/tf/versions/${VERSION} && \
+        unzip terraform_${VERSION}_linux_amd64.zip -d /usr/local/bin/tf/versions/${VERSION} && \
+        ln -s /usr/local/bin/tf/versions/${VERSION}/terraform /usr/local/bin/terraform${VERSION} && \
+        rm terraform_${VERSION}_linux_amd64.zip && \
+        rm terraform_${VERSION}_SHA256SUMS; \
+    done && \
     ln -s /usr/local/bin/tf/versions/${DEFAULT_TERRAFORM_VERSION}/terraform /usr/local/bin/terraform
 
 # copy binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN apk add --no-cache ca-certificates gnupg curl git unzip bash openssh libcap 
         rm -rf /root/.gnupg && rm -rf /var/cache/apk/*
 
 # install terraform binaries
-ENV DEFAULT_TERRAFORM_VERSION=0.11.5
+ENV DEFAULT_TERRAFORM_VERSION=0.11.7
 
 # In the official Atlantis image we only have the latest of each Terrafrom version.
 RUN AVAILABLE_TERRAFORM_VERSIONS="0.8.8 0.9.11 0.10.8 ${DEFAULT_TERRAFORM_VERSION}" && \

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const atlantisVersion = "0.3.7"
+const atlantisVersion = "0.3.8"
 
 func main() {
 	v := viper.New()


### PR DESCRIPTION
- Upgrade to Terraform 0.11.7
- Add SHA256 checksum verification for Terraform binaries
- Bump version to 0.3.8 and add release notes