### PR TITLE
Use new 'nickname' field for bitbucket cloud

### DIFF
--- a/server/events/event_parser.go
+++ b/server/events/event_parser.go
@@ -320,12 +320,12 @@ func (e *EventParser) parseCommonBitbucketCloudEventData(event bitbucketcloud.Co
 		URL:        *event.PullRequest.Links.HTML.HREF,
 		HeadBranch: *event.PullRequest.Source.Branch.Name,
 		BaseBranch: *event.PullRequest.Destination.Branch.Name,
-		Author:     *event.Actor.Username,
+		Author:     *event.Actor.Nickname,
 		State:      prState,
 		BaseRepo:   baseRepo,
 	}
 	user = models.User{
-		Username: *event.Actor.Username,
+		Username: *event.Actor.Nickname,
 	}
 	return
 }

--- a/server/events/testdata/bitbucket-cloud-comment-event.json
+++ b/server/events/testdata/bitbucket-cloud-comment-event.json
@@ -235,6 +235,7 @@
   },
   "actor": {
     "username": "lkysow",
+    "nickname": "lkysow",
     "display_name": "Luke",
     "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
     "links": {

--- a/server/events/testdata/bitbucket-cloud-pull-event-fulfilled.json
+++ b/server/events/testdata/bitbucket-cloud-pull-event-fulfilled.json
@@ -183,6 +183,7 @@
   },
   "actor": {
     "username": "lkysow",
+    "nickname": "lkysow",
     "display_name": "Luke",
     "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
     "links": {

--- a/server/events/vcs/bitbucketcloud/models.go
+++ b/server/events/vcs/bitbucketcloud/models.go
@@ -38,7 +38,7 @@ type DiffStatFile struct {
 }
 
 type Actor struct {
-	Username *string `json:"username,omitempty" validate:"required"`
+	Nickname *string `json:"nickname,omitempty" validate:"required"`
 }
 type Repository struct {
 	FullName *string `json:"full_name,omitempty" validate:"required"`


### PR DESCRIPTION
Bitbucket is deprecating the username field.
See: https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-gdpr