### PR TITLE
Rename bootstrap to testdrive.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Download from [https://github.com/runatlantis/atlantis/releases](https://github.
 
 Run
 ```
-./atlantis bootstrap
+./atlantis testdrive
 ```
-This will walk you through running Atlantis locally. It will
+This mode sets up Atlantis on a test repo so you can try it out. It will
 - fork an example terraform project
 - install terraform (if not already in your PATH)
 - install ngrok so we can expose Atlantis to GitHub

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -17,20 +17,20 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/runatlantis/atlantis/bootstrap"
+	"github.com/runatlantis/atlantis/testdrive"
 	"github.com/spf13/cobra"
 )
 
-// BootstrapCmd starts the bootstrap process for testing out Atlantis.
-type BootstrapCmd struct{}
+// TestdriveCmd starts the testdrive process for testing out Atlantis.
+type TestdriveCmd struct{}
 
 // Init returns the runnable cobra command.
-func (b *BootstrapCmd) Init() *cobra.Command {
+func (b *TestdriveCmd) Init() *cobra.Command {
 	return &cobra.Command{
-		Use:   "bootstrap",
+		Use:   "testdrive",
 		Short: "Start a guided tour of Atlantis",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := bootstrap.Start()
+			err := testdrive.Start()
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "\033[31mError: %s\033[39m\n\n", err.Error())
 			}

--- a/main.go
+++ b/main.go
@@ -32,9 +32,9 @@ func main() {
 		AtlantisVersion: atlantisVersion,
 	}
 	version := &cmd.VersionCmd{AtlantisVersion: atlantisVersion}
-	bootstrap := &cmd.BootstrapCmd{}
+	testdrive := &cmd.TestdriveCmd{}
 	cmd.RootCmd.AddCommand(server.Init())
 	cmd.RootCmd.AddCommand(version.Init())
-	cmd.RootCmd.AddCommand(bootstrap.Init())
+	cmd.RootCmd.AddCommand(testdrive.Init())
 	cmd.Execute()
 }

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -6,7 +6,7 @@
 # with multiple packages, see https://code.google.com/p/go/issues/detail?id=6909
 #
 # Usage: coverage.sh packages...
-# Example: coverage.sh github.com/runatlantis/atlantis github.com/runatlantis/atlantis/bootstrap
+# Example: coverage.sh github.com/runatlantis/atlantis github.com/runatlantis/atlantis/testdrive
 #
 
 set -e

--- a/testdrive/github.go
+++ b/testdrive/github.go
@@ -11,7 +11,7 @@
 // limitations under the License.
 // Modified hereafter by contributors to runatlantis/atlantis.
 //
-package bootstrap
+package testdrive
 
 import (
 	"context"

--- a/testdrive/testdrive.go
+++ b/testdrive/testdrive.go
@@ -11,9 +11,9 @@
 // limitations under the License.
 // Modified hereafter by contributors to runatlantis/atlantis.
 //
-// Package bootstrap is used by the bootstrap command as a quick-start of
+// Package testdrive is used by the testdrive command as a quick-start of
 // Atlantis.
-package bootstrap
+package testdrive
 
 import (
 	"context"
@@ -37,9 +37,9 @@ import (
 
 var terraformExampleRepoOwner = "runatlantis"
 var terraformExampleRepo = "atlantis-example"
-var bootstrapDescription = `[white]Welcome to Atlantis bootstrap!
+var bootstrapDescription = `[white]Welcome to Atlantis testdrive!
 
-This mode walks you through setting up and using Atlantis. We will
+This mode sets up Atlantis on a test repo so you can try it out. We will
 - fork an example terraform project to your username
 - install terraform (if not already in your PATH)
 - install ngrok so we can expose Atlantis to GitHub
@@ -53,12 +53,12 @@ var pullRequestBody = "In this pull request we will learn how to use atlantis. T
 	"* Now lets apply that plan. Type `atlantis apply` in the comments. This will run a `terraform apply`.\n" +
 	"\nThank you for trying out atlantis. For more info on running atlantis in production see https://github.com/runatlantis/atlantis"
 
-// Start begins the bootstrap process.
+// Start begins the testdrive process.
 // nolint: errcheck
 func Start() error {
 	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
 	colorstring.Println(bootstrapDescription)
-	colorstring.Print("\n[white][bold]GitHub username: ")
+	colorstring.Print("\n[white][bold]github.com username: ")
 	fmt.Scanln(&githubUsername)
 	if githubUsername == "" {
 		return fmt.Errorf("please enter a valid github username")
@@ -231,7 +231,7 @@ tunnels:
 	colorstring.Println("[green] [press Ctrl-c to exit]")
 
 	// Wait for SIGINT or SIGTERM signals meaning the user has Ctrl-C'd the
-	// bootstrap process and want's to stop.
+	// testdrive process and want's to stop.
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
 

--- a/testdrive/utils.go
+++ b/testdrive/utils.go
@@ -11,7 +11,7 @@
 // limitations under the License.
 // Modified hereafter by contributors to runatlantis/atlantis.
 //
-package bootstrap
+package testdrive
 
 import (
 	"archive/zip"


### PR DESCRIPTION
Bootstrap is meant for a system that sets itself up. This command is
more like a testing mode so I want to rename it to avoid confusion.

Fixes #129 and came out of #117.