### PR TITLE
Add project name to comments

### DIFF
--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -65,9 +65,10 @@ type ResultData struct {
 }
 
 type projectResultTmplData struct {
-	Workspace  string
-	RepoRelDir string
-	Rendered   string
+	Workspace   string
+	RepoRelDir  string
+	ProjectName string
+	Rendered    string
 }
 
 // Render formats the data into a markdown string.
@@ -90,8 +91,9 @@ func (m *MarkdownRenderer) renderProjectResults(results []ProjectResult, common 
 
 	for _, result := range results {
 		resultData := projectResultTmplData{
-			Workspace:  result.Workspace,
-			RepoRelDir: result.RepoRelDir,
+			Workspace:   result.Workspace,
+			RepoRelDir:  result.RepoRelDir,
+			ProjectName: result.ProjectName,
 		}
 		if result.Error != nil {
 			tmpl := unwrappedErrTmpl
@@ -178,23 +180,23 @@ func (m *MarkdownRenderer) renderTemplate(tmpl *template.Template, data interfac
 
 // todo: refactor to remove duplication #refactor
 var singleProjectApplyTmpl = template.Must(template.New("").Parse(
-	"{{$result := index .Results 0}}Ran {{.Command}} in dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n\n{{$result.Rendered}}\n" + logTmpl))
+	"{{$result := index .Results 0}}Ran {{.Command}} for {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n\n{{$result.Rendered}}\n" + logTmpl))
 var singleProjectPlanSuccessTmpl = template.Must(template.New("").Parse(
-	"{{$result := index .Results 0}}Ran {{.Command}} in dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n\n{{$result.Rendered}}\n" +
+	"{{$result := index .Results 0}}Ran {{.Command}} for {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n\n{{$result.Rendered}}\n" +
 		"\n" +
 		"---\n" +
 		"* :fast_forward: To **apply** all unapplied plans from this pull request, comment:\n" +
 		"    * `atlantis apply`" + logTmpl))
 var singleProjectPlanUnsuccessfulTmpl = template.Must(template.New("").Parse(
-	"{{$result := index .Results 0}}Ran {{.Command}} in dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n\n" +
+	"{{$result := index .Results 0}}Ran {{.Command}} for dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n\n" +
 		"{{$result.Rendered}}\n" + logTmpl))
 var multiProjectPlanTmpl = template.Must(template.New("").Funcs(sprig.TxtFuncMap()).Parse(
 	"Ran {{.Command}} for {{ len .Results }} projects:\n" +
 		"{{ range $result := .Results }}" +
-		"1. workspace: `{{$result.Workspace}}` dir: `{{$result.RepoRelDir}}`\n" +
+		"1. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n" +
 		"{{end}}\n" +
 		"{{ range $i, $result := .Results }}" +
-		"### {{add $i 1}}. workspace: `{{$result.Workspace}}` dir: `{{$result.RepoRelDir}}`\n" +
+		"### {{add $i 1}}. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n" +
 		"{{$result.Rendered}}\n\n" +
 		"---\n{{end}}{{ if gt (len .Results) 0 }}* :fast_forward: To **apply** all unapplied plans from this pull request, comment:\n" +
 		"    * `atlantis apply`{{end}}" +
@@ -202,10 +204,10 @@ var multiProjectPlanTmpl = template.Must(template.New("").Funcs(sprig.TxtFuncMap
 var multiProjectApplyTmpl = template.Must(template.New("").Funcs(sprig.TxtFuncMap()).Parse(
 	"Ran {{.Command}} for {{ len .Results }} projects:\n" +
 		"{{ range $result := .Results }}" +
-		"1. workspace: `{{$result.Workspace}}` dir: `{{$result.RepoRelDir}}`\n" +
+		"1. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n" +
 		"{{end}}\n" +
 		"{{ range $i, $result := .Results }}" +
-		"### {{add $i 1}}. workspace: `{{$result.Workspace}}` dir: `{{$result.RepoRelDir}}`\n" +
+		"### {{add $i 1}}. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n" +
 		"{{$result.Rendered}}\n\n" +
 		"---\n{{end}}" +
 		logTmpl))

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -315,3 +315,12 @@ func SplitRepoFullName(repoFullName string) (owner string, repo string) {
 	}
 	return repoFullName[:lastSlashIdx], repoFullName[lastSlashIdx+1:]
 }
+
+// GetProjectName returns the name of the project this context is for. If no
+// name is configured, it returns an empty string.
+func (p *ProjectCommandContext) GetProjectName() string {
+	if p.ProjectConfig != nil {
+		return p.ProjectConfig.GetName()
+	}
+	return ""
+}

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -100,6 +100,7 @@ func (p *DefaultProjectCommandRunner) Plan(ctx models.ProjectCommandContext) Pro
 		Failure:     failure,
 		RepoRelDir:  ctx.RepoRelDir,
 		Workspace:   ctx.Workspace,
+		ProjectName: ctx.GetProjectName(),
 	}
 }
 
@@ -112,6 +113,7 @@ func (p *DefaultProjectCommandRunner) Apply(ctx models.ProjectCommandContext) Pr
 		ApplySuccess: applyOut,
 		RepoRelDir:   ctx.RepoRelDir,
 		Workspace:    ctx.Workspace,
+		ProjectName:  ctx.GetProjectName(),
 	}
 }
 

--- a/server/events/project_result.go
+++ b/server/events/project_result.go
@@ -25,6 +25,7 @@ type ProjectResult struct {
 	Failure      string
 	PlanSuccess  *PlanSuccess
 	ApplySuccess string
+	ProjectName  string
 }
 
 // Status returns the vcs commit status of this project result.

--- a/server/testfixtures/test-repos/modules-yaml/exp-output-apply-production.txt
+++ b/server/testfixtures/test-repos/modules-yaml/exp-output-apply-production.txt
@@ -1,4 +1,4 @@
-Ran Apply in dir: `production` workspace: `default`
+Ran Apply for dir: `production` workspace: `default`
 
 ```diff
 module.null.null_resource.this: Creating...

--- a/server/testfixtures/test-repos/modules-yaml/exp-output-apply-staging.txt
+++ b/server/testfixtures/test-repos/modules-yaml/exp-output-apply-staging.txt
@@ -1,4 +1,4 @@
-Ran Apply in dir: `staging` workspace: `default`
+Ran Apply for dir: `staging` workspace: `default`
 
 ```diff
 module.null.null_resource.this: Creating...

--- a/server/testfixtures/test-repos/modules-yaml/exp-output-autoplan.txt
+++ b/server/testfixtures/test-repos/modules-yaml/exp-output-autoplan.txt
@@ -1,8 +1,8 @@
 Ran Plan for 2 projects:
-1. workspace: `default` dir: `staging`
-1. workspace: `default` dir: `production`
+1. dir: `staging` workspace: `default`
+1. dir: `production` workspace: `default`
 
-### 1. workspace: `default` dir: `staging`
+### 1. dir: `staging` workspace: `default`
 ```diff
 
 An execution plan has been generated and is shown below.
@@ -24,7 +24,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
     * `atlantis plan -d staging`
 
 ---
-### 2. workspace: `default` dir: `production`
+### 2. dir: `production` workspace: `default`
 ```diff
 
 An execution plan has been generated and is shown below.

--- a/server/testfixtures/test-repos/modules-yaml/exp-output-plan-production.txt
+++ b/server/testfixtures/test-repos/modules-yaml/exp-output-plan-production.txt
@@ -1,4 +1,4 @@
-Ran Plan in dir: `production` workspace: `default`
+Ran Plan for dir: `production` workspace: `default`
 ```diff
 Refreshing Terraform state in-memory prior to plan...
 The refreshed state will be used to calculate this plan, but will not be

--- a/server/testfixtures/test-repos/modules-yaml/exp-output-plan-staging.txt
+++ b/server/testfixtures/test-repos/modules-yaml/exp-output-plan-staging.txt
@@ -1,4 +1,4 @@
-Ran Plan in dir: `staging` workspace: `default`
+Ran Plan for dir: `staging` workspace: `default`
 ```diff
 Refreshing Terraform state in-memory prior to plan...
 The refreshed state will be used to calculate this plan, but will not be

--- a/server/testfixtures/test-repos/modules/exp-output-apply-production.txt
+++ b/server/testfixtures/test-repos/modules/exp-output-apply-production.txt
@@ -1,4 +1,4 @@
-Ran Apply in dir: `production` workspace: `default`
+Ran Apply for dir: `production` workspace: `default`
 
 ```diff
 module.null.null_resource.this: Creating...

--- a/server/testfixtures/test-repos/modules/exp-output-apply-staging.txt
+++ b/server/testfixtures/test-repos/modules/exp-output-apply-staging.txt
@@ -1,4 +1,4 @@
-Ran Apply in dir: `staging` workspace: `default`
+Ran Apply for dir: `staging` workspace: `default`
 
 ```diff
 module.null.null_resource.this: Creating...

--- a/server/testfixtures/test-repos/modules/exp-output-autoplan-only-staging.txt
+++ b/server/testfixtures/test-repos/modules/exp-output-autoplan-only-staging.txt
@@ -1,4 +1,4 @@
-Ran Plan in dir: `staging` workspace: `default`
+Ran Plan for dir: `staging` workspace: `default`
 
 ```diff
 

--- a/server/testfixtures/test-repos/modules/exp-output-plan-production.txt
+++ b/server/testfixtures/test-repos/modules/exp-output-plan-production.txt
@@ -1,4 +1,4 @@
-Ran Plan in dir: `production` workspace: `default`
+Ran Plan for dir: `production` workspace: `default`
 
 ```diff
 

--- a/server/testfixtures/test-repos/modules/exp-output-plan-staging.txt
+++ b/server/testfixtures/test-repos/modules/exp-output-plan-staging.txt
@@ -1,4 +1,4 @@
-Ran Plan in dir: `staging` workspace: `default`
+Ran Plan for dir: `staging` workspace: `default`
 
 ```diff
 

--- a/server/testfixtures/test-repos/simple-yaml/exp-output-apply-all.txt
+++ b/server/testfixtures/test-repos/simple-yaml/exp-output-apply-all.txt
@@ -1,8 +1,8 @@
 Ran Apply for 2 projects:
-1. workspace: `default` dir: `.`
-1. workspace: `staging` dir: `.`
+1. dir: `.` workspace: `default`
+1. dir: `.` workspace: `staging`
 
-### 1. workspace: `default` dir: `.`
+### 1. dir: `.` workspace: `default`
 ```diff
 null_resource.simple:
 null_resource.simple:
@@ -17,7 +17,7 @@ workspace = default
 ```
 
 ---
-### 2. workspace: `staging` dir: `.`
+### 2. dir: `.` workspace: `staging`
 <details><summary>Show Output</summary>
 
 ```diff

--- a/server/testfixtures/test-repos/simple-yaml/exp-output-apply-default.txt
+++ b/server/testfixtures/test-repos/simple-yaml/exp-output-apply-default.txt
@@ -1,4 +1,4 @@
-Ran Apply in dir: `.` workspace: `default`
+Ran Apply for dir: `.` workspace: `default`
 
 ```diff
 null_resource.simple:

--- a/server/testfixtures/test-repos/simple-yaml/exp-output-apply-staging.txt
+++ b/server/testfixtures/test-repos/simple-yaml/exp-output-apply-staging.txt
@@ -1,4 +1,4 @@
-Ran Apply in dir: `.` workspace: `staging`
+Ran Apply for dir: `.` workspace: `staging`
 
 <details><summary>Show Output</summary>
 

--- a/server/testfixtures/test-repos/simple-yaml/exp-output-autoplan.txt
+++ b/server/testfixtures/test-repos/simple-yaml/exp-output-autoplan.txt
@@ -1,8 +1,8 @@
 Ran Plan for 2 projects:
-1. workspace: `default` dir: `.`
-1. workspace: `staging` dir: `.`
+1. dir: `.` workspace: `default`
+1. dir: `.` workspace: `staging`
 
-### 1. workspace: `default` dir: `.`
+### 1. dir: `.` workspace: `default`
 <details><summary>Show Output</summary>
 
 ```diff
@@ -31,7 +31,7 @@ postplan
 </details>
 
 ---
-### 2. workspace: `staging` dir: `.`
+### 2. dir: `.` workspace: `staging`
 ```diff
 
 An execution plan has been generated and is shown below.

--- a/server/testfixtures/test-repos/simple/exp-output-apply-var-all.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-apply-var-all.txt
@@ -1,8 +1,8 @@
 Ran Apply for 2 projects:
-1. workspace: `default` dir: `.`
-1. workspace: `new_workspace` dir: `.`
+1. dir: `.` workspace: `default`
+1. dir: `.` workspace: `new_workspace`
 
-### 1. workspace: `default` dir: `.`
+### 1. dir: `.` workspace: `default`
 <details><summary>Show Output</summary>
 
 ```diff
@@ -24,7 +24,7 @@ workspace = default
 </details>
 
 ---
-### 2. workspace: `new_workspace` dir: `.`
+### 2. dir: `.` workspace: `new_workspace`
 <details><summary>Show Output</summary>
 
 ```diff

--- a/server/testfixtures/test-repos/simple/exp-output-apply-var-default-workspace.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-apply-var-default-workspace.txt
@@ -1,4 +1,4 @@
-Ran Apply in dir: `.` workspace: `default`
+Ran Apply for dir: `.` workspace: `default`
 
 <details><summary>Show Output</summary>
 

--- a/server/testfixtures/test-repos/simple/exp-output-apply-var-new-workspace.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-apply-var-new-workspace.txt
@@ -1,4 +1,4 @@
-Ran Apply in dir: `.` workspace: `new_workspace`
+Ran Apply for dir: `.` workspace: `new_workspace`
 
 <details><summary>Show Output</summary>
 

--- a/server/testfixtures/test-repos/simple/exp-output-apply-var.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-apply-var.txt
@@ -1,4 +1,4 @@
-Ran Apply in dir: `.` workspace: `default`
+Ran Apply for dir: `.` workspace: `default`
 
 <details><summary>Show Output</summary>
 

--- a/server/testfixtures/test-repos/simple/exp-output-apply.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-apply.txt
@@ -1,4 +1,4 @@
-Ran Apply in dir: `.` workspace: `default`
+Ran Apply for dir: `.` workspace: `default`
 
 <details><summary>Show Output</summary>
 

--- a/server/testfixtures/test-repos/simple/exp-output-atlantis-plan-new-workspace.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-atlantis-plan-new-workspace.txt
@@ -1,4 +1,4 @@
-Ran Plan in dir: `.` workspace: `new_workspace`
+Ran Plan for dir: `.` workspace: `new_workspace`
 
 <details><summary>Show Output</summary>
 

--- a/server/testfixtures/test-repos/simple/exp-output-atlantis-plan-var-overridden.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-atlantis-plan-var-overridden.txt
@@ -1,4 +1,4 @@
-Ran Plan in dir: `.` workspace: `default`
+Ran Plan for dir: `.` workspace: `default`
 
 <details><summary>Show Output</summary>
 

--- a/server/testfixtures/test-repos/simple/exp-output-atlantis-plan.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-atlantis-plan.txt
@@ -1,4 +1,4 @@
-Ran Plan in dir: `.` workspace: `default`
+Ran Plan for dir: `.` workspace: `default`
 
 <details><summary>Show Output</summary>
 

--- a/server/testfixtures/test-repos/simple/exp-output-autoplan.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-autoplan.txt
@@ -1,4 +1,4 @@
-Ran Plan in dir: `.` workspace: `default`
+Ran Plan for dir: `.` workspace: `default`
 
 <details><summary>Show Output</summary>
 

--- a/server/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-apply-default.txt
+++ b/server/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-apply-default.txt
@@ -1,4 +1,4 @@
-Ran Apply in dir: `.` workspace: `default`
+Ran Apply for project: `default` dir: `.` workspace: `default`
 
 <details><summary>Show Output</summary>
 

--- a/server/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-apply-staging.txt
+++ b/server/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-apply-staging.txt
@@ -1,4 +1,4 @@
-Ran Apply in dir: `.` workspace: `default`
+Ran Apply for project: `staging` dir: `.` workspace: `default`
 
 <details><summary>Show Output</summary>
 

--- a/server/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-default.txt
+++ b/server/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-default.txt
@@ -1,4 +1,4 @@
-Ran Plan in dir: `.` workspace: `default`
+Ran Plan for project: `default` dir: `.` workspace: `default`
 
 ```diff
 

--- a/server/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-staging.txt
+++ b/server/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-staging.txt
@@ -1,4 +1,4 @@
-Ran Plan in dir: `.` workspace: `default`
+Ran Plan for project: `staging` dir: `.` workspace: `default`
 
 ```diff
 

--- a/server/testfixtures/test-repos/tfvars-yaml/exp-output-apply-default.txt
+++ b/server/testfixtures/test-repos/tfvars-yaml/exp-output-apply-default.txt
@@ -1,4 +1,4 @@
-Ran Apply in dir: `.` workspace: `default`
+Ran Apply for project: `default` dir: `.` workspace: `default`
 
 <details><summary>Show Output</summary>
 

--- a/server/testfixtures/test-repos/tfvars-yaml/exp-output-apply-staging.txt
+++ b/server/testfixtures/test-repos/tfvars-yaml/exp-output-apply-staging.txt
@@ -1,4 +1,4 @@
-Ran Apply in dir: `.` workspace: `default`
+Ran Apply for project: `staging` dir: `.` workspace: `default`
 
 <details><summary>Show Output</summary>
 

--- a/server/testfixtures/test-repos/tfvars-yaml/exp-output-autoplan.txt
+++ b/server/testfixtures/test-repos/tfvars-yaml/exp-output-autoplan.txt
@@ -1,8 +1,8 @@
 Ran Plan for 2 projects:
-1. workspace: `default` dir: `.`
-1. workspace: `default` dir: `.`
+1. project: `default` dir: `.` workspace: `default`
+1. project: `staging` dir: `.` workspace: `default`
 
-### 1. workspace: `default` dir: `.`
+### 1. project: `default` dir: `.` workspace: `default`
 ```diff
 
 An execution plan has been generated and is shown below.
@@ -26,7 +26,7 @@ workspace=default
     * `atlantis plan -p default`
 
 ---
-### 2. workspace: `default` dir: `.`
+### 2. project: `staging` dir: `.` workspace: `default`
 ```diff
 
 An execution plan has been generated and is shown below.


### PR DESCRIPTION
If projects are configured using an atlantis.yaml with a specific
project name, include that in the output for comments. This is useful
because often the project names are better identifiers than the
directory and workspace names and also because some projects use the
same dir and workspace so the only way to differentiate them is via
their names.

Fixes #353