### PR TITLE
Change Atlantis tagline.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <img src="./runatlantis.io/.vuepress/public/hero.png" alt="Atlantis Logo"/><br><br>
-  <b>Terraform For Teams</b>
+  <b>Terraform Pull Request Automation</b>
 </p>
 
 ## Resources

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,7 +22,7 @@ import (
 // RootCmd is the base command onto which all other commands are added.
 var RootCmd = &cobra.Command{
 	Use:   "atlantis",
-	Short: "A unified workflow for collaborating on Terraform",
+	Short: "Terraform Pull Request Automation",
 }
 
 // Execute starts RootCmd.

--- a/runatlantis.io/.vuepress/config.js
+++ b/runatlantis.io/.vuepress/config.js
@@ -1,6 +1,6 @@
 module.exports = {
     title: 'Atlantis',
-    description: 'Atlantis: Terraform For Teams',
+    description: 'Atlantis: Terraform Pull Request Automation',
     ga: "UA-6850151-3",
     head: [
         ['link', { rel: 'icon', type: 'image/png', href: '/favicon-196x196.png', sizes: '196x196' }],

--- a/runatlantis.io/README.md
+++ b/runatlantis.io/README.md
@@ -5,5 +5,5 @@ heroImage: /hero.png
 heroText: Atlantis
 actionText: Get Started →
 actionLink: /guide/
-title: Terraform For Teams
+title: Terraform Pull Request Automation
 ---

--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -329,7 +329,7 @@ func (e *CommentParser) errMarkdown(errMsg string, command string, flagSet *pfla
 // `atlantis help`.
 var HelpComment = "```cmake\n" +
 	`atlantis
-Terraform For Teams
+Terraform Pull Request Automation
 
 Usage:
   atlantis <command> [options] -- [terraform options]


### PR DESCRIPTION
Atlantis has been focused on TF pull request automation for the last
year so I want to rename its tagline to be more focused.