### PR TITLE
 Make project locked message look better.

### DIFF
--- a/server/events/pending_plan_finder_test.go
+++ b/server/events/pending_plan_finder_test.go
@@ -184,7 +184,7 @@ func TestPendingPlanFinder_FindPlanCheckedIn(t *testing.T) {
 	runCmd(t, repoDir, "git", "add", ".")
 	runCmd(t, repoDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
 	runCmd(t, repoDir, "git", "config", "--local", "user.name", "atlantisbot")
-	runCmd(t, repoDir, "git", "commit", "-m", "initial commit")
+	runCmd(t, repoDir, "git", "commit", "--no-gpg-sign", "-m", "initial commit")
 
 	pf := &events.PendingPlanFinder{}
 	actPlans, err := pf.Find(tmpDir)
@@ -193,6 +193,7 @@ func TestPendingPlanFinder_FindPlanCheckedIn(t *testing.T) {
 }
 
 func runCmd(t *testing.T, dir string, name string, args ...string) string {
+	t.Helper()
 	cpCmd := exec.Command(name, args...)
 	cpCmd.Dir = dir
 	cpOut, err := cpCmd.CombinedOutput()

--- a/server/events/project_locker.go
+++ b/server/events/project_locker.go
@@ -63,7 +63,7 @@ func (p *DefaultProjectLocker) TryLock(log *logging.SimpleLogger, pull models.Pu
 	}
 	if !lockAttempt.LockAcquired && lockAttempt.CurrLock.Pull.Num != pull.Num {
 		failureMsg := fmt.Sprintf(
-			"**Unable to run `plan`**. This project is currently locked by an unapplied plan from pull #%d. To continue, delete the lock from #%d or apply that plan and merge the pull request.\n\nOnce the lock is released, comment `atlantis plan` here to re-plan.",
+			"This project is currently locked by an unapplied plan from pull #%d. To continue, delete the lock from #%d or apply that plan and merge the pull request.\n\nOnce the lock is released, comment `atlantis plan` here to re-plan.",
 			lockAttempt.CurrLock.Pull.Num,
 			lockAttempt.CurrLock.Pull.Num)
 		return &TryLockResponse{

--- a/server/events/project_locker_test.go
+++ b/server/events/project_locker_test.go
@@ -52,7 +52,7 @@ func TestDefaultProjectLocker_TryLockWhenLocked(t *testing.T) {
 	Ok(t, err)
 	Equals(t, &events.TryLockResponse{
 		LockAcquired:      false,
-		LockFailureReason: "**Unable to run `plan`**. This project is currently locked by an unapplied plan from pull #2. To continue, delete the lock from #2 or apply that plan and merge the pull request.\n\nOnce the lock is released, comment `atlantis plan` here to re-plan.",
+		LockFailureReason: "This project is currently locked by an unapplied plan from pull #2. To continue, delete the lock from #2 or apply that plan and merge the pull request.\n\nOnce the lock is released, comment `atlantis plan` here to re-plan.",
 	}, res)
 }
 


### PR DESCRIPTION
When the plan fails, it gets the error prepended with **Plan Failed**:.
Thus we don't need to add our own "**Unable to run plan**" error.

Some cleanup from #325 