### PR TITLE
change server startup log message from warn to info level

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -372,7 +372,7 @@ func (s *Server) Start() error {
 
 	server := &http.Server{Addr: fmt.Sprintf(":%d", s.Port), Handler: n}
 	go func() {
-		s.Logger.Warn("Atlantis started - listening on port %v", s.Port)
+		s.Logger.Info("Atlantis started - listening on port %v", s.Port)
 
 		var err error
 		if s.SSLCertFile != "" && s.SSLKeyFile != "" {


### PR DESCRIPTION
Server startup should be something expected therefore an info rather than a warning.

```
2018/08/28 18:37:50 [WARN] server: Atlantis started - listening on port 4141
```

Signed-off-by: Ben Abrams <me@benabrams.it>