### PR TITLE
HELM: add a helm chart for easy install into k8s

### DIFF
--- a/helm/atlantis/.helmignore
+++ b/helm/atlantis/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm/atlantis/Chart.yaml
+++ b/helm/atlantis/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+appVersion: "v0.4.5"
+description: A Helm chart for Atlantis https://www.runatlantis.io
+name: atlantis
+version: 0.1.0
+keywords:
+- terraform
+home: https://www.runatlantis.io
+icon: https://www.runatlantis.io/hero.png
+sources:
+- https://github.com/runatlantis/atlantis

--- a/helm/atlantis/templates/NOTES.txt
+++ b/helm/atlantis/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "atlantis.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "atlantis.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "atlantis.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "atlantis.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/helm/atlantis/templates/_helpers.tpl
+++ b/helm/atlantis/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "atlantis.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "atlantis.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "atlantis.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/atlantis/templates/deployment.yaml
+++ b/helm/atlantis/templates/deployment.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "atlantis.fullname" . }}
+  labels:
+    app: {{ template "atlantis.name" . }}
+    chart: {{ template "atlantis.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "atlantis.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "atlantis.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      volumes:
+      {{- range $name, $_ := .Values.serviceAccountSecrets }}
+        - name: {{ $name }}-volume
+          secret:
+            secretName: {{ $name }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: atlantis
+              containerPort: 4141
+          env:
+          - name: ATLANTIS_REPO_WHITELIST
+            value: {{ .Values.orgWhitelist }}
+          - name: ATLANTIS_PORT
+            value: "4141"
+          {{- if .Values.atlantisUrl }}
+          - name: ATLANTIS_ATLANTIS_URL
+            value: {{ .Values.atlantisUrl }}
+          {{- else if .Values.ingress.enabled }}
+          - name: ATLANTIS_ATLANTIS_URL
+            value: http://{{ .Values.ingress.host }}
+          {{- end }}
+          {{- range $vcsEnvVar := .Values.vcsUserSetup }}
+          - name: {{ $vcsEnvVar.name }}
+            {{- if $vcsEnvVar.valueFrom }}
+            valueFrom:
+{{ toYaml $vcsEnvVar.valueFrom | indent 14 }}
+            {{- else }}
+            value: {{ $vcsEnvVar.value | quote }}
+            {{- end -}}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 4141
+              scheme: {{ .Values.livenessProbe.scheme }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 4141
+              scheme: {{ .Values.readinessProbe.scheme }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          volumeMounts:
+          {{- range $name, $_ := .Values.serviceAccountSecrets }}
+            - name: {{ $name }}-volume
+              readOnly: true
+              mountPath: /etc/{{ $name }}
+          {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/helm/atlantis/templates/deployment.yaml
+++ b/helm/atlantis/templates/deployment.yaml
@@ -29,6 +29,12 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          cmd: atlantis
+          args:
+            - server
+          {{- if .Values.allowRepoConfig }}
+            - --allow-repo-config
+          {{- end }}
           ports:
             - name: atlantis
               containerPort: 4141

--- a/helm/atlantis/templates/ingress.yaml
+++ b/helm/atlantis/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "atlantis.fullname" . -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "atlantis.name" . }}
+    chart: {{ template "atlantis.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: atlantis
+{{- end }}

--- a/helm/atlantis/templates/secrets-webhook.yaml
+++ b/helm/atlantis/templates/secrets-webhook.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "atlantis.name" . }}-webhook
+  labels:
+    app: {{ template "atlantis.name" . }}
+    chart: {{ template "atlantis.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  token: {{ print .Values.webhook.token | b64enc }}
+  webhook-secret: {{ print .Values.webhook.secret | b64enc }}

--- a/helm/atlantis/templates/service-account-secrets.yaml
+++ b/helm/atlantis/templates/service-account-secrets.yaml
@@ -1,0 +1,16 @@
+{{- $all := . -}}
+{{ range $name, $secret := .Values.serviceAccountSecrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}
+  labels:
+    app: {{ $name }}
+    chart: {{ template "atlantis.chart" $all }}
+    component: service-account-secret
+    heritage: {{ $all.Release.Service }}
+    release: {{ $all.Release.Name }}
+data:
+  service-account.json: {{ $secret }}
+---
+{{ end }}

--- a/helm/atlantis/templates/service.yaml
+++ b/helm/atlantis/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "atlantis.fullname" . }}
+  labels:
+    app: {{ template "atlantis.name" . }}
+    chart: {{ template "atlantis.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 4141
+      protocol: TCP
+      name: atlantis
+  selector:
+    app: {{ template "atlantis.name" . }}
+    release: {{ .Release.Name }}

--- a/helm/atlantis/values.yaml
+++ b/helm/atlantis/values.yaml
@@ -1,0 +1,132 @@
+## -------------------------- ##
+# Values to override for your instance.
+## -------------------------- ##
+
+## An option to override the atlantis url,
+##   if not using an ingress, set it to the external IP.
+# atlantisUrl: http://10.0.0.0
+
+## set these based on instructions for VCS.
+##   https://www.runatlantis.io/docs/deployment.html#add-webhook
+webhook:
+  token:
+  secret:
+
+## Replace this with your own repo whitelist.
+orgWhitelist: github.com/yourorg/*
+
+## Based on which VCS you use, set the values accordingly.
+vcsUserSetup: {}
+  # ### GitHub Config ###
+  # atlantisGithubUser:
+  #   name: ATLANTIS_GH_USER
+  #   value: <YOUR_GITHUB_USER> # 3i. If you're using GitHub replace <YOUR_GITHUB_USER> with the username of your Atlantis GitHub user without the `@`.
+  # atlantisGithubToken:
+  #   name: ATLANTIS_GH_TOKEN
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: atlantis-webhook
+  #       key: token
+  # atlantisGithubWebhookSecret:
+  #   name: ATLANTIS_GH_WEBHOOK_SECRET
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: atlantis-webhook
+  #       key: webhook-secret
+  # ### -------------- ###
+
+  # ### GitLab Config ###
+  # atlantisGitLabUser:
+  #   name: ATLANTIS_GITLAB_USER
+  #   value: <YOUR_GITLAB_USER> # 4i. If you're using GitLab replace <YOUR_GITLAB_USER> with the username of your Atlantis GitLab user without the `@`.
+  # atlantisGitLabToken:
+  #   name: ATLANTIS_GITLAB_TOKEN
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: atlantis-webhook
+  #       key: token
+  # atlantisWebhookSecret:
+  #   name: ATLANTIS_GITLAB_WEBHOOK_SECRET
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: atlantis-webhook
+  #       key: webhook-secret
+  # ### -------------- ###
+
+  # ### Bitbucket Config ###
+  # atlantis_bitbucket_user:
+  #   name: ATLANTIS_BITBUCKET_USER
+  #   value: <YOUR_BITBUCKET_USER> # 5i. If you're using Bitbucket replace <YOUR_BITBUCKET_USER> with the username of your Atlantis Bitbucket user without the `@`.
+  # atlantis_bitbucket_token:
+  #   name: ATLANTIS_BITBUCKET_TOKEN
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: atlantis-webhook
+  #       key: token
+  # ### -------------- ###
+
+
+## To be used for mounting credential files (when using google provider).
+serviceAccountSecrets:
+  # credentials: <json file as base64 encoded string>
+  # credentials-staging: <json file as base64 encoded string>
+
+
+## -------------------------- ##
+# Default values for atlantis (override as needed).
+## -------------------------- ##
+
+image:
+  repository: runatlantis/atlantis
+  tag: v0.4.5
+  pullPolicy: IfNotPresent
+
+# We only need to check every 60s since Atlantis is not a high-throughput service.
+livenessProbe:
+  enabled: true
+  periodSeconds: 60
+  initialDelaySeconds: 5
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 5
+  scheme: HTTP
+readinessProbe:
+  enabled: true
+  periodSeconds: 60
+  initialDelaySeconds: 30
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 5
+  scheme: HTTP
+
+service:
+  type: NodePort
+  port: 80
+
+ingress:
+  enabled: true
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  host: chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources:
+  requests:
+    memory: 256Mi
+    cpu: 100m
+  limits:
+    memory: 256Mi
+    cpu: 100m
+
+replicaCount: 1
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/helm/atlantis/values.yaml
+++ b/helm/atlantis/values.yaml
@@ -81,6 +81,9 @@ image:
   tag: v0.4.5
   pullPolicy: IfNotPresent
 
+## enable using atlantis.yaml file
+allowRepoConfig: false
+
 # We only need to check every 60s since Atlantis is not a high-throughput service.
 livenessProbe:
   enabled: true


### PR DESCRIPTION
I've created a helm chart. The instructions for installing in k8s, while very clear and helpful, could use the benefit of simple overriding of values files. 

I think what you should do is submit this chart to https://github.com/helm/charts
and get more traction of using this tool from the greater kubernetes community. Regardless, there should probably be a readme and/or an update to your documentation. 

----

I chose to go with the deployment instead of statefulset, but that could easily just become another config option of the chart. I also made a few other assumptions that benefited our setup (ie, mounting service account files). 