### PR TITLE
Support basepath for bitbucket server

### DIFF
--- a/server/events/vcs/bitbucketserver/client.go
+++ b/server/events/vcs/bitbucketserver/client.go
@@ -42,7 +42,6 @@ func NewClient(httpClient *http.Client, username string, password string, baseUR
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	// Remove the trailing '/' from the URL.
 	parsedURL, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, errors.Wrapf(err, "parsing %s", baseURL)
@@ -50,12 +49,11 @@ func NewClient(httpClient *http.Client, username string, password string, baseUR
 	if parsedURL.Scheme == "" {
 		return nil, fmt.Errorf("must have 'http://' or 'https://' in base url %q", baseURL)
 	}
-	urlWithoutPath := fmt.Sprintf("%s://%s", parsedURL.Scheme, parsedURL.Host)
 	return &Client{
 		HTTPClient:  httpClient,
 		Username:    username,
 		Password:    password,
-		BaseURL:     urlWithoutPath,
+		BaseURL:     strings.TrimRight(parsedURL.String(), "/"),
 		AtlantisURL: atlantisURL,
 	}, nil
 }

--- a/server/events/vcs/bitbucketserver/client_test.go
+++ b/server/events/vcs/bitbucketserver/client_test.go
@@ -14,6 +14,60 @@ import (
 	. "github.com/runatlantis/atlantis/testing"
 )
 
+// Test that we include the base path in our base url.
+func TestClient_BasePath(t *testing.T) {
+	cases := []struct {
+		inputURL string
+		expURL   string
+		expErr   string
+	}{
+		{
+			inputURL: "mycompany.com",
+			expErr:   `must have 'http://' or 'https://' in base url "mycompany.com"`,
+		},
+		{
+			inputURL: "https://mycompany.com",
+			expURL:   "https://mycompany.com",
+		},
+		{
+			inputURL: "http://mycompany.com",
+			expURL:   "http://mycompany.com",
+		},
+		{
+			inputURL: "http://mycompany.com:7990",
+			expURL:   "http://mycompany.com:7990",
+		},
+		{
+			inputURL: "http://mycompany.com/",
+			expURL:   "http://mycompany.com",
+		},
+		{
+			inputURL: "http://mycompany.com:7990/",
+			expURL:   "http://mycompany.com:7990",
+		},
+		{
+			inputURL: "http://mycompany.com/basepath/",
+			expURL:   "http://mycompany.com/basepath",
+		},
+		{
+			inputURL: "http://mycompany.com:7990/basepath/",
+			expURL:   "http://mycompany.com:7990/basepath",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.inputURL, func(t *testing.T) {
+			client, err := bitbucketserver.NewClient(nil, "u", "p", c.inputURL, "atlantis-url")
+			if c.expErr != "" {
+				ErrEquals(t, c.expErr, err)
+			} else {
+				Ok(t, err)
+				Equals(t, c.expURL, client.BaseURL)
+			}
+		})
+	}
+}
+
 // Should follow pagination properly.
 func TestClient_GetModifiedFilesPagination(t *testing.T) {
 	respTemplate := `


### PR DESCRIPTION
Previously we were stripping the basepath from the passed in URL. i.e.
if I passed in --bitbucket-base-url=https://me.com/basepath then we
would just strip off /basepath.

This change fixes that bug (#508).