### PR TITLE
Quote the -out variable in terraform plan.

### DIFF
--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -31,10 +31,11 @@ import (
 // Repo is a VCS repository.
 type Repo struct {
 	// FullName is the owner and repo name separated
-	// by a "/", ex. "runatlantis/atlantis" or "gitlab/subgroup/atlantis"
+	// by a "/", ex. "runatlantis/atlantis", "gitlab/subgroup/atlantis", "Bitbucket Server/atlantis".
 	FullName string
 	// Owner is just the repo owner, ex. "runatlantis" or "gitlab/subgroup".
 	// This may contain /'s in the case of GitLab subgroups.
+	// This may contain spaces in the case of Bitbucket Server.
 	Owner string
 	// Name is just the repo name, ex. "atlantis". This will never have
 	// /'s in it.

--- a/server/events/runtime/plan_step_runner.go
+++ b/server/events/runtime/plan_step_runner.go
@@ -110,7 +110,9 @@ func (p *PlanStepRunner) buildPlanCmd(ctx models.ProjectCommandContext, extraArg
 	}
 
 	argList := [][]string{
-		{"plan", "-input=false", "-refresh", "-no-color", "-out", planFile},
+		// NOTE: we need to quote the plan filename because Bitbucket Server can
+		// have spaces in its repo owner names.
+		{"plan", "-input=false", "-refresh", "-no-color", "-out", fmt.Sprintf("%q", planFile)},
 		tfVars,
 		extraArgs,
 		ctx.CommentArgs,

--- a/server/events/runtime/plan_step_runner_test.go
+++ b/server/events/runtime/plan_step_runner_test.go
@@ -1,6 +1,7 @@
 package runtime_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -58,7 +59,7 @@ func TestRun_NoWorkspaceIn08(t *testing.T) {
 			"-refresh",
 			"-no-color",
 			"-out",
-			"/path/default.tfplan",
+			"\"/path/default.tfplan\"",
 			"-var",
 			"atlantis_user=username",
 			"-var",
@@ -187,7 +188,7 @@ func TestRun_SwitchesWorkspace(t *testing.T) {
 					"-refresh",
 					"-no-color",
 					"-out",
-					"/path/workspace.tfplan",
+					"\"/path/workspace.tfplan\"",
 					"-var",
 					"atlantis_user=username",
 					"-var",
@@ -252,7 +253,7 @@ func TestRun_CreatesWorkspace(t *testing.T) {
 				"-refresh",
 				"-no-color",
 				"-out",
-				"/path/workspace.tfplan",
+				"\"/path/workspace.tfplan\"",
 				"-var",
 				"atlantis_user=username",
 				"-var",
@@ -306,7 +307,7 @@ func TestRun_NoWorkspaceSwitchIfNotNecessary(t *testing.T) {
 		"-refresh",
 		"-no-color",
 		"-out",
-		"/path/workspace.tfplan",
+		"\"/path/workspace.tfplan\"",
 		"-var",
 		"atlantis_user=username",
 		"-var",
@@ -368,7 +369,7 @@ func TestRun_AddsEnvVarFile(t *testing.T) {
 		"-refresh",
 		"-no-color",
 		"-out",
-		filepath.Join(tmpDir, "workspace.tfplan"),
+		fmt.Sprintf("%q", filepath.Join(tmpDir, "workspace.tfplan")),
 		"-var",
 		"atlantis_user=username",
 		"-var",
@@ -423,7 +424,7 @@ func TestRun_UsesDiffPathForProject(t *testing.T) {
 		"-refresh",
 		"-no-color",
 		"-out",
-		"/path/projectname-default.tfplan",
+		"\"/path/projectname-default.tfplan\"",
 		"-var",
 		"atlantis_user=username",
 		"-var",


### PR DESCRIPTION
Fixes #290. In Bitbucket Server, the repo owner name can have spaces.
This causes errors when running terraform plan -out path with spaces so
we need to quote it: terraform plan -out "path with spaces".