### PR TITLE
Fix apply all with project name bug

### DIFF
--- a/server/events/pending_plan_finder.go
+++ b/server/events/pending_plan_finder.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"github.com/runatlantis/atlantis/server/events/runtime"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -29,7 +30,8 @@ type PendingPlan struct {
 	// the plan is for.
 	RepoRelDir string
 	// Workspace is the workspace this plan should execute in.
-	Workspace string
+	Workspace   string
+	ProjectName string
 }
 
 // Find finds all pending plans in pullDir. pullDir should be the working
@@ -67,11 +69,15 @@ func (p *DefaultPendingPlanFinder) findWithAbsPaths(pullDir string) ([]PendingPl
 					continue
 				}
 
-				repoRelDir := filepath.Dir(file)
+				projectName, err := runtime.ProjectNameFromPlanfile(workspace, filepath.Base(file))
+				if err != nil {
+					return nil, nil, err
+				}
 				plans = append(plans, PendingPlan{
-					RepoDir:    repoDir,
-					RepoRelDir: repoRelDir,
-					Workspace:  workspace,
+					RepoDir:     repoDir,
+					RepoRelDir:  filepath.Dir(file),
+					Workspace:   workspace,
+					ProjectName: projectName,
 				})
 				absPaths = append(absPaths, filepath.Join(repoDir, file))
 			}

--- a/server/events/pending_plan_finder_test.go
+++ b/server/events/pending_plan_finder_test.go
@@ -54,9 +54,26 @@ func TestPendingPlanFinder_Find(t *testing.T) {
 			},
 			[]events.PendingPlan{
 				{
-					RepoDir:    "???/default",
-					RepoRelDir: ".",
-					Workspace:  "default",
+					RepoDir:     "???/default",
+					RepoRelDir:  ".",
+					Workspace:   "default",
+					ProjectName: "projectname",
+				},
+			},
+		},
+		{
+			"root dir project plan with slashes",
+			map[string]interface{}{
+				"default": map[string]interface{}{
+					"project::name-default.tfplan": nil,
+				},
+			},
+			[]events.PendingPlan{
+				{
+					RepoDir:     "???/default",
+					RepoRelDir:  ".",
+					Workspace:   "default",
+					ProjectName: "project/name",
 				},
 			},
 		},

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -206,7 +206,7 @@ func (p *DefaultProjectCommandBuilder) buildApplyAllCommands(ctx *CommandContext
 
 	var cmds []models.ProjectCommandContext
 	for _, plan := range plans {
-		cmd, err := p.buildProjectCommandCtx(ctx, models.ApplyCommand, commentCmd.ProjectName, commentCmd.Flags, plan.RepoDir, plan.RepoRelDir, plan.Workspace, commentCmd.Verbose)
+		cmd, err := p.buildProjectCommandCtx(ctx, models.ApplyCommand, plan.ProjectName, commentCmd.Flags, plan.RepoDir, plan.RepoRelDir, plan.Workspace, commentCmd.Verbose)
 		if err != nil {
 			return nil, errors.Wrapf(err, "building command for dir %q", plan.RepoRelDir)
 		}

--- a/server/events/runtime/runtime_test.go
+++ b/server/events/runtime/runtime_test.go
@@ -21,18 +21,13 @@ func TestGetPlanFilename(t *testing.T) {
 		},
 		{
 			"workspace",
-			"",
-			"workspace.tfplan",
-		},
-		{
-			"workspace",
 			"project",
 			"project-workspace.tfplan",
 		},
 		{
 			"workspace",
 			"project/with/slash",
-			"project-with-slash-workspace.tfplan",
+			"project::with::slash-workspace.tfplan",
 		},
 		{
 			"workspace",
@@ -44,16 +39,57 @@ func TestGetPlanFilename(t *testing.T) {
 			"project😀",
 			"project😀-workspace😀.tfplan",
 		},
+		// Previously we replaced invalid chars with -'s, however we now
+		// rely on validation of the atlantis.yaml file to ensure the name's
+		// don't contain chars that need to be url encoded. So now these
+		// chars shouldn't get replaced.
 		{
 			"default",
 			`all.invalid.chars \/"*?<>`,
-			"all.invalid.chars --------default.tfplan",
+			"all.invalid.chars \\::\"*?<>-default.tfplan",
 		},
 	}
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
 			Equals(t, c.exp, runtime.GetPlanFilename(c.workspace, c.projectName))
+		})
+	}
+}
+
+func TestProjectNameFromPlanfile(t *testing.T) {
+	cases := []struct {
+		workspace string
+		filename  string
+		exp       string
+	}{
+		{
+			"workspace",
+			"workspace.tfplan",
+			"",
+		},
+		{
+			"workspace",
+			"project-workspace.tfplan",
+			"project",
+		},
+		{
+			"workspace",
+			"project-workspace-workspace.tfplan",
+			"project-workspace",
+		},
+		{
+			"workspace",
+			"project::with::slashes::-workspace.tfplan",
+			"project/with/slashes/",
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			act, err := runtime.ProjectNameFromPlanfile(c.workspace, c.filename)
+			Ok(t, err)
+			Equals(t, c.exp, act)
 		})
 	}
 }

--- a/server/events/yaml/valid/repo_cfg.go
+++ b/server/events/yaml/valid/repo_cfg.go
@@ -13,10 +13,10 @@ type RepoCfg struct {
 	Automerge bool
 }
 
-func (r RepoCfg) FindProjectsByDirWorkspace(dir string, workspace string) []Project {
+func (r RepoCfg) FindProjectsByDirWorkspace(repoRelDir string, workspace string) []Project {
 	var ps []Project
 	for _, p := range r.Projects {
-		if p.Dir == dir && p.Workspace == workspace {
+		if p.Dir == repoRelDir && p.Workspace == workspace {
 			ps = append(ps, p)
 		}
 	}


### PR DESCRIPTION
Previously, if you were using project names and you had two projects
with the same directory and workspace but different workflows, running
"atlantis apply" would fail. This was because we weren't figuring out
what the project name was for each pending plan.

This change fixes this by extracting the project name from the planfile.
We also handle /'s in the project name by substituting them with '::'.
This allows us to convert them back to /'s when we're figuring out the
project names from the filenames. It's safe to do this because : isn't
an allowed character for project names.

We also remove a final substitution of invalid filename characters
because we rely on the validation of the project names instead which
happens when validating the atlantis.yaml file.

Fixes #365