### PR TITLE
Stop Atlantis replying to non-atlantis comments.

### DIFF
--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -64,10 +64,9 @@ type CommentBuilder interface {
 
 // CommentParser implements CommentParsing
 type CommentParser struct {
-	GithubUser  string
-	GithubToken string
-	GitlabUser  string
-	GitlabToken string
+	GithubUser    string
+	GitlabUser    string
+	BitbucketUser string
 }
 
 // CommentParseResult describes the result of parsing a comment as a command.
@@ -117,9 +116,14 @@ func (e *CommentParser) Parse(comment string, vcsHost models.VCSHostType) Commen
 
 	// Atlantis can be invoked using the name of the VCS host user we're
 	// running under. Need to be able to match against that user.
-	vcsUser := e.GithubUser
-	if vcsHost == models.Gitlab {
+	var vcsUser string
+	switch vcsHost {
+	case models.Github:
+		vcsUser = e.GithubUser
+	case models.Gitlab:
 		vcsUser = e.GitlabUser
+	case models.BitbucketCloud, models.BitbucketServer:
+		vcsUser = e.BitbucketUser
 	}
 	executableNames := []string{"run", atlantisExecutable, "@" + vcsUser}
 	if !e.stringInSlice(args[0], executableNames) {

--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -24,10 +24,8 @@ import (
 )
 
 var commentParser = events.CommentParser{
-	GithubUser:  "github-user",
-	GithubToken: "github-token",
-	GitlabUser:  "gitlab-user",
-	GitlabToken: "gitlab-token",
+	GithubUser: "github-user",
+	GitlabUser: "gitlab-user",
 }
 
 func TestParse_Ignored(t *testing.T) {
@@ -640,6 +638,42 @@ func TestBuildPlanApplyComment(t *testing.T) {
 					Equals(t, fmt.Sprintf("atlantis apply %s", c.expApplyFlags), actComment)
 				}
 			}
+		})
+	}
+}
+
+func TestParse_VCSUsername(t *testing.T) {
+	cp := events.CommentParser{
+		GithubUser:    "gh",
+		GitlabUser:    "gl",
+		BitbucketUser: "bb",
+	}
+	cases := []struct {
+		vcs  models.VCSHostType
+		user string
+	}{
+		{
+			vcs:  models.Github,
+			user: "gh",
+		},
+		{
+			vcs:  models.Gitlab,
+			user: "gl",
+		},
+		{
+			vcs:  models.BitbucketServer,
+			user: "bb",
+		},
+		{
+			vcs:  models.BitbucketCloud,
+			user: "bb",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.vcs.String(), func(t *testing.T) {
+			r := cp.Parse(fmt.Sprintf("@%s %s", c.user, "help"), c.vcs)
+			Equals(t, events.HelpComment, r.CommentResponse)
 		})
 	}
 }

--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -37,6 +37,7 @@ func TestParse_Ignored(t *testing.T) {
 		"abc",
 		"atlantis plan\nbut with newlines",
 		"terraform plan\nbut with newlines",
+		"This shouldn't error, but it does.",
 	}
 	for _, c := range ignoreComments {
 		r := commentParser.Parse(c, models.Github)

--- a/server/events_controller_e2e_test.go
+++ b/server/events_controller_e2e_test.go
@@ -368,10 +368,8 @@ func setupE2E(t *testing.T) (server.EventsController, *vcsmocks.MockClient, *moc
 		GitlabToken: "gitlab-token",
 	}
 	commentParser := &events.CommentParser{
-		GithubUser:  "github-user",
-		GithubToken: "github-token",
-		GitlabUser:  "gitlab-user",
-		GitlabToken: "gitlab-token",
+		GithubUser: "github-user",
+		GitlabUser: "gitlab-user",
 	}
 	terraformClient, err := terraform.NewClient(dataDir, "")
 	Ok(t, err)

--- a/server/server.go
+++ b/server/server.go
@@ -217,10 +217,9 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		BitbucketServerURL: userConfig.BitbucketBaseURL,
 	}
 	commentParser := &events.CommentParser{
-		GithubUser:  userConfig.GithubUser,
-		GithubToken: userConfig.GithubToken,
-		GitlabUser:  userConfig.GitlabUser,
-		GitlabToken: userConfig.GitlabToken,
+		GithubUser:    userConfig.GithubUser,
+		GitlabUser:    userConfig.GitlabUser,
+		BitbucketUser: userConfig.BitbucketUser,
 	}
 	defaultTfVersion := terraformClient.Version()
 	pendingPlanFinder := &events.DefaultPendingPlanFinder{}


### PR DESCRIPTION
Fixes #533, a regression where Atlantis will respond with errors to
comments that aren't intended to invoke Atlantis.