### PR TITLE
Support Gitlab Subgroups

### DIFF
--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -93,12 +93,20 @@ func NewRepo(vcsHostType VCSHostType, repoFullName string, cloneURL string, vcsU
 	// Get the owner and repo names from the full name.
 	var owner string
 	var repo string
+
 	pathSplit := strings.Split(repoFullName, "/")
-	if len(pathSplit) != 2 || pathSplit[0] == "" || pathSplit[1] == "" {
+	if (len(pathSplit) != 2 && vcsHostType != Gitlab) || pathSplit[0] == "" || pathSplit[1] == "" {
 		return Repo{}, fmt.Errorf("invalid repo format %q", repoFullName)
 	}
+
 	owner = pathSplit[0]
 	repo = pathSplit[1]
+
+	// If repository has subgroup domain
+	// An example of this requirement is Gitlab subgroups
+	if len(pathSplit) > 2 {
+		repo = fmt.Sprintf("%s/%s", pathSplit[1], pathSplit[2])
+	}
 
 	return Repo{
 		FullName:          repoFullName,

--- a/server/events/models/models_test.go
+++ b/server/events/models/models_test.go
@@ -59,7 +59,7 @@ func TestNewRepo_CloneURLBitbucketServer(t *testing.T) {
 	}, repo)
 }
 
-func TestNewRepo_FullNameWrongFormat(t *testing.T) {
+func TestNewRepo_GithubFullNameWrongFormat(t *testing.T) {
 	cases := []string{
 		"owner/repo/extra",
 		"/",
@@ -68,11 +68,78 @@ func TestNewRepo_FullNameWrongFormat(t *testing.T) {
 		"a/",
 		"/b",
 	}
+
 	for _, c := range cases {
 		t.Run(c, func(t *testing.T) {
 			cloneURL := fmt.Sprintf("https://github.com/%s.git", c)
 			_, err := models.NewRepo(models.Github, c, cloneURL, "u", "p")
 			ErrEquals(t, fmt.Sprintf(`invalid repo format "%s"`, c), err)
+		})
+	}
+}
+
+func TestNewRepo_BitbucketFullNameFormatCases(t *testing.T) {
+
+	testCases := []struct {
+		Case            string
+		Vcs             models.VCSHostType
+		RepoName        string
+		ExpectedMessage string
+	}{
+		{"Valid Bitbucket cloud repository testing %s case", models.BitbucketCloud, "owner/repo", ""},
+		{"Invalid Bitbucket cloud repository testing %s case", models.BitbucketCloud, "owner/subgroup/repo", `invalid repo format "%s"`},
+		{"Invalid Bitbucket cloud repository testing `%s` case", models.BitbucketCloud, "/", `invalid repo format "%s"`},
+		{"Invalid Bitbucket cloud repository testing `%s` case", models.BitbucketCloud, "//", `invalid repo format "%s"`},
+		{"Invalid Bitbucket cloud repository testing `%s` case", models.BitbucketCloud, "///", `invalid repo format "%s"`},
+		{"Invalid Bitbucket cloud repository testing `%s` case", models.BitbucketCloud, "a/", `invalid repo format "%s"`},
+		{"Invalid Bitbucket cloud repository testing `%s` case", models.BitbucketCloud, "/b", `invalid repo format "%s"`},
+
+		{"Valid Bitbucket server repository testing %s case", models.BitbucketCloud, "owner/repo", ""},
+		{"Invalid Bitbucket server repository testing %s case", models.BitbucketServer, "owner/subgroup/repo", `invalid repo format "%s"`},
+		{"Invalid Bitbucket server repository testing `%s` case", models.BitbucketServer, "/", `invalid repo format "%s"`},
+		{"Invalid Bitbucket server repository testing `%s` case", models.BitbucketServer, "//", `invalid repo format "%s"`},
+		{"Invalid Bitbucket server repository testing `%s` case", models.BitbucketServer, "///", `invalid repo format "%s"`},
+		{"Invalid Bitbucket server repository testing `%s` case", models.BitbucketServer, "a/", `invalid repo format "%s"`},
+		{"Invalid Bitbucket server repository testing `%s` case", models.BitbucketServer, "/b", `invalid repo format "%s"`},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(fmt.Sprintf(testCase.Case, testCase.RepoName), func(t *testing.T) {
+			cloneURL := fmt.Sprintf("https://bitbucket.org/%s.git", testCase.RepoName)
+			_, err := models.NewRepo(testCase.Vcs, testCase.RepoName, cloneURL, "u", "p")
+
+			if err != nil {
+				ErrEquals(t, fmt.Sprintf(testCase.ExpectedMessage, testCase.RepoName), err)
+			}
+		})
+	}
+}
+
+func TestNewRepo_GitlabFullNameFormatCases(t *testing.T) {
+
+	testCases := []struct {
+		Case            string
+		Vcs             models.VCSHostType
+		RepoName        string
+		ExpectedMessage string
+	}{
+		{"Valid gitlab repository testing %s case", models.Gitlab, "owner/repo", ""},
+		{"Valid gitlab repository testing %s case", models.Gitlab, "owner/repo/extra", ""},
+		{"Invalid gitlab repository testing `%s` case", models.Gitlab, "/", `invalid repo format "%s"`},
+		{"Invalid gitlab repository testing `%s` case", models.Gitlab, "//", `invalid repo format "%s"`},
+		{"Invalid gitlab repository testing `%s` case", models.Gitlab, "///", `invalid repo format "%s"`},
+		{"Invalid gitlab repository testing `%s` case", models.Gitlab, "a/", `invalid repo format "%s"`},
+		{"Invalid gitlab repository testing `%s` case", models.Gitlab, "/b", `invalid repo format "%s"`},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(fmt.Sprintf(testCase.Case, testCase.RepoName), func(t *testing.T) {
+			cloneURL := fmt.Sprintf("https://gitlab.com/%s.git", testCase.RepoName)
+			_, err := models.NewRepo(testCase.Vcs, testCase.RepoName, cloneURL, "u", "p")
+
+			if err != nil {
+				ErrEquals(t, fmt.Sprintf(testCase.ExpectedMessage, testCase.RepoName), err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Gitlab VCS supports [subgroup](https://docs.gitlab.com/ee/user/group/subgroups/) namespaces, which atlantis is not currently supporting. This pull request is intended to allow the creation of new repositories with the following format /owner/subgroup/repo on repository internal model.

**Observed:**
On pipeline webhooks using a gitlab repository with subgroup the following error is throwed:
Error parsing webhook: invalid repo format "xxxx/yyyy/atlantis-playground"

**Expected:**
Repository should not be considered invalid as Gitlab suports 3 level repository format.
