### PR TITLE
Support slash in repo name

### DIFF
--- a/server/events/runtime/runtime.go
+++ b/server/events/runtime/runtime.go
@@ -4,6 +4,7 @@ package runtime
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/hashicorp/go-version"
 	"github.com/runatlantis/atlantis/server/events/yaml/valid"
@@ -23,11 +24,16 @@ func MustConstraint(constraint string) version.Constraints {
 	return c
 }
 
+var invalidFilenameChars = regexp.MustCompile(`[^a-zA-Z0-9-_\.]`)
+
 // GetPlanFilename returns the filename (not the path) of the generated tf plan
 // given a workspace and maybe a project's config.
 func GetPlanFilename(workspace string, maybeCfg *valid.Project) string {
+	var unescapedFilename string
 	if maybeCfg == nil || maybeCfg.Name == nil {
-		return fmt.Sprintf("%s.tfplan", workspace)
+		unescapedFilename = fmt.Sprintf("%s.tfplan", workspace)
+	} else {
+		unescapedFilename = fmt.Sprintf("%s-%s.tfplan", *maybeCfg.Name, workspace)
 	}
-	return fmt.Sprintf("%s-%s.tfplan", *maybeCfg.Name, workspace)
+	return invalidFilenameChars.ReplaceAllLiteralString(unescapedFilename, "-")
 }

--- a/server/events/runtime/runtime_test.go
+++ b/server/events/runtime/runtime_test.go
@@ -21,9 +21,19 @@ func TestGetPlanFilename(t *testing.T) {
 			"workspace.tfplan",
 		},
 		{
+			"workspace with space",
+			nil,
+			"workspace-with-space.tfplan",
+		},
+		{
 			"workspace",
 			&valid.Project{},
 			"workspace.tfplan",
+		},
+		{
+			"workspace with space",
+			&valid.Project{},
+			"workspace-with-space.tfplan",
 		},
 		{
 			"workspace",
@@ -31,6 +41,27 @@ func TestGetPlanFilename(t *testing.T) {
 				Name: String("project"),
 			},
 			"project-workspace.tfplan",
+		},
+		{
+			"workspace",
+			&valid.Project{
+				Name: String("project/with/slash"),
+			},
+			"project-with-slash-workspace.tfplan",
+		},
+		{
+			"workspace",
+			&valid.Project{
+				Name: String("project with space"),
+			},
+			"project-with-space-workspace.tfplan",
+		},
+		{
+			"workspace😀",
+			&valid.Project{
+				Name: String("project😀"),
+			},
+			"project--workspace-.tfplan",
 		},
 	}
 


### PR DESCRIPTION
Fixes #253

Changes
- Replace all '/' to '-' in plan filename

Alternatives considered:
- use HTML escape to escape whole filename: breaks backward compatibility to many repo names
- use HTML escape to escape '/': the escape result `&sol;` contains `;` , which is the shell delimiter, might break some stuffs.