### PR TITLE
Include src of moved files in list of modified files

### DIFF
--- a/server/events/vcs/bitbucketserver/client.go
+++ b/server/events/vcs/bitbucketserver/client.go
@@ -88,6 +88,12 @@ func (b *Client) GetModifiedFiles(repo models.Repo, pull models.PullRequest) ([]
 		}
 		for _, v := range changes.Values {
 			files = append(files, *v.Path.ToString)
+
+			// If the file was renamed, we'll want to run plan in the directory
+			// it was moved from as well.
+			if v.SrcPath != nil {
+				files = append(files, *v.SrcPath.ToString)
+			}
 		}
 		if *changes.IsLastPage {
 			break

--- a/server/events/vcs/bitbucketserver/models.go
+++ b/server/events/vcs/bitbucketserver/models.go
@@ -60,6 +60,9 @@ type Changes struct {
 		Path struct {
 			ToString *string `json:"toString,omitempty" validate:"required"`
 		} `json:"path,omitempty" validate:"required"`
+		SrcPath *struct {
+			ToString *string `json:"toString,omitempty"`
+		} `json:"srcPath,omitempty"`
 	} `json:"values,omitempty" validate:"required"`
 	NextPageStart *int  `json:"nextPageStart,omitempty"`
 	IsLastPage    *bool `json:"isLastPage,omitempty" validate:"required"`

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -79,6 +79,12 @@ func (g *GithubClient) GetModifiedFiles(repo models.Repo, pull models.PullReques
 		}
 		for _, f := range pageFiles {
 			files = append(files, f.GetFilename())
+
+			// If the file was renamed, we'll want to run plan in the directory
+			// it was moved from as well.
+			if f.GetStatus() == "renamed" {
+				files = append(files, f.GetPreviousFilename())
+			}
 		}
 		if resp.NextPage == 0 {
 			break

--- a/server/events/vcs/gitlab_client.go
+++ b/server/events/vcs/gitlab_client.go
@@ -114,6 +114,9 @@ func (g *GitlabClient) GetModifiedFiles(repo models.Repo, pull models.PullReques
 		}
 
 		for _, f := range mr.Changes {
+			if f.RenamedFile {
+				files = append(files, f.OldPath)
+			}
 			files = append(files, f.NewPath)
 		}
 		if resp.NextPage == 0 {

--- a/server/events/vcs/gitlab_client.go
+++ b/server/events/vcs/gitlab_client.go
@@ -114,10 +114,13 @@ func (g *GitlabClient) GetModifiedFiles(repo models.Repo, pull models.PullReques
 		}
 
 		for _, f := range mr.Changes {
+			files = append(files, f.NewPath)
+
+			// If the file was renamed, we'll want to run plan in the directory
+			// it was moved from as well.
 			if f.RenamedFile {
 				files = append(files, f.OldPath)
 			}
-			files = append(files, f.NewPath)
 		}
 		if resp.NextPage == 0 {
 			break


### PR DESCRIPTION
If a file is moved during a pull request, we want to run plan in both the new and old directories (since they've both changed).

Notes:
* Fixes #413 
* Takes commit from @kent-b in #414 (thanks!)
