### PR TITLE
Never use fast-forward merges

### DIFF
--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -151,8 +151,14 @@ func (w *FileWorkspace) forceClone(log *logging.SimpleLogger,
 			{
 				"git", "fetch", "head", fmt.Sprintf("+refs/heads/%s:", p.HeadBranch),
 			},
+			// We use --no-ff because we always want there to be a merge commit.
+			// This way, our branch will look the same regardless if the merge
+			// could be fast forwarded. This is useful later when we run
+			// git rev-parse HEAD^2 to get the head commit because it will
+			// always succeed whereas without --no-ff, if the merge was fast
+			// forwarded then git rev-parse HEAD^2 would fail.
 			{
-				"git", "merge", "-q", "-m", "atlantis-merge", "FETCH_HEAD",
+				"git", "merge", "-q", "--no-ff", "-m", "atlantis-merge", "FETCH_HEAD",
 			},
 		}
 	} else {

--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -106,23 +106,15 @@ func TestClone_CheckoutMergeNoReclone(t *testing.T) {
 	runCmd(t, repoDir, "git", "add", "branch-file")
 	runCmd(t, repoDir, "git", "commit", "-m", "branch-commit")
 
-	// Now switch back to master, advance the master branch by another
-	// commit and perform the merge.
+	// Now switch back to master and advance the master branch by another commit.
 	runCmd(t, repoDir, "git", "checkout", "master")
 	runCmd(t, repoDir, "touch", "master-file")
 	runCmd(t, repoDir, "git", "add", "master-file")
 	runCmd(t, repoDir, "git", "commit", "-m", "master-commit")
-	runCmd(t, repoDir, "git", "merge", "-m", "atlantis-merge", "branch")
 
-	// Our repo is set up, so now copy it into where Atlantis will have
-	// cloned it.
+	// Run the clone for the first time.
 	dataDir, cleanup2 := TempDir(t)
 	defer cleanup2()
-	runCmd(t, dataDir, "mkdir", "-p", "repos/0/")
-	runCmd(t, dataDir, "cp", "-R", repoDir, "repos/0/default")
-	// Create a file that we can use later to check if the repo was recloned.
-	runCmd(t, dataDir, "touch", "repos/0/default/proof")
-
 	overrideURL := fmt.Sprintf("file://%s", repoDir)
 	wd := &events.FileWorkspace{
 		DataDir:                     dataDir,
@@ -131,6 +123,62 @@ func TestClone_CheckoutMergeNoReclone(t *testing.T) {
 		TestingOverrideBaseCloneURL: overrideURL,
 	}
 
+	_, err := wd.Clone(nil, models.Repo{}, models.Repo{}, models.PullRequest{
+		HeadBranch: "branch",
+		BaseBranch: "master",
+	}, "default")
+	Ok(t, err)
+
+	// Create a file that we can use to check if the repo was recloned.
+	runCmd(t, dataDir, "touch", "repos/0/default/proof")
+
+	// Now run the clone again.
+	cloneDir, err := wd.Clone(nil, models.Repo{}, models.Repo{}, models.PullRequest{
+		HeadBranch: "branch",
+		BaseBranch: "master",
+	}, "default")
+	Ok(t, err)
+
+	// Check that our proof file is still there, proving that we didn't reclone.
+	_, err = os.Stat(filepath.Join(cloneDir, "proof"))
+	Ok(t, err)
+}
+
+// Same as TestClone_CheckoutMergeNoReclone however the branch that gets
+// merged is a fast-forward merge. See #584.
+func TestClone_CheckoutMergeNoRecloneFastForward(t *testing.T) {
+	// Initialize the git repo.
+	repoDir, cleanup := initRepo(t)
+	defer cleanup()
+
+	// Add a commit to branch 'branch' that's not on master.
+	// This will result in a fast-forwardable merge.
+	runCmd(t, repoDir, "git", "checkout", "branch")
+	runCmd(t, repoDir, "touch", "branch-file")
+	runCmd(t, repoDir, "git", "add", "branch-file")
+	runCmd(t, repoDir, "git", "commit", "-m", "branch-commit")
+
+	// Run the clone for the first time.
+	dataDir, cleanup2 := TempDir(t)
+	defer cleanup2()
+	overrideURL := fmt.Sprintf("file://%s", repoDir)
+	wd := &events.FileWorkspace{
+		DataDir:                     dataDir,
+		CheckoutMerge:               true,
+		TestingOverrideHeadCloneURL: overrideURL,
+		TestingOverrideBaseCloneURL: overrideURL,
+	}
+
+	_, err := wd.Clone(nil, models.Repo{}, models.Repo{}, models.PullRequest{
+		HeadBranch: "branch",
+		BaseBranch: "master",
+	}, "default")
+	Ok(t, err)
+
+	// Create a file that we can use to check if the repo was recloned.
+	runCmd(t, dataDir, "touch", "repos/0/default/proof")
+
+	// Now run the clone again.
 	cloneDir, err := wd.Clone(nil, models.Repo{}, models.Repo{}, models.PullRequest{
 		HeadBranch: "branch",
 		BaseBranch: "master",
@@ -176,7 +224,7 @@ func TestClone_CheckoutMergeConflict(t *testing.T) {
 		HeadBranch: "branch",
 		BaseBranch: "master",
 	}, "default")
-	ErrEquals(t, `running git merge -q -m atlantis-merge FETCH_HEAD: Auto-merging file
+	ErrEquals(t, `running git merge -q --no-ff -m atlantis-merge FETCH_HEAD: Auto-merging file
 CONFLICT (add/add): Merge conflict in file
 Automatic merge failed; fix conflicts and then commit the result.
 : exit status 1`, err)


### PR DESCRIPTION
When using --checkout-strategy merge, we were performing the merge
without the --no-ff flag. This meant that if the branch could be merged
via a fast-forward merge (without a merge commit), then later when we
ran git rev-parse HEAD^2 to determine if the repo was at the right
commit, it would fail.

Now we merge with --no-ff which ensures the commit tree will always look
the same and git rev-parse HEAD^2 will always succeed.

Fixes #584