### PR TITLE
Use alpine:3.9 in base docker image

### DIFF
--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile builds our base image with gosu, dumb-init and the atlantis
 # user. We split this from the main Dockerfile because this base doesn't change
 # and also because it kept breaking the build due to flakiness.
-FROM alpine:3.8
+FROM alpine:3.9
 LABEL authors="Anubhav Mishra, Luke Kysow"
 
 # We use gosu to step down from root and run as the atlantis user so we need


### PR DESCRIPTION
Mitigation for CVE-2018-19486 (https://nvd.nist.gov/vuln/detail/CVE-2018-19486)

Alpine 3.8 ships git version 2.18.1 which is vulnerable per above. This is one possible mitigation technique, though I do not know the impact of changing the FROM image in this project