### PR TITLE
Remove 'through GitHub and GitLab' from help description.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,7 +22,7 @@ import (
 // RootCmd is the base command onto which all other commands are added.
 var RootCmd = &cobra.Command{
 	Use:   "atlantis",
-	Short: "A unified workflow for collaborating on Terraform through GitHub and GitLab",
+	Short: "A unified workflow for collaborating on Terraform",
 }
 
 // Execute starts RootCmd.


### PR DESCRIPTION
We now support Bitbucket so this is inaccurate and also it's not
going to scale to keep adding all the VCS hosts we support.