### PR TITLE
Add mergeable GitHub requirement to docs

### DIFF
--- a/runatlantis.io/docs/apply-requirements.md
+++ b/runatlantis.io/docs/apply-requirements.md
@@ -70,6 +70,12 @@ If you set up Protected Branches then you can enforce:
 See [https://help.github.com/articles/about-protected-branches/](https://help.github.com/articles/about-protected-branches/)
 for more details.
 
+::: warning
+If you have the **Restrict who can push to this branch** requirement, then
+the Atlantis user needs to be part of that list in order for it to consider
+a pull request mergeable.
+:::
+
 #### GitLab
 For GitLab, a merge request will be mergeable if it has no conflicts and if all
 required approvers have approved the pull request.


### PR DESCRIPTION
Describe that the Atlantis user may need write/push permissions to the base branch before it considers a PR mergeable.

When I was attempting to figure out why Atlantis wasn't considering a PR mergeable even when all status checks passed and approvals were given, I realized that it's possible that the Atlantis GH user itself may need write/push permissions to the base branch if the "Restrict who can push to this branch" option is checked under the base branch protection.

This PR just adds a heads up for other users that may have the same branch protection setup.