### PR TITLE
Comment on why EROR and DBUG are not typos

### DIFF
--- a/server/logging/simple_logger.go
+++ b/server/logging/simple_logger.go
@@ -189,6 +189,8 @@ func (l *SimpleLogger) capitalizeFirstLetter(s string) string {
 	return string(runes)
 }
 
+// levelToString returns the logging level as a 4 character string. DEBUG and ERROR are shortened intentionally
+// so that logs line up.
 func (l *SimpleLogger) levelToString(level LogLevel) string {
 	switch level {
 	case Debug:


### PR DESCRIPTION
Includes the change in server/logging/simple_logger.go that will allow tests to pass but since its being vendored instead of being a relative path within the project, it won't take effect until after merging. Please let me know if there is a preferable way to doing this.