### PR TITLE
Add file so /etc/hosts works in Docker.

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,7 +1,7 @@
 {
   "Disable": ["gotype", "gotypex", "maligned", "gocyclo", "golint"],
   "Enable": [
-    "gas",
+    "gosec",
     "errcheck",
     "deadcode",
     "gochecknoinits",
@@ -32,7 +32,7 @@
   "Skip": ["server/static", "mocks"],
   "WarnUnmatchedDirective": true,
   "Linters": {
-    "gas": "gas -exclude=G104 -fmt=csv:^(?P<path>.*?\\.go),(?P<line>\\d+),(?P<message>[^,]+,[^,]+,[^,]+)",
+    "gosec": "gosec -exclude=G104 -fmt=csv:^(?P<path>.*?\\.go),(?P<line>\\d+),(?P<message>[^,]+,[^,]+,[^,]+)",
     "errcheck": {
       "Command": "errcheck -abspath -ignore 'fmt:.*'",
       "Pattern": "PATH:LINE:COL:MESSAGE",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# The runatlantis/atlantis-base image is described in the Dockerfile-base image.
+# The runatlantis/atlantis-base is created by docker-base/Dockerfile.
 FROM runatlantis/atlantis-base:latest
 LABEL authors="Anubhav Mishra, Luke Kysow"
 

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -34,3 +34,7 @@ RUN apk add --no-cache ca-certificates gnupg curl git unzip bash openssh libcap 
         rm -rf /tmp/build && \
         apk del gnupg openssl && \
         rm -rf /root/.gnupg && rm -rf /var/cache/apk/*
+
+# set up nsswitch.conf for Go's "netgo" implementation
+# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -43,11 +43,11 @@ const (
 	GHHostnameFlag        = "gh-hostname"
 	GHTokenFlag           = "gh-token"
 	GHUserFlag            = "gh-user"
-	GHWebHookSecret       = "gh-webhook-secret" // nolint: gas
+	GHWebHookSecret       = "gh-webhook-secret" // nolint: gosec
 	GitlabHostnameFlag    = "gitlab-hostname"
 	GitlabTokenFlag       = "gitlab-token"
 	GitlabUserFlag        = "gitlab-user"
-	GitlabWebHookSecret   = "gitlab-webhook-secret"
+	GitlabWebHookSecret   = "gitlab-webhook-secret" // nolint: gosec
 	LogLevelFlag          = "log-level"
 	PortFlag              = "port"
 	RepoWhitelistFlag     = "repo-whitelist"

--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -14,12 +14,12 @@ ENV ATLANTIS_HOME_DIR=/home/atlantis
 ENV DUMB_INIT_VERSION=1.2.0
 ENV GOSU_VERSION=1.10
 RUN apk add --no-cache ca-certificates gnupg curl git unzip bash openssh libcap openssl && \
-    curl -L -o -s /bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_amd64 && \
+    curl -L -s --output /bin/dumb-init "https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_amd64" && \
     chmod +x /bin/dumb-init && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
-    curl -L -o -s gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64" && \
-    curl -L -o -s gosu.asc "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc" && \
+    curl -L -s --output gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64" && \
+    curl -L -s --output gosu.asc "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc" && \
     for server in $(shuf -e ipv4.pool.sks-keyservers.net \
                             hkp://p80.pool.sks-keyservers.net:80 \
                             keyserver.ubuntu.com \

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -45,7 +45,7 @@ resource "null_resource" "hello" {
 }
 `
 
-// nolint: gas
+// nolint: gosec
 func (t *E2ETester) Start() (*E2EResult, error) {
 	cloneDir := fmt.Sprintf("%s/%s-test", t.cloneDirRoot, t.projectType.Name)
 	branchName := fmt.Sprintf("%s-%s", t.projectType.Name, time.Now().Format("20060102150405"))

--- a/server/events/project_config.go
+++ b/server/events/project_config.go
@@ -106,7 +106,7 @@ func (c *ProjectConfigManager) Exists(projectPath string) bool {
 func (c *ProjectConfigManager) Read(execPath string) (ProjectConfig, error) {
 	var pc ProjectConfig
 	filename := filepath.Join(execPath, ProjectConfigFile)
-	raw, err := ioutil.ReadFile(filename)
+	raw, err := ioutil.ReadFile(filename) // nolint: gosec
 	if err != nil {
 		return pc, errors.Wrapf(err, "reading %s", ProjectConfigFile)
 	}

--- a/server/events/yaml/parser_validator.go
+++ b/server/events/yaml/parser_validator.go
@@ -24,7 +24,7 @@ type ParserValidator struct{}
 // HasConfigFile.
 func (p *ParserValidator) ReadConfig(repoDir string) (valid.Config, error) {
 	configFile := p.configFilePath(repoDir)
-	configData, err := ioutil.ReadFile(configFile)
+	configData, err := ioutil.ReadFile(configFile) // nolint: gosec
 
 	// NOTE: the error we return here must also be os.IsNotExist since that's
 	// what our callers use to detect a missing config file.

--- a/server/recovery/recovery.go
+++ b/server/recovery/recovery.go
@@ -48,7 +48,7 @@ func Stack(skip int) []byte {
 		// Print this much at least.  If we can't find the source, it won't show.
 		fmt.Fprintf(buf, "%s:%d (0x%x)\n", file, line, pc)
 		if file != lastFile {
-			data, err := ioutil.ReadFile(file)
+			data, err := ioutil.ReadFile(file) // nolint: gosec
 			if err != nil {
 				continue
 			}

--- a/testdrive/utils.go
+++ b/testdrive/utils.go
@@ -69,7 +69,7 @@ func unzip(archive, target string) error {
 	}
 
 	for _, file := range reader.File {
-		path := filepath.Join(target, file.Name)
+		path := filepath.Join(target, file.Name) // nolint: gosec
 		if file.FileInfo().IsDir() {
 			if err := os.MkdirAll(path, file.Mode()); err != nil {
 				return err


### PR DESCRIPTION
If users are using /etc/hosts then because CGO is disabled golang
doesn't look at that file. This fix makes it so /etc/hosts is respected.

Fixes #196
References:
* https://github.com/docker-library/golang/blob/master/1.9/alpine3.7/Dockerfile#L9
* https://github.com/golang/go/issues/22846