### PR TITLE
Express how magical Atlantis is with aliases

### DIFF
--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -145,6 +145,18 @@ func TestParse_DidYouMeanAtlantis(t *testing.T) {
 	}
 }
 
+func TestParse_Aliases(t *testing.T) {
+	t.Log("given an alias, this should be expanded to the standard atlantis command")
+	plan := "abracadabra"
+	r1 := commentParser.Parse(plan, models.Github)
+	Assert(t, r1.Command.Name == models.PlanCommand, "For comment %q expected Command==%q, but got %q", plan, models.PlanCommand, r1.Command)
+	directory := "only/the/magical/parts"
+	apply := fmt.Sprintf("simsalabim -d %s", directory)
+	r2 := commentParser.Parse(apply, models.Github)
+	Assert(t, r2.Command.Name == models.ApplyCommand, "For comment %q expected Command=%q, but got %q", apply, models.ApplyCommand, r2.Command)
+	Assert(t, r2.Command.RepoRelDir == "only/the/magical/parts", "For comment %q expected RepoRelDir=%q, but got %q", apply, directory, r2.Command.RepoRelDir)
+}
+
 func TestParse_InvalidCommand(t *testing.T) {
 	t.Log("given a comment with an invalid atlantis command, should return " +
 		"a warning.")


### PR DESCRIPTION
When Atlantis is setup and properly integrated with your git
repository, it can seem like magic for the user. Simply by committing
a change to a terraform recipe, Atlantis can trigger terraform so that
it plans the changes needed (either on-premise or in the cloud), and
making the changes are only a single command away.

Normal users may not be familiar with the product name 'Atlantis',
though, and may think more of the allegory of Atlantis from Plato's
works (at least in countries where philosophy is a required part of the
curriculum of a computer science education). In Plato's work, the
island submerges into the Atlantic ocean -- going under -- which is
hardly what a user wants their infrastructure to do (water and
computers still don't go well together -- at least until Elon Musk
finds a need to fix that).

To counter this, we introduce the concept of aliases. In this commit
we introduce the two built in aliases "abracadabra" and "simsalabim"
to mean to plan and apply respectively, but with a more magical
flair. Instead of the user having to sit down and understand the
concept of a new piece of software like Atlantis, they can simply
accept that it is really magic, and use appropriate spells^Wcommands.

In the future, aliases can be expanded to be user configurable, and by
licensing intellectual property from literary works such as Harry
Potter or J.R.R Tolkien, a complete new world could open up for
developers and system administrators that have accepted that they
really don't control their infrastructure or computers in general,
especially in a cloud setting. It is really just a huge amount
of magic.