### PR TITLE
Update using-atlantis.md

### DIFF
--- a/runatlantis.io/docs/using-atlantis.md
+++ b/runatlantis.io/docs/using-atlantis.md
@@ -50,7 +50,7 @@ atlantis plan -w staging
 If you need to run `terraform plan` with additional arguments, like `-target=resource` or `-var 'foo-bar'` or `-var-file myfile.tfvars`
 you can append them to the end of the comment after `--`, ex.
 ```
-atlantis plan -d dir -- -var 'foo=bar'
+atlantis plan -d dir -- -var foo='bar'
 ```
 If you always need to append a certain flag, see [Custom Workflow Use Cases](custom-workflows.html#adding-extra-arguments-to-terraform-commands).
 


### PR DESCRIPTION
Running `atlantis plan -- -var 'foo=bar'` causes the following:

```
exit status 1: running "terraform plan -input=false -refresh -no-color -out \"/atlantis-data/path/to/repo/default.tfplan\" -var atlantis_user=\"xxxxx\" -var atlantis_repo=\"xxxxxx\" -var atlantis_repo_name=\"xxxxxx\" -var atlantis_repo_owner=\"xxxxx\" -var atlantis_pull_num=xx \"-var\" \"'foo=bar'\"" in "/atlantis-data/path/to/repo"

Error: Required variable not set: foo`
```

While running `atlantis plan -- -var foo='bar'` successfully pass the `foo` variable to terraform plan