### PR TITLE
Website: change apply'd to applied, add periods at end of bullets

### DIFF
--- a/runatlantis.io/.vuepress/components/HomeCustom.vue
+++ b/runatlantis.io/.vuepress/components/HomeCustom.vue
@@ -88,7 +88,7 @@
                 <li><img class="checkmark" src="/checkmark.svg">See exactly
                   which resources were changed.
                 </li>
-                <li><img class="checkmark" src="/checkmark.svg">Know who apply'd
+                <li><img class="checkmark" src="/checkmark.svg">Know who applied
                   the change and who approved it.
                 </li>
               </ul>
@@ -118,9 +118,9 @@
                 </li>
                 <li><img class="checkmark" src="/checkmark.svg">Runs as a Golang binary or Docker image and can be deployed on VMs, Kubernetes, Fargate, etc.
                 </li>
-                <li><img class="checkmark" src="/checkmark.svg">Listens for webhooks from GitHub/GitLab/Bitbucket
+                <li><img class="checkmark" src="/checkmark.svg">Listens for webhooks from GitHub/GitLab/Bitbucket.
                 </li>
-                <li><img class="checkmark" src="/checkmark.svg">Runs terraform commands remotely and comments back with their output
+                <li><img class="checkmark" src="/checkmark.svg">Runs terraform commands remotely and comments back with their output.
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
New page looks slick!

- In the home page `applied` is used first so this changes `apply'd` to `applied` for consistency.
- Added periods at end of bullets for consistency.

Other feedback: currently `Know who apply'd the change and who approved it.` barely takes up 2 lines and may look awkward.

### Before PR changes
![image](https://user-images.githubusercontent.com/9021054/44301411-244bf100-a2e4-11e8-85b2-c37c10b378eb.png)

### After PR changes
![image](https://user-images.githubusercontent.com/9021054/44301400-e8189080-a2e3-11e8-909e-5ac6f92d4e1f.png)
