### PR TITLE
Trying to fix #652 , Bitbucket Cloud GDPR Changes

### DIFF
--- a/server/events/event_parser.go
+++ b/server/events/event_parser.go
@@ -321,7 +321,7 @@ func (e *EventParser) parseCommonBitbucketCloudEventData(event bitbucketcloud.Co
 		HeadBranch: *event.PullRequest.Source.Branch.Name,
 		BaseBranch: *event.PullRequest.Destination.Branch.Name,
 		Author:     *event.Actor.Nickname,
-		AuthorId:   *event.Actor.AccountId,
+		AuthorID:   *event.Actor.AccountID,
 		State:      prState,
 		BaseRepo:   baseRepo,
 	}

--- a/server/events/event_parser.go
+++ b/server/events/event_parser.go
@@ -321,6 +321,7 @@ func (e *EventParser) parseCommonBitbucketCloudEventData(event bitbucketcloud.Co
 		HeadBranch: *event.PullRequest.Source.Branch.Name,
 		BaseBranch: *event.PullRequest.Destination.Branch.Name,
 		Author:     *event.Actor.Nickname,
+		AuthorId:   *event.Actor.AccountId,
 		State:      prState,
 		BaseRepo:   baseRepo,
 	}

--- a/server/events/event_parser_test.go
+++ b/server/events/event_parser_test.go
@@ -721,6 +721,7 @@ func TestParseBitbucketCloudCommentEvent_ValidEvent(t *testing.T) {
 		HeadBranch: "lkysow/maintf-edited-online-with-bitbucket-1532029690581",
 		BaseBranch: "master",
 		Author:     "lkysow",
+		AuthorId:   "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
 		State:      models.ClosedPullState,
 		BaseRepo:   expBaseRepo,
 	}, pull)
@@ -807,6 +808,7 @@ func TestParseBitbucketCloudPullEvent_ValidEvent(t *testing.T) {
 		HeadBranch: "lkysow/maintf-edited-online-with-bitbucket-1532029690581",
 		BaseBranch: "master",
 		Author:     "lkysow",
+		AuthorId:   "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
 		State:      models.ClosedPullState,
 		BaseRepo:   expBaseRepo,
 	}, pull)
@@ -908,6 +910,7 @@ func TestParseBitbucketServerCommentEvent_ValidEvent(t *testing.T) {
 		HeadBranch: "branch",
 		BaseBranch: "master",
 		Author:     "lkysow",
+		AuthorId:   "",
 		State:      models.OpenPullState,
 		BaseRepo:   expBaseRepo,
 	}, pull)
@@ -990,6 +993,7 @@ func TestParseBitbucketServerPullEvent_ValidEvent(t *testing.T) {
 		HeadBranch: "branch",
 		BaseBranch: "master",
 		Author:     "lkysow",
+		AuthorId:   "",
 		State:      models.ClosedPullState,
 		BaseRepo:   expBaseRepo,
 	}, pull)

--- a/server/events/event_parser_test.go
+++ b/server/events/event_parser_test.go
@@ -721,7 +721,7 @@ func TestParseBitbucketCloudCommentEvent_ValidEvent(t *testing.T) {
 		HeadBranch: "lkysow/maintf-edited-online-with-bitbucket-1532029690581",
 		BaseBranch: "master",
 		Author:     "lkysow",
-		AuthorId:   "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
+		AuthorID:   "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
 		State:      models.ClosedPullState,
 		BaseRepo:   expBaseRepo,
 	}, pull)
@@ -808,7 +808,7 @@ func TestParseBitbucketCloudPullEvent_ValidEvent(t *testing.T) {
 		HeadBranch: "lkysow/maintf-edited-online-with-bitbucket-1532029690581",
 		BaseBranch: "master",
 		Author:     "lkysow",
-		AuthorId:   "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
+		AuthorID:   "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
 		State:      models.ClosedPullState,
 		BaseRepo:   expBaseRepo,
 	}, pull)
@@ -910,7 +910,7 @@ func TestParseBitbucketServerCommentEvent_ValidEvent(t *testing.T) {
 		HeadBranch: "branch",
 		BaseBranch: "master",
 		Author:     "lkysow",
-		AuthorId:   "",
+		AuthorID:   "",
 		State:      models.OpenPullState,
 		BaseRepo:   expBaseRepo,
 	}, pull)
@@ -993,7 +993,7 @@ func TestParseBitbucketServerPullEvent_ValidEvent(t *testing.T) {
 		HeadBranch: "branch",
 		BaseBranch: "master",
 		Author:     "lkysow",
-		AuthorId:   "",
+		AuthorID:   "",
 		State:      models.ClosedPullState,
 		BaseRepo:   expBaseRepo,
 	}, pull)

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -153,6 +153,8 @@ type PullRequest struct {
 	BaseBranch string
 	// Author is the username of the pull request author.
 	Author string
+	// Author id is the account_id of the pull request author.
+	AuthorId string
 	// State will be one of Open or Closed.
 	// Gitlab supports an additional "merged" state but Github doesn't so we map
 	// merged to Closed.

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -154,7 +154,7 @@ type PullRequest struct {
 	// Author is the username of the pull request author.
 	Author string
 	// Author id is the account_id of the pull request author.
-	AuthorId string
+	AuthorID string
 	// State will be one of Open or Closed.
 	// Gitlab supports an additional "merged" state but Github doesn't so we map
 	// merged to Closed.

--- a/server/events/testdata/bitbucket-cloud-comment-event.json
+++ b/server/events/testdata/bitbucket-cloud-comment-event.json
@@ -30,7 +30,6 @@
     },
     "created_on": "2018-07-19T19:51:50.607374+00:00",
     "user": {
-      "username": "lkysow",
       "display_name": "Luke",
       "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
       "links": {
@@ -159,7 +158,6 @@
     },
     "state": "MERGED",
     "author": {
-      "username": "lkysow",
       "display_name": "Luke",
       "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
       "links": {
@@ -181,7 +179,6 @@
       {
         "type": "participant",
         "user": {
-          "username": "lkysow",
           "display_name": "Luke",
           "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
           "links": {
@@ -214,7 +211,6 @@
       }
     },
     "closed_by": {
-      "username": "lkysow",
       "display_name": "Luke",
       "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
       "links": {
@@ -234,7 +230,6 @@
     "task_count": 0
   },
   "actor": {
-    "username": "lkysow",
     "nickname": "lkysow",
     "display_name": "Luke",
     "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
@@ -269,7 +264,6 @@
     },
     "full_name": "lkysow/atlantis-example",
     "owner": {
-      "username": "lkysow",
       "display_name": "Luke",
       "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
       "links": {

--- a/server/events/testdata/bitbucket-cloud-pull-event-fulfilled.json
+++ b/server/events/testdata/bitbucket-cloud-pull-event-fulfilled.json
@@ -107,7 +107,6 @@
     },
     "state": "MERGED",
     "author": {
-      "username": "lkysow",
       "display_name": "Luke",
       "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
       "links": {
@@ -129,7 +128,6 @@
       {
         "type": "participant",
         "user": {
-          "username": "lkysow",
           "display_name": "Luke",
           "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
           "links": {
@@ -162,7 +160,6 @@
       }
     },
     "closed_by": {
-      "username": "lkysow",
       "display_name": "Luke",
       "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
       "links": {
@@ -182,7 +179,6 @@
     "task_count": 0
   },
   "actor": {
-    "username": "lkysow",
     "nickname": "lkysow",
     "display_name": "Luke",
     "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
@@ -217,7 +213,6 @@
     },
     "full_name": "lkysow/atlantis-example",
     "owner": {
-      "username": "lkysow",
       "display_name": "Luke",
       "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
       "links": {

--- a/server/events/vcs/bitbucketcloud/client.go
+++ b/server/events/vcs/bitbucketcloud/client.go
@@ -117,7 +117,7 @@ func (b *Client) PullIsApproved(repo models.Repo, pull models.PullRequest) (bool
 	for _, participant := range pullResp.Participants {
 		// Bitbucket allows the author to approve their own pull request. This
 		// defeats the purpose of approvals so we don't count that approval.
-		if *participant.Approved && *participant.User.Username != pull.Author {
+		if *participant.Approved && *participant.User.AccountId != pull.AuthorId {
 			return true, nil
 		}
 	}

--- a/server/events/vcs/bitbucketcloud/client.go
+++ b/server/events/vcs/bitbucketcloud/client.go
@@ -117,7 +117,7 @@ func (b *Client) PullIsApproved(repo models.Repo, pull models.PullRequest) (bool
 	for _, participant := range pullResp.Participants {
 		// Bitbucket allows the author to approve their own pull request. This
 		// defeats the purpose of approvals so we don't count that approval.
-		if *participant.Approved && *participant.User.AccountId != pull.AuthorId {
+		if *participant.Approved && *participant.User.AccountID != pull.AuthorID {
 			return true, nil
 		}
 	}

--- a/server/events/vcs/bitbucketcloud/client_test.go
+++ b/server/events/vcs/bitbucketcloud/client_test.go
@@ -205,7 +205,7 @@ func TestClient_PullIsApproved(t *testing.T) {
 			approved, err := client.PullIsApproved(repo, models.PullRequest{
 				Num:        1,
 				HeadBranch: "branch",
-				Author:     "author",
+				AuthorId:   "557058:dc3817de-8888-45cd-b81c-5c39d2560090",
 				BaseRepo:   repo,
 			})
 			Ok(t, err)

--- a/server/events/vcs/bitbucketcloud/client_test.go
+++ b/server/events/vcs/bitbucketcloud/client_test.go
@@ -205,7 +205,7 @@ func TestClient_PullIsApproved(t *testing.T) {
 			approved, err := client.PullIsApproved(repo, models.PullRequest{
 				Num:        1,
 				HeadBranch: "branch",
-				AuthorId:   "557058:dc3817de-8888-45cd-b81c-5c39d2560090",
+				AuthorID:   "557058:dc3817de-8888-45cd-b81c-5c39d2560090",
 				BaseRepo:   repo,
 			})
 			Ok(t, err)

--- a/server/events/vcs/bitbucketcloud/models.go
+++ b/server/events/vcs/bitbucketcloud/models.go
@@ -38,7 +38,8 @@ type DiffStatFile struct {
 }
 
 type Actor struct {
-	Nickname *string `json:"nickname,omitempty" validate:"required"`
+	Nickname  *string `json:"nickname,omitempty" validate:"required"`
+	AccountId *string `json:"account_id,omitempty" validate:"required"`
 }
 type Repository struct {
 	FullName *string `json:"full_name,omitempty" validate:"required"`
@@ -61,7 +62,8 @@ type Link struct {
 type Participant struct {
 	Approved *bool `json:"approved,omitempty" validate:"required"`
 	User     *struct {
-		Username *string `json:"username,omitempty" validate:"required"`
+		Username  *string `json:"username,omitempty" validate:"required"`
+		AccountId *string `json:"account_id,omitempty" validate:"required"`
 	} `json:"user,omitempty" validate:"required"`
 }
 type BranchMeta struct {

--- a/server/events/vcs/bitbucketcloud/models.go
+++ b/server/events/vcs/bitbucketcloud/models.go
@@ -39,7 +39,7 @@ type DiffStatFile struct {
 
 type Actor struct {
 	Nickname  *string `json:"nickname,omitempty" validate:"required"`
-	AccountId *string `json:"account_id,omitempty" validate:"required"`
+	AccountID *string `json:"account_id,omitempty" validate:"required"`
 }
 type Repository struct {
 	FullName *string `json:"full_name,omitempty" validate:"required"`
@@ -63,7 +63,7 @@ type Participant struct {
 	Approved *bool `json:"approved,omitempty" validate:"required"`
 	User     *struct {
 		Username  *string `json:"username,omitempty" validate:"required"`
-		AccountId *string `json:"account_id,omitempty" validate:"required"`
+		AccountID *string `json:"account_id,omitempty" validate:"required"`
 	} `json:"user,omitempty" validate:"required"`
 }
 type BranchMeta struct {

--- a/server/events/vcs/bitbucketcloud/testdata/pull-approved-by-author.json
+++ b/server/events/vcs/bitbucketcloud/testdata/pull-approved-by-author.json
@@ -122,9 +122,8 @@
       "type": "participant",
       "approved": true,
       "user": {
-        "username": "author",
         "display_name": "Luke",
-        "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
+        "account_id": "557058:dc3817de-8888-45cd-b81c-5c39d2560090",
         "links": {
           "self": {
             "href": "https://api.bitbucket.org/2.0/users/lkysow"
@@ -144,7 +143,6 @@
   "reason": "",
   "updated_on": "2018-07-28T00:06:42.257659+00:00",
   "author": {
-    "username": "lkysow",
     "display_name": "Luke",
     "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
     "links": {

--- a/server/events/vcs/bitbucketcloud/testdata/pull-approved-multiple.json
+++ b/server/events/vcs/bitbucketcloud/testdata/pull-approved-multiple.json
@@ -122,9 +122,8 @@
       "type": "participant",
       "approved": true,
       "user": {
-        "username": "author",
         "display_name": "Luke",
-        "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
+        "account_id": "557058:dc3817de-8888-45cd-b81c-5c39d2560090",
         "links": {
           "self": {
             "href": "https://api.bitbucket.org/2.0/users/lkysow"
@@ -146,9 +145,8 @@
       "type": "participant",
       "approved": true,
       "user": {
-        "username": "approver",
         "display_name": "Luke",
-        "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
+        "account_id": "557058:dc3817de-7777-45cd-b81c-5c39d2560090",
         "links": {
           "self": {
             "href": "https://api.bitbucket.org/2.0/users/lkysow"
@@ -168,7 +166,6 @@
   "reason": "",
   "updated_on": "2018-07-28T00:06:42.257659+00:00",
   "author": {
-    "username": "lkysow",
     "display_name": "Luke",
     "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
     "links": {

--- a/server/events/vcs/bitbucketcloud/testdata/pull-approved.json
+++ b/server/events/vcs/bitbucketcloud/testdata/pull-approved.json
@@ -116,9 +116,8 @@
       "type": "participant",
       "approved": true,
       "user": {
-        "username": "approver",
         "display_name": "Luke",
-        "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
+        "account_id": "557058:dc3817de-7777-45cd-b81c-5c39d2560090",
         "links": {
           "self": {
             "href": "https://api.bitbucket.org/2.0/users/lkysow"
@@ -138,7 +137,6 @@
   "reason": "",
   "updated_on": "2018-07-28T00:06:42.257659+00:00",
   "author": {
-    "username": "lkysow",
     "display_name": "Luke",
     "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
     "links": {

--- a/server/events/vcs/bitbucketcloud/testdata/pull-unapproved.json
+++ b/server/events/vcs/bitbucketcloud/testdata/pull-unapproved.json
@@ -113,7 +113,7 @@
   "reason": "",
   "updated_on": "2018-07-28T00:06:42.257659+00:00",
   "author": {
-    "username": "lkysow",
+
     "display_name": "Luke",
     "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
     "links": {


### PR DESCRIPTION
As @Phylu stated: 
> https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-gdpr/

I changed bitbucket cloud merge logic using account_id instead of username. 
Tested against real repository using self approval (with correct apply failed) and other users approval. 

I can't try on bitbucket server...