### PR TITLE
added pointer for Azure ACI deploy

### DIFF
--- a/runatlantis.io/docs/deployment.md
+++ b/runatlantis.io/docs/deployment.md
@@ -406,6 +406,11 @@ If you need to modify the Docker image that we provide, for instance to add the 
     docker run {YOUR_DOCKER_ORG}/atlantis-custom server --gh-user=GITHUB_USERNAME --gh-token=GITHUB_TOKEN
     ```
 
+### Microsoft Azure
+The standard [Kubernetes Helm Chart](#kubernetes-helm-chart) should work fine on [Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks/intro-kubernetes).
+
+Another option is [Azure Container Instances](https://docs.microsoft.com/en-us/azure/container-instances/). See this [repo](https://github.com/jplane/atlantis-on-aci) for install scripts and more information on running Atlantis on ACI.
+
 ### Roll Your Own
 If you want to roll your own Atlantis installation, you can get the `atlantis`
 binary from [https://github.com/runatlantis/atlantis/releases](https://github.com/runatlantis/atlantis/releases)

--- a/runatlantis.io/docs/deployment.md
+++ b/runatlantis.io/docs/deployment.md
@@ -409,7 +409,7 @@ If you need to modify the Docker image that we provide, for instance to add the 
 ### Microsoft Azure
 The standard [Kubernetes Helm Chart](#kubernetes-helm-chart) should work fine on [Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks/intro-kubernetes).
 
-Another option is [Azure Container Instances](https://docs.microsoft.com/en-us/azure/container-instances/). See this [repo](https://github.com/jplane/atlantis-on-aci) for install scripts and more information on running Atlantis on ACI.
+Another option is [Azure Container Instances](https://docs.microsoft.com/en-us/azure/container-instances/). See this community member's [repo](https://github.com/jplane/atlantis-on-aci) for install scripts and more information on running Atlantis on ACI.
 
 ### Roll Your Own
 If you want to roll your own Atlantis installation, you can get the `atlantis`


### PR DESCRIPTION
Short description of pointer to my separate GH repo with instructions/script for installing Atlantis on Azure Container Instances with self-signed cert, durable Azure backing store for Terraform, etc.