### PR TITLE
Add option flag to filter the modified files

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -46,6 +46,7 @@ const (
 	GitlabWebHookSecret = "gitlab-webhook-secret"
 	LogLevelFlag        = "log-level"
 	PortFlag            = "port"
+	RepoSubdirFlag      = "repo-subdir"
 	RepoWhitelistFlag   = "repo-whitelist"
 	RequireApprovalFlag = "require-approval"
 	SSLCertFileFlag     = "ssl-cert-file"
@@ -126,6 +127,11 @@ var stringFlags = []stringFlag{
 		description: "Comma separated list of repositories that Atlantis will operate on. " +
 			"The format is {hostname}/{owner}/{repo}, ex. github.com/runatlantis/atlantis. '*' matches any characters until the next comma and can be used for example to whitelist " +
 			"all repos: '*' (not recommended), an entire hostname: 'internalgithub.com/*' or an organization: 'github.com/runatlantis/*'.",
+	},
+	{
+		name:         RepoSubdirFlag,
+		description:  "Optional subdirectory inside the repository. to filter the modifications only from this particular subdirectory. It supports regular expression syntax.",
+		defaultValue: "",
 	},
 	{
 		name:        SSLCertFileFlag,

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -372,6 +372,7 @@ func TestExecute_Flags(t *testing.T) {
 		cmd.GitlabWebHookSecret: "gitlab-secret",
 		cmd.LogLevelFlag:        "debug",
 		cmd.PortFlag:            8181,
+		cmd.RepoSubdirFlag:      "/dir",
 		cmd.RepoWhitelistFlag:   "github.com/runatlantis/atlantis",
 		cmd.RequireApprovalFlag: true,
 		cmd.SSLCertFileFlag:     "cert-file",
@@ -393,6 +394,7 @@ func TestExecute_Flags(t *testing.T) {
 	Equals(t, "gitlab-secret", passedConfig.GitlabWebHookSecret)
 	Equals(t, "debug", passedConfig.LogLevel)
 	Equals(t, 8181, passedConfig.Port)
+	Equals(t, "/dir", passedConfig.RepoSubdir)
 	Equals(t, "github.com/runatlantis/atlantis", passedConfig.RepoWhitelist)
 	Equals(t, true, passedConfig.RequireApproval)
 	Equals(t, "cert-file", passedConfig.SSLCertFile)
@@ -531,6 +533,7 @@ gitlab-user: "gitlab-user"
 gitlab-webhook-secret: "gitlab-secret"
 log-level: "debug"
 port: 8181
+repo-subdir: 8181
 repo-whitelist: "github.com/runatlantis/atlantis"
 require-approval: true
 ssl-cert-file: cert-file
@@ -552,6 +555,7 @@ ssl-key-file: key-file
 		cmd.GitlabWebHookSecret: "override-gitlab-webhook-secret",
 		cmd.LogLevelFlag:        "info",
 		cmd.PortFlag:            8282,
+		cmd.RepoSubdirFlag:      "/override-dir",
 		cmd.RepoWhitelistFlag:   "override,override",
 		cmd.RequireApprovalFlag: false,
 		cmd.SSLCertFileFlag:     "override-cert-file",
@@ -572,6 +576,7 @@ ssl-key-file: key-file
 	Equals(t, "override-gitlab-webhook-secret", passedConfig.GitlabWebHookSecret)
 	Equals(t, "info", passedConfig.LogLevel)
 	Equals(t, 8282, passedConfig.Port)
+	Equals(t, "/override-dir", passedConfig.RepoSubdir)
 	Equals(t, "override,override", passedConfig.RepoWhitelist)
 	Equals(t, false, passedConfig.RequireApproval)
 	Equals(t, "override-cert-file", passedConfig.SSLCertFile)
@@ -595,6 +600,7 @@ func TestExecute_FlagEnvVarOverride(t *testing.T) {
 		"GITLAB_WEBHOOK_SECRET": "gitlab-webhook-secret",
 		"LOG_LEVEL":             "debug",
 		"PORT":                  "8181",
+		"REPO_SUBDIR":           "/dir",
 		"REPO_WHITELIST":        "*",
 		"REQUIRE_APPROVAL":      "true",
 		"SSL_CERT_FILE":         "cert-file",
@@ -617,6 +623,7 @@ func TestExecute_FlagEnvVarOverride(t *testing.T) {
 		cmd.GitlabWebHookSecret: "override-gitlab-webhook-secret",
 		cmd.LogLevelFlag:        "info",
 		cmd.PortFlag:            8282,
+		cmd.RepoSubdirFlag:      "/override-dir",
 		cmd.RepoWhitelistFlag:   "override,override",
 		cmd.RequireApprovalFlag: false,
 		cmd.SSLCertFileFlag:     "override-cert-file",
@@ -638,6 +645,7 @@ func TestExecute_FlagEnvVarOverride(t *testing.T) {
 	Equals(t, "override-gitlab-webhook-secret", passedConfig.GitlabWebHookSecret)
 	Equals(t, "info", passedConfig.LogLevel)
 	Equals(t, 8282, passedConfig.Port)
+	Equals(t, "/override-dir", passedConfig.RepoSubdir)
 	Equals(t, "override,override", passedConfig.RepoWhitelist)
 	Equals(t, false, passedConfig.RequireApproval)
 	Equals(t, "override-cert-file", passedConfig.SSLCertFile)

--- a/server/events/plan_executor.go
+++ b/server/events/plan_executor.go
@@ -45,6 +45,7 @@ type PlanExecutor struct {
 	Terraform         terraform.Client
 	Locker            locking.Locker
 	LockURL           func(id string) (url string)
+	RepoSubdir        string
 	Run               run.Runner
 	Workspace         AtlantisWorkspace
 	ProjectPreExecute ProjectPreExecutor
@@ -79,7 +80,7 @@ func (p *PlanExecutor) Execute(ctx *CommandContext) CommandResponse {
 			return CommandResponse{Error: errors.Wrap(err, "getting modified files")}
 		}
 		ctx.Log.Info("found %d files modified in this pull request", len(modifiedFiles))
-		projects = p.ProjectFinder.DetermineProjects(ctx.Log, modifiedFiles, ctx.BaseRepo.FullName, cloneDir)
+		projects = p.ProjectFinder.DetermineProjects(ctx.Log, modifiedFiles, p.RepoSubdir, ctx.BaseRepo.FullName, cloneDir)
 		if len(projects) == 0 {
 			return CommandResponse{Failure: "No Terraform files were modified."}
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -82,6 +82,7 @@ type UserConfig struct {
 	GitlabWebHookSecret string `mapstructure:"gitlab-webhook-secret"`
 	LogLevel            string `mapstructure:"log-level"`
 	Port                int    `mapstructure:"port"`
+	RepoSubdir          string `mapstructure:"repo-subdir"`
 	RepoWhitelist       string `mapstructure:"repo-whitelist"`
 	// RequireApproval is whether to require pull request approval before
 	// allowing terraform apply's to be run.
@@ -204,6 +205,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		Terraform:         terraformClient,
 		Run:               run,
 		Workspace:         workspace,
+		RepoSubdir:        userConfig.RepoSubdir,
 		ProjectPreExecute: projectPreExecute,
 		Locker:            lockingClient,
 		ProjectFinder:     &events.DefaultProjectFinder{},


### PR DESCRIPTION
Hi,
I use a mono-repo with a lot of non related terraform files or some projects that I don't want to plan/apply from atlantis.
So I want to filter on specific path from my repository to select only the sub-directory that I want to plan/apply.
To do that I added an option flag to filter the modifications on a specific path.