### PR TITLE
Split status checks

### DIFF
--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -166,7 +166,7 @@ func getAtlantisStatus(t *E2ETester, branchName string) (string, error) {
 	}
 
 	for _, status := range combinedStatus.Statuses {
-		if status.GetContext() == "Atlantis" {
+		if status.GetContext() == "plan/atlantis" {
 			return status.GetState(), nil
 		}
 	}

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -225,7 +225,7 @@ func (c *DefaultCommandRunner) RunCommentCommand(baseRepo models.Repo, maybeHead
 	}
 }
 
-func (c *DefaultCommandRunner) automerge(ctx *CommandContext, pullStatus *models.PullStatus) {
+func (c *DefaultCommandRunner) automerge(ctx *CommandContext, pullStatus models.PullStatus) {
 	// We only automerge if all projects have been successfully applied.
 	for _, p := range pullStatus.Projects {
 		if p.Status != models.AppliedPlanStatus {
@@ -364,7 +364,7 @@ func (c *DefaultCommandRunner) deletePlans(ctx *CommandContext) {
 	}
 }
 
-func (c *DefaultCommandRunner) updateDB(ctx *CommandContext, pull models.PullRequest, results []models.ProjectResult) (*models.PullStatus, error) {
+func (c *DefaultCommandRunner) updateDB(ctx *CommandContext, pull models.PullRequest, results []models.ProjectResult) (models.PullStatus, error) {
 	// Filter out results that errored due to the directory not existing. We
 	// don't store these in the database because they would never be "applyable"
 	// and so the pull request would always have errors.

--- a/server/events/command_runner_internal_test.go
+++ b/server/events/command_runner_internal_test.go
@@ -1,0 +1,145 @@
+package events
+
+import (
+	"github.com/runatlantis/atlantis/server/events/models"
+	. "github.com/runatlantis/atlantis/testing"
+	"testing"
+)
+
+func TestUpdateCommitStatus(t *testing.T) {
+	cases := map[string]struct {
+		cmd           models.CommandName
+		pullStatus    models.PullStatus
+		expStatus     models.CommitStatus
+		expNumSuccess int
+		expNumTotal   int
+	}{
+		"single plan success": {
+			cmd: models.PlanCommand,
+			pullStatus: models.PullStatus{
+				Projects: []models.ProjectStatus{
+					{
+						Status: models.PlannedPlanStatus,
+					},
+				},
+			},
+			expStatus:     models.SuccessCommitStatus,
+			expNumSuccess: 1,
+			expNumTotal:   1,
+		},
+		"one plan error, other errors": {
+			cmd: models.PlanCommand,
+			pullStatus: models.PullStatus{
+				Projects: []models.ProjectStatus{
+					{
+						Status: models.ErroredPlanStatus,
+					},
+					{
+						Status: models.PlannedPlanStatus,
+					},
+					{
+						Status: models.AppliedPlanStatus,
+					},
+					{
+						Status: models.ErroredApplyStatus,
+					},
+				},
+			},
+			expStatus:     models.FailedCommitStatus,
+			expNumSuccess: 3,
+			expNumTotal:   4,
+		},
+		"apply, one pending": {
+			cmd: models.ApplyCommand,
+			pullStatus: models.PullStatus{
+				Projects: []models.ProjectStatus{
+					{
+						Status: models.PlannedPlanStatus,
+					},
+					{
+						Status: models.AppliedPlanStatus,
+					},
+				},
+			},
+			expStatus:     models.PendingCommitStatus,
+			expNumSuccess: 1,
+			expNumTotal:   2,
+		},
+		"apply, all successful": {
+			cmd: models.ApplyCommand,
+			pullStatus: models.PullStatus{
+				Projects: []models.ProjectStatus{
+					{
+						Status: models.AppliedPlanStatus,
+					},
+					{
+						Status: models.AppliedPlanStatus,
+					},
+				},
+			},
+			expStatus:     models.SuccessCommitStatus,
+			expNumSuccess: 2,
+			expNumTotal:   2,
+		},
+		"apply, one errored, one pending": {
+			cmd: models.ApplyCommand,
+			pullStatus: models.PullStatus{
+				Projects: []models.ProjectStatus{
+					{
+						Status: models.AppliedPlanStatus,
+					},
+					{
+						Status: models.ErroredApplyStatus,
+					},
+					{
+						Status: models.PlannedPlanStatus,
+					},
+				},
+			},
+			expStatus:     models.FailedCommitStatus,
+			expNumSuccess: 1,
+			expNumTotal:   3,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			csu := &MockCSU{}
+			cr := &DefaultCommandRunner{
+				CommitStatusUpdater: csu,
+			}
+			cr.updateCommitStatus(&CommandContext{}, c.cmd, c.pullStatus)
+			Equals(t, models.Repo{}, csu.CalledRepo)
+			Equals(t, models.PullRequest{}, csu.CalledPull)
+			Equals(t, c.expStatus, csu.CalledStatus)
+			Equals(t, c.cmd, csu.CalledCommand)
+			Equals(t, c.expNumSuccess, csu.CalledNumSuccess)
+			Equals(t, c.expNumTotal, csu.CalledNumTotal)
+		})
+	}
+}
+
+type MockCSU struct {
+	CalledRepo       models.Repo
+	CalledPull       models.PullRequest
+	CalledStatus     models.CommitStatus
+	CalledCommand    models.CommandName
+	CalledNumSuccess int
+	CalledNumTotal   int
+}
+
+func (m *MockCSU) UpdateCombinedCount(repo models.Repo, pull models.PullRequest, status models.CommitStatus, command models.CommandName, numSuccess int, numTotal int) error {
+	m.CalledRepo = repo
+	m.CalledPull = pull
+	m.CalledStatus = status
+	m.CalledCommand = command
+	m.CalledNumSuccess = numSuccess
+	m.CalledNumTotal = numTotal
+	return nil
+}
+func (m *MockCSU) UpdateCombined(repo models.Repo, pull models.PullRequest, status models.CommitStatus, command models.CommandName) error {
+	return nil
+}
+func (m *MockCSU) UpdateProject(ctx models.ProjectCommandContext, cmdName models.CommandName, status models.CommitStatus, url string) error {
+	return nil
+}

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -36,7 +36,6 @@ import (
 var projectCommandBuilder *mocks.MockProjectCommandBuilder
 var projectCommandRunner *mocks.MockProjectCommandRunner
 var eventParsing *mocks.MockEventParsing
-var ghStatus *mocks.MockCommitStatusUpdater
 var githubGetter *mocks.MockGithubPullGetter
 var gitlabGetter *mocks.MockGitlabMergeRequestGetter
 var ch events.DefaultCommandRunner
@@ -48,7 +47,6 @@ func setup(t *testing.T) *vcsmocks.MockClient {
 	RegisterMockTestingT(t)
 	projectCommandBuilder = mocks.NewMockProjectCommandBuilder()
 	eventParsing = mocks.NewMockEventParsing()
-	ghStatus = mocks.NewMockCommitStatusUpdater()
 	vcsClient := vcsmocks.NewMockClient()
 	githubGetter = mocks.NewMockGithubPullGetter()
 	gitlabGetter = mocks.NewMockGitlabMergeRequestGetter()
@@ -62,7 +60,7 @@ func setup(t *testing.T) *vcsmocks.MockClient {
 		ThenReturn(pullLogger)
 	ch = events.DefaultCommandRunner{
 		VCSClient:                vcsClient,
-		CommitStatusUpdater:      ghStatus,
+		CommitStatusUpdater:      &events.DefaultCommitStatusUpdater{vcsClient},
 		EventParser:              eventParsing,
 		MarkdownRenderer:         &events.MarkdownRenderer{},
 		GithubPullGetter:         githubGetter,

--- a/server/events/commit_status_updater.go
+++ b/server/events/commit_status_updater.go
@@ -56,7 +56,7 @@ func (d *DefaultCommitStatusUpdater) UpdateProjectResult(ctx *CommandContext, co
 	} else {
 		var statuses []models.CommitStatus
 		for _, p := range res.ProjectResults {
-			statuses = append(statuses, p.Status())
+			statuses = append(statuses, p.CommitStatus())
 		}
 		status = d.worstStatus(statuses)
 	}

--- a/server/events/commit_status_updater.go
+++ b/server/events/commit_status_updater.go
@@ -26,12 +26,12 @@ import (
 // CommitStatusUpdater updates the status of a commit with the VCS host. We set
 // the status to signify whether the plan/apply succeeds.
 type CommitStatusUpdater interface {
-	// Update updates the status of the head commit of pull.
-	Update(repo models.Repo, pull models.PullRequest, status models.CommitStatus, command models.CommandName) error
-	// UpdateProjectResult updates the status of the head commit given the
-	// state of response.
-	// todo: rename this so it doesn't conflict with UpdateProject
-	UpdateProjectResult(ctx *CommandContext, commandName models.CommandName, res CommandResult) error
+	// UpdateCombined updates the combined status of the head commit of pull.
+	// A combined status represents all the projects modified in the pull.
+	UpdateCombined(repo models.Repo, pull models.PullRequest, status models.CommitStatus, command models.CommandName) error
+	// UpdateCombinedCount updates the combined status to reflect the
+	// numSuccess out of numTotal.
+	UpdateCombinedCount(repo models.Repo, pull models.PullRequest, status models.CommitStatus, command models.CommandName, numSuccess int, numTotal int) error
 	// UpdateProject sets the commit status for the project represented by
 	// ctx.
 	UpdateProject(ctx models.ProjectCommandContext, cmdName models.CommandName, status models.CommitStatus, url string) error
@@ -42,25 +42,28 @@ type DefaultCommitStatusUpdater struct {
 	Client vcs.Client
 }
 
-// Update updates the commit status.
-func (d *DefaultCommitStatusUpdater) Update(repo models.Repo, pull models.PullRequest, status models.CommitStatus, command models.CommandName) error {
-	description := fmt.Sprintf("%s %s", strings.Title(command.String()), strings.Title(status.String()))
-	return d.Client.UpdateStatus(repo, pull, status, "Atlantis", description, "")
+func (d *DefaultCommitStatusUpdater) UpdateCombined(repo models.Repo, pull models.PullRequest, status models.CommitStatus, command models.CommandName) error {
+	src := fmt.Sprintf("%s/atlantis", command.String())
+	var descripWords string
+	switch status {
+	case models.PendingCommitStatus:
+		descripWords = "in progress..."
+	case models.FailedCommitStatus:
+		descripWords = "failed."
+	case models.SuccessCommitStatus:
+		descripWords = "succeeded."
+	}
+	descrip := fmt.Sprintf("%s %s", strings.Title(command.String()), descripWords)
+	return d.Client.UpdateStatus(repo, pull, status, src, descrip, "")
 }
 
-// UpdateProjectResult updates the commit status based on the status of res.
-func (d *DefaultCommitStatusUpdater) UpdateProjectResult(ctx *CommandContext, commandName models.CommandName, res CommandResult) error {
-	var status models.CommitStatus
-	if res.Error != nil || res.Failure != "" {
-		status = models.FailedCommitStatus
-	} else {
-		var statuses []models.CommitStatus
-		for _, p := range res.ProjectResults {
-			statuses = append(statuses, p.CommitStatus())
-		}
-		status = d.worstStatus(statuses)
+func (d *DefaultCommitStatusUpdater) UpdateCombinedCount(repo models.Repo, pull models.PullRequest, status models.CommitStatus, command models.CommandName, numSuccess int, numTotal int) error {
+	src := fmt.Sprintf("%s/atlantis", command.String())
+	cmdVerb := "planned"
+	if command == models.ApplyCommand {
+		cmdVerb = "applied"
 	}
-	return d.Update(ctx.BaseRepo, ctx.Pull, status, commandName)
+	return d.Client.UpdateStatus(repo, pull, status, src, fmt.Sprintf("%d/%d projects %s successfully.", numSuccess, numTotal, cmdVerb), "")
 }
 
 func (d *DefaultCommitStatusUpdater) UpdateProject(ctx models.ProjectCommandContext, cmdName models.CommandName, status models.CommitStatus, url string) error {
@@ -80,13 +83,4 @@ func (d *DefaultCommitStatusUpdater) UpdateProject(ctx models.ProjectCommandCont
 	}
 	descrip := fmt.Sprintf("%s %s", strings.Title(cmdName.String()), descripWords)
 	return d.Client.UpdateStatus(ctx.BaseRepo, ctx.Pull, status, src, descrip, url)
-}
-
-func (d *DefaultCommitStatusUpdater) worstStatus(ss []models.CommitStatus) models.CommitStatus {
-	for _, s := range ss {
-		if s == models.FailedCommitStatus {
-			return models.FailedCommitStatus
-		}
-	}
-	return models.SuccessCommitStatus
 }

--- a/server/events/db/boltdb.go
+++ b/server/events/db/boltdb.go
@@ -258,7 +258,7 @@ func (b *BoltDB) UpdatePullWithResults(pull models.PullRequest, newResults []mod
 						res.RepoRelDir == proj.RepoRelDir &&
 						res.ProjectName == proj.ProjectName {
 
-						proj.Status = b.getPlanStatus(res)
+						proj.Status = res.PlanStatus()
 						updatedExisting = true
 						break
 					}
@@ -382,27 +382,11 @@ func (b *BoltDB) writePullToBucket(bucket *bolt.Bucket, key []byte, pull models.
 	return bucket.Put(key, serialized)
 }
 
-func (b *BoltDB) getPlanStatus(p models.ProjectResult) models.ProjectPlanStatus {
-	if p.Error != nil {
-		return models.ErroredPlanStatus
-	}
-	if p.Failure != "" {
-		return models.ErroredPlanStatus
-	}
-	if p.PlanSuccess != nil {
-		return models.PlannedPlanStatus
-	}
-	if p.ApplySuccess != "" {
-		return models.AppliedPlanStatus
-	}
-	return models.ErroredPlanStatus
-}
-
 func (b *BoltDB) projectResultToProject(p models.ProjectResult) models.ProjectStatus {
 	return models.ProjectStatus{
 		Workspace:   p.Workspace,
 		RepoRelDir:  p.RepoRelDir,
 		ProjectName: p.ProjectName,
-		Status:      b.getPlanStatus(p),
+		Status:      p.PlanStatus(),
 	}
 }

--- a/server/events/db/boltdb_test.go
+++ b/server/events/db/boltdb_test.go
@@ -381,6 +381,7 @@ func TestPullStatus_UpdateGet(t *testing.T) {
 		pull,
 		[]models.ProjectResult{
 			{
+				Command:    models.PlanCommand,
 				RepoRelDir: ".",
 				Workspace:  "default",
 				Failure:    "failure",
@@ -600,11 +601,20 @@ func TestPullStatus_UpdateMerge(t *testing.T) {
 		pull,
 		[]models.ProjectResult{
 			{
+				Command:    models.PlanCommand,
 				RepoRelDir: "mergeme",
 				Workspace:  "default",
 				Failure:    "failure",
 			},
 			{
+				Command:     models.PlanCommand,
+				RepoRelDir:  "projectname",
+				Workspace:   "default",
+				ProjectName: "projectname",
+				Failure:     "failure",
+			},
+			{
+				Command:    models.PlanCommand,
 				RepoRelDir: "staythesame",
 				Workspace:  "default",
 				PlanSuccess: &models.PlanSuccess{
@@ -620,11 +630,20 @@ func TestPullStatus_UpdateMerge(t *testing.T) {
 	updateStatus, err := b.UpdatePullWithResults(pull,
 		[]models.ProjectResult{
 			{
+				Command:      models.ApplyCommand,
 				RepoRelDir:   "mergeme",
 				Workspace:    "default",
 				ApplySuccess: "applied!",
 			},
 			{
+				Command:     models.ApplyCommand,
+				RepoRelDir:  "projectname",
+				Workspace:   "default",
+				ProjectName: "projectname",
+				Error:       errors.New("apply error"),
+			},
+			{
+				Command:      models.ApplyCommand,
 				RepoRelDir:   "newresult",
 				Workspace:    "default",
 				ApplySuccess: "success!",
@@ -644,6 +663,12 @@ func TestPullStatus_UpdateMerge(t *testing.T) {
 				RepoRelDir: "mergeme",
 				Workspace:  "default",
 				Status:     models.AppliedPlanStatus,
+			},
+			{
+				RepoRelDir:  "projectname",
+				Workspace:   "default",
+				ProjectName: "projectname",
+				Status:      models.ErroredApplyStatus,
 			},
 			{
 				RepoRelDir: "staythesame",

--- a/server/events/db/boltdb_test.go
+++ b/server/events/db/boltdb_test.go
@@ -387,11 +387,11 @@ func TestPullStatus_UpdateGet(t *testing.T) {
 			},
 		})
 	Ok(t, err)
-	Assert(t, status != nil, "exp non-nil")
 
-	status, err = b.GetPullStatus(pull)
+	maybeStatus, err := b.GetPullStatus(pull)
 	Ok(t, err)
-	Equals(t, pull, status.Pull)
+	Assert(t, maybeStatus != nil, "exp non-nil")
+	Equals(t, pull, maybeStatus.Pull)
 	Equals(t, []models.ProjectStatus{
 		{
 			Workspace:   "default",
@@ -428,7 +428,7 @@ func TestPullStatus_UpdateDeleteGet(t *testing.T) {
 			},
 		},
 	}
-	status, err := b.UpdatePullWithResults(
+	_, err := b.UpdatePullWithResults(
 		pull,
 		[]models.ProjectResult{
 			{
@@ -438,14 +438,13 @@ func TestPullStatus_UpdateDeleteGet(t *testing.T) {
 			},
 		})
 	Ok(t, err)
-	Assert(t, status != nil, "exp non-nil")
 
 	err = b.DeletePullStatus(pull)
 	Ok(t, err)
 
-	status, err = b.GetPullStatus(pull)
+	maybeStatus, err := b.GetPullStatus(pull)
 	Ok(t, err)
-	Assert(t, status == nil, "exp nil")
+	Assert(t, maybeStatus == nil, "exp nil")
 }
 
 // Test we can create a status, delete a specific project's status within that
@@ -475,7 +474,7 @@ func TestPullStatus_UpdateDeleteProject(t *testing.T) {
 			},
 		},
 	}
-	status, err := b.UpdatePullWithResults(
+	_, err := b.UpdatePullWithResults(
 		pull,
 		[]models.ProjectResult{
 			{
@@ -490,13 +489,13 @@ func TestPullStatus_UpdateDeleteProject(t *testing.T) {
 			},
 		})
 	Ok(t, err)
-	Assert(t, status != nil, "exp non-nil")
 
 	err = b.DeleteProjectStatus(pull, "default", ".")
 	Ok(t, err)
 
-	status, err = b.GetPullStatus(pull)
+	status, err := b.GetPullStatus(pull)
 	Ok(t, err)
+	Assert(t, status != nil, "exp non-nil")
 	Equals(t, pull, status.Pull)
 	Equals(t, []models.ProjectStatus{
 		{
@@ -534,7 +533,7 @@ func TestPullStatus_UpdateNewCommit(t *testing.T) {
 			},
 		},
 	}
-	status, err := b.UpdatePullWithResults(
+	_, err := b.UpdatePullWithResults(
 		pull,
 		[]models.ProjectResult{
 			{
@@ -544,10 +543,9 @@ func TestPullStatus_UpdateNewCommit(t *testing.T) {
 			},
 		})
 	Ok(t, err)
-	Assert(t, status != nil, "exp non-nil")
 
 	pull.HeadCommit = "newsha"
-	status, err = b.UpdatePullWithResults(pull,
+	status, err := b.UpdatePullWithResults(pull,
 		[]models.ProjectResult{
 			{
 				RepoRelDir:   ".",
@@ -559,9 +557,9 @@ func TestPullStatus_UpdateNewCommit(t *testing.T) {
 	Ok(t, err)
 	Equals(t, 1, len(status.Projects))
 
-	status, err = b.GetPullStatus(pull)
+	maybeStatus, err := b.GetPullStatus(pull)
 	Ok(t, err)
-	Equals(t, pull, status.Pull)
+	Equals(t, pull, maybeStatus.Pull)
 	Equals(t, []models.ProjectStatus{
 		{
 			Workspace:   "staging",
@@ -569,7 +567,7 @@ func TestPullStatus_UpdateNewCommit(t *testing.T) {
 			ProjectName: "",
 			Status:      models.AppliedPlanStatus,
 		},
-	}, status.Projects)
+	}, maybeStatus.Projects)
 }
 
 // Test that if we update an existing pull status and our new status is for a
@@ -598,7 +596,7 @@ func TestPullStatus_UpdateMerge(t *testing.T) {
 			},
 		},
 	}
-	status, err := b.UpdatePullWithResults(
+	_, err := b.UpdatePullWithResults(
 		pull,
 		[]models.ProjectResult{
 			{
@@ -618,9 +616,8 @@ func TestPullStatus_UpdateMerge(t *testing.T) {
 			},
 		})
 	Ok(t, err)
-	Assert(t, status != nil, "exp non-nil")
 
-	status, err = b.UpdatePullWithResults(pull,
+	updateStatus, err := b.UpdatePullWithResults(pull,
 		[]models.ProjectResult{
 			{
 				RepoRelDir:   "mergeme",
@@ -633,7 +630,6 @@ func TestPullStatus_UpdateMerge(t *testing.T) {
 				ApplySuccess: "success!",
 			},
 		})
-
 	Ok(t, err)
 
 	getStatus, err := b.GetPullStatus(pull)
@@ -641,7 +637,7 @@ func TestPullStatus_UpdateMerge(t *testing.T) {
 
 	// Test both the pull state returned from the update call *and* the get
 	// call.
-	for _, s := range []*models.PullStatus{status, getStatus} {
+	for _, s := range []models.PullStatus{updateStatus, *getStatus} {
 		Equals(t, pull, s.Pull)
 		Equals(t, []models.ProjectStatus{
 			{
@@ -659,7 +655,7 @@ func TestPullStatus_UpdateMerge(t *testing.T) {
 				Workspace:  "default",
 				Status:     models.AppliedPlanStatus,
 			},
-		}, status.Projects)
+		}, updateStatus.Projects)
 	}
 }
 

--- a/server/events/mocks/mock_commit_status_updater.go
+++ b/server/events/mocks/mock_commit_status_updater.go
@@ -5,7 +5,6 @@ package mocks
 
 import (
 	pegomock "github.com/petergtz/pegomock"
-	events "github.com/runatlantis/atlantis/server/events"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	"reflect"
 	"time"
@@ -19,12 +18,12 @@ func NewMockCommitStatusUpdater() *MockCommitStatusUpdater {
 	return &MockCommitStatusUpdater{fail: pegomock.GlobalFailHandler}
 }
 
-func (mock *MockCommitStatusUpdater) Update(repo models.Repo, pull models.PullRequest, status models.CommitStatus, command models.CommandName) error {
+func (mock *MockCommitStatusUpdater) UpdateCombined(repo models.Repo, pull models.PullRequest, status models.CommitStatus, command models.CommandName) error {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockCommitStatusUpdater().")
 	}
 	params := []pegomock.Param{repo, pull, status, command}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("Update", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
+	result := pegomock.GetGenericMockFrom(mock).Invoke("UpdateCombined", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 error
 	if len(result) != 0 {
 		if result[0] != nil {
@@ -34,12 +33,12 @@ func (mock *MockCommitStatusUpdater) Update(repo models.Repo, pull models.PullRe
 	return ret0
 }
 
-func (mock *MockCommitStatusUpdater) UpdateProjectResult(ctx *events.CommandContext, commandName models.CommandName, res events.CommandResult) error {
+func (mock *MockCommitStatusUpdater) UpdateCombinedCount(repo models.Repo, pull models.PullRequest, status models.CommitStatus, command models.CommandName, numSuccess int, numTotal int) error {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockCommitStatusUpdater().")
 	}
-	params := []pegomock.Param{ctx, commandName, res}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("UpdateProjectResult", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
+	params := []pegomock.Param{repo, pull, status, command, numSuccess, numTotal}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("UpdateCombinedCount", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 error
 	if len(result) != 0 {
 		if result[0] != nil {
@@ -101,23 +100,23 @@ type VerifierCommitStatusUpdater struct {
 	timeout                time.Duration
 }
 
-func (verifier *VerifierCommitStatusUpdater) Update(repo models.Repo, pull models.PullRequest, status models.CommitStatus, command models.CommandName) *CommitStatusUpdater_Update_OngoingVerification {
+func (verifier *VerifierCommitStatusUpdater) UpdateCombined(repo models.Repo, pull models.PullRequest, status models.CommitStatus, command models.CommandName) *CommitStatusUpdater_UpdateCombined_OngoingVerification {
 	params := []pegomock.Param{repo, pull, status, command}
-	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "Update", params, verifier.timeout)
-	return &CommitStatusUpdater_Update_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "UpdateCombined", params, verifier.timeout)
+	return &CommitStatusUpdater_UpdateCombined_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
 
-type CommitStatusUpdater_Update_OngoingVerification struct {
+type CommitStatusUpdater_UpdateCombined_OngoingVerification struct {
 	mock              *MockCommitStatusUpdater
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *CommitStatusUpdater_Update_OngoingVerification) GetCapturedArguments() (models.Repo, models.PullRequest, models.CommitStatus, models.CommandName) {
+func (c *CommitStatusUpdater_UpdateCombined_OngoingVerification) GetCapturedArguments() (models.Repo, models.PullRequest, models.CommitStatus, models.CommandName) {
 	repo, pull, status, command := c.GetAllCapturedArguments()
 	return repo[len(repo)-1], pull[len(pull)-1], status[len(status)-1], command[len(command)-1]
 }
 
-func (c *CommitStatusUpdater_Update_OngoingVerification) GetAllCapturedArguments() (_param0 []models.Repo, _param1 []models.PullRequest, _param2 []models.CommitStatus, _param3 []models.CommandName) {
+func (c *CommitStatusUpdater_UpdateCombined_OngoingVerification) GetAllCapturedArguments() (_param0 []models.Repo, _param1 []models.PullRequest, _param2 []models.CommitStatus, _param3 []models.CommandName) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]models.Repo, len(params[0]))
@@ -140,36 +139,48 @@ func (c *CommitStatusUpdater_Update_OngoingVerification) GetAllCapturedArguments
 	return
 }
 
-func (verifier *VerifierCommitStatusUpdater) UpdateProjectResult(ctx *events.CommandContext, commandName models.CommandName, res events.CommandResult) *CommitStatusUpdater_UpdateProjectResult_OngoingVerification {
-	params := []pegomock.Param{ctx, commandName, res}
-	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "UpdateProjectResult", params, verifier.timeout)
-	return &CommitStatusUpdater_UpdateProjectResult_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+func (verifier *VerifierCommitStatusUpdater) UpdateCombinedCount(repo models.Repo, pull models.PullRequest, status models.CommitStatus, command models.CommandName, numSuccess int, numTotal int) *CommitStatusUpdater_UpdateCombinedCount_OngoingVerification {
+	params := []pegomock.Param{repo, pull, status, command, numSuccess, numTotal}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "UpdateCombinedCount", params, verifier.timeout)
+	return &CommitStatusUpdater_UpdateCombinedCount_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
 
-type CommitStatusUpdater_UpdateProjectResult_OngoingVerification struct {
+type CommitStatusUpdater_UpdateCombinedCount_OngoingVerification struct {
 	mock              *MockCommitStatusUpdater
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *CommitStatusUpdater_UpdateProjectResult_OngoingVerification) GetCapturedArguments() (*events.CommandContext, models.CommandName, events.CommandResult) {
-	ctx, commandName, res := c.GetAllCapturedArguments()
-	return ctx[len(ctx)-1], commandName[len(commandName)-1], res[len(res)-1]
+func (c *CommitStatusUpdater_UpdateCombinedCount_OngoingVerification) GetCapturedArguments() (models.Repo, models.PullRequest, models.CommitStatus, models.CommandName, int, int) {
+	repo, pull, status, command, numSuccess, numTotal := c.GetAllCapturedArguments()
+	return repo[len(repo)-1], pull[len(pull)-1], status[len(status)-1], command[len(command)-1], numSuccess[len(numSuccess)-1], numTotal[len(numTotal)-1]
 }
 
-func (c *CommitStatusUpdater_UpdateProjectResult_OngoingVerification) GetAllCapturedArguments() (_param0 []*events.CommandContext, _param1 []models.CommandName, _param2 []events.CommandResult) {
+func (c *CommitStatusUpdater_UpdateCombinedCount_OngoingVerification) GetAllCapturedArguments() (_param0 []models.Repo, _param1 []models.PullRequest, _param2 []models.CommitStatus, _param3 []models.CommandName, _param4 []int, _param5 []int) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]*events.CommandContext, len(params[0]))
+		_param0 = make([]models.Repo, len(params[0]))
 		for u, param := range params[0] {
-			_param0[u] = param.(*events.CommandContext)
+			_param0[u] = param.(models.Repo)
 		}
-		_param1 = make([]models.CommandName, len(params[1]))
+		_param1 = make([]models.PullRequest, len(params[1]))
 		for u, param := range params[1] {
-			_param1[u] = param.(models.CommandName)
+			_param1[u] = param.(models.PullRequest)
 		}
-		_param2 = make([]events.CommandResult, len(params[2]))
+		_param2 = make([]models.CommitStatus, len(params[2]))
 		for u, param := range params[2] {
-			_param2[u] = param.(events.CommandResult)
+			_param2[u] = param.(models.CommitStatus)
+		}
+		_param3 = make([]models.CommandName, len(params[3]))
+		for u, param := range params[3] {
+			_param3[u] = param.(models.CommandName)
+		}
+		_param4 = make([]int, len(params[4]))
+		for u, param := range params[4] {
+			_param4[u] = param.(int)
+		}
+		_param5 = make([]int, len(params[5]))
+		for u, param := range params[5] {
+			_param5[u] = param.(int)
 		}
 	}
 	return

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -405,6 +405,17 @@ type PullStatus struct {
 	Pull PullRequest
 }
 
+// StatusCount returns the number of projects that have status.
+func (p PullStatus) StatusCount(status ProjectPlanStatus) int {
+	c := 0
+	for _, pr := range p.Projects {
+		if pr.Status == status {
+			c++
+		}
+	}
+	return c
+}
+
 // ProjectStatus is the status of a specific project.
 type ProjectStatus struct {
 	Workspace   string

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -345,8 +345,8 @@ type ProjectResult struct {
 	ProjectName  string
 }
 
-// Status returns the vcs commit status of this project result.
-func (p ProjectResult) Status() CommitStatus {
+// CommitStatus returns the vcs commit status of this project result.
+func (p ProjectResult) CommitStatus() CommitStatus {
 	if p.Error != nil {
 		return FailedCommitStatus
 	}
@@ -354,6 +354,30 @@ func (p ProjectResult) Status() CommitStatus {
 		return FailedCommitStatus
 	}
 	return SuccessCommitStatus
+}
+
+// PlanStatus returns the plan status.
+func (p ProjectResult) PlanStatus() ProjectPlanStatus {
+	switch p.Command {
+
+	case PlanCommand:
+		if p.Error != nil {
+			return ErroredPlanStatus
+		} else if p.Failure != "" {
+			return ErroredPlanStatus
+		}
+		return PlannedPlanStatus
+
+	case ApplyCommand:
+		if p.Error != nil {
+			return ErroredApplyStatus
+		} else if p.Failure != "" {
+			return ErroredApplyStatus
+		}
+		return AppliedPlanStatus
+	}
+
+	panic("PlanStatus() missing a combination")
 }
 
 // IsSuccessful returns true if this project result had no errors.
@@ -401,6 +425,9 @@ const (
 	// PlannedPlanStatus means that a plan has been successfully generated but
 	// not yet applied.
 	PlannedPlanStatus
+	// ErrorApplyStatus means that a plan has been generated but there was an
+	// error while applying it.
+	ErroredApplyStatus
 	// AppliedPlanStatus means that a plan has been generated and applied
 	// successfully.
 	AppliedPlanStatus
@@ -410,13 +437,15 @@ const (
 func (p ProjectPlanStatus) String() string {
 	switch p {
 	case ErroredPlanStatus:
-		return "errored"
+		return "plan_errored"
 	case PlannedPlanStatus:
 		return "planned"
+	case ErroredApplyStatus:
+		return "apply_errored"
 	case AppliedPlanStatus:
 		return "applied"
 	default:
-		return "errored"
+		panic("missing String() impl for ProjectPlanStatus")
 	}
 }
 

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -335,6 +335,7 @@ func (p *ProjectCommandContext) GetProjectName() string {
 
 // ProjectResult is the result of executing a plan/apply for a specific project.
 type ProjectResult struct {
+	Command      CommandName
 	RepoRelDir   string
 	Workspace    string
 	Error        error

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -94,6 +94,7 @@ type DefaultProjectCommandRunner struct {
 func (p *DefaultProjectCommandRunner) Plan(ctx models.ProjectCommandContext) models.ProjectResult {
 	planSuccess, failure, err := p.doPlan(ctx)
 	return models.ProjectResult{
+		Command:     models.PlanCommand,
 		PlanSuccess: planSuccess,
 		Error:       err,
 		Failure:     failure,
@@ -107,6 +108,7 @@ func (p *DefaultProjectCommandRunner) Plan(ctx models.ProjectCommandContext) mod
 func (p *DefaultProjectCommandRunner) Apply(ctx models.ProjectCommandContext) models.ProjectResult {
 	applyOut, failure, err := p.doApply(ctx)
 	return models.ProjectResult{
+		Command:      models.ApplyCommand,
 		Failure:      failure,
 		Error:        err,
 		ApplySuccess: applyOut,

--- a/server/events_controller_e2e_test.go
+++ b/server/events_controller_e2e_test.go
@@ -355,7 +355,7 @@ func setupE2E(t *testing.T) (server.EventsController, *vcsmocks.MockClient, *moc
 
 	// Mocks.
 	e2eVCSClient := vcsmocks.NewMockClient()
-	e2eStatusUpdater := mocks.NewMockCommitStatusUpdater()
+	e2eStatusUpdater := &events.DefaultCommitStatusUpdater{Client: e2eVCSClient}
 	e2eGithubGetter := mocks.NewMockGithubPullGetter()
 	e2eGitlabGetter := mocks.NewMockGitlabMergeRequestGetter()
 


### PR DESCRIPTION
Split single top-level status check into one plan and one apply check.
These checks will also now track the whole pull request status rather
than just the last action.

![image](https://user-images.githubusercontent.com/1034429/53828684-5bb28000-3f4c-11e9-9d54-df2bc92673d8.png)

Fixes #446