### PR TITLE
Updating message when project is locked.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ output
 node_modules/
 **/.vuepress/dist
 helm/test-values.yaml
+*.swp

--- a/server/events/project_locker.go
+++ b/server/events/project_locker.go
@@ -63,7 +63,8 @@ func (p *DefaultProjectLocker) TryLock(log *logging.SimpleLogger, pull models.Pu
 	}
 	if !lockAttempt.LockAcquired && lockAttempt.CurrLock.Pull.Num != pull.Num {
 		failureMsg := fmt.Sprintf(
-			"This project is currently locked by #%d. The locking plan must be applied or discarded before future plans can execute.",
+			"**Unable to run `plan`**. This project is currently locked by an unapplied plan from pull #%d. To continue, delete the lock from #%d or apply that plan and merge the pull request.\n\nOnce the lock is released, comment `atlantis plan` here to re-plan.",
+			lockAttempt.CurrLock.Pull.Num,
 			lockAttempt.CurrLock.Pull.Num)
 		return &TryLockResponse{
 			LockAcquired:      false,

--- a/server/events/project_locker_test.go
+++ b/server/events/project_locker_test.go
@@ -52,7 +52,7 @@ func TestDefaultProjectLocker_TryLockWhenLocked(t *testing.T) {
 	Ok(t, err)
 	Equals(t, &events.TryLockResponse{
 		LockAcquired:      false,
-		LockFailureReason: "This project is currently locked by #2. The locking plan must be applied or discarded before future plans can execute.",
+		LockFailureReason: "**Unable to run `plan`**. This project is currently locked by an unapplied plan from pull #2. To continue, delete the lock from #2 or apply that plan and merge the pull request.\n\nOnce the lock is released, comment `atlantis plan` here to re-plan.",
 	}, res)
 }
 


### PR DESCRIPTION
Just updating the message atlantis spits out when the project is locked. Once the locking plan is released, atlantis doesn't auto-run `plan` on subsequent PR's. This message makes it clear to users that they should manually run plan.