### PR TITLE
Use Bitbucket 2.0 API for comments.

### DIFF
--- a/server/events/vcs/bitbucketcloud/client.go
+++ b/server/events/vcs/bitbucketcloud/client.go
@@ -86,11 +86,16 @@ func (b *Client) GetModifiedFiles(repo models.Repo, pull models.PullRequest) ([]
 
 // CreateComment creates a comment on the merge request.
 func (b *Client) CreateComment(repo models.Repo, pullNum int, comment string) error {
-	bodyBytes, err := json.Marshal(map[string]string{"content": comment})
+	// NOTE: I tried to find the maximum size of a comment for bitbucket.org but
+	// I got up to 200k chars without issue so for now I'm not going to bother
+	// to detect this.
+	bodyBytes, err := json.Marshal(map[string]map[string]string{"content": {
+		"raw": comment,
+	}})
 	if err != nil {
 		return errors.Wrap(err, "json encoding")
 	}
-	path := fmt.Sprintf("%s/1.0/repositories/%s/pullrequests/%d/comments", b.BaseURL, repo.FullName, pullNum)
+	path := fmt.Sprintf("%s/2.0/repositories/%s/pullrequests/%d/comments", b.BaseURL, repo.FullName, pullNum)
 	_, err = b.makeRequest("POST", path, bytes.NewBuffer(bodyBytes))
 	return err
 }


### PR DESCRIPTION
Bitbucket released the 2.0 version for the commenting on pull requests
API:
https://community.atlassian.com/t5/Bitbucket-questions/Re-Bitbucket-Cloud-REST-API-v2-0-Commenting-on-Pull-Re/qaq-p/849427/comment-id/30070#M30070.
Previously, this was only available in version 1.0. Since 1.0 will be
deprecated, it's best to move to the latest version.