### PR TITLE
Don't include errored cmd output twice.

### DIFF
--- a/server/events/runtime/run_step_runner.go
+++ b/server/events/runtime/run_step_runner.go
@@ -50,7 +50,7 @@ func (r *RunStepRunner) Run(ctx models.ProjectCommandContext, command string, pa
 	if err != nil {
 		err = fmt.Errorf("%s: running %q in %q: \n%s", err, command, path, out)
 		ctx.Log.Debug("error: %s", err)
-		return string(out), err
+		return "", err
 	}
 	ctx.Log.Info("successfully ran %q in %q", command, path)
 	return string(out), nil


### PR DESCRIPTION
Since we're including the command output inside the error, we don't need
to also return the output. This was resulting in the error output being
printed twice.

Fixes #519