### PR TITLE
Update CONTRIBUTING.md atlantis command example, pluralize Webhook boxes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ go install
 
 Run Atlantis:
 ```
-atlantis server --gh-user <your username> --gh-token <your token> --log-level debug
+atlantis server --gh-user <your username> --gh-token <your token> --repo-whitelist <your repo> --log-level debug
 ```
 If you get an error like `command not found: atlantis`, ensure that `$GOPATH/bin` is in your `$PATH`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ go install
 
 Run Atlantis:
 ```
-atlantis server --gh-user <your username> --gh-token <your token> --repo-whitelist <your repo> --log-level debug
+atlantis server --gh-user <your username> --gh-token <your token> --repo-whitelist <your repo> --gh-webhook-secret <your webhook secret> --log-level debug
 ```
 If you get an error like `command not found: atlantis`, ensure that `$GOPATH/bin` is in your `$PATH`.
 
@@ -42,7 +42,7 @@ If you get an error like `command not found: atlantis`, ensure that `$GOPATH/bin
 - Create a personal access token for Atlantis. See [Create a GitHub token](https://github.com/runatlantis/atlantis#create-a-github-token).
 - Start Atlantis in server mode using that token:
 ```
-atlantis server --gh-user <your username> --gh-token <your token> --log-level debug
+atlantis server --gh-user <your username> --gh-token <your token> --repo-whitelist <your repo> --gh-webhook-secret <your webhook secret> --log-level debug
 ```
 - Download ngrok from https://ngrok.com/download. This will enable you to expose Atlantis running on your laptop to the internet so GitHub can call it.
 - When you've downloaded and extracted ngrok, run it on port `4141`:

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ If installing on a single repository, navigate to the repository home page and c
 - Click **Add webhook**
 - set **Payload URL** to `http://$URL/events` where `$URL` is where Atlantis is hosted. **Be sure to add `/events`**
 - set **Content type** to `application/json`
-- leave **Secret** blank or set this to a random key (https://www.random.org/strings/). If you set it, you'll need to use the `--gh-webhook-secret` option when you start Atlantis
+- set **Secret** to a random key (https://www.random.org/strings/). You'll need to pass this value to the `--gh-webhook-secret` option when you start Atlantis
 - select **Let me select individual events**
 - check the boxes
 	- **Pull request reviews**

--- a/README.md
+++ b/README.md
@@ -337,10 +337,10 @@ If installing on a single repository, navigate to the repository home page and c
 - leave **Secret** blank or set this to a random key (https://www.random.org/strings/). If you set it, you'll need to use the `--gh-webhook-secret` option when you start Atlantis
 - select **Let me select individual events**
 - check the boxes
-	- **Pull request review**
-	- **Push**
-	- **Issue comment**
-	- **Pull request**
+	- **Pull request reviews**
+	- **Pushes**
+	- **Issue comments**
+	- **Pull requests**
 - leave **Active** checked
 - click **Add webhook**
 

--- a/README.md
+++ b/README.md
@@ -773,13 +773,13 @@ A: No. Atlantis does not interfere with Terraform remote state in any way. Under
 
 **Q: How does Atlantis locking interact with Terraform [locking](https://www.terraform.io/docs/state/locking.html)?**
 
-A: Atlantis provides locking of pull requests that prevents concurrent modification of the same infrastructure (Terraform project) whereas Terraform locking only prevents two concurrent `terraform apply`'s from happening. 
+A: Atlantis provides locking of pull requests that prevents concurrent modification of the same infrastructure (Terraform project) whereas Terraform locking only prevents two concurrent `terraform apply`'s from happening.
 
 Terraform locking can be used alongside Atlantis locking since Atlantis is simply executing terraform commands.
 
 **Q: How to run Atlantis in high availability mode? Does it need to be?**
 
-A: Atlantis server can easily be run under the supervision of a init system like `upstart` or `systemd` to make sure `atlantis server` is always running. 
+A: Atlantis server can easily be run under the supervision of a init system like `upstart` or `systemd` to make sure `atlantis server` is always running.
 
 Atlantis currently stores all locking and Terraform plans locally on disk under the `--data-dir` directory (defaults to `~/.atlantis`). Because of this there is currently no way to run two or more Atlantis instances concurrently.
 


### PR DESCRIPTION
### What does this PR do?
👋 🐧:penguin: Going through `CONTRIBUTING.md` and updated 
- example `Run Atlantis` to include `--repo-whitelist` because of `v0.3.2`
- `Add Github Webhook` check boxes section with plural nouns to be consistent with Github
  <details>
  <img width="649" alt="screen shot 2018-05-29 at 8 14 36 pm" src="https://user-images.githubusercontent.com/9021054/40692464-fac82090-637f-11e8-9de6-4981be14f529.png">
  </details>

And should the bullet below be updated to recommend using a secret?

> - leave **Secret** blank or set this to a random key (https://www.random.org/strings/). If you set it, you'll need to use the `--gh-webhook-secret` option when you start Atlantis

Running without it warns
```
[WARN] No GitHub webhook secret set. This could allow attackers to spoof requests from GitHub. See https://git.io/vAF3t
```
