### PR TITLE
Add --disable-apply-all flag

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -203,7 +203,7 @@ var boolFlags = map[string]boolFlag{
 		defaultValue: false,
 	},
 	DisableApplyAllFlag: {
-		description:  "Disable `atlantis apply` so a project or workspace or directory has to be specified",
+		description:  "Disable \"atlantis apply\" command so a specific project/workspace/directory has to be specified for applies.",
 		defaultValue: false,
 	},
 	RequireApprovalFlag: {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -48,6 +48,7 @@ const (
 	CheckoutStrategyFlag       = "checkout-strategy"
 	DataDirFlag                = "data-dir"
 	DefaultTFVersionFlag       = "default-tf-version"
+	DisableApplyAllFlag        = "disable-apply-all"
 	GHHostnameFlag             = "gh-hostname"
 	GHTokenFlag                = "gh-token"
 	GHUserFlag                 = "gh-user"
@@ -199,6 +200,10 @@ var boolFlags = map[string]boolFlag{
 	},
 	AutomergeFlag: {
 		description:  "Automatically merge pull requests when all plans are successfully applied.",
+		defaultValue: false,
+	},
+	DisableApplyAllFlag: {
+		description:  "Disable `atlantis apply` so a project or workspace or directory has to be specified",
 		defaultValue: false,
 	},
 	RequireApprovalFlag: {

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -449,7 +449,7 @@ func TestExecute_Flags(t *testing.T) {
 		cmd.CheckoutStrategyFlag:       "merge",
 		cmd.DataDirFlag:                "/path",
 		cmd.DefaultTFVersionFlag:       "v0.11.0",
-		cmd.DisableApplyAll:            true,
+		cmd.DisableApplyAllFlag:        true,
 		cmd.GHHostnameFlag:             "ghhostname",
 		cmd.GHTokenFlag:                "token",
 		cmd.GHUserFlag:                 "user",
@@ -619,6 +619,7 @@ tfe-token: my-token
 		"BITBUCKET_WEBHOOK_SECRET": "override-bitbucket-secret",
 		"CHECKOUT_STRATEGY":        "branch",
 		"DATA_DIR":                 "/override-path",
+		"DISABLE_APPLY_ALL":        "false",
 		"DEFAULT_TF_VERSION":       "v0.12.0",
 		"GH_HOSTNAME":              "override-gh-hostname",
 		"GH_TOKEN":                 "override-gh-token",
@@ -723,7 +724,7 @@ tfe-token: my-token
 		cmd.CheckoutStrategyFlag:       "branch",
 		cmd.DataDirFlag:                "/override-path",
 		cmd.DefaultTFVersionFlag:       "v0.12.0",
-		cmd.DisableApplyAllFlag         false,
+		cmd.DisableApplyAllFlag:        false,
 		cmd.GHHostnameFlag:             "override-gh-hostname",
 		cmd.GHTokenFlag:                "override-gh-token",
 		cmd.GHUserFlag:                 "override-gh-user",
@@ -754,7 +755,7 @@ tfe-token: my-token
 	Equals(t, "branch", passedConfig.CheckoutStrategy)
 	Equals(t, "/override-path", passedConfig.DataDir)
 	Equals(t, "v0.12.0", passedConfig.DefaultTFVersion)
-	Equals(t, false, passedconfig.DisableApplyAll)
+	Equals(t, false, passedConfig.DisableApplyAll)
 	Equals(t, "override-gh-hostname", passedConfig.GithubHostname)
 	Equals(t, "override-gh-token", passedConfig.GithubToken)
 	Equals(t, "override-gh-user", passedConfig.GithubUser)

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -341,7 +341,7 @@ func TestExecute_Defaults(t *testing.T) {
 	Equals(t, dataDir, passedConfig.DataDir)
 
 	Equals(t, "branch", passedConfig.CheckoutStrategy)
-        Equals(t, false, passedConfig.DisableApplyAll)
+	Equals(t, false, passedConfig.DisableApplyAll)
 	Equals(t, "", passedConfig.DefaultTFVersion)
 	Equals(t, "github.com", passedConfig.GithubHostname)
 	Equals(t, "token", passedConfig.GithubToken)
@@ -449,7 +449,7 @@ func TestExecute_Flags(t *testing.T) {
 		cmd.CheckoutStrategyFlag:       "merge",
 		cmd.DataDirFlag:                "/path",
 		cmd.DefaultTFVersionFlag:       "v0.11.0",
-                cmd.DisableApplyAll:            true,
+		cmd.DisableApplyAll:            true,
 		cmd.GHHostnameFlag:             "ghhostname",
 		cmd.GHTokenFlag:                "token",
 		cmd.GHUserFlag:                 "user",
@@ -482,7 +482,7 @@ func TestExecute_Flags(t *testing.T) {
 	Equals(t, "merge", passedConfig.CheckoutStrategy)
 	Equals(t, "/path", passedConfig.DataDir)
 	Equals(t, "v0.11.0", passedConfig.DefaultTFVersion)
-        Equals(t, true, passedConfig.DisableApplyAll)
+	Equals(t, true, passedConfig.DisableApplyAll)
 	Equals(t, "ghhostname", passedConfig.GithubHostname)
 	Equals(t, "token", passedConfig.GithubToken)
 	Equals(t, "user", passedConfig.GithubUser)
@@ -553,7 +553,7 @@ tfe-token: my-token
 	Equals(t, "merge", passedConfig.CheckoutStrategy)
 	Equals(t, "/path", passedConfig.DataDir)
 	Equals(t, "v0.11.0", passedConfig.DefaultTFVersion)
-        Equals(t, true, passedConfig.DisableApplyAll)
+	Equals(t, true, passedConfig.DisableApplyAll)
 	Equals(t, "ghhostname", passedConfig.GithubHostname)
 	Equals(t, "token", passedConfig.GithubToken)
 	Equals(t, "user", passedConfig.GithubUser)
@@ -656,7 +656,7 @@ tfe-token: my-token
 	Equals(t, "branch", passedConfig.CheckoutStrategy)
 	Equals(t, "/override-path", passedConfig.DataDir)
 	Equals(t, "v0.12.0", passedConfig.DefaultTFVersion)
-        Equals(t, false, passedConfig.DisableApplyAll)
+	Equals(t, false, passedConfig.DisableApplyAll)
 	Equals(t, "override-gh-hostname", passedConfig.GithubHostname)
 	Equals(t, "override-gh-token", passedConfig.GithubToken)
 	Equals(t, "override-gh-user", passedConfig.GithubUser)
@@ -723,7 +723,7 @@ tfe-token: my-token
 		cmd.CheckoutStrategyFlag:       "branch",
 		cmd.DataDirFlag:                "/override-path",
 		cmd.DefaultTFVersionFlag:       "v0.12.0",
-                cmd.DisableApplyAllFlag         false,
+		cmd.DisableApplyAllFlag         false,
 		cmd.GHHostnameFlag:             "override-gh-hostname",
 		cmd.GHTokenFlag:                "override-gh-token",
 		cmd.GHUserFlag:                 "override-gh-user",
@@ -754,7 +754,7 @@ tfe-token: my-token
 	Equals(t, "branch", passedConfig.CheckoutStrategy)
 	Equals(t, "/override-path", passedConfig.DataDir)
 	Equals(t, "v0.12.0", passedConfig.DefaultTFVersion)
-        Equals(t, false, passedconfig.DisableApplyAll)
+	Equals(t, false, passedconfig.DisableApplyAll)
 	Equals(t, "override-gh-hostname", passedConfig.GithubHostname)
 	Equals(t, "override-gh-token", passedConfig.GithubToken)
 	Equals(t, "override-gh-user", passedConfig.GithubUser)
@@ -830,7 +830,7 @@ func TestExecute_FlagEnvVarOverride(t *testing.T) {
 		cmd.CheckoutStrategyFlag:       "branch",
 		cmd.DataDirFlag:                "/override-path",
 		cmd.DefaultTFVersionFlag:       "v0.12.0",
-                cmd.DisableApplyAllFlag:        false,
+		cmd.DisableApplyAllFlag:        false,
 		cmd.GHHostnameFlag:             "override-gh-hostname",
 		cmd.GHTokenFlag:                "override-gh-token",
 		cmd.GHUserFlag:                 "override-gh-user",
@@ -863,7 +863,7 @@ func TestExecute_FlagEnvVarOverride(t *testing.T) {
 	Equals(t, "branch", passedConfig.CheckoutStrategy)
 	Equals(t, "/override-path", passedConfig.DataDir)
 	Equals(t, "v0.12.0", passedConfig.DefaultTFVersion)
-        Equals(t, false, passedConfig.DisableApplyAll)
+	Equals(t, false, passedConfig.DisableApplyAll)
 	Equals(t, "override-gh-hostname", passedConfig.GithubHostname)
 	Equals(t, "override-gh-token", passedConfig.GithubToken)
 	Equals(t, "override-gh-user", passedConfig.GithubUser)

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -341,6 +341,7 @@ func TestExecute_Defaults(t *testing.T) {
 	Equals(t, dataDir, passedConfig.DataDir)
 
 	Equals(t, "branch", passedConfig.CheckoutStrategy)
+        Equals(t, false, passedConfig.DisableApplyAll)
 	Equals(t, "", passedConfig.DefaultTFVersion)
 	Equals(t, "github.com", passedConfig.GithubHostname)
 	Equals(t, "token", passedConfig.GithubToken)
@@ -448,6 +449,7 @@ func TestExecute_Flags(t *testing.T) {
 		cmd.CheckoutStrategyFlag:       "merge",
 		cmd.DataDirFlag:                "/path",
 		cmd.DefaultTFVersionFlag:       "v0.11.0",
+                cmd.DisableApplyAll:            true,
 		cmd.GHHostnameFlag:             "ghhostname",
 		cmd.GHTokenFlag:                "token",
 		cmd.GHUserFlag:                 "user",
@@ -480,6 +482,7 @@ func TestExecute_Flags(t *testing.T) {
 	Equals(t, "merge", passedConfig.CheckoutStrategy)
 	Equals(t, "/path", passedConfig.DataDir)
 	Equals(t, "v0.11.0", passedConfig.DefaultTFVersion)
+        Equals(t, true, passedConfig.DisableApplyAll)
 	Equals(t, "ghhostname", passedConfig.GithubHostname)
 	Equals(t, "token", passedConfig.GithubToken)
 	Equals(t, "user", passedConfig.GithubUser)
@@ -513,6 +516,7 @@ bitbucket-webhook-secret: "bitbucket-secret"
 checkout-strategy: "merge"
 data-dir: "/path"
 default-tf-version: "v0.11.0"
+disable-apply-all: true
 gh-hostname: "ghhostname"
 gh-token: "token"
 gh-user: "user"
@@ -549,6 +553,7 @@ tfe-token: my-token
 	Equals(t, "merge", passedConfig.CheckoutStrategy)
 	Equals(t, "/path", passedConfig.DataDir)
 	Equals(t, "v0.11.0", passedConfig.DefaultTFVersion)
+        Equals(t, true, passedConfig.DisableApplyAll)
 	Equals(t, "ghhostname", passedConfig.GithubHostname)
 	Equals(t, "token", passedConfig.GithubToken)
 	Equals(t, "user", passedConfig.GithubUser)
@@ -582,6 +587,7 @@ bitbucket-webhook-secret: "bitbucket-secret"
 checkout-strategy: "merge"
 data-dir: "/path"
 default-tf-version: "v0.11.0"
+disable-apply-all: true
 gh-hostname: "ghhostname"
 gh-token: "token"
 gh-user: "user"
@@ -650,6 +656,7 @@ tfe-token: my-token
 	Equals(t, "branch", passedConfig.CheckoutStrategy)
 	Equals(t, "/override-path", passedConfig.DataDir)
 	Equals(t, "v0.12.0", passedConfig.DefaultTFVersion)
+        Equals(t, false, passedConfig.DisableApplyAll)
 	Equals(t, "override-gh-hostname", passedConfig.GithubHostname)
 	Equals(t, "override-gh-token", passedConfig.GithubToken)
 	Equals(t, "override-gh-user", passedConfig.GithubUser)
@@ -683,6 +690,7 @@ bitbucket-webhook-secret: "bitbucket-secret"
 checkout-strategy: "merge"
 data-dir: "/path"
 default-tf-version: "v0.11.0"
+disable-apply-all: true
 gh-hostname: "ghhostname"
 gh-token: "token"
 gh-user: "user"
@@ -715,6 +723,7 @@ tfe-token: my-token
 		cmd.CheckoutStrategyFlag:       "branch",
 		cmd.DataDirFlag:                "/override-path",
 		cmd.DefaultTFVersionFlag:       "v0.12.0",
+                cmd.DisableApplyAllFlag         false,
 		cmd.GHHostnameFlag:             "override-gh-hostname",
 		cmd.GHTokenFlag:                "override-gh-token",
 		cmd.GHUserFlag:                 "override-gh-user",
@@ -745,6 +754,7 @@ tfe-token: my-token
 	Equals(t, "branch", passedConfig.CheckoutStrategy)
 	Equals(t, "/override-path", passedConfig.DataDir)
 	Equals(t, "v0.12.0", passedConfig.DefaultTFVersion)
+        Equals(t, false, passedconfig.DisableApplyAll)
 	Equals(t, "override-gh-hostname", passedConfig.GithubHostname)
 	Equals(t, "override-gh-token", passedConfig.GithubToken)
 	Equals(t, "override-gh-user", passedConfig.GithubUser)
@@ -820,6 +830,7 @@ func TestExecute_FlagEnvVarOverride(t *testing.T) {
 		cmd.CheckoutStrategyFlag:       "branch",
 		cmd.DataDirFlag:                "/override-path",
 		cmd.DefaultTFVersionFlag:       "v0.12.0",
+                cmd.DisableApplyAllFlag:        false,
 		cmd.GHHostnameFlag:             "override-gh-hostname",
 		cmd.GHTokenFlag:                "override-gh-token",
 		cmd.GHUserFlag:                 "override-gh-user",
@@ -852,6 +863,7 @@ func TestExecute_FlagEnvVarOverride(t *testing.T) {
 	Equals(t, "branch", passedConfig.CheckoutStrategy)
 	Equals(t, "/override-path", passedConfig.DataDir)
 	Equals(t, "v0.12.0", passedConfig.DefaultTFVersion)
+        Equals(t, false, passedConfig.DisableApplyAll)
 	Equals(t, "override-gh-hostname", passedConfig.GithubHostname)
 	Equals(t, "override-gh-token", passedConfig.GithubToken)
 	Equals(t, "override-gh-user", passedConfig.GithubUser)

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -48,7 +48,7 @@ Values are chosen in this order:
   atlantis server --allow-fork-prs
   ```
   Respond to pull requests from forks. Defaults to `false`.
-  
+
   :::warning SECURITY WARNING
   Potentially dangerous to enable
   because if attackers can create a pull request to your repo then they can cause Atlantis
@@ -56,7 +56,7 @@ Values are chosen in this order:
   Atlantis will automatically run `terraform plan`
   which can run arbitrary code if given a malicious Terraform configuration.
   :::
-  
+
 * ### `--allow-repo-config`
   <Badge text="Deprecated" type="warn"/>
   ```bash
@@ -64,7 +64,7 @@ Values are chosen in this order:
   ```
   This flag is deprecated. It allows all repos to use all restricted
   `atlantis.yaml` keys. See [Repo Level Atlantis.yaml](repo-level-atlantis-yaml.html) for more details.
-  
+
   Instead of using this flag, create a server-side `--repo-config` file:
   ```yaml
   # repos.yaml
@@ -77,7 +77,7 @@ Values are chosen in this order:
   ```bash
   --repo-config-json='{"repos":[{"id":"/.*/", "allowed_overrides":["apply_requirements","workflow"], "allow_custom_workflows":true}]}'
   ````
-  
+
   ::: warning SECURITY WARNING
   This setting enables pull requests to run arbitrary code on the Atlantis server.
   Only enable in trusted settings.
@@ -105,7 +105,7 @@ Values are chosen in this order:
   Base URL of Bitbucket Server (aka Stash) installation. Must include
   `http://` or `https://`. If using Bitbucket Cloud (bitbucket.org), do not set. Defaults to
   `https://api.bitbucket.org`.
-  
+
 * ### `--bitbucket-token`
   ```bash
   atlantis server --bitbucket-token="token"
@@ -119,7 +119,7 @@ Values are chosen in this order:
   atlantis server --bitbucket-user="myuser"
   ```
   Bitbucket username of API user.
-  
+
 * ### `--bitbucket-webhook-secret`
   ```bash
   atlantis server --bitbucket-webhook-secret="secret"
@@ -128,19 +128,19 @@ Values are chosen in this order:
   ```
   Secret used to validate Bitbucket webhooks. Only Bitbucket Server supports webhook secrets.
   For Bitbucket.org, see [Security](security.html#bitbucket-cloud-bitbucket-org) for mitigations.
-  
+
   ::: warning SECURITY WARNING
   If not specified, Atlantis won't be able to validate that the incoming webhook call came from Bitbucket.
   This means that an attacker could spoof calls to Atlantis and cause it to perform malicious actions.
   :::
-  
+
 * ### `--checkout-strategy`
   ```bash
   atlantis server --checkout-strategy="<branch|merge>"
   ```
   How to check out pull requests.
   Defaults to `branch`. See [Checkout Strategy](checkout-strategy.html) for more details.
-  
+
 * ### `--config`
   ```bash
   atlantis server --config="my/config/file.yaml"
@@ -155,7 +155,7 @@ Values are chosen in this order:
   Defaults to `~/.atlantis`. Atlantis will store its database, checked out repos, Terraform plans and downloaded
   Terraform binaries here. If Atlantis loses this directory, [locks](locking.html)
   will be lost and unapplied plans will be lost.
-  
+
 * ### `--default-tf-version`
   ```bash
   atlantis server --default-tf-version="v0.12.0"
@@ -163,13 +163,20 @@ Values are chosen in this order:
   Terraform version to default to. Will download to `<data-dir>/bin/terraform<version>`
   if not in `PATH`. See [Terraform Versions](terraform-versions.html) for more details.
 
+* ### `--disable-apply-all`
+  ```bash
+  atlantis server --disable-apply-all
+  ```
+  Disable \"atlantis apply\" command so a specific project/workspace/directory has to
+  be specified for applies.
+
 * ### `--gh-hostname`
   ```bash
   atlantis server --gh-hostname="my.github.enterprise.com"
   ```
   Hostname of your GitHub Enterprise installation. If using [Github.com](https://github.com),
   don't set. Defaults to `github.com`.
-  
+
 * ### `--gh-token`
   ```bash
   atlantis server --gh-token="token"
@@ -183,7 +190,7 @@ Values are chosen in this order:
   atlantis server --gh-user="myuser"
   ```
    GitHub username of API user.
-  
+
 * ### `--gh-webhook-secret`
   ```bash
   atlantis server --gh-webhook-secret="secret"
@@ -191,7 +198,7 @@ Values are chosen in this order:
   ATLANTIS_GH_WEBHOOK_SECRET='secret' atlantis server
   ```
   Secret used to validate GitHub webhooks (see [https://developer.github.com/webhooks/securing/](https://developer.github.com/webhooks/securing/)).
-  
+
   ::: warning SECURITY WARNING
   If not specified, Atlantis won't be able to validate that the incoming webhook call came from GitHub.
   This means that an attacker could spoof calls to Atlantis and cause it to perform malicious actions.
@@ -203,7 +210,7 @@ Values are chosen in this order:
   ```
   Hostname of your GitLab Enterprise installation. If using [Gitlab.com](https://gitlab.com),
   don't set. Defaults to `gitlab.com`.
-  
+
 * ### `--gitlab-token`
   ```bash
   atlantis server --gitlab-token="token"
@@ -217,7 +224,7 @@ Values are chosen in this order:
   atlantis server --gitlab-user="myuser"
   ```
    GitLab username of API user.
-  
+
 * ### `--gitlab-webhook-secret`
   ```bash
   atlantis server --gh-webhook-secret="secret"
@@ -225,12 +232,12 @@ Values are chosen in this order:
   ATLANTIS_GITLAB_WEBHOOK_SECRET='secret' atlantis server
   ```
   Secret used to validate GitLab webhooks.
-  
+
   ::: warning SECURITY WARNING
   If not specified, Atlantis won't be able to validate that the incoming webhook call came from GitLab.
   This means that an attacker could spoof calls to Atlantis and cause it to perform malicious actions.
   :::
-  
+
 * ### `--help`
   ```bash
   atlantis server --help
@@ -248,7 +255,7 @@ Values are chosen in this order:
   atlantis server --port=8080
   ```
   Port to bind to. Defaults to `4141`.
-  
+
 * ### `--repo-config`
   ```bash
   atlantis server --repo-config="path/to/repos.yaml"
@@ -261,7 +268,7 @@ Values are chosen in this order:
   ```
   Specify server-side repo config as a JSON string. Useful if you don't want to write a config file to disk.
   See [Server Side Repo Config](server-side-repo-config.html) for more details.
-  
+
   ::: tip
   If specifying a [Workflow](custom-workflows.html#reference), [step](custom-workflows.html#step)'s
   can be specified as follows:
@@ -288,7 +295,7 @@ Values are chosen in this order:
   }
   ```
   :::
-  
+
 * ### `--repo-whitelist`
   ```bash
   # NOTE: Use single quotes to avoid shell expansion of *.
@@ -311,7 +318,7 @@ Values are chosen in this order:
     * `--repo-whitelist='github.yourcompany.com/*'`
   * Whitelist all repositories
     * `--repo-whitelist='*'`
-  
+
 * ### `--require-approval`
   <Badge text="Deprecated" type="warn"/>
   ```bash
@@ -319,7 +326,7 @@ Values are chosen in this order:
   ```
   This flag is deprecated. It requires all pull requests to be approved
   before `atlantis apply` is allowed. See [Apply Requirements](apply-requirements.html) for more details.
-  
+
   Instead of using this flag, create a server-side `--repo-config` file:
   ```yaml
   # repos.yaml
@@ -328,7 +335,7 @@ Values are chosen in this order:
     apply_requirements: [approved]
   ```
   Or use `--repo-config-json='{"repos":[{"id":"/.*/", "apply_requirements":["approved"]}]}'` instead.
-  
+
 * ### `--require-mergeable`
   <Badge text="Deprecated" type="warn"/>
   ```bash
@@ -336,7 +343,7 @@ Values are chosen in this order:
   ```
   This flag is deprecated. It causes all pull requests to be mergeable
   before `atlantis apply` is allowed. See [Apply Requirements](apply-requirements.html) for more details.
-  
+
   Instead of using this flag, create a server-side `--repo-config` file:
   ```yaml
   # repos.yaml
@@ -345,7 +352,7 @@ Values are chosen in this order:
     apply_requirements: [mergeable]
   ```
   Or use `--repo-config-json='{"repos":[{"id":"/.*/", "apply_requirements":["mergeable"]}]}'` instead.
-  
+
 * ### `--silence-whitelist-errors`
   ```bash
   atlantis server --silence-whitelist-errors
@@ -372,13 +379,13 @@ Values are chosen in this order:
   File containing x509 Certificate used for serving HTTPS.
   If the cert is signed by a CA, the file should be the concatenation
   of the server's certificate, any intermediates, and the CA's certificate.
-  
+
 * ### `--ssl-key-file`
   ```bash
   atlantis server --ssl-cert-file="/etc/ssl/private/my-cert.key"
   ```
   File containing x509 private key matching `--ssl-cert-file`.
-  
+
 * ### `--tfe-token`
   ```bash
   atlantis server --tfe-token="xxx.atlasv1.yyy"

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -59,7 +59,7 @@ type DefaultCommandRunner struct {
 	GithubPullGetter         GithubPullGetter
 	GitlabMergeRequestGetter GitlabMergeRequestGetter
 	CommitStatusUpdater      CommitStatusUpdater
-        DisableApplyAll          bool
+	DisableApplyAll          bool
 	EventParser              EventParsing
 	MarkdownRenderer         *MarkdownRenderer
 	Logger                   logging.SimpleLogging
@@ -141,7 +141,7 @@ func (c *DefaultCommandRunner) RunAutoplanCommand(baseRepo models.Repo, headRepo
 func (c *DefaultCommandRunner) RunCommentCommand(baseRepo models.Repo, maybeHeadRepo *models.Repo, maybePull *models.PullRequest, user models.User, pullNum int, cmd *CommentCommand) {
 	log := c.buildLogger(baseRepo.FullName, pullNum)
 	defer c.logPanics(baseRepo, pullNum, log)
-        if c.DisableApplyAll && cmd.Name == models.ApplyCommand && !cmd.IsForSpecificProject() {
+	if c.DisableApplyAll && cmd.Name == models.ApplyCommand && !cmd.IsForSpecificProject() {
 		var applyAllDisabledComment = "**Error:** Running `atlantis apply` without flags is disabled. You must specify which project to apply via the `-d <dir>`, `-w <workspace>` or `-p <project name>` flags."
 		if err := c.VCSClient.CreateComment(baseRepo, pullNum, applyAllDisabledComment); err != nil {
 			log.Err("unable to comment on pull request: %s", err)

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -59,6 +59,7 @@ type DefaultCommandRunner struct {
 	GithubPullGetter         GithubPullGetter
 	GitlabMergeRequestGetter GitlabMergeRequestGetter
 	CommitStatusUpdater      CommitStatusUpdater
+        DisableApplyAll          bool
 	EventParser              EventParsing
 	MarkdownRenderer         *MarkdownRenderer
 	Logger                   logging.SimpleLogging
@@ -140,6 +141,13 @@ func (c *DefaultCommandRunner) RunAutoplanCommand(baseRepo models.Repo, headRepo
 func (c *DefaultCommandRunner) RunCommentCommand(baseRepo models.Repo, maybeHeadRepo *models.Repo, maybePull *models.PullRequest, user models.User, pullNum int, cmd *CommentCommand) {
 	log := c.buildLogger(baseRepo.FullName, pullNum)
 	defer c.logPanics(baseRepo, pullNum, log)
+        if c.DisableApplyAll && cmd.Name == models.ApplyCommand && !cmd.IsForSpecificProject() {
+		var applyAllDisabledComment = "**Error:** Running `atlantis apply` without flags is disabled. You must specify which project to apply via the `-d <dir>`, `-w <workspace>` or `-p <project name>` flags."
+		if err := c.VCSClient.CreateComment(baseRepo, pullNum, applyAllDisabledComment); err != nil {
+			log.Err("unable to comment on pull request: %s", err)
+		}
+		return
+	}
 
 	var headRepo models.Repo
 	if maybeHeadRepo != nil {

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -72,6 +72,7 @@ func setup(t *testing.T) *vcsmocks.MockClient {
 		ProjectCommandRunner:     projectCommandRunner,
 		PendingPlanFinder:        pendingPlanFinder,
 		WorkingDir:               workingDir,
+		DisableApplyAll:          false,
 	}
 	return vcsClient
 }
@@ -144,6 +145,16 @@ func TestRunCommentCommand_ForkPRDisabled(t *testing.T) {
 
 	ch.RunCommentCommand(fixtures.GithubRepo, nil, nil, fixtures.User, fixtures.Pull.Num, nil)
 	vcsClient.VerifyWasCalledOnce().CreateComment(fixtures.GithubRepo, modelPull.Num, "Atlantis commands can't be run on fork pull requests. To enable, set --"+ch.AllowForkPRsFlag)
+}
+
+func TestRunCommentCommand_DisableApplyAllDisabled(t *testing.T) {
+	t.Log("if \"atlantis apply\" is run and this is disabled atlantis should" +
+		" comment saying that this is not allowed")
+	vcsClient := setup(t)
+	ch.DisableApplyAll = true
+	modelPull := models.PullRequest{State: models.OpenPullState}
+	ch.RunCommentCommand(fixtures.GithubRepo, nil, nil, fixtures.User, modelPull.Num, &events.CommentCommand{Name: models.ApplyCommand})
+	vcsClient.VerifyWasCalledOnce().CreateComment(fixtures.GithubRepo, modelPull.Num, "**Error:** Running `atlantis apply` without flags is disabled. You must specify which project to apply via the `-d <dir>`, `-w <workspace>` or `-p <project name>` flags.")
 }
 
 func TestRunCommentCommand_ClosedPull(t *testing.T) {

--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -65,9 +65,10 @@ type CommentBuilder interface {
 
 // CommentParser implements CommentParsing
 type CommentParser struct {
-	GithubUser    string
-	GitlabUser    string
-	BitbucketUser string
+	GithubUser      string
+	GitlabUser      string
+	BitbucketUser   string
+	DisableApplyAll bool
 }
 
 // CommentParseResult describes the result of parsing a comment as a command.
@@ -237,6 +238,13 @@ func (e *CommentParser) Parse(comment string, vcsHost models.VCSHostType) Commen
 	// an error.
 	if project != "" && (workspace != "" || dir != "") {
 		err := fmt.Sprintf("cannot use -%s/--%s at same time as -%s/--%s or -%s/--%s", projectFlagShort, projectFlagLong, dirFlagShort, dirFlagLong, workspaceFlagShort, workspaceFlagLong)
+		return CommentParseResult{CommentResponse: e.errMarkdown(err, command, flagSet)}
+	}
+
+	// If no project, workspace, or dir is specified and the flag disable-apply-all is set and the command is apply,
+	// return an error that a project or workspace or dir must be set
+	if project == "" && workspace == "" && dir == "" && e.DisableApplyAll && command == "apply" {
+		err := fmt.Sprintf("disable-apply-all flag is set, you must specify a project or workspace or directory")
 		return CommentParseResult{CommentResponse: e.errMarkdown(err, command, flagSet)}
 	}
 

--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -68,7 +68,6 @@ type CommentParser struct {
 	GithubUser      string
 	GitlabUser      string
 	BitbucketUser   string
-	DisableApplyAll bool
 }
 
 // CommentParseResult describes the result of parsing a comment as a command.
@@ -238,13 +237,6 @@ func (e *CommentParser) Parse(comment string, vcsHost models.VCSHostType) Commen
 	// an error.
 	if project != "" && (workspace != "" || dir != "") {
 		err := fmt.Sprintf("cannot use -%s/--%s at same time as -%s/--%s or -%s/--%s", projectFlagShort, projectFlagLong, dirFlagShort, dirFlagLong, workspaceFlagShort, workspaceFlagLong)
-		return CommentParseResult{CommentResponse: e.errMarkdown(err, command, flagSet)}
-	}
-
-	// If no project, workspace, or dir is specified and the flag disable-apply-all is set and the command is apply,
-	// return an error that a project or workspace or dir must be set
-	if project == "" && workspace == "" && dir == "" && e.DisableApplyAll && command == "apply" {
-		err := fmt.Sprintf("disable-apply-all flag is set, you must specify a project or workspace or directory")
 		return CommentParseResult{CommentResponse: e.errMarkdown(err, command, flagSet)}
 	}
 

--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -65,9 +65,9 @@ type CommentBuilder interface {
 
 // CommentParser implements CommentParsing
 type CommentParser struct {
-	GithubUser      string
-	GitlabUser      string
-	BitbucketUser   string
+	GithubUser    string
+	GitlabUser    string
+	BitbucketUser string
 }
 
 // CommentParseResult describes the result of parsing a comment as a command.

--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -198,8 +198,8 @@ var singleProjectApplyTmpl = template.Must(template.New("").Parse(
 var singleProjectPlanSuccessTmpl = template.Must(template.New("").Parse(
 	"{{$result := index .Results 0}}Ran {{.Command}} for {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n\n{{$result.Rendered}}\n" +
 		"\n" +
-		"---\n" +
-		"{{ if ne .DisableApplyAll true  }}* :fast_forward: To **apply** all unapplied plans from this pull request, comment:\n" +
+		"{{ if ne .DisableApplyAll true  }}---\n" +
+		"* :fast_forward: To **apply** all unapplied plans from this pull request, comment:\n" +
 		"    * `atlantis apply`{{ end }}" + logTmpl))
 var singleProjectPlanUnsuccessfulTmpl = template.Must(template.New("").Parse(
 	"{{$result := index .Results 0}}Ran {{.Command}} for dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n\n" +
@@ -209,10 +209,10 @@ var multiProjectPlanTmpl = template.Must(template.New("").Funcs(sprig.TxtFuncMap
 		"{{ range $result := .Results }}" +
 		"1. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n" +
 		"{{end}}\n" +
-		"{{ range $i, $result := .Results }}" +
+		"{{ $disableApplyAll := .DisableApplyAll }}{{ range $i, $result := .Results }}" +
 		"### {{add $i 1}}. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n" +
 		"{{$result.Rendered}}\n\n" +
-		"---\n{{end}}{{ if ne .DisableApplyAll true }}{{ if and (gt (len .Results) 0) (not .PlansDeleted) }}* :fast_forward: To **apply** all unapplied plans from this pull request, comment:\n" +
+		"{{ if ne $disableApplyAll true }}---\n{{end}}{{end}}{{ if ne .DisableApplyAll true }}{{ if and (gt (len .Results) 0) (not .PlansDeleted) }}* :fast_forward: To **apply** all unapplied plans from this pull request, comment:\n" +
 		"    * `atlantis apply`{{end}}{{end}}" +
 		logTmpl))
 var multiProjectApplyTmpl = template.Must(template.New("").Funcs(sprig.TxtFuncMap()).Parse(

--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -37,14 +37,16 @@ type MarkdownRenderer struct {
 	// using supports the CommonMark markdown format.
 	// If we're not configured with a GitLab client, this will be false.
 	GitlabSupportsCommonMark bool
+	DisableApplyAll          bool
 }
 
 // commonData is data that all responses have.
 type commonData struct {
-	Command      string
-	Verbose      bool
-	Log          string
-	PlansDeleted bool
+	Command         string
+	Verbose         bool
+	Log             string
+	PlansDeleted    bool
+	DisableApplyAll bool
 }
 
 // errData is data about an error response.
@@ -82,10 +84,11 @@ type projectResultTmplData struct {
 func (m *MarkdownRenderer) Render(res CommandResult, cmdName models.CommandName, log string, verbose bool, vcsHost models.VCSHostType) string {
 	commandStr := strings.Title(cmdName.String())
 	common := commonData{
-		Command:      commandStr,
-		Verbose:      verbose,
-		Log:          log,
-		PlansDeleted: res.PlansDeleted,
+		Command:         commandStr,
+		Verbose:         verbose,
+		Log:             log,
+		PlansDeleted:    res.PlansDeleted,
+		DisableApplyAll: m.DisableApplyAll,
 	}
 	if res.Error != nil {
 		return m.renderTemplate(unwrappedErrWithLogTmpl, errData{res.Error.Error(), common})
@@ -196,8 +199,8 @@ var singleProjectPlanSuccessTmpl = template.Must(template.New("").Parse(
 	"{{$result := index .Results 0}}Ran {{.Command}} for {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n\n{{$result.Rendered}}\n" +
 		"\n" +
 		"---\n" +
-		"* :fast_forward: To **apply** all unapplied plans from this pull request, comment:\n" +
-		"    * `atlantis apply`" + logTmpl))
+		"{{ if ne .DisableApplyAll true  }}* :fast_forward: To **apply** all unapplied plans from this pull request, comment:\n" +
+		"    * `atlantis apply`{{ end }}" + logTmpl))
 var singleProjectPlanUnsuccessfulTmpl = template.Must(template.New("").Parse(
 	"{{$result := index .Results 0}}Ran {{.Command}} for dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n\n" +
 		"{{$result.Rendered}}\n" + logTmpl))
@@ -209,8 +212,8 @@ var multiProjectPlanTmpl = template.Must(template.New("").Funcs(sprig.TxtFuncMap
 		"{{ range $i, $result := .Results }}" +
 		"### {{add $i 1}}. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n" +
 		"{{$result.Rendered}}\n\n" +
-		"---\n{{end}}{{ if and (gt (len .Results) 0) (not .PlansDeleted) }}* :fast_forward: To **apply** all unapplied plans from this pull request, comment:\n" +
-		"    * `atlantis apply`{{end}}" +
+		"---\n{{end}}{{ if ne .DisableApplyAll true }}{{ if and (gt (len .Results) 0) (not .PlansDeleted) }}* :fast_forward: To **apply** all unapplied plans from this pull request, comment:\n" +
+		"    * `atlantis apply`{{end}}{{end}}" +
 		logTmpl))
 var multiProjectApplyTmpl = template.Must(template.New("").Funcs(sprig.TxtFuncMap()).Parse(
 	"Ran {{.Command}} for {{ len .Results }} projects:\n\n" +

--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -545,6 +545,159 @@ $$$
 	}
 }
 
+// Test that if disable apply all is set then the apply all footer is not added
+func TestRenderProjectResultsDisableApplyAll(t *testing.T) {
+	cases := []struct {
+		Description    string
+		Command        models.CommandName
+		ProjectResults []models.ProjectResult
+		VCSHost        models.VCSHostType
+		Expected       string
+	}{
+		{
+			"single successful plan with disable apply all set",
+			models.PlanCommand,
+			[]models.ProjectResult{
+				{
+					PlanSuccess: &models.PlanSuccess{
+						TerraformOutput: "terraform-output",
+						LockURL:         "lock-url",
+						RePlanCmd:       "atlantis plan -d path -w workspace",
+						ApplyCmd:        "atlantis apply -d path -w workspace",
+					},
+					Workspace:  "workspace",
+					RepoRelDir: "path",
+				},
+			},
+			models.Github,
+			`Ran Plan for dir: $path$ workspace: $workspace$
+
+$$$diff
+terraform-output
+$$$
+
+* :arrow_forward: To **apply** this plan, comment:
+    * $atlantis apply -d path -w workspace$
+* :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
+* :repeat: To **plan** this project again, comment:
+    * $atlantis plan -d path -w workspace$
+
+
+`,
+		},
+		{
+			"single successful plan with project name with disable apply all set",
+			models.PlanCommand,
+			[]models.ProjectResult{
+				{
+					PlanSuccess: &models.PlanSuccess{
+						TerraformOutput: "terraform-output",
+						LockURL:         "lock-url",
+						RePlanCmd:       "atlantis plan -d path -w workspace",
+						ApplyCmd:        "atlantis apply -d path -w workspace",
+					},
+					Workspace:   "workspace",
+					RepoRelDir:  "path",
+					ProjectName: "projectname",
+				},
+			},
+			models.Github,
+			`Ran Plan for project: $projectname$ dir: $path$ workspace: $workspace$
+
+$$$diff
+terraform-output
+$$$
+
+* :arrow_forward: To **apply** this plan, comment:
+    * $atlantis apply -d path -w workspace$
+* :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
+* :repeat: To **plan** this project again, comment:
+    * $atlantis plan -d path -w workspace$
+
+
+`,
+		},
+		{
+			"multiple successful plans, disable apply all set",
+			models.PlanCommand,
+			[]models.ProjectResult{
+				{
+					Workspace:  "workspace",
+					RepoRelDir: "path",
+					PlanSuccess: &models.PlanSuccess{
+						TerraformOutput: "terraform-output",
+						LockURL:         "lock-url",
+						ApplyCmd:        "atlantis apply -d path -w workspace",
+						RePlanCmd:       "atlantis plan -d path -w workspace",
+					},
+				},
+				{
+					Workspace:   "workspace",
+					RepoRelDir:  "path2",
+					ProjectName: "projectname",
+					PlanSuccess: &models.PlanSuccess{
+						TerraformOutput: "terraform-output2",
+						LockURL:         "lock-url2",
+						ApplyCmd:        "atlantis apply -d path2 -w workspace",
+						RePlanCmd:       "atlantis plan -d path2 -w workspace",
+					},
+				},
+			},
+			models.Github,
+			`Ran Plan for 2 projects:
+
+1. dir: $path$ workspace: $workspace$
+1. project: $projectname$ dir: $path2$ workspace: $workspace$
+
+### 1. dir: $path$ workspace: $workspace$
+$$$diff
+terraform-output
+$$$
+
+* :arrow_forward: To **apply** this plan, comment:
+    * $atlantis apply -d path -w workspace$
+* :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
+* :repeat: To **plan** this project again, comment:
+    * $atlantis plan -d path -w workspace$
+
+### 2. project: $projectname$ dir: $path2$ workspace: $workspace$
+$$$diff
+terraform-output2
+$$$
+
+* :arrow_forward: To **apply** this plan, comment:
+    * $atlantis apply -d path2 -w workspace$
+* :put_litter_in_its_place: To **delete** this plan click [here](lock-url2)
+* :repeat: To **plan** this project again, comment:
+    * $atlantis plan -d path2 -w workspace$
+
+
+`,
+		},
+	}
+	r := events.MarkdownRenderer{
+		DisableApplyAll: true,
+	}
+	for _, c := range cases {
+		t.Run(c.Description, func(t *testing.T) {
+			res := events.CommandResult{
+				ProjectResults: c.ProjectResults,
+			}
+			for _, verbose := range []bool{true, false} {
+				t.Run(c.Description, func(t *testing.T) {
+					s := r.Render(res, c.Command, "log", verbose, c.VCSHost)
+					expWithBackticks := strings.Replace(c.Expected, "$", "`", -1)
+					if !verbose {
+						Equals(t, expWithBackticks, s)
+					} else {
+						Equals(t, expWithBackticks+"<details><summary>Log</summary>\n  <p>\n\n```\nlog```\n</p></details>\n", s)
+					}
+				})
+			}
+		})
+	}
+}
+
 // Test that if the output is longer than 12 lines, it gets wrapped on the right
 // VCS hosts during an error.
 func TestRenderProjectResults_WrappedErr(t *testing.T) {

--- a/server/server.go
+++ b/server/server.go
@@ -236,9 +236,9 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		BitbucketServerURL: userConfig.BitbucketBaseURL,
 	}
 	commentParser := &events.CommentParser{
-		GithubUser:      userConfig.GithubUser,
-		GitlabUser:      userConfig.GitlabUser,
-		BitbucketUser:   userConfig.BitbucketUser,
+		GithubUser:    userConfig.GithubUser,
+		GitlabUser:    userConfig.GitlabUser,
+		BitbucketUser: userConfig.BitbucketUser,
 	}
 	defaultTfVersion := terraformClient.DefaultVersion()
 	pendingPlanFinder := &events.DefaultPendingPlanFinder{}

--- a/server/server.go
+++ b/server/server.go
@@ -177,6 +177,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	}
 	markdownRenderer := &events.MarkdownRenderer{
 		GitlabSupportsCommonMark: gitlabClient.SupportsCommonMark(),
+		DisableApplyAll:          userConfig.DisableApplyAll,
 	}
 	boltdb, err := db.New(userConfig.DataDir)
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -238,7 +238,6 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		GithubUser:      userConfig.GithubUser,
 		GitlabUser:      userConfig.GitlabUser,
 		BitbucketUser:   userConfig.BitbucketUser,
-		DisableApplyAll: userConfig.DisableApplyAll,
 	}
 	defaultTfVersion := terraformClient.DefaultVersion()
 	pendingPlanFinder := &events.DefaultPendingPlanFinder{}
@@ -252,6 +251,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		Logger:                   logger,
 		AllowForkPRs:             userConfig.AllowForkPRs,
 		AllowForkPRsFlag:         config.AllowForkPRsFlag,
+		DisableApplyAll:          userConfig.DisableApplyAll,
 		ProjectCommandBuilder: &events.DefaultProjectCommandBuilder{
 			ParserValidator:   validator,
 			ProjectFinder:     &events.DefaultProjectFinder{},

--- a/server/server.go
+++ b/server/server.go
@@ -235,9 +235,10 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		BitbucketServerURL: userConfig.BitbucketBaseURL,
 	}
 	commentParser := &events.CommentParser{
-		GithubUser:    userConfig.GithubUser,
-		GitlabUser:    userConfig.GitlabUser,
-		BitbucketUser: userConfig.BitbucketUser,
+		GithubUser:      userConfig.GithubUser,
+		GitlabUser:      userConfig.GitlabUser,
+		BitbucketUser:   userConfig.BitbucketUser,
+		DisableApplyAll: userConfig.DisableApplyAll,
 	}
 	defaultTfVersion := terraformClient.DefaultVersion()
 	pendingPlanFinder := &events.DefaultPendingPlanFinder{}

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -16,6 +16,7 @@ type UserConfig struct {
 	BitbucketWebhookSecret string `mapstructure:"bitbucket-webhook-secret"`
 	CheckoutStrategy       string `mapstructure:"checkout-strategy"`
 	DataDir                string `mapstructure:"data-dir"`
+	DisableApplyAll        bool   `mapstructure:"disable-apply-all"`
 	GithubHostname         string `mapstructure:"gh-hostname"`
 	GithubToken            string `mapstructure:"gh-token"`
 	GithubUser             string `mapstructure:"gh-user"`


### PR DESCRIPTION
Add a flag to disable the use of the command `atlantis apply` so you
can enforce that each plan must be applied separately.