### PR TITLE
Update example for new tf run variables

### DIFF
--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -70,7 +70,7 @@ variable "atlantis_pull_num" {
 provider "aws" {
   assume_role {
     role_arn     = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
-    session_name = "${var.atlantis_user}:${var.atlantis_repo}:${var.atlantis_pull_num}"
+    session_name = "${var.atlantis_user}-${var.atlantis_repo}-${var.atlantis_pull_num}"
   }
 }
 ```


### PR DESCRIPTION
After trying out the new tf run variables implemented in #287 I found an error that I couldn't assume the role. I had a suspicion that the session_name was invalid so I consulted the [documentation](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html).

The valid pattern for session_name is: `Pattern: [\w+=,.@-]*`
> The regex used to validate this parameter is a string of characters consisting of upper- and lower-case alphanumeric characters with no spaces. You can also include underscores or any of the following characters: =,.@-

