### PR TITLE
Improve error handling

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -153,7 +153,7 @@ tunnels:
 	cancelNgrok, ngrokErrors := executeBackgroundCmd("/tmp/ngrok", []string{"start", "atlantis", "--config", ngrokConfigFile.Name()})
 	// Check if we got a fast error. Move on if we haven't (the command is still running).
 	select {
-	case err := <-ngrokErrors:
+	case err = <-ngrokErrors:
 		return errors.Wrap(err, "creating ngrok tunnel")
 	default:
 	}
@@ -178,7 +178,7 @@ tunnels:
 
 	// Check if we got a fast error. Move on if we haven't (the command is still running).
 	select {
-	case err := <-atlantisErrors:
+	case err = <-atlantisErrors:
 		return errors.Wrap(err, "creating atlantis server")
 	default:
 	}

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -110,7 +110,10 @@ Follow these instructions to create a token (we don't store any tokens):
 		if err != nil {
 			return errors.Wrapf(err, "moving terraform binary into /usr/local/bin")
 		}
-		terraformCmd.Wait()
+		err = terraformCmd.Wait()
+		if err != nil {
+			return errors.Wrapf(err, "moving terraform binary into /usr/local/bin")
+		}
 		colorstring.Println("[green]=> installed terraform successfully at /usr/local/bin")
 	} else {
 		colorstring.Println("[green]=> terraform found in $PATH!")

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -220,7 +220,7 @@ tunnels:
 	time.Sleep(2 * time.Second)
 	_, err = executeCmd("open", []string{pullRequestURL})
 	if err != nil {
-		colorstring.Printf("[red]=> opening pull request failed. please go to: %s on the browser", pullRequestURL)
+		colorstring.Printf("[red]=> opening pull request failed. please go to: %s on the browser\n", pullRequestURL)
 	}
 	s.Stop()
 

--- a/bootstrap/utils.go
+++ b/bootstrap/utils.go
@@ -137,7 +137,7 @@ func downloadAndUnzip(url string, path string, target string) error {
 
 // Executes a command, waits for it to finish and returns any errors.
 func executeCmd(cmd string, args []string) error {
-	command := exec.Command(cmd, args...)
+	command := exec.Command(cmd, args...) // #nosec
 	return command.Run()
 }
 

--- a/bootstrap/utils.go
+++ b/bootstrap/utils.go
@@ -135,14 +135,14 @@ func downloadAndUnzip(url string, path string, target string) error {
 	return unzip(path, target)
 }
 
-// Executes a command, waits for it to finish and returns any errors.
+// executeCmd executes a command, waits for it to finish and returns any errors.
 func executeCmd(cmd string, args []string) error {
 	command := exec.Command(cmd, args...) // #nosec
 	return command.Run()
 }
 
-// Executes a command in the background. Returns a context so that the caller may cancel the
-// command prematurely if necessary, as well as an errors channel.
+// executeBackgroundCmd executes a command in the background. The function returns a context so
+// that the caller may cancel the command prematurely if necessary, as well as an errors channel.
 func executeBackgroundCmd(cmd string, args []string) (context.CancelFunc, <-chan error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	command := exec.CommandContext(ctx, cmd, args...) // #nosec

--- a/bootstrap/utils.go
+++ b/bootstrap/utils.go
@@ -138,7 +138,11 @@ func downloadAndUnzip(url string, path string, target string) error {
 // executeCmd executes a command, waits for it to finish and returns any errors.
 func executeCmd(cmd string, args []string) error {
 	command := exec.Command(cmd, args...) // #nosec
-	return command.Run()
+	bytes, err := command.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %s", err, bytes)
+	}
+	return nil
 }
 
 // executeBackgroundCmd executes a command in the background. The function returns a context so


### PR DESCRIPTION
Hi,

Thanks for the work on this awesome project!

I've encountered a bug running `atlantis bootstrap` on Amazon Linux - the process failed to copy the Terraform binary to `/usr/local/bin` but the error got silently ignored. This error caused another error when running the Atlantis server, which got ignored, too.

Therefore, I've refactored the overall error handling inside the bootstrap process. It doesn't fix the permissions problem on Amazon Linux (`sudo` needs to be used, which is outside the scope of this PR), but it does show an error to the user instead of reporting that everything is OK.

Any comments are welcome :-)