### PR TITLE
Remove "Refreshing..." output from top of plan.

### DIFF
--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -541,12 +541,6 @@ Terraform will perform the following actions:
 <details><summary>Show Output</summary>
 
 $$$diff
-Refreshing Terraform state in-memory prior to plan...
-The refreshed state will be used to calculate this plan, but will not be
-persisted to local or remote state storage.
-
-
-------------------------------------------------------------------------
 
 An execution plan has been generated and is shown below.
 Resource actions are indicated with the following symbols:

--- a/server/events_controller_e2e_test.go
+++ b/server/events_controller_e2e_test.go
@@ -486,6 +486,12 @@ func assertCommentEquals(t *testing.T, expFile string, act string, repoDir strin
 	idRegex := regexp.MustCompile(`Creation complete after [0-9]+s \(ID: [0-9]+\)`)
 	act = idRegex.ReplaceAllString(act, "Creation complete after *s (ID: ******************)")
 
+	// Replace all null_resource.simple{n} with null_resource.simple because with
+	// multiple resources they might be created at different times and so the
+	// output is unordered.
+	resourceRegex := regexp.MustCompile(`null_resource\.simple\d:`)
+	act = resourceRegex.ReplaceAllString(act, "null_resource.simple:")
+
 	if string(exp) != act {
 		// If in CI, we write the diff to the console. Otherwise we write the diff
 		// to file so we can use our local diff viewer.

--- a/server/testfixtures/test-repos/modules-yaml/exp-output-autoplan.txt
+++ b/server/testfixtures/test-repos/modules-yaml/exp-output-autoplan.txt
@@ -3,15 +3,7 @@ Ran Plan for 2 projects:
 1. workspace: `default` dir: `production`
 
 ### 1. workspace: `default` dir: `staging`
-<details><summary>Show Output</summary>
-
 ```diff
-Refreshing Terraform state in-memory prior to plan...
-The refreshed state will be used to calculate this plan, but will not be
-persisted to local or remote state storage.
-
-
-------------------------------------------------------------------------
 
 An execution plan has been generated and is shown below.
 Resource actions are indicated with the following symbols:
@@ -30,19 +22,10 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d staging`
-</details>
 
 ---
 ### 2. workspace: `default` dir: `production`
-<details><summary>Show Output</summary>
-
 ```diff
-Refreshing Terraform state in-memory prior to plan...
-The refreshed state will be used to calculate this plan, but will not be
-persisted to local or remote state storage.
-
-
-------------------------------------------------------------------------
 
 An execution plan has been generated and is shown below.
 Resource actions are indicated with the following symbols:
@@ -61,7 +44,6 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d production`
-</details>
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/modules/exp-output-autoplan-only-staging.txt
+++ b/server/testfixtures/test-repos/modules/exp-output-autoplan-only-staging.txt
@@ -1,14 +1,6 @@
 Ran Plan in dir: `staging` workspace: `default`
 
-<details><summary>Show Output</summary>
-
 ```diff
-Refreshing Terraform state in-memory prior to plan...
-The refreshed state will be used to calculate this plan, but will not be
-persisted to local or remote state storage.
-
-
-------------------------------------------------------------------------
 
 An execution plan has been generated and is shown below.
 Resource actions are indicated with the following symbols:
@@ -27,7 +19,6 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d staging`
-</details>
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/modules/exp-output-plan-production.txt
+++ b/server/testfixtures/test-repos/modules/exp-output-plan-production.txt
@@ -1,14 +1,6 @@
 Ran Plan in dir: `production` workspace: `default`
 
-<details><summary>Show Output</summary>
-
 ```diff
-Refreshing Terraform state in-memory prior to plan...
-The refreshed state will be used to calculate this plan, but will not be
-persisted to local or remote state storage.
-
-
-------------------------------------------------------------------------
 
 An execution plan has been generated and is shown below.
 Resource actions are indicated with the following symbols:
@@ -27,7 +19,6 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d production`
-</details>
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/modules/exp-output-plan-staging.txt
+++ b/server/testfixtures/test-repos/modules/exp-output-plan-staging.txt
@@ -1,14 +1,6 @@
 Ran Plan in dir: `staging` workspace: `default`
 
-<details><summary>Show Output</summary>
-
 ```diff
-Refreshing Terraform state in-memory prior to plan...
-The refreshed state will be used to calculate this plan, but will not be
-persisted to local or remote state storage.
-
-
-------------------------------------------------------------------------
 
 An execution plan has been generated and is shown below.
 Resource actions are indicated with the following symbols:
@@ -27,7 +19,6 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d staging`
-</details>
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/simple-yaml/exp-output-autoplan.txt
+++ b/server/testfixtures/test-repos/simple-yaml/exp-output-autoplan.txt
@@ -3,15 +3,7 @@ Ran Plan for 2 projects:
 1. workspace: `staging` dir: `.`
 
 ### 1. workspace: `default` dir: `.`
-<details><summary>Show Output</summary>
-
 ```diff
-Refreshing Terraform state in-memory prior to plan...
-The refreshed state will be used to calculate this plan, but will not be
-persisted to local or remote state storage.
-
-
-------------------------------------------------------------------------
 
 An execution plan has been generated and is shown below.
 Resource actions are indicated with the following symbols:
@@ -30,19 +22,10 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d .`
-</details>
 
 ---
 ### 2. workspace: `staging` dir: `.`
-<details><summary>Show Output</summary>
-
 ```diff
-Refreshing Terraform state in-memory prior to plan...
-The refreshed state will be used to calculate this plan, but will not be
-persisted to local or remote state storage.
-
-
-------------------------------------------------------------------------
 
 An execution plan has been generated and is shown below.
 Resource actions are indicated with the following symbols:
@@ -61,7 +44,6 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -w staging`
-</details>
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/simple/exp-output-apply-var-all.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-apply-var-all.txt
@@ -3,11 +3,17 @@ Ran Apply for 2 projects:
 1. workspace: `new_workspace` dir: `.`
 
 ### 1. workspace: `default` dir: `.`
+<details><summary>Show Output</summary>
+
 ```diff
 null_resource.simple: Creating...
+null_resource.simple: Creating...
+null_resource.simple: Creating...
+null_resource.simple: Creation complete after *s (ID: ******************)
+null_resource.simple: Creation complete after *s (ID: ******************)
 null_resource.simple: Creation complete after *s (ID: ******************)
 
-Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
 
 Outputs:
 
@@ -15,14 +21,21 @@ var = default_workspace
 workspace = default
 
 ```
+</details>
 
 ---
 ### 2. workspace: `new_workspace` dir: `.`
+<details><summary>Show Output</summary>
+
 ```diff
 null_resource.simple: Creating...
+null_resource.simple: Creating...
+null_resource.simple: Creating...
+null_resource.simple: Creation complete after *s (ID: ******************)
+null_resource.simple: Creation complete after *s (ID: ******************)
 null_resource.simple: Creation complete after *s (ID: ******************)
 
-Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
 
 Outputs:
 
@@ -30,6 +43,7 @@ var = new_workspace
 workspace = new_workspace
 
 ```
+</details>
 
 ---
 

--- a/server/testfixtures/test-repos/simple/exp-output-apply-var-default-workspace.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-apply-var-default-workspace.txt
@@ -1,10 +1,16 @@
 Ran Apply in dir: `.` workspace: `default`
 
+<details><summary>Show Output</summary>
+
 ```diff
 null_resource.simple: Creating...
+null_resource.simple: Creating...
+null_resource.simple: Creating...
+null_resource.simple: Creation complete after *s (ID: ******************)
+null_resource.simple: Creation complete after *s (ID: ******************)
 null_resource.simple: Creation complete after *s (ID: ******************)
 
-Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
 
 Outputs:
 
@@ -12,4 +18,5 @@ var = default_workspace
 workspace = default
 
 ```
+</details>
 

--- a/server/testfixtures/test-repos/simple/exp-output-apply-var-new-workspace.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-apply-var-new-workspace.txt
@@ -1,10 +1,16 @@
 Ran Apply in dir: `.` workspace: `new_workspace`
 
+<details><summary>Show Output</summary>
+
 ```diff
 null_resource.simple: Creating...
+null_resource.simple: Creating...
+null_resource.simple: Creating...
+null_resource.simple: Creation complete after *s (ID: ******************)
+null_resource.simple: Creation complete after *s (ID: ******************)
 null_resource.simple: Creation complete after *s (ID: ******************)
 
-Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
 
 Outputs:
 
@@ -12,4 +18,5 @@ var = new_workspace
 workspace = new_workspace
 
 ```
+</details>
 

--- a/server/testfixtures/test-repos/simple/exp-output-apply-var.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-apply-var.txt
@@ -1,10 +1,16 @@
 Ran Apply in dir: `.` workspace: `default`
 
+<details><summary>Show Output</summary>
+
 ```diff
 null_resource.simple: Creating...
+null_resource.simple: Creating...
+null_resource.simple: Creating...
+null_resource.simple: Creation complete after *s (ID: ******************)
+null_resource.simple: Creation complete after *s (ID: ******************)
 null_resource.simple: Creation complete after *s (ID: ******************)
 
-Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
 
 Outputs:
 
@@ -12,4 +18,5 @@ var = overridden
 workspace = default
 
 ```
+</details>
 

--- a/server/testfixtures/test-repos/simple/exp-output-apply.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-apply.txt
@@ -1,10 +1,16 @@
 Ran Apply in dir: `.` workspace: `default`
 
+<details><summary>Show Output</summary>
+
 ```diff
 null_resource.simple: Creating...
+null_resource.simple: Creating...
+null_resource.simple: Creating...
+null_resource.simple: Creation complete after *s (ID: ******************)
+null_resource.simple: Creation complete after *s (ID: ******************)
 null_resource.simple: Creation complete after *s (ID: ******************)
 
-Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
 
 Outputs:
 
@@ -12,4 +18,5 @@ var = default
 workspace = default
 
 ```
+</details>
 

--- a/server/testfixtures/test-repos/simple/exp-output-atlantis-plan-new-workspace.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-atlantis-plan-new-workspace.txt
@@ -3,12 +3,6 @@ Ran Plan in dir: `.` workspace: `new_workspace`
 <details><summary>Show Output</summary>
 
 ```diff
-Refreshing Terraform state in-memory prior to plan...
-The refreshed state will be used to calculate this plan, but will not be
-persisted to local or remote state storage.
-
-
-------------------------------------------------------------------------
 
 An execution plan has been generated and is shown below.
 Resource actions are indicated with the following symbols:
@@ -18,7 +12,13 @@ Terraform will perform the following actions:
 
 + null_resource.simple
       id: <computed>
-Plan: 1 to add, 0 to change, 0 to destroy.
+
++ null_resource.simple2
+      id: <computed>
+
++ null_resource.simple3
+      id: <computed>
+Plan: 3 to add, 0 to change, 0 to destroy.
 
 ```
 

--- a/server/testfixtures/test-repos/simple/exp-output-atlantis-plan-var-overridden.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-atlantis-plan-var-overridden.txt
@@ -3,12 +3,6 @@ Ran Plan in dir: `.` workspace: `default`
 <details><summary>Show Output</summary>
 
 ```diff
-Refreshing Terraform state in-memory prior to plan...
-The refreshed state will be used to calculate this plan, but will not be
-persisted to local or remote state storage.
-
-
-------------------------------------------------------------------------
 
 An execution plan has been generated and is shown below.
 Resource actions are indicated with the following symbols:
@@ -18,7 +12,13 @@ Terraform will perform the following actions:
 
 + null_resource.simple
       id: <computed>
-Plan: 1 to add, 0 to change, 0 to destroy.
+
++ null_resource.simple2
+      id: <computed>
+
++ null_resource.simple3
+      id: <computed>
+Plan: 3 to add, 0 to change, 0 to destroy.
 
 ```
 

--- a/server/testfixtures/test-repos/simple/exp-output-atlantis-plan.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-atlantis-plan.txt
@@ -3,12 +3,6 @@ Ran Plan in dir: `.` workspace: `default`
 <details><summary>Show Output</summary>
 
 ```diff
-Refreshing Terraform state in-memory prior to plan...
-The refreshed state will be used to calculate this plan, but will not be
-persisted to local or remote state storage.
-
-
-------------------------------------------------------------------------
 
 An execution plan has been generated and is shown below.
 Resource actions are indicated with the following symbols:
@@ -18,7 +12,13 @@ Terraform will perform the following actions:
 
 + null_resource.simple
       id: <computed>
-Plan: 1 to add, 0 to change, 0 to destroy.
+
++ null_resource.simple2
+      id: <computed>
+
++ null_resource.simple3
+      id: <computed>
+Plan: 3 to add, 0 to change, 0 to destroy.
 
 ```
 

--- a/server/testfixtures/test-repos/simple/exp-output-autoplan.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-autoplan.txt
@@ -3,12 +3,6 @@ Ran Plan in dir: `.` workspace: `default`
 <details><summary>Show Output</summary>
 
 ```diff
-Refreshing Terraform state in-memory prior to plan...
-The refreshed state will be used to calculate this plan, but will not be
-persisted to local or remote state storage.
-
-
-------------------------------------------------------------------------
 
 An execution plan has been generated and is shown below.
 Resource actions are indicated with the following symbols:
@@ -18,7 +12,13 @@ Terraform will perform the following actions:
 
 + null_resource.simple
       id: <computed>
-Plan: 1 to add, 0 to change, 0 to destroy.
+
++ null_resource.simple2
+      id: <computed>
+
++ null_resource.simple3
+      id: <computed>
+Plan: 3 to add, 0 to change, 0 to destroy.
 
 ```
 

--- a/server/testfixtures/test-repos/simple/main.tf
+++ b/server/testfixtures/test-repos/simple/main.tf
@@ -2,6 +2,9 @@ resource "null_resource" "simple" {
   count = 1
 }
 
+resource "null_resource" "simple2" {}
+resource "null_resource" "simple3" {}
+
 variable "var" {
   default = "default"
 }

--- a/server/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-default.txt
+++ b/server/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-default.txt
@@ -1,14 +1,6 @@
 Ran Plan in dir: `.` workspace: `default`
 
-<details><summary>Show Output</summary>
-
 ```diff
-Refreshing Terraform state in-memory prior to plan...
-The refreshed state will be used to calculate this plan, but will not be
-persisted to local or remote state storage.
-
-
-------------------------------------------------------------------------
 
 An execution plan has been generated and is shown below.
 Resource actions are indicated with the following symbols:
@@ -27,7 +19,6 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -p default`
-</details>
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-staging.txt
+++ b/server/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-staging.txt
@@ -1,14 +1,6 @@
 Ran Plan in dir: `.` workspace: `default`
 
-<details><summary>Show Output</summary>
-
 ```diff
-Refreshing Terraform state in-memory prior to plan...
-The refreshed state will be used to calculate this plan, but will not be
-persisted to local or remote state storage.
-
-
-------------------------------------------------------------------------
 
 An execution plan has been generated and is shown below.
 Resource actions are indicated with the following symbols:
@@ -27,7 +19,6 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -p staging`
-</details>
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/tfvars-yaml/exp-output-autoplan.txt
+++ b/server/testfixtures/test-repos/tfvars-yaml/exp-output-autoplan.txt
@@ -3,15 +3,7 @@ Ran Plan for 2 projects:
 1. workspace: `default` dir: `.`
 
 ### 1. workspace: `default` dir: `.`
-<details><summary>Show Output</summary>
-
 ```diff
-Refreshing Terraform state in-memory prior to plan...
-The refreshed state will be used to calculate this plan, but will not be
-persisted to local or remote state storage.
-
-
-------------------------------------------------------------------------
 
 An execution plan has been generated and is shown below.
 Resource actions are indicated with the following symbols:
@@ -32,19 +24,10 @@ workspace=default
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -p default`
-</details>
 
 ---
 ### 2. workspace: `default` dir: `.`
-<details><summary>Show Output</summary>
-
 ```diff
-Refreshing Terraform state in-memory prior to plan...
-The refreshed state will be used to calculate this plan, but will not be
-persisted to local or remote state storage.
-
-
-------------------------------------------------------------------------
 
 An execution plan has been generated and is shown below.
 Resource actions are indicated with the following symbols:
@@ -63,7 +46,6 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -p staging`
-</details>
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:


### PR DESCRIPTION
When running terraform plan, Terraform writes a line for each resource
it updates. For example:

	null_resource.b: Refreshing state... (ID: 700288721293508840)
	null_resource.a: Refreshing state... (ID: 2853194762920164292)
	null_resource.f: Refreshing state... (ID: 6634469389761751950)

This change removes those lines by splitting the output string after a
separator.

This change is being made because the Refreshing output isn't important
and it will make the comments shorter.

From:
![image](https://user-images.githubusercontent.com/1034429/47750654-df3a2880-dc5d-11e8-8e95-b01952a364e7.png)

To:
![image](https://user-images.githubusercontent.com/1034429/47750670-e7926380-dc5d-11e8-82f2-1291e55a8fa3.png)

Notes:
* This is thanks to suggestions from @jonboulle, @BlackTurtle123 and @majormoses 
* This will help with #280 and #111