### PR TITLE
Bump Terraform version to 0.11.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
     docker:
     - image: circleci/golang:1.11
       environment:
-        TERRAFORM_VERSION: 0.11.10
+        TERRAFORM_VERSION: 0.11.11
     steps:
     - checkout
     - run: make build-service

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM runatlantis/atlantis-base:v2.0
 LABEL authors="Anubhav Mishra, Luke Kysow"
 
 # install terraform binaries
-ENV DEFAULT_TERRAFORM_VERSION=0.11.10
+ENV DEFAULT_TERRAFORM_VERSION=0.11.11
 
 # In the official Atlantis image we only have the latest of each Terrafrom version.
 RUN AVAILABLE_TERRAFORM_VERSIONS="0.8.8 0.9.11 0.10.8 ${DEFAULT_TERRAFORM_VERSION}" && \

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -4,7 +4,7 @@
 FROM circleci/golang:1.11
 
 # Install Terraform
-ENV TERRAFORM_VERSION=0.11.10
+ENV TERRAFORM_VERSION=0.11.11
 RUN curl -LOks https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
     sudo mkdir -p /usr/local/bin/tf/versions/${TERRAFORM_VERSION} && \
     sudo unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/local/bin/tf/versions/${TERRAFORM_VERSION} && \


### PR DESCRIPTION
Hi!

This upgrades the used version of Terraform to 0.11.11.
It would be awesome to get a release very soon! 😄

Thanks!