### PR TITLE
 Support dirs with spaces

### DIFF
--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -445,7 +445,7 @@ func TestParse_Parsing(t *testing.T) {
 			"",
 			"",
 			false,
-			`"\";echo" "\"hi"`,
+			`";echo hi"`,
 			"",
 		},
 		{
@@ -510,6 +510,14 @@ func TestParse_Parsing(t *testing.T) {
 			"-d ./adir",
 			"",
 			"adir",
+			false,
+			"",
+			"",
+		},
+		{
+			"-d \"dir with space\"",
+			"",
+			"dir with space",
 			false,
 			"",
 			"",
@@ -609,6 +617,13 @@ func TestBuildPlanApplyComment(t *testing.T) {
 			commentArgs:   []string{`"arg1"`, `"arg2"`, `arg3`},
 			expPlanFlags:  "-d dir -w workspace -- arg1 arg2 arg3",
 			expApplyFlags: "-d dir -w workspace",
+		},
+		{
+			repoRelDir:    "dir with spaces",
+			workspace:     "default",
+			project:       "",
+			expPlanFlags:  "-d \"dir with spaces\"",
+			expApplyFlags: "-d \"dir with spaces\"",
 		},
 	}
 

--- a/server/events/terraform/terraform_client.go
+++ b/server/events/terraform/terraform_client.go
@@ -110,8 +110,8 @@ func (c *DefaultClient) Version() *version.Version {
 // RunCommandWithVersion executes the provided version of terraform with
 // the provided args in path. v is the version of terraform executable to use.
 // If v is nil, will use the default version.
-// Workspace is the terraform workspace to run in. We won't switch workspaces
-// but will set the TERRAFORM_WORKSPACE environment variable.
+// Workspace is the terraform workspace to run in. We won't switch workspaces,
+// just set a WORKSPACE environment variable.
 func (c *DefaultClient) RunCommandWithVersion(log *logging.SimpleLogger, path string, args []string, v *version.Version, workspace string) (string, error) {
 	tfCmd, cmd := c.prepCmd(v, workspace, path, args)
 	out, err := cmd.CombinedOutput()


### PR DESCRIPTION
Allow running atlantis plan -d "dir with spaces" to target a directory
that contains spaces.

Fixes #423