### PR TITLE
Add require-workspace option

### DIFF
--- a/server/events/apply_executor.go
+++ b/server/events/apply_executor.go
@@ -123,6 +123,7 @@ func (a *ApplyExecutor) apply(ctx *CommandContext, repoDir string, plan models.P
 	applyExtraArgs := config.GetExtraArguments(ctx.Command.Name.String())
 	absolutePath := filepath.Join(repoDir, plan.Project.Path)
 	workspace := ctx.Command.Workspace
+
 	tfApplyCmd := append(append(append([]string{"apply", "-no-color"}, applyExtraArgs...), ctx.Command.Flags...), plan.LocalPath)
 	output, err := a.Terraform.RunCommandWithVersion(ctx.Log, absolutePath, tfApplyCmd, terraformVersion, workspace)
 

--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -44,10 +44,11 @@ type CommentParsing interface {
 
 // CommentParser implements CommentParsing
 type CommentParser struct {
-	GithubUser  string
-	GithubToken string
-	GitlabUser  string
-	GitlabToken string
+	GithubUser        string
+	GithubToken       string
+	GitlabUser        string
+	GitlabToken       string
+	RequiredWorkspace string
 }
 
 // CommentParseResult describes the result of parsing a comment as a command.
@@ -188,6 +189,11 @@ func (e *CommentParser) Parse(comment string, vcsHost models.VCSHostType) Commen
 	dir, err = e.validateDir(dir)
 	if err != nil {
 		return CommentParseResult{CommentResponse: e.errMarkdown(err.Error(), command, flagSet)}
+	}
+
+	// If RequiredWorkspace flag is set then ignore all other workspaces
+	if len(e.RequiredWorkspace) != 0 && e.RequiredWorkspace != workspace {
+		return CommentParseResult{CommentResponse: e.errMarkdown(fmt.Sprintf("required workspace set to %s – ignoring workspace %s", e.RequiredWorkspace, workspace), command, flagSet)}
 	}
 
 	// Use the same validation that Terraform uses: https://git.io/vxGhU. Plus

--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -30,6 +30,18 @@ var commentParser = events.CommentParser{
 	GitlabToken: "gitlab-token",
 }
 
+func TestRequiredWorkspace(t *testing.T) {
+	fwParser := commentParser
+	fwParser.RequiredWorkspace = "test-workspace"
+	comment := "atlantis plan -w test-workspace"
+	r := fwParser.Parse(comment, models.Github)
+	Assert(t, r.Command.Workspace == fwParser.RequiredWorkspace, "expected 'test-workspace'")
+
+	comment = "atlantis plan"
+	r = fwParser.Parse(comment, models.Github)
+	Assert(t, r.Command == nil, "command should be nil when required workspace does not match")
+}
+
 func TestParse_Ignored(t *testing.T) {
 	t.Log("given a comment that should be ignored we should set " +
 		"CommentParseResult.Ignore to true")

--- a/server/server.go
+++ b/server/server.go
@@ -85,11 +85,12 @@ type UserConfig struct {
 	RepoWhitelist       string `mapstructure:"repo-whitelist"`
 	// RequireApproval is whether to require pull request approval before
 	// allowing terraform apply's to be run.
-	RequireApproval bool            `mapstructure:"require-approval"`
-	SlackToken      string          `mapstructure:"slack-token"`
-	SSLCertFile     string          `mapstructure:"ssl-cert-file"`
-	SSLKeyFile      string          `mapstructure:"ssl-key-file"`
-	Webhooks        []WebhookConfig `mapstructure:"webhooks"`
+	RequireApproval   bool            `mapstructure:"require-approval"`
+	RequiredWorkspace string          `mapstructure:"required-workspace"`
+	SlackToken        string          `mapstructure:"slack-token"`
+	SSLCertFile       string          `mapstructure:"ssl-cert-file"`
+	SSLKeyFile        string          `mapstructure:"ssl-key-file"`
+	Webhooks          []WebhookConfig `mapstructure:"webhooks"`
 }
 
 // Config holds config for server that isn't passed in by the user.
@@ -221,10 +222,11 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		GitlabToken: userConfig.GitlabToken,
 	}
 	commentParser := &events.CommentParser{
-		GithubUser:  userConfig.GithubUser,
-		GithubToken: userConfig.GithubToken,
-		GitlabUser:  userConfig.GitlabUser,
-		GitlabToken: userConfig.GitlabToken,
+		GithubUser:        userConfig.GithubUser,
+		GithubToken:       userConfig.GithubToken,
+		GitlabUser:        userConfig.GitlabUser,
+		GitlabToken:       userConfig.GitlabToken,
+		RequiredWorkspace: userConfig.RequiredWorkspace,
 	}
 	commandHandler := &events.CommandHandler{
 		ApplyExecutor:            applyExecutor,


### PR DESCRIPTION
This PR adds the `force-workspace` option for allowing the server-side configuration to force override the workspace. This is handy if you have multiple atlantis instances (multiple, non-communicating accounts) per repo. 