### PR TITLE
Add a dockerignore to speedup docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!docker-entrypoint.sh
+!atlantis


### PR DESCRIPTION
This docker really speeds up the docker build as we do not have to send the entire repository to the docker daemon. We only send the files it actually needs