### PR TITLE
Update to alpine 3.8 to fix security vuln.

### DIFF
--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile builds our base image with gosu, dumb-init and the atlantis
 # user. We split this from the main Dockerfile because this base doesn't change
 # and also because it kept breaking the build due to flakiness.
-FROM alpine:3.6
+FROM alpine:3.8
 LABEL authors="Anubhav Mishra, Luke Kysow"
 
 # create atlantis user


### PR DESCRIPTION
See https://justi.cz/security/2018/09/13/alpine-apk-rce.html

Fixes #271 

NOTE: I rebuilt `runatlantis/atlantis-base` locally on alpine 3.8 and pushed it. When I release the next version of Atlantis it will build from that new base image.