### PR TITLE
Disable code coverage GitHub statuses.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    # This disables the GitHub statuses from CodeCov. I found that many of the
+    # PRs I wanted to merge failed the status checks because often some code
+    # isn't testable or testing it isn't the highest priority. The comment with
+    # the code coverage is all that is needed right now.
+    project: off
+    patch: off


### PR DESCRIPTION
Many pull requests that I've wanted to merge have failed CodeCov
statuses. This indicates that they're not useful for this project at
this time so I'm disabling them. The comment from CodeCov is the most
useful part.