### PR TITLE
Allow slashes in project names

### DIFF
--- a/server/events/runtime/runtime.go
+++ b/server/events/runtime/runtime.go
@@ -24,7 +24,10 @@ func MustConstraint(constraint string) version.Constraints {
 	return c
 }
 
-var invalidFilenameChars = regexp.MustCompile(`[^a-zA-Z0-9-_\.]`)
+// invalidFilenameChars matches chars that are invalid for linux and windows
+// filenames.
+// From https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch08s25.html
+var invalidFilenameChars = regexp.MustCompile(`[\\/:"*?<>|]`)
 
 // GetPlanFilename returns the filename (not the path) of the generated tf plan
 // given a workspace and maybe a project's config.

--- a/server/events/runtime/runtime.go
+++ b/server/events/runtime/runtime.go
@@ -4,6 +4,7 @@ package runtime
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/hashicorp/go-version"
 	"github.com/runatlantis/atlantis/server/events/yaml/valid"
@@ -23,11 +24,16 @@ func MustConstraint(constraint string) version.Constraints {
 	return c
 }
 
+var invalidFilenameChars = regexp.MustCompile(`[^a-zA-Z0-9-_\.]`)
+
 // GetPlanFilename returns the filename (not the path) of the generated tf plan
 // given a workspace and maybe a project's config.
 func GetPlanFilename(workspace string, maybeCfg *valid.Project) string {
+	var unescapedFilename string
 	if maybeCfg == nil || maybeCfg.Name == nil {
-		return fmt.Sprintf("%s.tfplan", workspace)
+		unescapedFilename = fmt.Sprintf("%s.tfplan", workspace)
+	} else {
+		unescapedFilename = fmt.Sprintf("%s-%s.tfplan", *maybeCfg.Name, workspace)
 	}
-	return fmt.Sprintf("%s-%s.tfplan", *maybeCfg.Name, workspace)
+	return invalidFilenameChars.ReplaceAllLiteralString(unescapedFilename, "-")
 }

--- a/server/events/runtime/runtime_test.go
+++ b/server/events/runtime/runtime_test.go
@@ -21,19 +21,9 @@ func TestGetPlanFilename(t *testing.T) {
 			"workspace.tfplan",
 		},
 		{
-			"workspace with space",
-			nil,
-			"workspace-with-space.tfplan",
-		},
-		{
 			"workspace",
 			&valid.Project{},
 			"workspace.tfplan",
-		},
-		{
-			"workspace with space",
-			&valid.Project{},
-			"workspace-with-space.tfplan",
 		},
 		{
 			"workspace",
@@ -54,14 +44,21 @@ func TestGetPlanFilename(t *testing.T) {
 			&valid.Project{
 				Name: String("project with space"),
 			},
-			"project-with-space-workspace.tfplan",
+			"project with space-workspace.tfplan",
 		},
 		{
 			"workspace😀",
 			&valid.Project{
 				Name: String("project😀"),
 			},
-			"project--workspace-.tfplan",
+			"project😀-workspace😀.tfplan",
+		},
+		{
+			"default",
+			&valid.Project{
+				Name: String(`all.invalid.chars \/"*?<>`),
+			},
+			"all.invalid.chars --------default.tfplan",
 		},
 	}
 

--- a/server/events/runtime/runtime_test.go
+++ b/server/events/runtime/runtime_test.go
@@ -21,9 +21,19 @@ func TestGetPlanFilename(t *testing.T) {
 			"workspace.tfplan",
 		},
 		{
+			"workspace with space",
+			nil,
+			"workspace-with-space.tfplan",
+		},
+		{
 			"workspace",
 			&valid.Project{},
 			"workspace.tfplan",
+		},
+		{
+			"workspace with space",
+			&valid.Project{},
+			"workspace-with-space.tfplan",
 		},
 		{
 			"workspace",
@@ -31,6 +41,27 @@ func TestGetPlanFilename(t *testing.T) {
 				Name: String("project"),
 			},
 			"project-workspace.tfplan",
+		},
+		{
+			"workspace",
+			&valid.Project{
+				Name: String("project/with/slash"),
+			},
+			"project-with-slash-workspace.tfplan",
+		},
+		{
+			"workspace",
+			&valid.Project{
+				Name: String("project with space"),
+			},
+			"project-with-space-workspace.tfplan",
+		},
+		{
+			"workspace😀",
+			&valid.Project{
+				Name: String("project😀"),
+			},
+			"project--workspace-.tfplan",
 		},
 	}
 

--- a/server/events/yaml/raw/project.go
+++ b/server/events/yaml/raw/project.go
@@ -2,6 +2,7 @@ package raw
 
 import (
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"strings"
 
@@ -58,6 +59,9 @@ func (p Project) Validate() error {
 		if *strPtr == "" {
 			return errors.New("if set cannot be empty")
 		}
+		if !validProjectName(*strPtr) {
+			return fmt.Errorf("%q is not allowed: must contain only URL safe characters", *strPtr)
+		}
 		return nil
 	}
 	return validation.ValidateStruct(&p,
@@ -98,4 +102,13 @@ func (p Project) ToValid() valid.Project {
 	v.Name = p.Name
 
 	return v
+}
+
+// validProjectName returns true if the project name is valid.
+// Since the name might be used in URLs and definitely in files we don't
+// support any characters that must be url escaped *except* for '/' because
+// users like to name their projects to match the directory it's in.
+func validProjectName(name string) bool {
+	nameWithoutSlashes := strings.Replace(name, "/", "-", -1)
+	return nameWithoutSlashes == url.QueryEscape(nameWithoutSlashes)
 }

--- a/server/events/yaml/raw/project_test.go
+++ b/server/events/yaml/raw/project_test.go
@@ -143,6 +143,46 @@ func TestProject_Validate(t *testing.T) {
 			},
 			expErr: "name: if set cannot be empty.",
 		},
+		{
+			description: "project name with slashes",
+			input: raw.Project{
+				Dir:  String("."),
+				Name: String("my/name"),
+			},
+			expErr: "",
+		},
+		{
+			description: "project name with emoji",
+			input: raw.Project{
+				Dir:  String("."),
+				Name: String("😀"),
+			},
+			expErr: "name: \"😀\" is not allowed: must contain only URL safe characters.",
+		},
+		{
+			description: "project name with spaces",
+			input: raw.Project{
+				Dir:  String("."),
+				Name: String("name with spaces"),
+			},
+			expErr: "name: \"name with spaces\" is not allowed: must contain only URL safe characters.",
+		},
+		{
+			description: "project name with +",
+			input: raw.Project{
+				Dir:  String("."),
+				Name: String("namewith+"),
+			},
+			expErr: "name: \"namewith+\" is not allowed: must contain only URL safe characters.",
+		},
+		{
+			description: `project name with \`,
+			input: raw.Project{
+				Dir:  String("."),
+				Name: String(`namewith\`),
+			},
+			expErr: `name: "namewith\\" is not allowed: must contain only URL safe characters.`,
+		},
 	}
 	validation.ErrorTag = "yaml"
 	for _, c := range cases {


### PR DESCRIPTION
Allow the project name in `atlantis.yaml` file to contain slashes:
```yaml
projects:
- dir: terraform/myservice
  name: terraform/myservice
```

Also in this PR:
* Validate project names to ensure they don't contain invalid characters
* Ensure the planfile names (which are generated from the project names) don't contain invalid filename chars

Notes
* With commit from @johnlinvc in #319. I've added the validation of the config file and also changed the allowed filename chars regex
* Made change recommended by @kipkoan to only remove invalid filename chars
* Fixes #253