### PR TITLE
Total cowboy approach to server-side config

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -39,6 +39,7 @@ const (
 	AllowForkPRsFlag           = "allow-fork-prs"
 	AllowRepoConfigFlag        = "allow-repo-config"
 	AtlantisURLFlag            = "atlantis-url"
+	AtlantisConfigBranch       = "atlantis-config-branch"
 	BitbucketBaseURLFlag       = "bitbucket-base-url"
 	BitbucketTokenFlag         = "bitbucket-token"
 	BitbucketUserFlag          = "bitbucket-user"
@@ -78,6 +79,10 @@ var stringFlags = []stringFlag{
 	{
 		name:        AtlantisURLFlag,
 		description: "URL that Atlantis can be reached at. Defaults to http://$(hostname):$port where $port is from --" + PortFlag + ". Supports a base path ex. https://example.com/basepath.",
+	},
+	{
+		name:        AtlantisConfigBranch,
+		description: "The repository branch that is used to source the atlantis.yaml for each atlantis run, e.g., 'master'.",
 	},
 	{
 		name:        BitbucketUserFlag,

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -50,6 +50,7 @@ type DefaultProjectCommandBuilder struct {
 	WorkingDirLocker    WorkingDirLocker
 	AllowRepoConfig     bool
 	AllowRepoConfigFlag string
+	ConfigBranch        string
 	PendingPlanFinder   *PendingPlanFinder
 	CommentBuilder      CommentBuilder
 }
@@ -105,7 +106,7 @@ func (p *DefaultProjectCommandBuilder) buildPlanAllCommands(ctx *CommandContext,
 		if !p.AllowRepoConfig {
 			return nil, fmt.Errorf("%s files not allowed because Atlantis is not running with --%s", yaml.AtlantisYAMLFilename, p.AllowRepoConfigFlag)
 		}
-		config, err = p.ParserValidator.ReadConfig(repoDir)
+		config, err = p.ParserValidator.ReadConfig(repoDir, p.ConfigBranch)
 		if err != nil {
 			return nil, err
 		}
@@ -343,7 +344,7 @@ func (p *DefaultProjectCommandBuilder) getCfg(projectName string, dir string, wo
 		return
 	}
 
-	globalCfgStruct, err := p.ParserValidator.ReadConfig(repoDir)
+	globalCfgStruct, err := p.ParserValidator.ReadConfig(repoDir, p.ConfigBranch)
 	if err != nil {
 		return
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -239,6 +239,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 			WorkingDirLocker:    workingDirLocker,
 			AllowRepoConfig:     userConfig.AllowRepoConfig,
 			AllowRepoConfigFlag: config.AllowRepoConfigFlag,
+			ConfigBranch:        userConfig.AtlantisConfigBranch,
 			PendingPlanFinder:   &events.PendingPlanFinder{},
 			CommentBuilder:      commentParser,
 		},

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -9,6 +9,7 @@ type UserConfig struct {
 	AllowForkPRs           bool   `mapstructure:"allow-fork-prs"`
 	AllowRepoConfig        bool   `mapstructure:"allow-repo-config"`
 	AtlantisURL            string `mapstructure:"atlantis-url"`
+	AtlantisConfigBranch   string `mapstructure:"atlantis-config-branch"`
 	BitbucketBaseURL       string `mapstructure:"bitbucket-base-url"`
 	BitbucketToken         string `mapstructure:"bitbucket-token"`
 	BitbucketUser          string `mapstructure:"bitbucket-user"`


### PR DESCRIPTION
Make the assumption that we have a valid git repository within what
atlantis clones. Then use git show to retrieve the contents of a
atlantis.yaml file, rather than a local read.