### PR TITLE
Use latest atlantis-base.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # The runatlantis/atlantis-base is created by docker-base/Dockerfile.
-FROM runatlantis/atlantis-base:latest
+FROM runatlantis/atlantis-base:v2.0
 LABEL authors="Anubhav Mishra, Luke Kysow"
 
 # install terraform binaries

--- a/helm/atlantis/templates/statefulset.yaml
+++ b/helm/atlantis/templates/statefulset.yaml
@@ -23,7 +23,8 @@ spec:
         app: {{ template "atlantis.name" . }}
         release: {{ .Release.Name }}
     spec:
-      securityContext: {}
+      securityContext:
+        fsGroup: 1000
       volumes:
       {{- range $name, $_ := .Values.serviceAccountSecrets }}
       - name: {{ $name }}-volume


### PR DESCRIPTION
- Upon merging https://github.com/runatlantis/atlantis/pull/346 I
manually built and pushed a new version of runatlantis/atlantis-base and
tagged it as runatlantis/atlantis-base:v2.0. This change uses that new
tag. Before it was using :latest which isn't good if other people see
that and use atlantis-base:latest because we could break it for them.
- I've also put back the fsContext to 1000 because the atlantis user is
still in that group so we need that for kubernetes.