### PR TITLE
Return plan output on error.

### DIFF
--- a/server/events/runtime/plan_step_runner.go
+++ b/server/events/runtime/plan_step_runner.go
@@ -39,7 +39,7 @@ func (p *PlanStepRunner) Run(ctx models.ProjectCommandContext, extraArgs []strin
 	planCmd := p.buildPlanCmd(ctx, extraArgs, path)
 	output, err := p.TerraformExecutor.RunCommandWithVersion(ctx.Log, filepath.Clean(path), planCmd, tfVersion, ctx.Workspace)
 	if err != nil {
-		return "", err
+		return output, err
 	}
 	return p.fmtPlanOutput(output), nil
 }


### PR DESCRIPTION
If terraform plan returns an error, we still want to print the output to
the pull request.