### PR TITLE
Add Server Side YAML Restrictions

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -57,6 +57,7 @@ const (
 	GitlabWebhookSecretFlag    = "gitlab-webhook-secret" // nolint: gosec
 	LogLevelFlag               = "log-level"
 	PortFlag                   = "port"
+	RepoConfigFlag             = "repo-config"
 	RepoWhitelistFlag          = "repo-whitelist"
 	RequireApprovalFlag        = "require-approval"
 	RequireMergeableFlag       = "require-mergeable"
@@ -168,6 +169,10 @@ var stringFlags = []stringFlag{
 		defaultValue: DefaultLogLevel,
 	},
 	{
+		name:        RepoConfigFlag,
+		description: "Path to a repo config file, used to configure how atlantis.yaml will behave on repos.  Repos can be specified as an exact string or using regular expressions",
+	},
+	{
 		name: RepoWhitelistFlag,
 		description: "Comma separated list of repositories that Atlantis will operate on. " +
 			"The format is {hostname}/{owner}/{repo}, ex. github.com/runatlantis/atlantis. '*' matches any characters until the next comma and can be used for example to whitelist " +
@@ -205,6 +210,7 @@ var boolFlags = []boolFlag{
 			" Should only be enabled in a trusted environment since it enables a pull request to run arbitrary commands" +
 			" on the Atlantis server.",
 		defaultValue: false,
+		deprecated:   fmt.Sprintf("use --%s to allow sensitive keys in atlantis.yaml", RepoConfigFlag),
 	},
 	{
 		name:         AutomergeFlag,
@@ -239,16 +245,19 @@ type stringFlag struct {
 	name         string
 	description  string
 	defaultValue string
+	deprecated   string
 }
 type intFlag struct {
 	name         string
 	description  string
 	defaultValue int
+	deprecated   string
 }
 type boolFlag struct {
 	name         string
 	description  string
 	defaultValue bool
+	deprecated   string
 }
 
 // ServerCmd is an abstraction that helps us test. It allows
@@ -324,6 +333,9 @@ func (s *ServerCmd) Init() *cobra.Command {
 			usage = fmt.Sprintf("%s (default \"%s\")", usage, f.defaultValue)
 		}
 		c.Flags().String(f.name, "", usage+"\n")
+		if f.deprecated != "" {
+			c.Flags().MarkDeprecated(f.name, f.deprecated) // nolint: errcheck
+		}
 		s.Viper.BindPFlag(f.name, c.Flags().Lookup(f.name)) // nolint: errcheck
 	}
 
@@ -334,12 +346,18 @@ func (s *ServerCmd) Init() *cobra.Command {
 			usage = fmt.Sprintf("%s (default %d)", usage, f.defaultValue)
 		}
 		c.Flags().Int(f.name, 0, usage+"\n")
+		if f.deprecated != "" {
+			c.Flags().MarkDeprecated(f.name, f.deprecated) // nolint: errcheck
+		}
 		s.Viper.BindPFlag(f.name, c.Flags().Lookup(f.name)) // nolint: errcheck
 	}
 
 	// Set bool flags.
 	for _, f := range boolFlags {
 		c.Flags().Bool(f.name, f.defaultValue, f.description+"\n")
+		if f.deprecated != "" {
+			c.Flags().MarkDeprecated(f.name, f.deprecated) // nolint: errcheck
+		}
 		s.Viper.BindPFlag(f.name, c.Flags().Lookup(f.name)) // nolint: errcheck
 	}
 
@@ -430,6 +448,9 @@ func (s *ServerCmd) validate(userConfig server.UserConfig) error {
 
 	if (userConfig.SSLKeyFile == "") != (userConfig.SSLCertFile == "") {
 		return fmt.Errorf("--%s and --%s are both required for ssl", SSLKeyFileFlag, SSLCertFileFlag)
+	}
+	if userConfig.AllowRepoConfig && userConfig.RepoConfig != "" {
+		return fmt.Errorf("You cannot use both --%s and --%s together.  --%s is deprecated and will be removed in a later version, you should use --%s instead", AllowRepoConfigFlag, RepoConfigFlag, AllowRepoConfigFlag, RepoConfigFlag)
 	}
 
 	// The following combinations are valid.

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -900,6 +900,16 @@ func TestExecute_BitbucketServerBaseURLPort(t *testing.T) {
 	Equals(t, "http://mydomain.com:7990", passedConfig.BitbucketBaseURL)
 }
 
+// Cannot use both --allow-repo-config and --repo-config
+func TestExecute_AllowRepoConfigWithAllowRestrictedRepoConfig(t *testing.T) {
+	c := setup(map[string]interface{}{
+		cmd.AllowRepoConfigFlag: true,
+		cmd.RepoConfigFlag:      "somefile",
+	})
+	err := c.Execute()
+	ErrEquals(t, "You cannot use both --allow-repo-config and --repo-config together.  --allow-repo-config is deprecated and will be removed in a later version, you should use --repo-config instead", err)
+}
+
 func setup(flags map[string]interface{}) *cobra.Command {
 	vipr := viper.New()
 	for k, v := range flags {

--- a/runatlantis.io/.vuepress/config.js
+++ b/runatlantis.io/.vuepress/config.js
@@ -69,6 +69,7 @@ module.exports = {
                     collapsable: true,
                     children: [
                         ['customizing-atlantis', 'Overview'],
+                        'repos-yaml-reference',
                         'atlantis-yaml-reference',
                         'upgrading-atlantis-yaml-to-version-2',
                         'apply-requirements'

--- a/runatlantis.io/docs/apply-requirements.md
+++ b/runatlantis.io/docs/apply-requirements.md
@@ -20,7 +20,21 @@ by at least one person other than the author.
 #### Usage
 You can set the `approved` requirement by:
 1. Passing the `--require-approval` flag to `atlantis server` or
-1. Creating an `atlantis.yaml` file with the `apply_requirements` key:
+1. Creating a `repos.yaml` file with the `apply_requirements` key:
+   ```yaml
+   repos:
+   - id: /.*/
+     apply_requirements: [approved]
+   ```
+1. Or by allowing an `atlantis.yaml` file to specify the `apply_requirements` key in your `repos.yaml` config:
+    #### repos.yaml
+    ```yaml
+    repos:
+    - id: /.*/
+      allowed_overrides: [apply_requirements]
+    ```
+    
+    #### atlantis.yaml
     ```yaml
     version: 2
     projects:
@@ -47,14 +61,29 @@ The `mergeable` requirement will prevent applies unless a pull request is able t
 #### Usage
 You can set the `mergeable` requirement by:
 1. Passing the `--require-mergeable` flag to `atlantis server` or
-1. Creating an `atlantis.yaml` file with the `apply_requirements` key:
+1. Creating a `repos.yaml` file with the `apply_requirements` key:
+   ```yaml
+   repos:
+   - id: /.*/
+     apply_requirements: [mergeable]
+    ```
+  
+1. Or by allowing an `atlantis.yaml` file to specify the `apply_requirements` key in your `repos.yaml` config:
+    #### repos.yaml
+    ```yaml
+    repos:
+    - id: /.*/
+      allowed_overrides: [apply_requirements]
+    ```
+     
+    #### atlantis.yaml
     ```yaml
     version: 2
     projects:
     - dir: .
       apply_requirements: [mergeable]
-     ```
-
+    ```
+     
 #### Meaning
 Each VCS provider has a different concept of "mergeability":
 #### GitHub
@@ -86,18 +115,47 @@ If you need a specific check, please
 [open an issue](https://github.com/runatlantis/atlantis/issues/new).
 
 ## Setting Apply Requirements
-As mentioned above, you can set apply requirements via flags or `atlantis.yaml`.
+As mentioned above, you can set apply requirements via flags, in `repos.yaml`, or in `atlantis.yaml` if `repos.yaml`
+allows the override.
 
 ### Flags Override
-Flags **override** any `atlantis.yaml` settings so they are equivalent to always
+Flags **override** any `repos.yaml` or `atlantis.yaml` settings so they are equivalent to always
 having that apply requirement set.
 
 ### Project-Specific Settings
 If you only want some projects/repos to have apply requirements, then you must
 1. Not set the `--require-approval` or `--require-mergeable` flags, since those
-   will override any `atlantis.yaml` settings
-1. Specify which projects have which requirements via an `atlantis.yaml` file.
+   will override any `repos.yaml` or `atlantis.yaml` settings
+1. Specifying which repos have which requirements via the `repos.yaml` file.
+   ```yaml
+   repos:
+   - id: /.*/
+     apply_requirements: [approved]
+   # Regex that defaults all repos to requiring approval
+   - id: /github.com/runatlantis/.*/
+     # Regex to match any repo under the atlantis namespace, and not require approval
+     # except for repos that might match later in the chain
+     apply_requirements: []
+   - id: github.com/runatlantis/atlantis
+     apply_requirements: [approved]
+     # Exact string match of the github.com/runatlantis/atlantis repo
+     # that sets apply_requirements to approved
+   ```
+
+1. Specify which projects have which requirements via an `atlantis.yaml` file, and allowing
+   `apply_requirements` to be set in in `atlantis.yaml` by the server side `repos.yaml`
+   config.
+   
    For example if I have two directories, `staging` and `production`, I might use:
+   #### repos.yaml
+   ```yaml
+   repos:
+   - id: /.*/
+     allowed_overrides: [apply_requirements]
+     # Allow any repo to specify apply_requirements in atlantis.yaml
+   ```
+   
+   #### atlatis.yaml
    ```yaml
    version: 2
    projects:

--- a/runatlantis.io/docs/atlantis-yaml-reference.md
+++ b/runatlantis.io/docs/atlantis-yaml-reference.md
@@ -10,8 +10,12 @@ See [www.runatlantis.io/guide/atlantis-yaml-use-cases.html](../guide/atlantis-ya
 :::
 
 ## Enabling atlantis.yaml
-The atlantis server must be running with `--allow-repo-config` to allow Atlantis
-to use `atlantis.yaml` files.
+By default all repos are allowed to have an `atlantis.yaml` file, but not all of the keys are enabled by default due to
+the sensitive nature of some keys.
+
+Restricted keys can be set in the server side `repos.yaml` file, and you can enable `atlantis.yaml` to override restricted
+keys by setting `allowed_overrides` in the `repos.yaml`.  See the [repos.yaml reference](repos-yaml-reference.html) for
+more information.
 
 ## Example Using All Keys
 ```yaml
@@ -58,11 +62,10 @@ likely hold your highest privilege credentials.
 The risk is increased because Atlantis uses the `atlantis.yaml` file from the
 pull request so anyone that can submit a pull request can submit a malicious file.
 
-As such, **`atlantis.yaml` files should only be enabled in a trusted environment**.
-
-::: danger
-It should be noted that `atlantis apply` itself could be exploited if run on a malicious terraform file. See [Security](security.html#exploits).
-:::
+By default, the keys that are sensitive in nature are restricted from being used in the `atlantis.yaml` file.
+Restricted keys can be set in the server side `repos.yaml` file, and you can enable `atlantis.yaml` to override restricted
+keys by setting `allowed_overrides` in the `repos.yaml`.  See the [repos.yaml reference](repos-yaml-reference.html) for
+more information.
 
 ## Reference
 ### Top-Level Keys
@@ -72,12 +75,12 @@ automerge:
 projects:
 workflows:
 ```
-| Key       | Type                                                             | Default | Required | Description                                                 |
-| --------- | ---------------------------------------------------------------- | ------- | -------- | ----------------------------------------------------------- |
-| version   | int                                                              | none    | yes      | This key is required and must be set to `2`                 |
-| automerge | bool                                                             | false   | no       | Automatically merge pull request when all plans are applied |
-| projects  | array[[Project](atlantis-yaml-reference.html#project)]           | []      | no       | Lists the projects in this repo                             |
-| workflows | map[string -> [Workflow](atlantis-yaml-reference.html#workflow)] | {}      | no       | Custom workflows                                            |
+| Key                           | Type                                                             | Default | Required | Description                                                 |
+| ----------------------------- | ---------------------------------------------------------------- | ------- | -------- | ----------------------------------------------------------- |
+| version                       | int                                                              | none    | yes      | This key is required and must be set to `2`                 |
+| automerge                     | bool                                                             | false   | no       | Automatically merge pull request when all plans are applied |
+| projects                      | array[[Project](atlantis-yaml-reference.html#project)]           | []      | no       | Lists the projects in this repo                             |
+| workflows<br />*(restricted)* | map[string -> [Workflow](atlantis-yaml-reference.html#workflow)] | {}      | no       | Custom workflows                                            |
 
 ### Project
 ```yaml
@@ -90,15 +93,15 @@ apply_requirements: ["approved"]
 workflow: myworkflow
 ```
 
-| Key                | Type                                              | Default | Required | Description                                                                                                                                                                                                           |
-| ------------------ | ------------------------------------------------- | ------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| name               | string                                            | none    | maybe    | Required if there is more than one project with the same `dir` and `workspace`. This project name can be used with the `-p` flag.                                                                                     |
-| dir                | string                                            | none    | yes      | The directory of this project relative to the repo root. Use `.` for the root. For example if the project was under `./project1` then use `project1`                                                                  |
-| workspace          | string                                            | default | no       | The [Terraform workspace](https://www.terraform.io/docs/state/workspaces.html) for this project. Atlantis will switch to this workplace when planning/applying and will create it if it doesn't exist.                |
-| autoplan           | [Autoplan](atlantis-yaml-reference.html#autoplan) | none    | no       | A custom autoplan configuration. If not specified, will use the default algorithm. See [Autoplanning](autoplanning.html).                                                                                             |
-| terraform_version  | string                                            | none    | no       | A specific Terraform version to use when running commands for this project. Requires there to be a binary in the Atlantis `PATH` with the name `terraform{VERSION}`, ex. `terraform0.11.0`                            |
-| apply_requirements | array[string]                                     | []      | no       | Requirements that must be satisfied before `atlantis apply` can be run. Currently the only supported requirements are `approved` and `mergeable`. See [Apply Requirements](apply-requirements.html) for more details. |
-| workflow           | string                                            | none    | no       | A custom workflow. If not specified, Atlantis will use its default workflow.                                                                                                                                          |
+| Key                                    | Type                                              | Default | Required | Description                                                                                                                                                                                                           |
+| -------------------------------------- | ------------------------------------------------- | ------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| name                                   | string                                            | none    | maybe    | Required if there is more than one project with the same `dir` and `workspace`. This project name can be used with the `-p` flag.                                                                                     |
+| dir                                    | string                                            | none    | yes      | The directory of this project relative to the repo root. Use `.` for the root. For example if the project was under `./project1` then use `project1`                                                                  |
+| workspace                              | string                                            | default | no       | The [Terraform workspace](https://www.terraform.io/docs/state/workspaces.html) for this project. Atlantis will switch to this workplace when planning/applying and will create it if it doesn't exist.                |
+| autoplan                               | [Autoplan](atlantis-yaml-reference.html#autoplan) | none    | no       | A custom autoplan configuration. If not specified, will use the default algorithm. See [Autoplanning](autoplanning.html).                                                                                             |
+| terraform_version                      | string                                            | none    | no       | A specific Terraform version to use when running commands for this project. Requires there to be a binary in the Atlantis `PATH` with the name `terraform{VERSION}`, ex. `terraform0.11.0`                            |
+| apply_requirements<br />*(restricted)* | array[string]                                     | []      | no       | Requirements that must be satisfied before `atlantis apply` can be run. Currently the only supported requirements are `approved` and `mergeable`. See [Apply Requirements](apply-requirements.html) for more details. |
+| workflow <br />*(restricted)*          | string                                            | none    | no       | A custom workflow. If not specified, Atlantis will use its default workflow.                                                                                                                                          |
 
 ::: tip
 A project represents a Terraform state. Typically, there is one state per directory and workspace however it's possible to
@@ -112,7 +115,7 @@ enabled: true
 when_modified: ["*.tf"]
 ```
 | Key           | Type          | Default | Required | Description                                                                                                                                                                                                                                                                                                              |
-| ------------- | ------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| ------------- | ------------- | ------- | -------- |  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | enabled       | boolean       | true    | no       | Whether autoplanning is enabled for this project.                                                                                                                                                                                                                                                                        |
 | when_modified | array[string] | no      | no       | Uses [.dockerignore](https://docs.docker.com/engine/reference/builder/#dockerignore-file) syntax. If any modified file in the pull request matches, this project will be planned. If not specified, Atlantis will use its own algorithm. See [Autoplanning](autoplanning.html). Paths are relative to the project's dir. |
 
@@ -122,8 +125,8 @@ plan:
 apply:
 ```
 
-| Key   | Type                                        | Default               | Required | Description                    |
-| ----- | ------------------------------------------- | --------------------- | -------- | ------------------------------ |
+| Key   | Type                                        | Default               | Required |  Description                    |
+| ----- | ------------------------------------------- | --------------------- | -------- |  ------------------------------ |
 | plan  | [Stage](atlantis-yaml-reference.html#stage) | `steps: [init, plan]` | no       | How to plan for this project.  |
 | apply | [Stage](atlantis-yaml-reference.html#stage) | `steps: [apply]`      | no       | How to apply for this project. |
 

--- a/runatlantis.io/docs/customizing-atlantis.md
+++ b/runatlantis.io/docs/customizing-atlantis.md
@@ -1,7 +1,8 @@
 # Customizing Atlantis
 
-How Atlantis exactly operates for each repo can be customized via an
-`atlantis.yaml` file placed at the root of each repo.
+How Atlantis exactly operates for each repo can be customized by using a `repos.yaml` file when starting the Atlantis
+server and via an `atlantis.yaml` file placed at the root of each repo.
 
 * Read about the possible [use cases](/guide/atlantis-yaml-use-cases.html)
 * Check out the [atlantis.yaml reference](atlantis-yaml-reference.html)
+* Check out the [repos.yaml reference](repos-yaml-reference.html)

--- a/runatlantis.io/docs/repos-yaml-reference.md
+++ b/runatlantis.io/docs/repos-yaml-reference.md
@@ -1,0 +1,126 @@
+# repos.yaml Reference
+[[toc]]
+
+::: tip Do I need a repos.yaml file?
+A `repos.yaml` file is only required if you wish to customize some aspect of Atlantis.
+You can provide even more customizations by combining a server side `repos.yaml` file with an
+`atlantis.yaml` file in a repository.  See the [atlantis.yaml reference](atlantis-yaml-reference.html) for
+more information on additional customizations.
+:::
+
+## Enabling repos.yaml
+The atlantis server must be running with the `--allow-restricted-repo-config` option to allow Atlantis to use
+`repos.yaml` and `atlantis.yaml` files.  The location of the `repos.yaml` file on the Atlantis server must be provided
+to the `--repos-config` option.
+
+## Overview
+The `repos.yaml` file lets you provide customized settings to be applied globally to repositories that match a 
+regular expression or an exact string.  An `atlantis.yaml` file allows you to provide more fine grained configuration
+about how atlantis should act on a specific repository.
+
+Some of the settings in `repos.yaml` are sensitive in nature, and would allow users to run arbitrary code on the
+Atlantis server if they were allowed in the `atlantis.yaml` file.  These settings are restricted to the `repos.yaml`
+file by default, but the `repos.yaml` file can allow them to be set in an `atlantis.yaml` file.
+
+The `repos.yaml` file allows a list of repos to be defined, using either a regex or exact string to match a repository
+path.  If a repository matches multiple entries, the settings from the last entry in the list take precedence.
+
+## Example Using All Keys
+```yaml
+repos:
+- id: /.*/
+  apply_requirements: [approved, mergeable]
+  workflow: repoworkflow
+  allowed_overrides: [apply_requirements, workflow]
+  allow_custom_workflows: true
+ 
+workflows:
+  repoworkflow:
+    plan:
+      steps:
+        - run: my-custom-command arg1 arg2
+        - init
+        - plan:
+            extra_args: ["-lock", "false"]
+        - run: my-custom-command arg1 arg2
+    apply:
+      steps:
+        - run: echo hi
+        - apply
+```
+
+## Reference
+
+
+### Top-Level Keys
+| Key       | Type                                          | Default | Required | Description                       |
+| --------- | --------------------------------------------- | ------- | -------- | --------------------------------- |
+| repos     | array[[Repo](repos-yaml-reference.html#repo)] |[]       | no       | List of repos to apply settings to|
+| workflows | map[string -> [Workflow](repos-yaml-reference.html#workflow)]
+
+### Repo
+| Key                | Type     | Default | Required | Description                                                                                                                                                                                                           |
+| ------------------ | -------- | ------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| id                 | string   | none    | yes      | Value can be a regular expersion when specified as /&lt;regex&gt;/ or an exact string match                                                                                                                           |
+| workflow           | string   | none    | no       | A custom workflow.  If not specified, Atlantis will use its default workflow                                                                                                                                          |
+| apply_requirements | []string | none    | no       | Requirements that must be satisfied before `atlantis apply` can be run. Currently the only supported requirements are `approved` and `mergeable`. See [Apply Requirements](apply-requirements.html) for more details. |
+| allowed_overrides  | []string | none    | no       | A list of restricted keys to allow the `atlantis.yaml` file to override settings from the `repos.yaml` file.  <br /><br />Restricted Keys Include:<br /><ul><li>apply_requirements</li><li>workflow</li></ul>         |
+
+### Workflow
+```yaml
+plan:
+apply:
+```
+
+| Key   | Type                                        | Default               | Required |  Description                    |
+| ----- | ------------------------------------------- | --------------------- | -------- |  ------------------------------ |
+| plan  | [Stage](atlantis-yaml-reference.html#stage) | `steps: [init, plan]` | no       | How to plan for this project.  |
+| apply | [Stage](atlantis-yaml-reference.html#stage) | `steps: [apply]`      | no       | How to apply for this project. |
+
+### Stage
+```yaml
+steps:
+- run: custom-command
+- init
+- plan:
+    extra_args: [-lock=false]
+```
+
+| Key   | Type                                             | Default | Required | Description                                                                                   |
+| ----- | ------------------------------------------------ | ------- | -------- | --------------------------------------------------------------------------------------------- |
+| steps | array[[Step](atlantis-yaml-reference.html#step)] | `[]`    | no       | List of steps for this stage. If the steps key is empty, no steps will be run for this stage. |
+
+### Step
+#### Built-In Commands: init, plan, apply
+Steps can be a single string for a built-in command.
+```yaml
+- init
+- plan
+- apply
+```
+| Key             | Type   | Default | Required | Description                                                                                            |
+| --------------- | ------ | ------- | -------- | ------------------------------------------------------------------------------------------------------ |
+| init/plan/apply | string | none    | no       | Use a built-in command without additional configuration. Only `init`, `plan` and `apply` are supported |
+
+#### Built-In Command With Extra Args
+A map from string to `extra_args` for a built-in command with extra arguments.
+```yaml
+- init:
+    extra_args: [arg1, arg2]
+- plan:
+    extra_args: [arg1, arg2]
+- apply:
+    extra_args: [arg1, arg2]
+```
+| Key             | Type                               | Default | Required | Description                                                                                                                                         |
+| --------------- | ---------------------------------- | ------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| init/plan/apply | map[`extra_args` -> array[string]] | none    | no       | Use a built-in command and append `extra_args`. Only `init`, `plan` and `apply` are supported as keys and only `extra_args` is supported as a value |
+#### Custom `run` Command
+Or a custom command
+```yaml
+- run: custom-command
+```
+| Key | Type   | Default | Required | Description          |
+| --- | ------ | ------- | -------- | -------------------- |
+| run | string | none    | no       | Run a custom command |
+

--- a/server/events/event_parser_test.go
+++ b/server/events/event_parser_test.go
@@ -46,6 +46,7 @@ func TestParseGithubRepo(t *testing.T) {
 	Equals(t, models.Repo{
 		Owner:             "owner",
 		FullName:          "owner/repo",
+		FullNameWithHost:  "github.com/owner/repo",
 		CloneURL:          "https://github-user:github-token@github.com/owner/repo.git",
 		SanitizedCloneURL: Repo.GetCloneURL(),
 		Name:              "repo",
@@ -95,6 +96,7 @@ func TestParseGithubIssueCommentEvent(t *testing.T) {
 	Equals(t, models.Repo{
 		Owner:             *comment.Repo.Owner.Login,
 		FullName:          *comment.Repo.FullName,
+		FullNameWithHost:  "github.com/owner/repo",
 		CloneURL:          "https://github-user:github-token@github.com/owner/repo.git",
 		SanitizedCloneURL: *comment.Repo.CloneURL,
 		Name:              "repo",
@@ -133,6 +135,7 @@ func TestParseGithubPullEvent(t *testing.T) {
 	expBaseRepo := models.Repo{
 		Owner:             "owner",
 		FullName:          "owner/repo",
+		FullNameWithHost:  "github.com/owner/repo",
 		CloneURL:          "https://github-user:github-token@github.com/owner/repo.git",
 		SanitizedCloneURL: Repo.GetCloneURL(),
 		Name:              "repo",
@@ -251,6 +254,7 @@ func TestParseGithubPull(t *testing.T) {
 	expBaseRepo := models.Repo{
 		Owner:             "owner",
 		FullName:          "owner/repo",
+		FullNameWithHost:  "github.com/owner/repo",
 		CloneURL:          "https://github-user:github-token@github.com/owner/repo.git",
 		SanitizedCloneURL: Repo.GetCloneURL(),
 		Name:              "repo",
@@ -286,6 +290,7 @@ func TestParseGitlabMergeEvent(t *testing.T) {
 
 	expBaseRepo := models.Repo{
 		FullName:          "lkysow/atlantis-example",
+		FullNameWithHost:  "gitlab.com/lkysow/atlantis-example",
 		Name:              "atlantis-example",
 		SanitizedCloneURL: "https://gitlab.com/lkysow/atlantis-example.git",
 		Owner:             "lkysow",
@@ -311,6 +316,7 @@ func TestParseGitlabMergeEvent(t *testing.T) {
 	Equals(t, expBaseRepo, actBaseRepo)
 	Equals(t, models.Repo{
 		FullName:          "sourceorg/atlantis-example",
+		FullNameWithHost:  "gitlab.com/sourceorg/atlantis-example",
 		Name:              "atlantis-example",
 		SanitizedCloneURL: "https://gitlab.com/sourceorg/atlantis-example.git",
 		Owner:             "sourceorg",
@@ -343,6 +349,7 @@ func TestParseGitlabMergeEvent_Subgroup(t *testing.T) {
 
 	expBaseRepo := models.Repo{
 		FullName:          "lkysow-test/subgroup/sub-subgroup/atlantis-example",
+		FullNameWithHost:  "gitlab.com/lkysow-test/subgroup/sub-subgroup/atlantis-example",
 		Name:              "atlantis-example",
 		SanitizedCloneURL: "https://gitlab.com/lkysow-test/subgroup/sub-subgroup/atlantis-example.git",
 		Owner:             "lkysow-test/subgroup/sub-subgroup",
@@ -368,6 +375,7 @@ func TestParseGitlabMergeEvent_Subgroup(t *testing.T) {
 	Equals(t, expBaseRepo, actBaseRepo)
 	Equals(t, models.Repo{
 		FullName:          "lkysow-test/subgroup/sub-subgroup/atlantis-example",
+		FullNameWithHost:  "gitlab.com/lkysow-test/subgroup/sub-subgroup/atlantis-example",
 		Name:              "atlantis-example",
 		SanitizedCloneURL: "https://gitlab.com/lkysow-test/subgroup/sub-subgroup/atlantis-example.git",
 		Owner:             "lkysow-test/subgroup/sub-subgroup",
@@ -439,6 +447,7 @@ func TestParseGitlabMergeRequest(t *testing.T) {
 	Ok(t, err)
 	repo := models.Repo{
 		FullName:          "gitlabhq/gitlab-test",
+		FullNameWithHost:  "example.com/gitlabhq/gitlab-test",
 		Name:              "gitlab-test",
 		SanitizedCloneURL: "https://example.com/gitlabhq/gitlab-test.git",
 		Owner:             "gitlabhq",
@@ -478,6 +487,7 @@ func TestParseGitlabMergeRequest_Subgroup(t *testing.T) {
 
 	repo := models.Repo{
 		FullName:          "lkysow-test/subgroup/sub-subgroup/atlantis-example",
+		FullNameWithHost:  "gitlab.com/lkysow-test/subgroup/sub-subgroup/atlantis-example",
 		Name:              "atlantis-example",
 		SanitizedCloneURL: "https://gitlab.com/lkysow-test/subgroup/sub-subgroup/atlantis-example.git",
 		Owner:             "lkysow-test/subgroup/sub-subgroup",
@@ -512,6 +522,7 @@ func TestParseGitlabMergeCommentEvent(t *testing.T) {
 	Ok(t, err)
 	Equals(t, models.Repo{
 		FullName:          "gitlabhq/gitlab-test",
+		FullNameWithHost:  "example.com/gitlabhq/gitlab-test",
 		Name:              "gitlab-test",
 		SanitizedCloneURL: "https://example.com/gitlabhq/gitlab-test.git",
 		Owner:             "gitlabhq",
@@ -523,6 +534,7 @@ func TestParseGitlabMergeCommentEvent(t *testing.T) {
 	}, baseRepo)
 	Equals(t, models.Repo{
 		FullName:          "gitlab-org/gitlab-test",
+		FullNameWithHost:  "example.com/gitlab-org/gitlab-test",
 		Name:              "gitlab-test",
 		SanitizedCloneURL: "https://example.com/gitlab-org/gitlab-test.git",
 		Owner:             "gitlab-org",
@@ -550,6 +562,7 @@ func TestParseGitlabMergeCommentEvent_Subgroup(t *testing.T) {
 
 	Equals(t, models.Repo{
 		FullName:          "lkysow-test/subgroup/sub-subgroup/atlantis-example",
+		FullNameWithHost:  "gitlab.com/lkysow-test/subgroup/sub-subgroup/atlantis-example",
 		Name:              "atlantis-example",
 		SanitizedCloneURL: "https://gitlab.com/lkysow-test/subgroup/sub-subgroup/atlantis-example.git",
 		Owner:             "lkysow-test/subgroup/sub-subgroup",
@@ -561,6 +574,7 @@ func TestParseGitlabMergeCommentEvent_Subgroup(t *testing.T) {
 	}, baseRepo)
 	Equals(t, models.Repo{
 		FullName:          "lkysow-test/subgroup/sub-subgroup/atlantis-example",
+		FullNameWithHost:  "gitlab.com/lkysow-test/subgroup/sub-subgroup/atlantis-example",
 		Name:              "atlantis-example",
 		SanitizedCloneURL: "https://gitlab.com/lkysow-test/subgroup/sub-subgroup/atlantis-example.git",
 		Owner:             "lkysow-test/subgroup/sub-subgroup",
@@ -704,6 +718,7 @@ func TestParseBitbucketCloudCommentEvent_ValidEvent(t *testing.T) {
 	Ok(t, err)
 	expBaseRepo := models.Repo{
 		FullName:          "lkysow/atlantis-example",
+		FullNameWithHost:  "bitbucket.org/lkysow/atlantis-example",
 		Owner:             "lkysow",
 		Name:              "atlantis-example",
 		CloneURL:          "https://bitbucket-user:bitbucket-token@bitbucket.org/lkysow/atlantis-example.git",
@@ -726,6 +741,7 @@ func TestParseBitbucketCloudCommentEvent_ValidEvent(t *testing.T) {
 	}, pull)
 	Equals(t, models.Repo{
 		FullName:          "lkysow-fork/atlantis-example",
+		FullNameWithHost:  "bitbucket.org/lkysow-fork/atlantis-example",
 		Owner:             "lkysow-fork",
 		Name:              "atlantis-example",
 		CloneURL:          "https://bitbucket-user:bitbucket-token@bitbucket.org/lkysow-fork/atlantis-example.git",
@@ -790,6 +806,7 @@ func TestParseBitbucketCloudPullEvent_ValidEvent(t *testing.T) {
 	Ok(t, err)
 	expBaseRepo := models.Repo{
 		FullName:          "lkysow/atlantis-example",
+		FullNameWithHost:  "bitbucket.org/lkysow/atlantis-example",
 		Owner:             "lkysow",
 		Name:              "atlantis-example",
 		CloneURL:          "https://bitbucket-user:bitbucket-token@bitbucket.org/lkysow/atlantis-example.git",
@@ -812,6 +829,7 @@ func TestParseBitbucketCloudPullEvent_ValidEvent(t *testing.T) {
 	}, pull)
 	Equals(t, models.Repo{
 		FullName:          "lkysow-fork/atlantis-example",
+		FullNameWithHost:  "bitbucket.org/lkysow-fork/atlantis-example",
 		Owner:             "lkysow-fork",
 		Name:              "atlantis-example",
 		CloneURL:          "https://bitbucket-user:bitbucket-token@bitbucket.org/lkysow-fork/atlantis-example.git",
@@ -891,6 +909,7 @@ func TestParseBitbucketServerCommentEvent_ValidEvent(t *testing.T) {
 	Ok(t, err)
 	expBaseRepo := models.Repo{
 		FullName:          "atlantis/atlantis-example",
+		FullNameWithHost:  "mycorp.com:7490/atlantis/atlantis-example",
 		Owner:             "atlantis",
 		Name:              "atlantis-example",
 		CloneURL:          "http://bitbucket-user:bitbucket-token@mycorp.com:7490/scm/at/atlantis-example.git",
@@ -913,6 +932,7 @@ func TestParseBitbucketServerCommentEvent_ValidEvent(t *testing.T) {
 	}, pull)
 	Equals(t, models.Repo{
 		FullName:          "atlantis-fork/atlantis-example",
+		FullNameWithHost:  "mycorp.com:7490/atlantis-fork/atlantis-example",
 		Owner:             "atlantis-fork",
 		Name:              "atlantis-example",
 		CloneURL:          "http://bitbucket-user:bitbucket-token@mycorp.com:7490/scm/fk/atlantis-example.git",
@@ -973,6 +993,7 @@ func TestParseBitbucketServerPullEvent_ValidEvent(t *testing.T) {
 	Ok(t, err)
 	expBaseRepo := models.Repo{
 		FullName:          "atlantis/atlantis-example",
+		FullNameWithHost:  "mycorp.com:7490/atlantis/atlantis-example",
 		Owner:             "atlantis",
 		Name:              "atlantis-example",
 		CloneURL:          "http://bitbucket-user:bitbucket-token@mycorp.com:7490/scm/at/atlantis-example.git",
@@ -995,6 +1016,7 @@ func TestParseBitbucketServerPullEvent_ValidEvent(t *testing.T) {
 	}, pull)
 	Equals(t, models.Repo{
 		FullName:          "atlantis-fork/atlantis-example",
+		FullNameWithHost:  "mycorp.com:7490/atlantis-fork/atlantis-example",
 		Owner:             "atlantis-fork",
 		Name:              "atlantis-example",
 		CloneURL:          "http://bitbucket-user:bitbucket-token@mycorp.com:7490/scm/fk/atlantis-example.git",

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -35,6 +35,9 @@ type Repo struct {
 	// FullName is the owner and repo name separated
 	// by a "/", ex. "runatlantis/atlantis", "gitlab/subgroup/atlantis", "Bitbucket Server/atlantis".
 	FullName string
+	// FullNameWithHost
+	// This is the full name of the repo including the hostname. ex github.com/runatlantis/atlantis
+	FullNameWithHost string
 	// Owner is just the repo owner, ex. "runatlantis" or "gitlab/subgroup".
 	// This may contain /'s in the case of GitLab subgroups.
 	// This may contain spaces in the case of Bitbucket Server.
@@ -72,6 +75,12 @@ func NewRepo(vcsHostType VCSHostType, repoFullName string, cloneURL string, vcsU
 	if err != nil {
 		return Repo{}, errors.Wrap(err, "invalid clone url")
 	}
+
+	repoHostname := cloneURLParsed.Hostname()
+	if cloneURLParsed.Port() != "" {
+		repoHostname = fmt.Sprintf("%s:%s", repoHostname, cloneURLParsed.Port())
+	}
+	repoFullNameWithHost := fmt.Sprintf("%s/%s", repoHostname, repoFullName)
 
 	// Ensure the Clone URL is for the same repo to avoid something malicious.
 	// We skip this check for Bitbucket Server because its format is different
@@ -111,6 +120,7 @@ func NewRepo(vcsHostType VCSHostType, repoFullName string, cloneURL string, vcsU
 
 	return Repo{
 		FullName:          repoFullName,
+		FullNameWithHost:  repoFullNameWithHost,
 		Owner:             owner,
 		Name:              repo,
 		CloneURL:          authedCloneURL,

--- a/server/events/models/models_test.go
+++ b/server/events/models/models_test.go
@@ -49,6 +49,7 @@ func TestNewRepo_CloneURLBitbucketServer(t *testing.T) {
 	Ok(t, err)
 	Equals(t, models.Repo{
 		FullName:          "owner/repo",
+		FullNameWithHost:  "mycorp.com:7990/owner/repo",
 		Owner:             "owner",
 		Name:              "repo",
 		CloneURL:          "http://u:p@mycorp.com:7990/scm/at/atlantis-example.git",
@@ -119,6 +120,7 @@ func TestNewRepo_HTTPAuth(t *testing.T) {
 		SanitizedCloneURL: "http://github.com/owner/repo.git",
 		CloneURL:          "http://u:p@github.com/owner/repo.git",
 		FullName:          "owner/repo",
+		FullNameWithHost:  "github.com/owner/repo",
 		Owner:             "owner",
 		Name:              "repo",
 	}, repo)
@@ -136,6 +138,7 @@ func TestNewRepo_HTTPSAuth(t *testing.T) {
 		SanitizedCloneURL: "https://github.com/owner/repo.git",
 		CloneURL:          "https://u:p@github.com/owner/repo.git",
 		FullName:          "owner/repo",
+		FullNameWithHost:  "github.com/owner/repo",
 		Owner:             "owner",
 		Name:              "repo",
 	}, repo)

--- a/server/events/yaml/parser_validator_test.go
+++ b/server/events/yaml/parser_validator_test.go
@@ -1,6 +1,8 @@
 package yaml_test
 
 import (
+	"fmt"
+	"github.com/runatlantis/atlantis/server/events/yaml/raw"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -14,7 +16,7 @@ import (
 
 func TestReadConfig_DirDoesNotExist(t *testing.T) {
 	r := yaml.ParserValidator{}
-	_, err := r.ReadConfig("/not/exist")
+	_, err := r.ReadConfig("/not/exist", raw.RepoConfig{}, "", false)
 	Assert(t, os.IsNotExist(err), "exp nil ptr")
 
 	exists, err := r.HasConfigFile("/not/exist")
@@ -27,7 +29,7 @@ func TestReadConfig_FileDoesNotExist(t *testing.T) {
 	defer cleanup()
 
 	r := yaml.ParserValidator{}
-	_, err := r.ReadConfig(tmpDir)
+	_, err := r.ReadConfig(tmpDir, raw.RepoConfig{}, "", false)
 	Assert(t, os.IsNotExist(err), "exp nil ptr")
 
 	exists, err := r.HasConfigFile(tmpDir)
@@ -42,7 +44,7 @@ func TestReadConfig_BadPermissions(t *testing.T) {
 	Ok(t, err)
 
 	r := yaml.ParserValidator{}
-	_, err = r.ReadConfig(tmpDir)
+	_, err = r.ReadConfig(tmpDir, raw.RepoConfig{}, "", false)
 	ErrContains(t, "unable to read atlantis.yaml file: ", err)
 }
 
@@ -74,14 +76,13 @@ func TestReadConfig_UnmarshalErrors(t *testing.T) {
 			err := ioutil.WriteFile(filepath.Join(tmpDir, "atlantis.yaml"), []byte(c.input), 0600)
 			Ok(t, err)
 			r := yaml.ParserValidator{}
-			_, err = r.ReadConfig(tmpDir)
+			_, err = r.ReadConfig(tmpDir, raw.RepoConfig{}, "", false)
 			ErrEquals(t, c.expErr, err)
 		})
 	}
 }
 
-func TestReadConfig(t *testing.T) {
-	tfVersion, _ := version.NewVersion("v0.11.0")
+func TestReadConfig_CommonKeys(t *testing.T) {
 	cases := []struct {
 		description string
 		input       string
@@ -160,6 +161,143 @@ projects:
 				Workflows: map[string]valid.Workflow{},
 			},
 		},
+		{
+			description: "project dir with ..",
+			input: `
+version: 2
+projects:
+- dir: ..`,
+			expErr: "projects: (0: (dir: cannot contain '..'.).).",
+		},
+
+		// Project must have dir set.
+		{
+			description: "project with no config",
+			input: `
+version: 2
+projects:
+-`,
+			expErr: "projects: (0: (dir: cannot be blank.).).",
+		},
+		{
+			description: "project with no config at index 1",
+			input: `
+version: 2
+projects:
+- dir: "."
+-`,
+			expErr: "projects: (1: (dir: cannot be blank.).).",
+		},
+		{
+			description: "project with unknown key",
+			input: `
+version: 2
+projects:
+- unknown: value`,
+			expErr: "yaml: unmarshal errors:\n  line 4: field unknown not found in struct raw.Project",
+		},
+		{
+			description: "two projects with same dir/workspace without names",
+			input: `
+version: 2
+projects:
+- dir: .
+  workspace: workspace
+- dir: .
+  workspace: workspace`,
+			expErr: "there are two or more projects with dir: \".\" workspace: \"workspace\" that are not all named; they must have a 'name' key so they can be targeted for apply's separately",
+		},
+		{
+			description: "two projects with same dir/workspace only one with name",
+			input: `
+version: 2
+projects:
+- name: myname
+  dir: .
+  workspace: workspace
+- dir: .
+  workspace: workspace`,
+			expErr: "there are two or more projects with dir: \".\" workspace: \"workspace\" that are not all named; they must have a 'name' key so they can be targeted for apply's separately",
+		},
+		{
+			description: "two projects with same dir/workspace both with same name",
+			input: `
+version: 2
+projects:
+- name: myname
+  dir: .
+  workspace: workspace
+- name: myname
+  dir: .
+  workspace: workspace`,
+			expErr: "found two or more projects with name \"myname\"; project names must be unique",
+		},
+		{
+			description: "two projects with same dir/workspace with different names",
+			input: `
+version: 2
+projects:
+- name: myname
+  dir: .
+  workspace: workspace
+- name: myname2
+  dir: .
+  workspace: workspace`,
+			exp: valid.Config{
+				Version: 2,
+				Projects: []valid.Project{
+					{
+						Name:      String("myname"),
+						Dir:       ".",
+						Workspace: "workspace",
+						Autoplan: valid.Autoplan{
+							WhenModified: []string{"**/*.tf*"},
+							Enabled:      true,
+						},
+					},
+					{
+						Name:      String("myname2"),
+						Dir:       ".",
+						Workspace: "workspace",
+						Autoplan: valid.Autoplan{
+							WhenModified: []string{"**/*.tf*"},
+							Enabled:      true,
+						},
+					},
+				},
+				Workflows: map[string]valid.Workflow{},
+			},
+		},
+	}
+
+	tmpDir, cleanup := TempDir(t)
+	defer cleanup()
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			err := ioutil.WriteFile(filepath.Join(tmpDir, "atlantis.yaml"), []byte(c.input), 0600)
+			Ok(t, err)
+
+			r := yaml.ParserValidator{}
+			act, err := r.ReadConfig(tmpDir, raw.RepoConfig{}, "", false)
+			if c.expErr != "" {
+				ErrEquals(t, "parsing atlantis.yaml: "+c.expErr, err)
+				return
+			}
+			Ok(t, err)
+			Equals(t, c.exp, act)
+		})
+	}
+}
+
+func TestReadConfig_AllowRepoConfig(t *testing.T) {
+	tfVersion, _ := version.NewVersion("v0.11.0")
+	cases := []struct {
+		description string
+		input       string
+		expErr      string
+		exp         valid.Config
+	}{
 		{
 			description: "project fields set except autoplan",
 			input: `
@@ -295,41 +433,6 @@ workflows:
 			},
 		},
 		{
-			description: "project dir with ..",
-			input: `
-version: 2
-projects:
-- dir: ..`,
-			expErr: "projects: (0: (dir: cannot contain '..'.).).",
-		},
-
-		// Project must have dir set.
-		{
-			description: "project with no config",
-			input: `
-version: 2
-projects:
--`,
-			expErr: "projects: (0: (dir: cannot be blank.).).",
-		},
-		{
-			description: "project with no config at index 1",
-			input: `
-version: 2
-projects:
-- dir: "."
--`,
-			expErr: "projects: (1: (dir: cannot be blank.).).",
-		},
-		{
-			description: "project with unknown key",
-			input: `
-version: 2
-projects:
-- unknown: value`,
-			expErr: "yaml: unmarshal errors:\n  line 4: field unknown not found in struct raw.Project",
-		},
-		{
 			description: "referencing workflow that doesn't exist",
 			input: `
 version: 2
@@ -337,78 +440,6 @@ projects:
 - dir: .
   workflow: undefined`,
 			expErr: "workflow \"undefined\" is not defined",
-		},
-		{
-			description: "two projects with same dir/workspace without names",
-			input: `
-version: 2
-projects:
-- dir: .
-  workspace: workspace
-- dir: .
-  workspace: workspace`,
-			expErr: "there are two or more projects with dir: \".\" workspace: \"workspace\" that are not all named; they must have a 'name' key so they can be targeted for apply's separately",
-		},
-		{
-			description: "two projects with same dir/workspace only one with name",
-			input: `
-version: 2
-projects:
-- name: myname
-  dir: .
-  workspace: workspace
-- dir: .
-  workspace: workspace`,
-			expErr: "there are two or more projects with dir: \".\" workspace: \"workspace\" that are not all named; they must have a 'name' key so they can be targeted for apply's separately",
-		},
-		{
-			description: "two projects with same dir/workspace both with same name",
-			input: `
-version: 2
-projects:
-- name: myname
-  dir: .
-  workspace: workspace
-- name: myname
-  dir: .
-  workspace: workspace`,
-			expErr: "found two or more projects with name \"myname\"; project names must be unique",
-		},
-		{
-			description: "two projects with same dir/workspace with different names",
-			input: `
-version: 2
-projects:
-- name: myname
-  dir: .
-  workspace: workspace
-- name: myname2
-  dir: .
-  workspace: workspace`,
-			exp: valid.Config{
-				Version: 2,
-				Projects: []valid.Project{
-					{
-						Name:      String("myname"),
-						Dir:       ".",
-						Workspace: "workspace",
-						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*"},
-							Enabled:      true,
-						},
-					},
-					{
-						Name:      String("myname2"),
-						Dir:       ".",
-						Workspace: "workspace",
-						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*"},
-							Enabled:      true,
-						},
-					},
-				},
-				Workflows: map[string]valid.Workflow{},
-			},
 		},
 	}
 
@@ -421,7 +452,7 @@ projects:
 			Ok(t, err)
 
 			r := yaml.ParserValidator{}
-			act, err := r.ReadConfig(tmpDir)
+			act, err := r.ReadConfig(tmpDir, raw.RepoConfig{}, "", true)
 			if c.expErr != "" {
 				ErrEquals(t, "parsing atlantis.yaml: "+c.expErr, err)
 				return
@@ -430,9 +461,9 @@ projects:
 			Equals(t, c.exp, act)
 		})
 	}
-}
 
-func TestReadConfig_Successes(t *testing.T) {
+}
+func TestReadConfig_Successes_AllowRepoConfig(t *testing.T) {
 	basicProjects := []valid.Project{
 		{
 			Autoplan: valid.Autoplan{
@@ -685,9 +716,338 @@ workflows:
 			Ok(t, err)
 
 			r := yaml.ParserValidator{}
-			act, err := r.ReadConfig(tmpDir)
+			act, err := r.ReadConfig(tmpDir, raw.RepoConfig{}, "", true)
 			Ok(t, err)
 			Equals(t, c.expOutput, act)
+		})
+	}
+}
+
+func TestReadConfig_ServerSideRepoConfig(t *testing.T) {
+	cases := []struct {
+		description  string
+		atlantisYaml string
+		repoYaml     string
+		repoName     string
+		expErr       string
+		exp          valid.Config
+	}{
+		{
+			description: "atlantis config with workflow denied by repo config",
+			repoName:    "anything",
+			atlantisYaml: `
+version: 2
+projects:
+- dir: .
+  workflow: projworkflow
+`,
+			repoYaml: `
+repos:
+- id: /.*/
+`,
+			expErr: `"workflow" cannot be specified in "atlantis.yaml" by default.  To enable this, add "workflow" to "allowed_overrides" in the server side repo config`,
+		},
+		{
+			description: "atlantis config with custom workflows denied by repo config",
+			repoName:    "anything",
+			atlantisYaml: `
+version: 2
+projects:
+- dir: .
+  workflow: projworkflow
+workflows: 
+  projworkflow: ~
+`,
+			repoYaml: `
+repos:
+- id: /.*/
+  allowed_overrides: ["workflow"]
+`,
+			expErr: `"workflows" cannot be specified in "atlantis.yaml" by default.  To enable this, set "workflows" to true in the server side repo config`,
+		},
+		{
+			description: "atlantis config with workflow override allowed by repo config",
+			repoName:    "thisproject",
+			atlantisYaml: `
+version: 2
+projects:
+- dir: .
+  workflow: workflow2
+`,
+			repoYaml: `
+repos:
+- id: /.*/
+  workflow: workflow1
+  allowed_overrides: ["workflow"]
+workflows:
+  workflow1: ~
+  workflow2: ~
+`,
+			exp: valid.Config{
+				Version: 2,
+				Projects: []valid.Project{
+					{
+						Dir:       ".",
+						Workspace: "default",
+						Workflow:  String("workflow2"),
+						Autoplan: valid.Autoplan{
+							WhenModified: []string{"**/*.tf*"},
+							Enabled:      true,
+						},
+					},
+				},
+				Workflows: map[string]valid.Workflow{
+					"workflow1": {},
+					"workflow2": {},
+				},
+			},
+		},
+		{
+			description: "atlantis config with no workflow, using workflow from repo config",
+			repoName:    "thisproject",
+			atlantisYaml: `
+version: 2
+projects:
+- dir: .
+`,
+			repoYaml: `
+repos:
+- id: /.*/
+  workflow: workflow1
+  allowed_overrides: ["workflow"]
+workflows:
+  workflow1: ~
+  workflow2: ~
+`,
+			exp: valid.Config{
+				Version: 2,
+				Projects: []valid.Project{
+					{
+						Dir:       ".",
+						Workspace: "default",
+						Workflow:  String("workflow1"),
+						Autoplan: valid.Autoplan{
+							WhenModified: []string{"**/*.tf*"},
+							Enabled:      true,
+						},
+					},
+				},
+				Workflows: map[string]valid.Workflow{
+					"workflow1": {},
+					"workflow2": {},
+				},
+			},
+		},
+		{
+			description: "atlantis config with apply_requirements denied by repo config",
+			repoName:    "anything",
+			atlantisYaml: `
+version: 2
+projects:
+- dir: .
+  apply_requirements: ["approved"]
+`,
+			repoYaml: `
+repos:
+- id: /.*/
+`,
+			expErr: `"apply_requirements" cannot be specified in "atlantis.yaml" by default.  To enable this, add "apply_requirements" to "allowed_overrides" in the server side repo config`,
+		},
+		{
+			description: "last matching repo should be used",
+			repoName:    "thisproject",
+			atlantisYaml: `
+version: 2
+projects:
+- dir: .
+`,
+			repoYaml: `
+repos:
+- id: /.*/
+  workflow: workflow1
+- id: "thisproject"
+  workflow: workflow2
+workflows:
+  workflow1: ~
+  workflow2: ~
+`,
+			exp: valid.Config{
+				Version: 2,
+				Projects: []valid.Project{
+					{
+						Dir:       ".",
+						Workspace: "default",
+						Workflow:  String("workflow2"),
+						Autoplan: valid.Autoplan{
+							WhenModified: []string{"**/*.tf*"},
+							Enabled:      true,
+						},
+					},
+				},
+				Workflows: map[string]valid.Workflow{
+					"workflow1": {},
+					"workflow2": {},
+				},
+			},
+		},
+		{
+			description: "atlantis config uses a workflow that doesn't exist in atlantis.yaml or repo config",
+			repoName:    "anything",
+			atlantisYaml: `
+version: 2
+projects:
+- dir: .
+  workflow: notexist
+`,
+			repoYaml: `
+repos:
+- id: /.*/
+  allowed_overrides: ["workflow"]
+`,
+			expErr: `workflow "notexist" is not defined`,
+		},
+		{
+			description: "repo config contains invalid regex",
+			repoName:    "anything",
+			atlantisYaml: `
+version: 2
+projects:
+- dir: .
+`,
+			repoYaml: `
+repos:
+- id: /inva\lid.regex/
+`,
+			expErr: "regex compile of repo.ID `/inva\\lid.regex/`: error parsing regexp: invalid escape sequence: `\\l`",
+		},
+	}
+
+	tmpDir, cleanup := TempDir(t)
+	defer cleanup()
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			err := ioutil.WriteFile(filepath.Join(tmpDir, "atlantis.yaml"), []byte(c.atlantisYaml), 0600)
+			Ok(t, err)
+
+			err = ioutil.WriteFile(filepath.Join(tmpDir, "repo.yaml"), []byte(c.repoYaml), 0600)
+			Ok(t, err)
+
+			r := yaml.ParserValidator{}
+			repoConfig, err := r.ReadServerConfig(filepath.Join(tmpDir, "repo.yaml"))
+			Ok(t, err)
+			act, err := r.ReadConfig(tmpDir, repoConfig, c.repoName, false)
+			if c.expErr != "" {
+				ErrEquals(t, "parsing atlantis.yaml: "+c.expErr, err)
+				return
+			}
+			Equals(t, c.exp, act)
+		})
+	}
+
+}
+
+func TestReadServerConfig_DirDoesNotExist(t *testing.T) {
+	r := yaml.ParserValidator{}
+	_, err := r.ReadServerConfig("/not/exist")
+	Assert(t, os.IsNotExist(err), "exp nil ptr")
+}
+
+func TestReadServerConfig_FileDoesNotExist(t *testing.T) {
+	tmpDir, cleanup := TempDir(t)
+	defer cleanup()
+
+	r := yaml.ParserValidator{}
+	_, err := r.ReadServerConfig(tmpDir + "repos.yaml")
+	Assert(t, os.IsNotExist(err), "exp nil ptr")
+}
+
+func TestReadServerConfig_BadPermissions(t *testing.T) {
+	tmpDir, cleanup := TempDir(t)
+	defer cleanup()
+	repoYamlFile := filepath.Join(tmpDir, "repos.yaml")
+	err := ioutil.WriteFile(repoYamlFile, nil, 0000)
+	Ok(t, err)
+
+	r := yaml.ParserValidator{}
+	_, err = r.ReadServerConfig(repoYamlFile)
+	ErrContains(t, "unable to read "+repoYamlFile, err)
+}
+
+func TestServerReadConfig_UnmarshalErrors(t *testing.T) {
+	// We only have a few cases here because we assume the YAML library to be
+	// well tested. See https://github.com/go-yaml/yaml/blob/v2/decode_test.go#L810.
+	cases := []struct {
+		description string
+		input       string
+		expErr      string
+	}{
+		{
+			"random characters",
+			"slkjds",
+			"yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `slkjds` into raw.RepoConfig",
+		},
+		{
+			"just a colon",
+			":",
+			"yaml: did not find expected key",
+		},
+	}
+
+	tmpDir, cleanup := TempDir(t)
+	defer cleanup()
+
+	repoYamlFile := filepath.Join(tmpDir, "repos.yaml")
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			err := ioutil.WriteFile(repoYamlFile, []byte(c.input), 0600)
+			Ok(t, err)
+			r := yaml.ParserValidator{}
+			_, err = r.ReadServerConfig(repoYamlFile)
+			c.expErr = fmt.Sprintf("parsing %s: %s", repoYamlFile, c.expErr)
+			ErrEquals(t, c.expErr, err)
+		})
+	}
+}
+
+func TestReadServerConfigValidation(t *testing.T) {
+	cases := []struct {
+		description string
+		input       string
+		expErr      string
+	}{
+		{
+			"workflow doesn't exist",
+			`
+repos:
+- id: /.*/
+  workflow: notexist
+`,
+			`workflow "notexist" is not defined`,
+		},
+		{
+			description: "invalid override",
+			input: `
+repos:
+- id: /.*/
+  allowed_overrides: ["notvalid"]
+`,
+			expErr: "repos: (0: (allowed_overrides: value must be one of [apply_requirements workflow].).).",
+		},
+	}
+
+	tmpDir, cleanup := TempDir(t)
+	defer cleanup()
+
+	repoYamlFile := filepath.Join(tmpDir, "repos.yaml")
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			err := ioutil.WriteFile(repoYamlFile, []byte(c.input), 0600)
+			Ok(t, err)
+			r := yaml.ParserValidator{}
+			_, err = r.ReadServerConfig(repoYamlFile)
+			c.expErr = fmt.Sprintf("parsing %s: %s", repoYamlFile, c.expErr)
+			ErrEquals(t, c.expErr, err)
 		})
 	}
 }

--- a/server/events/yaml/raw/repo_config.go
+++ b/server/events/yaml/raw/repo_config.go
@@ -1,0 +1,75 @@
+package raw
+
+import (
+	"fmt"
+	"github.com/go-ozzo/ozzo-validation"
+	"regexp"
+	"strings"
+)
+
+const ApplyRequirementsKey string = "apply_requirements"
+const WorkflowKey string = "workflow"
+const CustomWorkflowsKey string = "workflows"
+const AllowedOverridesKey string = "allowed_overrides"
+
+type RepoConfig struct {
+	Repos     []Repo              `yaml:"repos"`
+	Workflows map[string]Workflow `yaml:"workflows"`
+}
+
+type Repo struct {
+	ID                   string   `yaml:"id"`
+	ApplyRequirements    []string `yaml:"apply_requirements"`
+	Workflow             *string  `yaml:"workflow,omitempty"`
+	AllowedOverrides     []string `yaml:"allowed_overrides"`
+	AllowCustomWorkflows bool     `yaml:"allow_custom_workflows"`
+}
+
+func (r RepoConfig) Validate() error {
+	return validation.ValidateStruct(&r,
+		validation.Field(&r.Repos),
+		validation.Field(&r.Workflows))
+}
+
+func (r Repo) Validate() error {
+	return validation.ValidateStruct(&r,
+		validation.Field(&r.ID, validation.Required),
+		validation.Field(&r.AllowedOverrides, validation.By(checkOverrideValues)),
+	)
+}
+
+func checkOverrideValues(values interface{}) error {
+	if allValues, _ := values.([]string); allValues != nil {
+		validOverrides := []string{"apply_requirements", "workflow"}
+		for _, value := range allValues {
+			for _, validStr := range validOverrides {
+				if value == validStr {
+					return nil
+				}
+			}
+		}
+		return fmt.Errorf("value must be one of %v", validOverrides)
+	}
+	return nil
+}
+
+func (r *Repo) IsOverrideAllowed(override string) bool {
+	for _, allowed := range r.AllowedOverrides {
+		if allowed == override {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Repo) Matches(repoName string) (bool, error) {
+	if strings.Index(r.ID, "/") == 0 && strings.LastIndex(r.ID, "/") == len(r.ID)-1 {
+		matchString := strings.Trim(r.ID, "/")
+		compiled, err := regexp.Compile(matchString)
+		if err != nil {
+			return false, fmt.Errorf("regex compile of repo.ID `%s`: %s", r.ID, err)
+		}
+		return compiled.MatchString(repoName), nil
+	}
+	return repoName == r.ID, nil
+}

--- a/server/events_controller_test.go
+++ b/server/events_controller_test.go
@@ -578,6 +578,7 @@ func TestPost_BBServerPullClosed(t *testing.T) {
 
 			expRepo := models.Repo{
 				FullName:          "project/repository",
+				FullNameWithHost:  "bbserver.com/project/repository",
 				Owner:             "project",
 				Name:              "repository",
 				CloneURL:          "https://bb-user:bb-token@bbserver.com/scm/proj/repository.git",

--- a/server/server.go
+++ b/server/server.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/runatlantis/atlantis/server/events/db"
+	"github.com/runatlantis/atlantis/server/events/yaml/raw"
 	"log"
 	"net/http"
 	"net/url"
@@ -193,6 +194,21 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		return nil, errors.Wrapf(err,
 			"parsing --%s flag %q", config.AtlantisURLFlag, userConfig.AtlantisURL)
 	}
+	validator := &yaml.ParserValidator{}
+
+	// This is a default config that will allow safe keys to be used in atlantis.yaml by default
+	// but restrict all sensitive keys.  This is used if the server is started without --repo-config.
+	repoConfig := raw.RepoConfig{
+		Repos: []raw.Repo{{ID: "/.*/"}},
+	}
+
+	if userConfig.RepoConfig != "" {
+		repoConfig, err = validator.ReadServerConfig(userConfig.RepoConfig)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	underlyingRouter := mux.NewRouter()
 	router := &Router{
 		AtlantisURL:               parsedURL,
@@ -235,12 +251,13 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		AllowForkPRs:             userConfig.AllowForkPRs,
 		AllowForkPRsFlag:         config.AllowForkPRsFlag,
 		ProjectCommandBuilder: &events.DefaultProjectCommandBuilder{
-			ParserValidator:     &yaml.ParserValidator{},
+			ParserValidator:     validator,
 			ProjectFinder:       &events.DefaultProjectFinder{},
 			VCSClient:           vcsClient,
 			WorkingDir:          workingDir,
 			WorkingDirLocker:    workingDirLocker,
 			AllowRepoConfig:     userConfig.AllowRepoConfig,
+			RepoConfig:          repoConfig,
 			AllowRepoConfigFlag: config.AllowRepoConfigFlag,
 			PendingPlanFinder:   pendingPlanFinder,
 			CommentBuilder:      commentParser,

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -26,6 +26,7 @@ type UserConfig struct {
 	GitlabWebhookSecret    string `mapstructure:"gitlab-webhook-secret"`
 	LogLevel               string `mapstructure:"log-level"`
 	Port                   int    `mapstructure:"port"`
+	RepoConfig             string `mapstructure:"repo-config"`
 	RepoWhitelist          string `mapstructure:"repo-whitelist"`
 	// RequireApproval is whether to require pull request approval before
 	// allowing terraform apply's to be run.


### PR DESCRIPTION
Added new --allow-restricted-repo-config and --repo-config options

This allows usage of a server side repo config file to restrict certain fields from being used in a repos atlantis.yaml file.

When this feature is activated apply_requirements, workflow, and workflows can only be specified in an atlantis.yaml file if explicitly allowed by the server side repo config.

The repo config file provides the ability to specify a default set of workflows, and default values for apply_requirements and workflow to use use on a per repo basis.  It also supports applying to a collection of repos by using regex to match a repo name.

If more than one repo name matches, the values from last repo matched are used.

Closes #47 