### PR TITLE
Execute tf with vars that give source of run.

### DIFF
--- a/server/events/runtime/plan_step_runner_test.go
+++ b/server/events/runtime/plan_step_runner_test.go
@@ -40,15 +40,55 @@ func TestRun_NoWorkspaceIn08(t *testing.T) {
 		Workspace:   workspace,
 		RepoRelDir:  ".",
 		User:        models.User{Username: "username"},
+		Pull: models.PullRequest{
+			Num: 2,
+		},
+		BaseRepo: models.Repo{
+			FullName: "owner/repo",
+		},
 	}, []string{"extra", "args"}, "/path")
 	Ok(t, err)
 
 	Equals(t, "output", output)
-	terraform.VerifyWasCalledOnce().RunCommandWithVersion(logger, "/path", []string{"plan", "-input=false", "-refresh", "-no-color", "-out", "/path/default.tfplan", "-var", "atlantis_user=username", "extra", "args", "comment", "args"}, tfVersion, workspace)
+	terraform.VerifyWasCalledOnce().RunCommandWithVersion(
+		logger,
+		"/path",
+		[]string{"plan",
+			"-input=false",
+			"-refresh",
+			"-no-color",
+			"-out",
+			"/path/default.tfplan",
+			"-var",
+			"atlantis_user=username",
+			"-var",
+			"atlantis_repo=owner/repo",
+			"-var",
+			"atlantis_pull_num=2",
+			"extra",
+			"args",
+			"comment",
+			"args"},
+		tfVersion,
+		workspace)
 
 	// Verify that no env or workspace commands were run
-	terraform.VerifyWasCalled(Never()).RunCommandWithVersion(logger, "/path", []string{"env", "select", "-no-color", "workspace"}, tfVersion, workspace)
-	terraform.VerifyWasCalled(Never()).RunCommandWithVersion(logger, "/path", []string{"workspace", "select", "-no-color", "workspace"}, tfVersion, workspace)
+	terraform.VerifyWasCalled(Never()).RunCommandWithVersion(logger,
+		"/path",
+		[]string{"env",
+			"select",
+			"-no-color",
+			"workspace"},
+		tfVersion,
+		workspace)
+	terraform.VerifyWasCalled(Never()).RunCommandWithVersion(logger,
+		"/path",
+		[]string{"workspace",
+			"select",
+			"-no-color",
+			"workspace"},
+		tfVersion,
+		workspace)
 }
 
 func TestRun_ErrWorkspaceIn08(t *testing.T) {
@@ -121,13 +161,45 @@ func TestRun_SwitchesWorkspace(t *testing.T) {
 				RepoRelDir:  ".",
 				User:        models.User{Username: "username"},
 				CommentArgs: []string{"comment", "args"},
+				Pull: models.PullRequest{
+					Num: 2,
+				},
+				BaseRepo: models.Repo{
+					FullName: "owner/repo",
+				},
 			}, []string{"extra", "args"}, "/path")
 			Ok(t, err)
 
 			Equals(t, "output", output)
 			// Verify that env select was called as well as plan.
-			terraform.VerifyWasCalledOnce().RunCommandWithVersion(logger, "/path", []string{c.expWorkspaceCmd, "select", "-no-color", "workspace"}, tfVersion, "workspace")
-			terraform.VerifyWasCalledOnce().RunCommandWithVersion(logger, "/path", []string{"plan", "-input=false", "-refresh", "-no-color", "-out", "/path/workspace.tfplan", "-var", "atlantis_user=username", "extra", "args", "comment", "args"}, tfVersion, "workspace")
+			terraform.VerifyWasCalledOnce().RunCommandWithVersion(logger,
+				"/path",
+				[]string{c.expWorkspaceCmd,
+					"select",
+					"-no-color",
+					"workspace"},
+				tfVersion,
+				"workspace")
+			terraform.VerifyWasCalledOnce().RunCommandWithVersion(logger,
+				"/path",
+				[]string{"plan",
+					"-input=false",
+					"-refresh",
+					"-no-color",
+					"-out",
+					"/path/workspace.tfplan",
+					"-var",
+					"atlantis_user=username",
+					"-var",
+					"atlantis_repo=owner/repo",
+					"-var",
+					"atlantis_pull_num=2",
+					"extra",
+					"args",
+					"comment",
+					"args"},
+				tfVersion,
+				"workspace")
 		})
 	}
 }
@@ -175,7 +247,22 @@ func TestRun_CreatesWorkspace(t *testing.T) {
 			expWorkspaceArgs := []string{c.expWorkspaceCommand, "select", "-no-color", "workspace"}
 			When(terraform.RunCommandWithVersion(logger, "/path", expWorkspaceArgs, tfVersion, "workspace")).ThenReturn("", errors.New("workspace does not exist"))
 
-			expPlanArgs := []string{"plan", "-input=false", "-refresh", "-no-color", "-out", "/path/workspace.tfplan", "-var", "atlantis_user=username", "extra", "args", "comment", "args"}
+			expPlanArgs := []string{"plan",
+				"-input=false",
+				"-refresh",
+				"-no-color",
+				"-out",
+				"/path/workspace.tfplan",
+				"-var",
+				"atlantis_user=username",
+				"-var",
+				"atlantis_repo=owner/repo",
+				"-var",
+				"atlantis_pull_num=2",
+				"extra",
+				"args",
+				"comment",
+				"args"}
 			When(terraform.RunCommandWithVersion(logger, "/path", expPlanArgs, tfVersion, "workspace")).ThenReturn("output", nil)
 
 			output, err := s.Run(models.ProjectCommandContext{
@@ -184,6 +271,12 @@ func TestRun_CreatesWorkspace(t *testing.T) {
 				RepoRelDir:  ".",
 				User:        models.User{Username: "username"},
 				CommentArgs: []string{"comment", "args"},
+				Pull: models.PullRequest{
+					Num: 2,
+				},
+				BaseRepo: models.Repo{
+					FullName: "owner/repo",
+				},
 			}, []string{"extra", "args"}, "/path")
 			Ok(t, err)
 
@@ -208,7 +301,22 @@ func TestRun_NoWorkspaceSwitchIfNotNecessary(t *testing.T) {
 	}
 	When(terraform.RunCommandWithVersion(logger, "/path", []string{"workspace", "show"}, tfVersion, "workspace")).ThenReturn("workspace\n", nil)
 
-	expPlanArgs := []string{"plan", "-input=false", "-refresh", "-no-color", "-out", "/path/workspace.tfplan", "-var", "atlantis_user=username", "extra", "args", "comment", "args"}
+	expPlanArgs := []string{"plan",
+		"-input=false",
+		"-refresh",
+		"-no-color",
+		"-out",
+		"/path/workspace.tfplan",
+		"-var",
+		"atlantis_user=username",
+		"-var",
+		"atlantis_repo=owner/repo",
+		"-var",
+		"atlantis_pull_num=2",
+		"extra",
+		"args",
+		"comment",
+		"args"}
 	When(terraform.RunCommandWithVersion(logger, "/path", expPlanArgs, tfVersion, "workspace")).ThenReturn("output", nil)
 
 	output, err := s.Run(models.ProjectCommandContext{
@@ -217,6 +325,12 @@ func TestRun_NoWorkspaceSwitchIfNotNecessary(t *testing.T) {
 		RepoRelDir:  ".",
 		User:        models.User{Username: "username"},
 		CommentArgs: []string{"comment", "args"},
+		Pull: models.PullRequest{
+			Num: 2,
+		},
+		BaseRepo: models.Repo{
+			FullName: "owner/repo",
+		},
 	}, []string{"extra", "args"}, "/path")
 	Ok(t, err)
 
@@ -249,7 +363,25 @@ func TestRun_AddsEnvVarFile(t *testing.T) {
 		DefaultTFVersion:  tfVersion,
 	}
 
-	expPlanArgs := []string{"plan", "-input=false", "-refresh", "-no-color", "-out", filepath.Join(tmpDir, "workspace.tfplan"), "-var", "atlantis_user=username", "extra", "args", "comment", "args", "-var-file", envVarsFile}
+	expPlanArgs := []string{"plan",
+		"-input=false",
+		"-refresh",
+		"-no-color",
+		"-out",
+		filepath.Join(tmpDir, "workspace.tfplan"),
+		"-var",
+		"atlantis_user=username",
+		"-var",
+		"atlantis_repo=owner/repo",
+		"-var",
+		"atlantis_pull_num=2",
+		"extra",
+		"args",
+		"comment",
+		"args",
+		"-var-file",
+		envVarsFile,
+	}
 	When(terraform.RunCommandWithVersion(logger, tmpDir, expPlanArgs, tfVersion, "workspace")).ThenReturn("output", nil)
 
 	output, err := s.Run(models.ProjectCommandContext{
@@ -258,6 +390,12 @@ func TestRun_AddsEnvVarFile(t *testing.T) {
 		RepoRelDir:  ".",
 		User:        models.User{Username: "username"},
 		CommentArgs: []string{"comment", "args"},
+		Pull: models.PullRequest{
+			Num: 2,
+		},
+		BaseRepo: models.Repo{
+			FullName: "owner/repo",
+		},
 	}, []string{"extra", "args"}, tmpDir)
 	Ok(t, err)
 
@@ -280,7 +418,23 @@ func TestRun_UsesDiffPathForProject(t *testing.T) {
 	}
 	When(terraform.RunCommandWithVersion(logger, "/path", []string{"workspace", "show"}, tfVersion, "workspace")).ThenReturn("workspace\n", nil)
 
-	expPlanArgs := []string{"plan", "-input=false", "-refresh", "-no-color", "-out", "/path/projectname-default.tfplan", "-var", "atlantis_user=username", "extra", "args", "comment", "args"}
+	expPlanArgs := []string{"plan",
+		"-input=false",
+		"-refresh",
+		"-no-color",
+		"-out",
+		"/path/projectname-default.tfplan",
+		"-var",
+		"atlantis_user=username",
+		"-var",
+		"atlantis_repo=owner/repo",
+		"-var",
+		"atlantis_pull_num=2",
+		"extra",
+		"args",
+		"comment",
+		"args",
+	}
 	When(terraform.RunCommandWithVersion(logger, "/path", expPlanArgs, tfVersion, "default")).ThenReturn("output", nil)
 
 	projectName := "projectname"
@@ -292,6 +446,12 @@ func TestRun_UsesDiffPathForProject(t *testing.T) {
 		CommentArgs: []string{"comment", "args"},
 		ProjectConfig: &valid.Project{
 			Name: &projectName,
+		},
+		Pull: models.PullRequest{
+			Num: 2,
+		},
+		BaseRepo: models.Repo{
+			FullName: "owner/repo",
 		},
 	}, []string{"extra", "args"}, "/path")
 	Ok(t, err)


### PR DESCRIPTION
Add new variables to execute TF with:
```
  -var atlantis_repo=owner/repo
  -var atlantis_pull_num=10
```

These can be used within TF to set the session_name of the AWS session
that Terraform creates. This allows all API calls to be traced back to a
specific pull request and user.

Fixes #256, refactored work from @jolexa in #285