### PR TITLE
Add --silence-whitelist-errors server flag

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -55,6 +55,7 @@ const (
 	PortFlag                   = "port"
 	RepoWhitelistFlag          = "repo-whitelist"
 	RequireApprovalFlag        = "require-approval"
+	SilenceWhitelistErrorsFlag = "silence-whitelist-errors"
 	SSLCertFileFlag            = "ssl-cert-file"
 	SSLKeyFileFlag             = "ssl-key-file"
 
@@ -183,6 +184,11 @@ var boolFlags = []boolFlag{
 	{
 		name:         RequireApprovalFlag,
 		description:  "Require pull requests to be \"Approved\" before allowing the apply command to be run.",
+		defaultValue: false,
+	},
+	{
+		name:         SilenceWhitelistErrorsFlag,
+		description:  "Silences the posting of whitelist error comments.",
 		defaultValue: false,
 	},
 }

--- a/server/events_controller.go
+++ b/server/events_controller.go
@@ -57,8 +57,8 @@ type EventsController struct {
 	// request validation is done.
 	GitlabWebhookSecret  []byte
 	RepoWhitelistChecker *events.RepoWhitelistChecker
-	// Signifies if we post a comment when an event comes in for a non-whitelisted
-	// repository
+	// SilenceWhitelistErrors controls whether we write an error comment on
+	// pull requests from non-whitelisted repos.
 	SilenceWhitelistErrors bool
 	// SupportedVCSHosts is which VCS hosts Atlantis was configured upon
 	// startup to support.
@@ -419,7 +419,7 @@ func (e *EventsController) respond(w http.ResponseWriter, lvl logging.LogLevel, 
 }
 
 // commentNotWhitelisted comments on the pull request that the repo is not
-// whitelisted.
+// whitelisted unless whitelist error comments are disabled.
 func (e *EventsController) commentNotWhitelisted(baseRepo models.Repo, pullNum int) {
 	if e.SilenceWhitelistErrors {
 		return

--- a/server/events_controller_test.go
+++ b/server/events_controller_test.go
@@ -199,7 +199,7 @@ func TestPost_GitlabCommentNotWhitelisted(t *testing.T) {
 }
 
 func TestPost_GitlabCommentNotWhitelistedWithSilenceErrors(t *testing.T) {
-	t.Log("when the event is a gitlab comment from a repo that isn't whitelisted and we are silencing errors, do no comment with an error")
+	t.Log("when the event is a gitlab comment from a repo that isn't whitelisted and we are silencing errors, do not comment with an error")
 	RegisterMockTestingT(t)
 	vcsClient := vcsmocks.NewMockClientProxy()
 	e := server.EventsController{
@@ -223,8 +223,9 @@ func TestPost_GitlabCommentNotWhitelistedWithSilenceErrors(t *testing.T) {
 	body, _ := ioutil.ReadAll(w.Result().Body)
 	exp := "Repo not whitelisted"
 	Assert(t, strings.Contains(string(body), exp), "exp %q to be contained in %q", exp, string(body))
-	expRepo, _ := models.NewRepo(models.Gitlab, "gitlabhq/gitlab-test", "https://example.com/gitlabhq/gitlab-test.git", "", "")
-	vcsClient.VerifyWasCalled(Never()).CreateComment(expRepo, 1, "```\nError: This repo is not whitelisted for Atlantis.\n```")
+	models.NewRepo(models.Gitlab, "gitlabhq/gitlab-test", "https://example.com/gitlabhq/gitlab-test.git", "", "")
+	vcsClient.VerifyWasCalled(Never()).CreateComment(matchers.AnyModelsRepo(), AnyInt(), AnyString())
+
 }
 
 func TestPost_GithubCommentNotWhitelisted(t *testing.T) {
@@ -257,7 +258,7 @@ func TestPost_GithubCommentNotWhitelisted(t *testing.T) {
 }
 
 func TestPost_GithubCommentNotWhitelistedWithSilenceErrors(t *testing.T) {
-	t.Log("when the event is a github comment from a repo that isn't whitelisted and we are silencing errors, do no comment with an error")
+	t.Log("when the event is a github comment from a repo that isn't whitelisted and we are silencing errors, do not comment with an error")
 	RegisterMockTestingT(t)
 	vcsClient := vcsmocks.NewMockClientProxy()
 	e := server.EventsController{
@@ -282,8 +283,8 @@ func TestPost_GithubCommentNotWhitelistedWithSilenceErrors(t *testing.T) {
 	body, _ := ioutil.ReadAll(w.Result().Body)
 	exp := "Repo not whitelisted"
 	Assert(t, strings.Contains(string(body), exp), "exp %q to be contained in %q", exp, string(body))
-	expRepo, _ := models.NewRepo(models.Github, "baxterthehacker/public-repo", "https://github.com/baxterthehacker/public-repo.git", "", "")
-	vcsClient.VerifyWasCalled(Never()).CreateComment(expRepo, 2, "```\nError: This repo is not whitelisted for Atlantis.\n```")
+	models.NewRepo(models.Github, "baxterthehacker/public-repo", "https://github.com/baxterthehacker/public-repo.git", "", "")
+	vcsClient.VerifyWasCalled(Never()).CreateComment(matchers.AnyModelsRepo(), AnyInt(), AnyString())
 }
 
 func TestPost_GitlabCommentResponse(t *testing.T) {

--- a/server/events_controller_test.go
+++ b/server/events_controller_test.go
@@ -223,7 +223,6 @@ func TestPost_GitlabCommentNotWhitelistedWithSilenceErrors(t *testing.T) {
 	body, _ := ioutil.ReadAll(w.Result().Body)
 	exp := "Repo not whitelisted"
 	Assert(t, strings.Contains(string(body), exp), "exp %q to be contained in %q", exp, string(body))
-	models.NewRepo(models.Gitlab, "gitlabhq/gitlab-test", "https://example.com/gitlabhq/gitlab-test.git", "", "")
 	vcsClient.VerifyWasCalled(Never()).CreateComment(matchers.AnyModelsRepo(), AnyInt(), AnyString())
 
 }
@@ -283,7 +282,6 @@ func TestPost_GithubCommentNotWhitelistedWithSilenceErrors(t *testing.T) {
 	body, _ := ioutil.ReadAll(w.Result().Body)
 	exp := "Repo not whitelisted"
 	Assert(t, strings.Contains(string(body), exp), "exp %q to be contained in %q", exp, string(body))
-	models.NewRepo(models.Github, "baxterthehacker/public-repo", "https://github.com/baxterthehacker/public-repo.git", "", "")
 	vcsClient.VerifyWasCalled(Never()).CreateComment(matchers.AnyModelsRepo(), AnyInt(), AnyString())
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -102,11 +102,12 @@ type UserConfig struct {
 	RepoWhitelist          string `mapstructure:"repo-whitelist"`
 	// RequireApproval is whether to require pull request approval before
 	// allowing terraform apply's to be run.
-	RequireApproval bool            `mapstructure:"require-approval"`
-	SlackToken      string          `mapstructure:"slack-token"`
-	SSLCertFile     string          `mapstructure:"ssl-cert-file"`
-	SSLKeyFile      string          `mapstructure:"ssl-key-file"`
-	Webhooks        []WebhookConfig `mapstructure:"webhooks"`
+	RequireApproval        bool            `mapstructure:"require-approval"`
+	SilenceWhitelistErrors bool            `mapstructure:"silence-whitelist-errors"`
+	SlackToken             string          `mapstructure:"slack-token"`
+	SSLCertFile            string          `mapstructure:"ssl-cert-file"`
+	SSLKeyFile             string          `mapstructure:"ssl-key-file"`
+	Webhooks               []WebhookConfig `mapstructure:"webhooks"`
 }
 
 // Config holds config for server that isn't passed in by the user.
@@ -326,6 +327,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		GitlabRequestParserValidator: &DefaultGitlabRequestParserValidator{},
 		GitlabWebhookSecret:          []byte(userConfig.GitlabWebhookSecret),
 		RepoWhitelistChecker:         repoWhitelist,
+		SilenceWhitelistErrors:       userConfig.SilenceWhitelistErrors,
 		SupportedVCSHosts:            supportedVCSHosts,
 		VCSClient:                    vcsClient,
 		BitbucketWebhookSecret:       []byte(userConfig.BitbucketWebhookSecret),


### PR DESCRIPTION
Fixes #312 

Some users would like to add the Atlantis webhook at the org level and then use the whitelist to configure which repos Atlantis actually runs on. In this configuration, it's annoying that Atlantis continually comments on pull requests "Repo is not whitelisted".

This PR adds a flag `--silence-whitelist-errors` which will prevent commenting back on the pull request.