### PR TITLE
Upgrade to Terraform 0.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,11 @@ jobs:
     docker:
     - image: circleci/golang:1.12
       environment:
-        TERRAFORM_VERSION: 0.11.13
+        # This version of TF will be downloaded before Atlantis is started.
+        # We do this instead of setting --default-tf-version because setting
+        # that flag starts the download asynchronously so we'd have a race
+        # condition.
+        TERRAFORM_VERSION: 0.12.0
     steps:
     - checkout
     - run: make build-service

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM runatlantis/atlantis-base:v3.0
 LABEL authors="Anubhav Mishra, Luke Kysow"
 
 # install terraform binaries
-ENV DEFAULT_TERRAFORM_VERSION=0.11.13
+ENV DEFAULT_TERRAFORM_VERSION=0.12.0
 
 # In the official Atlantis image we only have the latest of each Terrafrom version.
 RUN AVAILABLE_TERRAFORM_VERSIONS="0.8.8 0.9.11 0.10.8 ${DEFAULT_TERRAFORM_VERSION}" && \

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -8,7 +8,13 @@ ${CIRCLE_WORKING_DIRECTORY}/scripts/e2e-deps.sh
 cd "${CIRCLE_WORKING_DIRECTORY}/e2e"
 
 # start atlantis server in the background and wait for it to start
-./atlantis server --gh-user="$GITHUB_USERNAME" --gh-token="$GITHUB_PASSWORD" --data-dir="/tmp" --log-level="debug" --repo-whitelist="github.com/runatlantis/atlantis-tests" --allow-repo-config &> /tmp/atlantis-server.log &
+./atlantis server \
+  --gh-user="$GITHUB_USERNAME" \
+  --gh-token="$GITHUB_PASSWORD" \
+  --data-dir="/tmp" \
+  --log-level="debug" \
+  --repo-whitelist="github.com/runatlantis/atlantis-tests" \
+  --allow-repo-config &> /tmp/atlantis-server.log &
 sleep 2
 
 # start ngrok in the background and wait for it to start

--- a/server/events/terraform/terraform_client_test.go
+++ b/server/events/terraform/terraform_client_test.go
@@ -218,14 +218,14 @@ func TestRunCommandWithVersion_DLsTF(t *testing.T) {
 
 	mockDownloader := mocks.NewMockDownloader()
 	// Set up our mock downloader to write a fake tf binary when it's called.
-	baseURL := "https://releases.hashicorp.com/terraform/0.12.0"
-	expURL := fmt.Sprintf("%s/terraform_0.12.0_%s_%s.zip?checksum=file:%s/terraform_0.12.0_SHA256SUMS",
+	baseURL := "https://releases.hashicorp.com/terraform/99.99.99"
+	expURL := fmt.Sprintf("%s/terraform_99.99.99_%s_%s.zip?checksum=file:%s/terraform_99.99.99_SHA256SUMS",
 		baseURL,
 		runtime.GOOS,
 		runtime.GOARCH,
 		baseURL)
-	When(mockDownloader.GetFile(filepath.Join(tmp, "bin", "terraform0.12.0"), expURL)).Then(func(params []pegomock.Param) pegomock.ReturnValues {
-		err := ioutil.WriteFile(params[0].(string), []byte("#!/bin/sh\necho '\nTerraform v0.12.0\n'"), 0755)
+	When(mockDownloader.GetFile(filepath.Join(tmp, "bin", "terraform99.99.99"), expURL)).Then(func(params []pegomock.Param) pegomock.ReturnValues {
+		err := ioutil.WriteFile(params[0].(string), []byte("#!/bin/sh\necho '\nTerraform v99.99.99\n'"), 0755)
 		return []pegomock.ReturnValue{err}
 	})
 
@@ -233,11 +233,11 @@ func TestRunCommandWithVersion_DLsTF(t *testing.T) {
 	Ok(t, err)
 	Equals(t, "0.11.10", c.DefaultVersion().String())
 
-	v, err := version.NewVersion("0.12.0")
+	v, err := version.NewVersion("99.99.99")
 	Ok(t, err)
 	output, err := c.RunCommandWithVersion(nil, tmp, nil, v, "")
 	Assert(t, err == nil, "err: %s: %s", err, output)
-	Equals(t, "\nTerraform v0.12.0\n\n", output)
+	Equals(t, "\nTerraform v99.99.99\n\n", output)
 }
 
 // tempSetEnv sets env var key to value. It returns a function that when called

--- a/server/testfixtures/test-repos/automerge/exp-output-apply-dir1.txt
+++ b/server/testfixtures/test-repos/automerge/exp-output-apply-dir1.txt
@@ -1,10 +1,17 @@
 Ran Apply for dir: `dir1` workspace: `default`
 
 ```diff
-null_resource.automerge: Creating...
-null_resource.automerge: Creation complete after *s (ID: ******************)
+null_resource.automerge[0]: Creating...
+null_resource.automerge[0]: Creation complete after *s [id=*******************]
 
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+
+The state of your infrastructure has been saved to the path
+below. This state is required to modify and destroy your
+infrastructure, so keep it safe. To inspect the complete state
+use the `terraform show` command.
+
+State path: terraform.tfstate
 
 ```
 

--- a/server/testfixtures/test-repos/automerge/exp-output-apply-dir2.txt
+++ b/server/testfixtures/test-repos/automerge/exp-output-apply-dir2.txt
@@ -1,10 +1,17 @@
 Ran Apply for dir: `dir2` workspace: `default`
 
 ```diff
-null_resource.automerge: Creating...
-null_resource.automerge: Creation complete after *s (ID: ******************)
+null_resource.automerge[0]: Creating...
+null_resource.automerge[0]: Creation complete after *s [id=*******************]
 
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+
+The state of your infrastructure has been saved to the path
+below. This state is required to modify and destroy your
+infrastructure, so keep it safe. To inspect the complete state
+use the `terraform show` command.
+
+State path: terraform.tfstate
 
 ```
 

--- a/server/testfixtures/test-repos/automerge/exp-output-autoplan.txt
+++ b/server/testfixtures/test-repos/automerge/exp-output-autoplan.txt
@@ -4,6 +4,8 @@ Ran Plan for 2 projects:
 1. dir: `dir2` workspace: `default`
 
 ### 1. dir: `dir1` workspace: `default`
+<details><summary>Show Output</summary>
+
 ```diff
 
 An execution plan has been generated and is shown below.
@@ -12,8 +14,11 @@ Resource actions are indicated with the following symbols:
 
 Terraform will perform the following actions:
 
-+ null_resource.automerge
-      id: <computed>
+  # null_resource.automerge[0] will be created
++ resource "null_resource" "automerge" {
+      + id = (known after apply)
+    }
+
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ```
@@ -23,9 +28,12 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d dir1`
+</details>
 
 ---
 ### 2. dir: `dir2` workspace: `default`
+<details><summary>Show Output</summary>
+
 ```diff
 
 An execution plan has been generated and is shown below.
@@ -34,8 +42,11 @@ Resource actions are indicated with the following symbols:
 
 Terraform will perform the following actions:
 
-+ null_resource.automerge
-      id: <computed>
+  # null_resource.automerge[0] will be created
++ resource "null_resource" "automerge" {
+      + id = (known after apply)
+    }
+
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ```
@@ -45,6 +56,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d dir2`
+</details>
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/modules-yaml/exp-output-apply-production.txt
+++ b/server/testfixtures/test-repos/modules-yaml/exp-output-apply-production.txt
@@ -1,14 +1,24 @@
 Ran Apply for dir: `production` workspace: `default`
 
+<details><summary>Show Output</summary>
+
 ```diff
 module.null.null_resource.this: Creating...
-module.null.null_resource.this: Creation complete after *s (ID: ******************)
+module.null.null_resource.this: Creation complete after *s [id=*******************]
 
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+
+The state of your infrastructure has been saved to the path
+below. This state is required to modify and destroy your
+infrastructure, so keep it safe. To inspect the complete state
+use the `terraform show` command.
+
+State path: terraform.tfstate
 
 Outputs:
 
 var = production
 
 ```
+</details>
 

--- a/server/testfixtures/test-repos/modules-yaml/exp-output-apply-staging.txt
+++ b/server/testfixtures/test-repos/modules-yaml/exp-output-apply-staging.txt
@@ -1,14 +1,24 @@
 Ran Apply for dir: `staging` workspace: `default`
 
+<details><summary>Show Output</summary>
+
 ```diff
 module.null.null_resource.this: Creating...
-module.null.null_resource.this: Creation complete after *s (ID: ******************)
+module.null.null_resource.this: Creation complete after *s [id=*******************]
 
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+
+The state of your infrastructure has been saved to the path
+below. This state is required to modify and destroy your
+infrastructure, so keep it safe. To inspect the complete state
+use the `terraform show` command.
+
+State path: terraform.tfstate
 
 Outputs:
 
 var = staging
 
 ```
+</details>
 

--- a/server/testfixtures/test-repos/modules-yaml/exp-output-autoplan.txt
+++ b/server/testfixtures/test-repos/modules-yaml/exp-output-autoplan.txt
@@ -4,6 +4,8 @@ Ran Plan for 2 projects:
 1. dir: `production` workspace: `default`
 
 ### 1. dir: `staging` workspace: `default`
+<details><summary>Show Output</summary>
+
 ```diff
 
 An execution plan has been generated and is shown below.
@@ -12,8 +14,11 @@ Resource actions are indicated with the following symbols:
 
 Terraform will perform the following actions:
 
-+ module.null.null_resource.this
-      id: <computed>
+  # module.null.null_resource.this will be created
++ resource "null_resource" "this" {
+      + id = (known after apply)
+    }
+
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ```
@@ -23,9 +28,12 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d staging`
+</details>
 
 ---
 ### 2. dir: `production` workspace: `default`
+<details><summary>Show Output</summary>
+
 ```diff
 
 An execution plan has been generated and is shown below.
@@ -34,8 +42,11 @@ Resource actions are indicated with the following symbols:
 
 Terraform will perform the following actions:
 
-+ module.null.null_resource.this
-      id: <computed>
+  # module.null.null_resource.this will be created
++ resource "null_resource" "this" {
+      + id = (known after apply)
+    }
+
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ```
@@ -45,6 +56,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d production`
+</details>
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/modules/exp-output-apply-production.txt
+++ b/server/testfixtures/test-repos/modules/exp-output-apply-production.txt
@@ -1,14 +1,24 @@
 Ran Apply for dir: `production` workspace: `default`
 
+<details><summary>Show Output</summary>
+
 ```diff
 module.null.null_resource.this: Creating...
-module.null.null_resource.this: Creation complete after *s (ID: ******************)
+module.null.null_resource.this: Creation complete after *s [id=*******************]
 
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+
+The state of your infrastructure has been saved to the path
+below. This state is required to modify and destroy your
+infrastructure, so keep it safe. To inspect the complete state
+use the `terraform show` command.
+
+State path: terraform.tfstate
 
 Outputs:
 
 var = production
 
 ```
+</details>
 

--- a/server/testfixtures/test-repos/modules/exp-output-apply-staging.txt
+++ b/server/testfixtures/test-repos/modules/exp-output-apply-staging.txt
@@ -1,14 +1,24 @@
 Ran Apply for dir: `staging` workspace: `default`
 
+<details><summary>Show Output</summary>
+
 ```diff
 module.null.null_resource.this: Creating...
-module.null.null_resource.this: Creation complete after *s (ID: ******************)
+module.null.null_resource.this: Creation complete after *s [id=*******************]
 
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+
+The state of your infrastructure has been saved to the path
+below. This state is required to modify and destroy your
+infrastructure, so keep it safe. To inspect the complete state
+use the `terraform show` command.
+
+State path: terraform.tfstate
 
 Outputs:
 
 var = staging
 
 ```
+</details>
 

--- a/server/testfixtures/test-repos/modules/exp-output-autoplan-only-staging.txt
+++ b/server/testfixtures/test-repos/modules/exp-output-autoplan-only-staging.txt
@@ -1,5 +1,7 @@
 Ran Plan for dir: `staging` workspace: `default`
 
+<details><summary>Show Output</summary>
+
 ```diff
 
 An execution plan has been generated and is shown below.
@@ -8,8 +10,11 @@ Resource actions are indicated with the following symbols:
 
 Terraform will perform the following actions:
 
-+ module.null.null_resource.this
-      id: <computed>
+  # module.null.null_resource.this will be created
++ resource "null_resource" "this" {
+      + id = (known after apply)
+    }
+
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ```
@@ -19,6 +24,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d staging`
+</details>
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/modules/exp-output-plan-production.txt
+++ b/server/testfixtures/test-repos/modules/exp-output-plan-production.txt
@@ -1,5 +1,7 @@
 Ran Plan for dir: `production` workspace: `default`
 
+<details><summary>Show Output</summary>
+
 ```diff
 
 An execution plan has been generated and is shown below.
@@ -8,8 +10,11 @@ Resource actions are indicated with the following symbols:
 
 Terraform will perform the following actions:
 
-+ module.null.null_resource.this
-      id: <computed>
+  # module.null.null_resource.this will be created
++ resource "null_resource" "this" {
+      + id = (known after apply)
+    }
+
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ```
@@ -19,6 +24,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d production`
+</details>
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/modules/exp-output-plan-staging.txt
+++ b/server/testfixtures/test-repos/modules/exp-output-plan-staging.txt
@@ -1,5 +1,7 @@
 Ran Plan for dir: `staging` workspace: `default`
 
+<details><summary>Show Output</summary>
+
 ```diff
 
 An execution plan has been generated and is shown below.
@@ -8,8 +10,11 @@ Resource actions are indicated with the following symbols:
 
 Terraform will perform the following actions:
 
-+ module.null.null_resource.this
-      id: <computed>
+  # module.null.null_resource.this will be created
++ resource "null_resource" "this" {
+      + id = (known after apply)
+    }
+
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ```
@@ -19,6 +24,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d staging`
+</details>
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/server-side-cfg/exp-output-apply-default-workspace.txt
+++ b/server/testfixtures/test-repos/server-side-cfg/exp-output-apply-default-workspace.txt
@@ -1,14 +1,24 @@
 Ran Apply for dir: `.` workspace: `default`
 
+<details><summary>Show Output</summary>
+
 ```diff
 null_resource.simple:
 null_resource.simple:
 
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 
+The state of your infrastructure has been saved to the path
+below. This state is required to modify and destroy your
+infrastructure, so keep it safe. To inspect the complete state
+use the `terraform show` command.
+
+State path: terraform.tfstate
+
 Outputs:
 
 workspace = default
 
 ```
+</details>
 

--- a/server/testfixtures/test-repos/server-side-cfg/exp-output-apply-staging-workspace.txt
+++ b/server/testfixtures/test-repos/server-side-cfg/exp-output-apply-staging-workspace.txt
@@ -1,14 +1,24 @@
 Ran Apply for dir: `.` workspace: `staging`
 
+<details><summary>Show Output</summary>
+
 ```diff
 null_resource.simple:
 null_resource.simple:
 
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 
+The state of your infrastructure has been saved to the path
+below. This state is required to modify and destroy your
+infrastructure, so keep it safe. To inspect the complete state
+use the `terraform show` command.
+
+State path: terraform.tfstate
+
 Outputs:
 
 workspace = staging
 
 ```
+</details>
 

--- a/server/testfixtures/test-repos/server-side-cfg/exp-output-autoplan.txt
+++ b/server/testfixtures/test-repos/server-side-cfg/exp-output-autoplan.txt
@@ -16,8 +16,11 @@ Resource actions are indicated with the following symbols:
 
 Terraform will perform the following actions:
 
-+ null_resource.simple
-      id: <computed>
+  # null_resource.simple[0] will be created
++ resource "null_resource" "simple" {
+      + id = (known after apply)
+    }
+
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 postplan custom
@@ -33,6 +36,8 @@ postplan custom
 
 ---
 ### 2. dir: `.` workspace: `staging`
+<details><summary>Show Output</summary>
+
 ```diff
 preinit staging
 
@@ -43,8 +48,11 @@ Resource actions are indicated with the following symbols:
 
 Terraform will perform the following actions:
 
-+ null_resource.simple
-      id: <computed>
+  # null_resource.simple[0] will be created
++ resource "null_resource" "simple" {
+      + id = (known after apply)
+    }
+
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ```
@@ -54,6 +62,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -w staging`
+</details>
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/simple-yaml/exp-output-apply-all.txt
+++ b/server/testfixtures/test-repos/simple-yaml/exp-output-apply-all.txt
@@ -4,11 +4,20 @@ Ran Apply for 2 projects:
 1. dir: `.` workspace: `staging`
 
 ### 1. dir: `.` workspace: `default`
+<details><summary>Show Output</summary>
+
 ```diff
 null_resource.simple:
 null_resource.simple:
 
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+
+The state of your infrastructure has been saved to the path
+below. This state is required to modify and destroy your
+infrastructure, so keep it safe. To inspect the complete state
+use the `terraform show` command.
+
+State path: terraform.tfstate
 
 Outputs:
 
@@ -16,6 +25,7 @@ var = fromconfig
 workspace = default
 
 ```
+</details>
 
 ---
 ### 2. dir: `.` workspace: `staging`
@@ -28,6 +38,13 @@ null_resource.simple:
 null_resource.simple:
 
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+
+The state of your infrastructure has been saved to the path
+below. This state is required to modify and destroy your
+infrastructure, so keep it safe. To inspect the complete state
+use the `terraform show` command.
+
+State path: terraform.tfstate
 
 Outputs:
 

--- a/server/testfixtures/test-repos/simple-yaml/exp-output-apply-default.txt
+++ b/server/testfixtures/test-repos/simple-yaml/exp-output-apply-default.txt
@@ -1,10 +1,19 @@
 Ran Apply for dir: `.` workspace: `default`
 
+<details><summary>Show Output</summary>
+
 ```diff
 null_resource.simple:
 null_resource.simple:
 
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+
+The state of your infrastructure has been saved to the path
+below. This state is required to modify and destroy your
+infrastructure, so keep it safe. To inspect the complete state
+use the `terraform show` command.
+
+State path: terraform.tfstate
 
 Outputs:
 
@@ -12,4 +21,5 @@ var = fromconfig
 workspace = default
 
 ```
+</details>
 

--- a/server/testfixtures/test-repos/simple-yaml/exp-output-apply-staging.txt
+++ b/server/testfixtures/test-repos/simple-yaml/exp-output-apply-staging.txt
@@ -10,6 +10,13 @@ null_resource.simple:
 
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 
+The state of your infrastructure has been saved to the path
+below. This state is required to modify and destroy your
+infrastructure, so keep it safe. To inspect the complete state
+use the `terraform show` command.
+
+State path: terraform.tfstate
+
 Outputs:
 
 var = fromfile

--- a/server/testfixtures/test-repos/simple-yaml/exp-output-autoplan.txt
+++ b/server/testfixtures/test-repos/simple-yaml/exp-output-autoplan.txt
@@ -16,8 +16,11 @@ Resource actions are indicated with the following symbols:
 
 Terraform will perform the following actions:
 
-+ null_resource.simple
-      id: <computed>
+  # null_resource.simple[0] will be created
++ resource "null_resource" "simple" {
+      + id = (known after apply)
+    }
+
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 postplan
@@ -33,6 +36,8 @@ postplan
 
 ---
 ### 2. dir: `.` workspace: `staging`
+<details><summary>Show Output</summary>
+
 ```diff
 
 An execution plan has been generated and is shown below.
@@ -41,8 +46,11 @@ Resource actions are indicated with the following symbols:
 
 Terraform will perform the following actions:
 
-+ null_resource.simple
-      id: <computed>
+  # null_resource.simple[0] will be created
++ resource "null_resource" "simple" {
+      + id = (known after apply)
+    }
+
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ```
@@ -52,6 +60,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -w staging`
+</details>
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/simple/exp-output-apply-var-all.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-apply-var-all.txt
@@ -16,6 +16,13 @@ null_resource.simple:
 
 Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
 
+The state of your infrastructure has been saved to the path
+below. This state is required to modify and destroy your
+infrastructure, so keep it safe. To inspect the complete state
+use the `terraform show` command.
+
+State path: terraform.tfstate
+
 Outputs:
 
 var = default_workspace
@@ -37,6 +44,13 @@ null_resource.simple:
 null_resource.simple:
 
 Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
+
+The state of your infrastructure has been saved to the path
+below. This state is required to modify and destroy your
+infrastructure, so keep it safe. To inspect the complete state
+use the `terraform show` command.
+
+State path: terraform.tfstate
 
 Outputs:
 

--- a/server/testfixtures/test-repos/simple/exp-output-apply-var-default-workspace.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-apply-var-default-workspace.txt
@@ -12,6 +12,13 @@ null_resource.simple:
 
 Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
 
+The state of your infrastructure has been saved to the path
+below. This state is required to modify and destroy your
+infrastructure, so keep it safe. To inspect the complete state
+use the `terraform show` command.
+
+State path: terraform.tfstate
+
 Outputs:
 
 var = default_workspace

--- a/server/testfixtures/test-repos/simple/exp-output-apply-var-new-workspace.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-apply-var-new-workspace.txt
@@ -12,6 +12,13 @@ null_resource.simple:
 
 Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
 
+The state of your infrastructure has been saved to the path
+below. This state is required to modify and destroy your
+infrastructure, so keep it safe. To inspect the complete state
+use the `terraform show` command.
+
+State path: terraform.tfstate
+
 Outputs:
 
 var = new_workspace

--- a/server/testfixtures/test-repos/simple/exp-output-apply-var.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-apply-var.txt
@@ -12,6 +12,13 @@ null_resource.simple:
 
 Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
 
+The state of your infrastructure has been saved to the path
+below. This state is required to modify and destroy your
+infrastructure, so keep it safe. To inspect the complete state
+use the `terraform show` command.
+
+State path: terraform.tfstate
+
 Outputs:
 
 var = overridden

--- a/server/testfixtures/test-repos/simple/exp-output-apply.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-apply.txt
@@ -12,6 +12,13 @@ null_resource.simple:
 
 Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
 
+The state of your infrastructure has been saved to the path
+below. This state is required to modify and destroy your
+infrastructure, so keep it safe. To inspect the complete state
+use the `terraform show` command.
+
+State path: terraform.tfstate
+
 Outputs:
 
 var = default

--- a/server/testfixtures/test-repos/simple/exp-output-atlantis-plan-new-workspace.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-atlantis-plan-new-workspace.txt
@@ -10,14 +10,21 @@ Resource actions are indicated with the following symbols:
 
 Terraform will perform the following actions:
 
-+ null_resource.simple
-      id: <computed>
+  # null_resource.simple[0] will be created
++ resource "null_resource" "simple" {
+      + id = (known after apply)
+    }
 
-+ null_resource.simple2
-      id: <computed>
+  # null_resource.simple2 will be created
++ resource "null_resource" "simple2" {
+      + id = (known after apply)
+    }
 
-+ null_resource.simple3
-      id: <computed>
+  # null_resource.simple3 will be created
++ resource "null_resource" "simple3" {
+      + id = (known after apply)
+    }
+
 Plan: 3 to add, 0 to change, 0 to destroy.
 
 ```

--- a/server/testfixtures/test-repos/simple/exp-output-atlantis-plan-var-overridden.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-atlantis-plan-var-overridden.txt
@@ -10,14 +10,21 @@ Resource actions are indicated with the following symbols:
 
 Terraform will perform the following actions:
 
-+ null_resource.simple
-      id: <computed>
+  # null_resource.simple[0] will be created
++ resource "null_resource" "simple" {
+      + id = (known after apply)
+    }
 
-+ null_resource.simple2
-      id: <computed>
+  # null_resource.simple2 will be created
++ resource "null_resource" "simple2" {
+      + id = (known after apply)
+    }
 
-+ null_resource.simple3
-      id: <computed>
+  # null_resource.simple3 will be created
++ resource "null_resource" "simple3" {
+      + id = (known after apply)
+    }
+
 Plan: 3 to add, 0 to change, 0 to destroy.
 
 ```

--- a/server/testfixtures/test-repos/simple/exp-output-atlantis-plan.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-atlantis-plan.txt
@@ -10,14 +10,21 @@ Resource actions are indicated with the following symbols:
 
 Terraform will perform the following actions:
 
-+ null_resource.simple
-      id: <computed>
+  # null_resource.simple[0] will be created
++ resource "null_resource" "simple" {
+      + id = (known after apply)
+    }
 
-+ null_resource.simple2
-      id: <computed>
+  # null_resource.simple2 will be created
++ resource "null_resource" "simple2" {
+      + id = (known after apply)
+    }
 
-+ null_resource.simple3
-      id: <computed>
+  # null_resource.simple3 will be created
++ resource "null_resource" "simple3" {
+      + id = (known after apply)
+    }
+
 Plan: 3 to add, 0 to change, 0 to destroy.
 
 ```

--- a/server/testfixtures/test-repos/simple/exp-output-autoplan.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-autoplan.txt
@@ -10,14 +10,21 @@ Resource actions are indicated with the following symbols:
 
 Terraform will perform the following actions:
 
-+ null_resource.simple
-      id: <computed>
+  # null_resource.simple[0] will be created
++ resource "null_resource" "simple" {
+      + id = (known after apply)
+    }
 
-+ null_resource.simple2
-      id: <computed>
+  # null_resource.simple2 will be created
++ resource "null_resource" "simple2" {
+      + id = (known after apply)
+    }
 
-+ null_resource.simple3
-      id: <computed>
+  # null_resource.simple3 will be created
++ resource "null_resource" "simple3" {
+      + id = (known after apply)
+    }
+
 Plan: 3 to add, 0 to change, 0 to destroy.
 
 ```

--- a/server/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-default.txt
+++ b/server/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-default.txt
@@ -1,5 +1,7 @@
 Ran Plan for project: `default` dir: `.` workspace: `default`
 
+<details><summary>Show Output</summary>
+
 ```diff
 
 An execution plan has been generated and is shown below.
@@ -8,8 +10,11 @@ Resource actions are indicated with the following symbols:
 
 Terraform will perform the following actions:
 
-+ null_resource.simple
-      id: <computed>
+  # null_resource.simple[0] will be created
++ resource "null_resource" "simple" {
+      + id = (known after apply)
+    }
+
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ```
@@ -19,6 +24,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -p default`
+</details>
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-staging.txt
+++ b/server/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-staging.txt
@@ -1,5 +1,7 @@
 Ran Plan for project: `staging` dir: `.` workspace: `default`
 
+<details><summary>Show Output</summary>
+
 ```diff
 
 An execution plan has been generated and is shown below.
@@ -8,8 +10,11 @@ Resource actions are indicated with the following symbols:
 
 Terraform will perform the following actions:
 
-+ null_resource.simple
-      id: <computed>
+  # null_resource.simple[0] will be created
++ resource "null_resource" "simple" {
+      + id = (known after apply)
+    }
+
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ```
@@ -19,6 +24,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -p staging`
+</details>
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/tfvars-yaml/exp-output-autoplan.txt
+++ b/server/testfixtures/test-repos/tfvars-yaml/exp-output-autoplan.txt
@@ -4,6 +4,8 @@ Ran Plan for 2 projects:
 1. project: `staging` dir: `.` workspace: `default`
 
 ### 1. project: `default` dir: `.` workspace: `default`
+<details><summary>Show Output</summary>
+
 ```diff
 
 An execution plan has been generated and is shown below.
@@ -12,8 +14,11 @@ Resource actions are indicated with the following symbols:
 
 Terraform will perform the following actions:
 
-+ null_resource.simple
-      id: <computed>
+  # null_resource.simple[0] will be created
++ resource "null_resource" "simple" {
+      + id = (known after apply)
+    }
+
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 workspace=default
@@ -25,9 +30,12 @@ workspace=default
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -p default`
+</details>
 
 ---
 ### 2. project: `staging` dir: `.` workspace: `default`
+<details><summary>Show Output</summary>
+
 ```diff
 
 An execution plan has been generated and is shown below.
@@ -36,8 +44,11 @@ Resource actions are indicated with the following symbols:
 
 Terraform will perform the following actions:
 
-+ null_resource.simple
-      id: <computed>
+  # null_resource.simple[0] will be created
++ resource "null_resource" "simple" {
+      + id = (known after apply)
+    }
+
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ```
@@ -47,6 +58,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -p staging`
+</details>
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -5,7 +5,7 @@
 FROM circleci/golang:1.12
 
 # Install Terraform
-ENV TERRAFORM_VERSION=0.11.13
+ENV TERRAFORM_VERSION=0.12.0
 RUN curl -LOks https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
     sudo mkdir -p /usr/local/bin/tf/versions/${TERRAFORM_VERSION} && \
     sudo unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/local/bin/tf/versions/${TERRAFORM_VERSION} && \


### PR DESCRIPTION
To be clear, Atlantis was compatible with 0.12 before this commit, but
this change makes 0.12 the default version *if* users haven't set the
--default-tf-version flag.