### PR TITLE
Testdrive readPassword fix to allow Windows build

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -37,7 +37,6 @@
       "Command": "errcheck -abspath -ignore 'fmt:.*'",
       "Pattern": "PATH:LINE:COL:MESSAGE",
       "PartitionStrategy": "packages"
-    },
-    "unconvert": {"Command": "unconvert --all"}
+    }
   }
 }

--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -37,7 +37,7 @@
       "Command": "errcheck -abspath -ignore 'fmt:.*'",
       "Pattern": "PATH:LINE:COL:MESSAGE",
       "PartitionStrategy": "packages"
-    }
+    },
     "unconvert": {"Command": "unconvert --all"}
   }
 }

--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -38,5 +38,6 @@
       "Pattern": "PATH:LINE:COL:MESSAGE",
       "PartitionStrategy": "packages"
     }
+    "unconvert": {"Command": "unconvert --all"}
   }
 }

--- a/testdrive/utils.go
+++ b/testdrive/utils.go
@@ -41,7 +41,7 @@ const ngrokAPIURL = "localhost:41414" // We hope this isn't used.
 const atlantisPort = 4141
 
 func readPassword() (string, error) {
-	password, err := terminal.ReadPassword(int(syscall.Stdin))
+	password, err := terminal.ReadPassword(int(syscall.Stdin)) // nolint: unconvert
 	return string(password), err
 }
 

--- a/testdrive/utils.go
+++ b/testdrive/utils.go
@@ -41,7 +41,7 @@ const ngrokAPIURL = "localhost:41414" // We hope this isn't used.
 const atlantisPort = 4141
 
 func readPassword() (string, error) {
-	password, err := terminal.ReadPassword(syscall.Stdin)
+	password, err := terminal.ReadPassword(int(syscall.Stdin))
 	return string(password), err
 }
 


### PR DESCRIPTION
Atlantis currently errors when building on Windows with:

`testdrive\utils.go:44:40: cannot use syscall.Stdin (type syscall.Handle) as type int in argument to terminal.ReadPassword`

This pull request fixes this by type casting `syscall.Stdin` to `int`, as shown in Google's go-github example code: [main.go](https://github.com/google/go-github/blob/master/example/basicauth/main.go)

This should then successfully build on Windows and Linux.