### PR TITLE
Adding in slack-token to flags

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -175,7 +175,7 @@ var stringFlags = []stringFlag{
 	},
 	{
 		name:        SlackTokenFlag,
-		description: "API token for Slack notifications",
+		description: "API token for Slack notifications.",
 	},
 	{
 		name:        SSLCertFileFlag,
@@ -512,26 +512,4 @@ func (s *ServerCmd) securityWarnings(userConfig *server.UserConfig) {
 	if userConfig.GitlabUser != "" && userConfig.GitlabWebhookSecret == "" && !s.SilenceOutput {
 		s.Logger.Warn("no GitLab webhook secret set. This could allow attackers to spoof requests from GitLab")
 	}
-	if userConfig.BitbucketUser != "" && userConfig.BitbucketBaseURL != DefaultBitbucketBaseURL && userConfig.BitbucketWebhookSecret == "" && !s.SilenceOutput {
-		s.Logger.Warn("no Bitbucket webhook secret set. This could allow attackers to spoof requests from Bitbucket")
-	}
-	if userConfig.BitbucketUser != "" && userConfig.BitbucketBaseURL == DefaultBitbucketBaseURL && !s.SilenceOutput {
-		s.Logger.Warn("Bitbucket Cloud does not support webhook secrets. This could allow attackers to spoof requests from Bitbucket. Ensure you are whitelisting Bitbucket IPs")
-	}
-}
-
-// withErrPrint prints out any cmd errors to stderr.
-func (s *ServerCmd) withErrPrint(f func(*cobra.Command, []string) error) func(*cobra.Command, []string) error {
-	return func(cmd *cobra.Command, args []string) error {
-		err := f(cmd, args)
-		if err != nil && !s.SilenceOutput {
-			s.printErr(err)
-		}
-		return err
-	}
-}
-
-// printErr prints err to stderr using a red terminal colour.
-func (s *ServerCmd) printErr(err error) {
-	fmt.Fprintf(os.Stderr, "%sError: %s%s\n", "\033[31m", err.Error(), "\033[39m")
-}
+	if userConfig.BitbucketUser != "" && userConfig.BitbucketBaseURL != 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -60,6 +60,7 @@ const (
 	RequireApprovalFlag        = "require-approval"
 	RequireMergeableFlag       = "require-mergeable"
 	SilenceWhitelistErrorsFlag = "silence-whitelist-errors"
+	SlackTokenFlag             = "slack-token"
 	SSLCertFileFlag            = "ssl-cert-file"
 	SSLKeyFileFlag             = "ssl-key-file"
 	TFETokenFlag               = "tfe-token"
@@ -171,6 +172,10 @@ var stringFlags = []stringFlag{
 			"The format is {hostname}/{owner}/{repo}, ex. github.com/runatlantis/atlantis. '*' matches any characters until the next comma and can be used for example to whitelist " +
 			"all repos: '*' (not recommended), an entire hostname: 'internalgithub.com/*' or an organization: 'github.com/runatlantis/*'." +
 			" For Bitbucket Server, {hostname} is the domain without scheme and port, {owner} is the name of the project (not the key), and {repo} is the repo name.",
+	},
+	{
+		name:        SlackTokenFlag,
+		description: "API token for Slack notifications",
 	},
 	{
 		name:        SSLCertFileFlag,

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -356,6 +356,7 @@ func TestExecute_Defaults(t *testing.T) {
 	Equals(t, 4141, passedConfig.Port)
 	Equals(t, false, passedConfig.RequireApproval)
 	Equals(t, false, passedConfig.RequireMergeable)
+	Equals(t, "", passedConfig.SlackToken)
 	Equals(t, "", passedConfig.SSLCertFile)
 	Equals(t, "", passedConfig.SSLKeyFile)
 	Equals(t, "", passedConfig.TFEToken)
@@ -456,6 +457,7 @@ func TestExecute_Flags(t *testing.T) {
 		cmd.RepoWhitelistFlag:          "github.com/runatlantis/atlantis",
 		cmd.RequireApprovalFlag:        true,
 		cmd.RequireMergeableFlag:       true,
+		cmd.SlackTokenFlag:             "slack-token",
 		cmd.SSLCertFileFlag:            "cert-file",
 		cmd.SSLKeyFileFlag:             "key-file",
 		cmd.TFETokenFlag:               "my-token",
@@ -485,6 +487,7 @@ func TestExecute_Flags(t *testing.T) {
 	Equals(t, "github.com/runatlantis/atlantis", passedConfig.RepoWhitelist)
 	Equals(t, true, passedConfig.RequireApproval)
 	Equals(t, true, passedConfig.RequireMergeable)
+	Equals(t, "slack-token", passedConfig.SlackToken)
 	Equals(t, "cert-file", passedConfig.SSLCertFile)
 	Equals(t, "key-file", passedConfig.SSLKeyFile)
 	Equals(t, "my-token", passedConfig.TFEToken)
@@ -515,6 +518,7 @@ port: 8181
 repo-whitelist: "github.com/runatlantis/atlantis"
 require-approval: true
 require-mergeable: true
+slack-token: slack-token
 ssl-cert-file: cert-file
 ssl-key-file: key-file
 tfe-token: my-token
@@ -548,6 +552,7 @@ tfe-token: my-token
 	Equals(t, "github.com/runatlantis/atlantis", passedConfig.RepoWhitelist)
 	Equals(t, true, passedConfig.RequireApproval)
 	Equals(t, true, passedConfig.RequireMergeable)
+	Equals(t, "slack-token", passedConfig.SlackToken)
 	Equals(t, "cert-file", passedConfig.SSLCertFile)
 	Equals(t, "key-file", passedConfig.SSLKeyFile)
 	Equals(t, "my-token", passedConfig.TFEToken)
@@ -577,9 +582,10 @@ log-level: "debug"
 port: 8181
 repo-whitelist: "github.com/runatlantis/atlantis"
 require-approval: true
+slack-token: slack-token
 ssl-cert-file: cert-file
 ssl-key-file: key-file
-ssl-key-file: my-token
+tfe-token: my-token
 `)
 	defer os.Remove(tmpFile) // nolint: errcheck
 
@@ -607,6 +613,7 @@ ssl-key-file: my-token
 		"REPO_WHITELIST":           "override,override",
 		"REQUIRE_APPROVAL":         "false",
 		"REQUIRE_MERGEABLE":        "false",
+		"SLACK_TOKEN":              "override-slack-token",
 		"SSL_CERT_FILE":            "override-cert-file",
 		"SSL_KEY_FILE":             "override-key-file",
 		"TFE_TOKEN":                "override-my-token",
@@ -640,6 +647,7 @@ ssl-key-file: my-token
 	Equals(t, "override,override", passedConfig.RepoWhitelist)
 	Equals(t, false, passedConfig.RequireApproval)
 	Equals(t, false, passedConfig.RequireMergeable)
+	Equals(t, "override-slack-token", passedConfig.SlackToken)
 	Equals(t, "override-cert-file", passedConfig.SSLCertFile)
 	Equals(t, "override-key-file", passedConfig.SSLKeyFile)
 	Equals(t, "override-my-token", passedConfig.TFEToken)
@@ -670,6 +678,7 @@ port: 8181
 repo-whitelist: "github.com/runatlantis/atlantis"
 require-approval: true
 require-mergeable: true
+slack-token: slack-token
 ssl-cert-file: cert-file
 ssl-key-file: key-file
 tfe-token: my-token
@@ -699,6 +708,7 @@ tfe-token: my-token
 		cmd.RepoWhitelistFlag:          "override,override",
 		cmd.RequireApprovalFlag:        false,
 		cmd.RequireMergeableFlag:       false,
+		cmd.SlackTokenFlag:             "override-slack-token",
 		cmd.SSLCertFileFlag:            "override-cert-file",
 		cmd.SSLKeyFileFlag:             "override-key-file",
 		cmd.TFETokenFlag:               "override-my-token",
@@ -726,9 +736,11 @@ tfe-token: my-token
 	Equals(t, "override,override", passedConfig.RepoWhitelist)
 	Equals(t, false, passedConfig.RequireApproval)
 	Equals(t, false, passedConfig.RequireMergeable)
+	Equals(t, "override-slack-token", passedConfig.SlackToken)
 	Equals(t, "override-cert-file", passedConfig.SSLCertFile)
 	Equals(t, "override-key-file", passedConfig.SSLKeyFile)
 	Equals(t, "override-my-token", passedConfig.TFEToken)
+
 }
 
 func TestExecute_FlagEnvVarOverride(t *testing.T) {
@@ -757,6 +769,7 @@ func TestExecute_FlagEnvVarOverride(t *testing.T) {
 		"REPO_WHITELIST":           "*",
 		"REQUIRE_APPROVAL":         "true",
 		"REQUIRE_MERGEABLE":        "true",
+		"SLACK_TOKEN":              "slack-token",
 		"SSL_CERT_FILE":            "cert-file",
 		"SSL_KEY_FILE":             "key-file",
 		"TFE_TOKEN":                "my-token",
@@ -794,6 +807,7 @@ func TestExecute_FlagEnvVarOverride(t *testing.T) {
 		cmd.RepoWhitelistFlag:          "override,override",
 		cmd.RequireApprovalFlag:        false,
 		cmd.RequireMergeableFlag:       false,
+		cmd.SlackTokenFlag:             "override-slack-token",
 		cmd.SSLCertFileFlag:            "override-cert-file",
 		cmd.SSLKeyFileFlag:             "override-key-file",
 		cmd.TFETokenFlag:               "override-my-token",
@@ -823,6 +837,7 @@ func TestExecute_FlagEnvVarOverride(t *testing.T) {
 	Equals(t, "override,override", passedConfig.RepoWhitelist)
 	Equals(t, false, passedConfig.RequireApproval)
 	Equals(t, false, passedConfig.RequireMergeable)
+	Equals(t, "override-slack-token", passedConfig.SlackToken)
 	Equals(t, "override-cert-file", passedConfig.SSLCertFile)
 	Equals(t, "override-key-file", passedConfig.SSLKeyFile)
 	Equals(t, "override-my-token", passedConfig.TFEToken)


### PR DESCRIPTION
In my testing of the slack functionality, I found I was able to specify the token via the config.yaml, but the env var/flag wasn't working. This allow env/flag/config to work as the rest of the flags do.


Signed-off-by: Jacob Foard <jacob.foard@formation.ai>