### PR TITLE
Use temp dir for testdrive.

### DIFF
--- a/testdrive/testdrive.go
+++ b/testdrive/testdrive.go
@@ -210,10 +210,15 @@ tunnels:
 	// Start atlantis server.
 	colorstring.Println("[white]=> starting atlantis server")
 	s.Start()
+	tmpDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		return errors.Wrap(err, "creating a temporary data directory for Atlantis")
+	}
+	defer os.RemoveAll(tmpDir)
 	serverReadyLog := regexp.MustCompile("Atlantis started - listening on port 4141")
 	serverReadyTimeout := 5 * time.Second
 	cancelAtlantis, atlantisErrors, err := execAndWaitForStderr(&wg, serverReadyLog, serverReadyTimeout,
-		os.Args[0], "server", "--gh-user", githubUsername, "--gh-token", githubToken, "--data-dir", "/tmp/atlantis/data", "--atlantis-url", tunnelURL, "--repo-whitelist", fmt.Sprintf("github.com/%s/%s", githubUsername, terraformExampleRepo))
+		os.Args[0], "server", "--gh-user", githubUsername, "--gh-token", githubToken, "--data-dir", tmpDir, "--atlantis-url", tunnelURL, "--repo-whitelist", fmt.Sprintf("github.com/%s/%s", githubUsername, terraformExampleRepo))
 	// Check if we got a fast error. Move on if we haven't (the command is still running).
 	if err != nil {
 		return errors.Wrap(err, "creating atlantis server")


### PR DESCRIPTION
This will prevent old locks from a previous run from sticking around.