### PR TITLE
add flag for rebasing branch off master

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -55,6 +55,7 @@ const (
 	PortFlag                   = "port"
 	RepoWhitelistFlag          = "repo-whitelist"
 	RequireApprovalFlag        = "require-approval"
+	RebaseRepo                 = "rebase-repo"
 	SilenceWhitelistErrorsFlag = "silence-whitelist-errors"
 	SSLCertFileFlag            = "ssl-cert-file"
 	SSLKeyFileFlag             = "ssl-key-file"
@@ -184,6 +185,11 @@ var boolFlags = []boolFlag{
 	{
 		name:         RequireApprovalFlag,
 		description:  "Require pull requests to be \"Approved\" before allowing the apply command to be run.",
+		defaultValue: false,
+	},
+	{
+		name:         RebaseRepo,
+		description:  "Prior to running any commands the pull request is rebased off of master.",
 		defaultValue: false,
 	},
 	{

--- a/server/events/command_context.go
+++ b/server/events/command_context.go
@@ -30,6 +30,7 @@ type CommandContext struct {
 	HeadRepo models.Repo
 	Pull     models.PullRequest
 	// User is the user that triggered this command.
-	User models.User
-	Log  *logging.SimpleLogger
+	User       models.User
+	Log        *logging.SimpleLogger
+	RebaseRepo bool
 }

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -69,17 +69,19 @@ type DefaultCommandRunner struct {
 	AllowForkPRsFlag      string
 	ProjectCommandBuilder ProjectCommandBuilder
 	ProjectCommandRunner  ProjectCommandRunner
+	RebaseRepo            bool
 }
 
 // RunAutoplanCommand runs plan when a pull request is opened or updated.
 func (c *DefaultCommandRunner) RunAutoplanCommand(baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User) {
 	log := c.buildLogger(baseRepo.FullName, pull.Num)
 	ctx := &CommandContext{
-		User:     user,
-		Log:      log,
-		Pull:     pull,
-		HeadRepo: headRepo,
-		BaseRepo: baseRepo,
+		User:       user,
+		Log:        log,
+		Pull:       pull,
+		HeadRepo:   headRepo,
+		BaseRepo:   baseRepo,
+		RebaseRepo: c.RebaseRepo,
 	}
 	defer c.logPanics(ctx)
 	if !c.validateCtxAndComment(ctx) {
@@ -138,11 +140,12 @@ func (c *DefaultCommandRunner) RunCommentCommand(baseRepo models.Repo, maybeHead
 		return
 	}
 	ctx := &CommandContext{
-		User:     user,
-		Log:      log,
-		Pull:     pull,
-		HeadRepo: headRepo,
-		BaseRepo: baseRepo,
+		User:       user,
+		Log:        log,
+		Pull:       pull,
+		HeadRepo:   headRepo,
+		BaseRepo:   baseRepo,
+		RebaseRepo: c.RebaseRepo,
 	}
 	defer c.logPanics(ctx)
 	if !c.validateCtxAndComment(ctx) {

--- a/server/events/mocks/mock_working_dir.go
+++ b/server/events/mocks/mock_working_dir.go
@@ -19,8 +19,8 @@ func NewMockWorkingDir() *MockWorkingDir {
 	return &MockWorkingDir{fail: pegomock.GlobalFailHandler}
 }
 
-func (mock *MockWorkingDir) Clone(log *logging.SimpleLogger, baseRepo models.Repo, headRepo models.Repo, p models.PullRequest, workspace string) (string, error) {
-	params := []pegomock.Param{log, baseRepo, headRepo, p, workspace}
+func (mock *MockWorkingDir) Clone(log *logging.SimpleLogger, baseRepo models.Repo, headRepo models.Repo, p models.PullRequest, rebase bool, workspace string) (string, error) {
+	params := []pegomock.Param{log, baseRepo, headRepo, p, rebase, workspace}
 	result := pegomock.GetGenericMockFrom(mock).Invoke("Clone", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 string
 	var ret1 error

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -301,6 +301,8 @@ type ProjectCommandContext struct {
 	// ApplyCmd is the command that users should run to apply this plan. If
 	// this is an apply then this will be empty.
 	ApplyCmd string
+
+	RebaseRepo bool
 }
 
 // SplitRepoFullName splits a repo full name up into its owner and repo name

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -89,7 +89,7 @@ func (p *DefaultProjectCommandBuilder) buildPlanAllCommands(ctx *CommandContext,
 	ctx.Log.Debug("got workspace lock")
 	defer unlockFn()
 
-	repoDir, err := p.WorkingDir.Clone(ctx.Log, ctx.BaseRepo, ctx.HeadRepo, ctx.Pull, workspace)
+	repoDir, err := p.WorkingDir.Clone(ctx.Log, ctx.BaseRepo, ctx.HeadRepo, ctx.Pull, ctx.RebaseRepo, workspace)
 	if err != nil {
 		return nil, err
 	}
@@ -143,6 +143,7 @@ func (p *DefaultProjectCommandBuilder) buildPlanAllCommands(ctx *CommandContext,
 				Verbose:       verbose,
 				RePlanCmd:     p.CommentBuilder.BuildPlanComment(mp.Path, DefaultWorkspace, "", commentFlags),
 				ApplyCmd:      p.CommentBuilder.BuildApplyComment(mp.Path, DefaultWorkspace, ""),
+				RebaseRepo:    ctx.RebaseRepo,
 			})
 		}
 	} else {
@@ -172,6 +173,7 @@ func (p *DefaultProjectCommandBuilder) buildPlanAllCommands(ctx *CommandContext,
 				Verbose:       verbose,
 				RePlanCmd:     p.CommentBuilder.BuildPlanComment(mp.Dir, mp.Workspace, mp.GetName(), commentFlags),
 				ApplyCmd:      p.CommentBuilder.BuildApplyComment(mp.Dir, mp.Workspace, mp.GetName()),
+				RebaseRepo:    ctx.RebaseRepo,
 			})
 		}
 	}
@@ -193,7 +195,7 @@ func (p *DefaultProjectCommandBuilder) buildProjectPlanCommand(ctx *CommandConte
 	defer unlockFn()
 
 	ctx.Log.Debug("cloning repository")
-	repoDir, err := p.WorkingDir.Clone(ctx.Log, ctx.BaseRepo, ctx.HeadRepo, ctx.Pull, workspace)
+	repoDir, err := p.WorkingDir.Clone(ctx.Log, ctx.BaseRepo, ctx.HeadRepo, ctx.Pull, ctx.RebaseRepo, workspace)
 	if err != nil {
 		return pcc, err
 	}
@@ -315,6 +317,7 @@ func (p *DefaultProjectCommandBuilder) buildProjectCommandCtx(ctx *CommandContex
 		GlobalConfig:  globalCfg,
 		RePlanCmd:     p.CommentBuilder.BuildPlanComment(repoRelDir, workspace, projectName, commentFlags),
 		ApplyCmd:      p.CommentBuilder.BuildApplyComment(repoRelDir, workspace, projectName),
+		RebaseRepo:    ctx.RebaseRepo,
 	}, nil
 }
 

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -179,7 +179,7 @@ projects:
 			pull := models.PullRequest{}
 			logger := logging.NewNoopLogger()
 			workingDir := mocks.NewMockWorkingDir()
-			When(workingDir.Clone(logger, baseRepo, headRepo, pull, "default")).ThenReturn(tmpDir, nil)
+			When(workingDir.Clone(logger, baseRepo, headRepo, pull, false, "default")).ThenReturn(tmpDir, nil)
 			if c.AtlantisYAML != "" {
 				err := ioutil.WriteFile(filepath.Join(tmpDir, yaml.AtlantisYAMLFilename), []byte(c.AtlantisYAML), 0600)
 				Ok(t, err)
@@ -405,7 +405,7 @@ projects:
 					expWorkspace = "default"
 				}
 				if cmdName == events.PlanCommand {
-					When(workingDir.Clone(logger, baseRepo, headRepo, pull, expWorkspace)).ThenReturn(tmpDir, nil)
+					When(workingDir.Clone(logger, baseRepo, headRepo, pull, false, expWorkspace)).ThenReturn(tmpDir, nil)
 				} else {
 					When(workingDir.GetWorkingDir(baseRepo, pull, expWorkspace)).ThenReturn(tmpDir, nil)
 				}
@@ -487,6 +487,7 @@ func TestDefaultProjectCommandBuilder_BuildMultiPlanNoAtlantisYAML(t *testing.T)
 		matchers.AnyModelsRepo(),
 		matchers.AnyModelsRepo(),
 		matchers.AnyModelsPullRequest(),
+		AnyBool(),
 		AnyString())).ThenReturn(tmpDir, nil)
 	vcsClient := vcsmocks.NewMockClientProxy()
 	When(vcsClient.GetModifiedFiles(matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest())).ThenReturn([]string{"project1/main.tf", "project2/main.tf"}, nil)
@@ -540,6 +541,7 @@ func TestDefaultProjectCommandBuilder_BuildMultiPlanNoAtlantisYAMLNoModified(t *
 		matchers.AnyModelsRepo(),
 		matchers.AnyModelsRepo(),
 		matchers.AnyModelsPullRequest(),
+		AnyBool(),
 		AnyString())).ThenReturn(tmpDir, nil)
 	vcsClient := vcsmocks.NewMockClientProxy()
 	When(vcsClient.GetModifiedFiles(matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest())).ThenReturn([]string{}, nil)
@@ -610,6 +612,7 @@ projects:
 		matchers.AnyModelsRepo(),
 		matchers.AnyModelsRepo(),
 		matchers.AnyModelsPullRequest(),
+		AnyBool(),
 		AnyString())).ThenReturn(tmpDir, nil)
 	vcsClient := vcsmocks.NewMockClientProxy()
 	When(vcsClient.GetModifiedFiles(matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest())).ThenReturn([]string{
@@ -674,6 +677,7 @@ projects:
 		matchers.AnyModelsRepo(),
 		matchers.AnyModelsRepo(),
 		matchers.AnyModelsPullRequest(),
+		AnyBool(),
 		AnyString())).ThenReturn(tmpDir, nil)
 	vcsClient := vcsmocks.NewMockClientProxy()
 	When(vcsClient.GetModifiedFiles(matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest())).ThenReturn([]string{"main.tf"}, nil)
@@ -809,6 +813,7 @@ func TestDefaultProjectCommandBuilder_RepoConfigDisabled(t *testing.T) {
 		matchers.AnyModelsRepo(),
 		matchers.AnyModelsRepo(),
 		matchers.AnyModelsPullRequest(),
+		AnyBool(),
 		AnyString())).ThenReturn(repoDir, nil)
 	When(workingDir.GetWorkingDir(
 		matchers.AnyModelsRepo(),

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -135,14 +135,16 @@ func (p *DefaultProjectCommandRunner) doPlan(ctx models.ProjectCommandContext) (
 	}
 	defer unlockFn()
 
-	// Clone is idempotent so okay to run even if the repo was already cloned.
-	repoDir, cloneErr := p.WorkingDir.Clone(ctx.Log, ctx.BaseRepo, ctx.HeadRepo, ctx.Pull, ctx.Workspace)
+	// Clone is idempotent when rebase is not true so okay to run even if the repo was already cloned.
+	ctx.Log.Err("WHAT IS REBASE %v", ctx.RebaseRepo)
+	repoDir, cloneErr := p.WorkingDir.Clone(ctx.Log, ctx.BaseRepo, ctx.HeadRepo, ctx.Pull, ctx.RebaseRepo, ctx.Workspace)
 	if cloneErr != nil {
 		if unlockErr := lockAttempt.UnlockFn(); unlockErr != nil {
 			ctx.Log.Err("error unlocking state after plan error: %v", unlockErr)
 		}
 		return nil, "", cloneErr
 	}
+
 	projAbsPath := filepath.Join(repoDir, ctx.RepoRelDir)
 
 	// Use default stage unless another workflow is defined in config

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -152,6 +152,7 @@ func TestDefaultProjectCommandRunner_Plan(t *testing.T) {
 				matchers.AnyModelsRepo(),
 				matchers.AnyModelsRepo(),
 				matchers.AnyModelsPullRequest(),
+				AnyBool(),
 				AnyString(),
 			)).ThenReturn(repoDir, nil)
 			When(mockLocker.TryLock(

--- a/server/server.go
+++ b/server/server.go
@@ -99,6 +99,7 @@ type UserConfig struct {
 	GitlabWebhookSecret    string `mapstructure:"gitlab-webhook-secret"`
 	LogLevel               string `mapstructure:"log-level"`
 	Port                   int    `mapstructure:"port"`
+	RebaseRepo             bool   `mapstructure:"rebase-repo"`
 	RepoWhitelist          string `mapstructure:"repo-whitelist"`
 	// RequireApproval is whether to require pull request approval before
 	// allowing terraform apply's to be run.
@@ -263,6 +264,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		Logger:                   logger,
 		AllowForkPRs:             userConfig.AllowForkPRs,
 		AllowForkPRsFlag:         config.AllowForkPRsFlag,
+		RebaseRepo:               userConfig.RebaseRepo,
 		ProjectCommandBuilder: &events.DefaultProjectCommandBuilder{
 			ParserValidator:     &yaml.ParserValidator{},
 			ProjectFinder:       &events.DefaultProjectFinder{},


### PR DESCRIPTION
This adds a flag to the CLI to have the PR rebased onto the master branch when the flag `--rebase-repo` is set.

I did not implement the configuration for the atlantis.yml as I was not sure if we would want that interaction where once rebased we would have to reread the atlantis.yml.