### PR TITLE
Ignore extra newlines in comments.

### DIFF
--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -18,6 +18,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/runatlantis/atlantis/server/events/models"
@@ -37,6 +38,13 @@ const (
 	DefaultWorkspace   = "default"
 	DefaultDir         = "."
 )
+
+// multiLineRegex is used to ignore multi-line comments since those aren't valid
+// Atlantis commands. If the second line just has newlines then we let it pass
+// through because when you double click on a comment in GitHub and then you
+// paste it again, GitHub adds two newlines and so we wanted to allow copying
+// and pasting GitHub comments.
+var multiLineRegex = regexp.MustCompile(`.*\r?\n[^\r\n]+`)
 
 //go:generate pegomock generate -m --use-experimental-model-gen --package mocks -o mocks/mock_comment_parsing.go CommentParsing
 

--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -235,6 +235,31 @@ func TestParse_RelativeDirPath(t *testing.T) {
 	}
 }
 
+// If there's multiple lines but it's whitespace, allow the command. This
+// occurs when you copy and paste via GitHub.
+func TestParse_Multiline(t *testing.T) {
+	comments := []string{
+		"atlantis plan\n",
+		"atlantis plan\n\n",
+		"atlantis plan\r\n",
+		"atlantis plan\r\n\r\n",
+	}
+	for _, comment := range comments {
+		t.Run(comment, func(t *testing.T) {
+			r := commentParser.Parse(comment, models.Github)
+			Equals(t, "", r.CommentResponse)
+			Equals(t, &events.CommentCommand{
+				RepoRelDir:  ".",
+				Flags:       nil,
+				Name:        events.PlanCommand,
+				Verbose:     false,
+				Workspace:   "default",
+				ProjectName: "",
+			}, r.Command)
+		})
+	}
+}
+
 func TestParse_InvalidWorkspace(t *testing.T) {
 	t.Log("if -w is used with '..' or '/', should return an error")
 	comments := []string{

--- a/server/events/event_parser.go
+++ b/server/events/event_parser.go
@@ -17,7 +17,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path"
-	"regexp"
 	"strings"
 
 	"github.com/google/go-github/github"
@@ -31,10 +30,6 @@ import (
 
 const gitlabPullOpened = "opened"
 const usagesCols = 90
-
-// multiLineRegex is used to ignore multi-line comments since those aren't valid
-// Atlantis commands.
-var multiLineRegex = regexp.MustCompile(`.*\r?\n.+`)
 
 type CommandInterface interface {
 	CommandName() CommandName


### PR DESCRIPTION
Accept comments like
```
atlantis plan

```
So that when a comment is copy-pasted in GitHub and GitHub adds two
newlines, Atlantis still parses that comment.