### PR TITLE
Fix require-approval for Bitbucket Cloud.

### DIFF
--- a/server/events/vcs/bitbucketcloud/client.go
+++ b/server/events/vcs/bitbucketcloud/client.go
@@ -114,10 +114,11 @@ func (b *Client) PullIsApproved(repo models.Repo, pull models.PullRequest) (bool
 	if err := validator.New().Struct(pullResp); err != nil {
 		return false, errors.Wrapf(err, "API response %q was missing fields", string(resp))
 	}
+	authorUUID := *pullResp.Author.UUID
 	for _, participant := range pullResp.Participants {
 		// Bitbucket allows the author to approve their own pull request. This
 		// defeats the purpose of approvals so we don't count that approval.
-		if *participant.Approved && *participant.User.Username != pull.Author {
+		if *participant.Approved && *participant.User.UUID != authorUUID {
 			return true, nil
 		}
 	}

--- a/server/events/vcs/bitbucketcloud/models.go
+++ b/server/events/vcs/bitbucketcloud/models.go
@@ -51,6 +51,7 @@ type PullRequest struct {
 	Participants []Participant `json:"participants,omitempty" validate:"required"`
 	Links        *Links        `json:"links,omitempty" validate:"required"`
 	State        *string       `json:"state,omitempty" validate:"required"`
+	Author       *Author       `jsonN:"author,omitempty" validate:"required"`
 }
 type Links struct {
 	HTML *Link `json:"html,omitempty" validate:"required"`
@@ -61,7 +62,7 @@ type Link struct {
 type Participant struct {
 	Approved *bool `json:"approved,omitempty" validate:"required"`
 	User     *struct {
-		Username *string `json:"username,omitempty" validate:"required"`
+		UUID *string `json:"uuid,omitempty" validate:"required"`
 	} `json:"user,omitempty" validate:"required"`
 }
 type BranchMeta struct {
@@ -85,4 +86,8 @@ type CommentContent struct {
 type ConflictStatus struct {
 	MergeImpossible *bool `json:"mergeimpossible,omitempty" validate:"required"`
 	IsConflicted    *bool `json:"isconflicted,omitempty" validate:"required"`
+}
+
+type Author struct {
+	UUID *string `json:"uuid,omitempty" validate:"required"`
 }

--- a/server/events/vcs/bitbucketcloud/testdata/pull-approved-by-author.json
+++ b/server/events/vcs/bitbucketcloud/testdata/pull-approved-by-author.json
@@ -1,52 +1,66 @@
 {
+  "rendered": {
+    "description": {
+      "raw": "main.tf edited online with Bitbucket",
+      "markup": "markdown",
+      "html": "<p>main.tf edited online with Bitbucket</p>",
+      "type": "rendered"
+    },
+    "title": {
+      "raw": "main.tf edited online with Bitbucket",
+      "markup": "markdown",
+      "html": "<p>main.tf edited online with Bitbucket</p>",
+      "type": "rendered"
+    }
+  },
   "type": "pullrequest",
   "description": "main.tf edited online with Bitbucket",
   "links": {
     "decline": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/decline"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/decline"
     },
     "commits": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/commits"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/commits"
     },
     "self": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12"
     },
     "comments": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/comments"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/comments"
     },
     "merge": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/merge"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/merge"
     },
     "html": {
-      "href": "https://bitbucket.org/lkysow/atlantis-example/pull-requests/5"
+      "href": "https://bitbucket.org/lkysow/atlantis-example/pull-requests/12"
     },
     "activity": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/activity"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/activity"
     },
     "diff": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/diff"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/diff"
     },
     "approve": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/approve"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/approve"
     },
     "statuses": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/statuses"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/statuses"
     }
   },
   "title": "main.tf edited online with Bitbucket",
   "close_source_branch": true,
   "reviewers": [],
-  "id": 5,
+  "id": 12,
   "destination": {
     "commit": {
-      "hash": "fe607a7f5172",
+      "hash": "c641f2c615ad",
       "type": "commit",
       "links": {
         "self": {
-          "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/commit/fe607a7f5172"
+          "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/commit/c641f2c615ad"
         },
         "html": {
-          "href": "https://bitbucket.org/lkysow/atlantis-example/commits/fe607a7f5172"
+          "href": "https://bitbucket.org/lkysow/atlantis-example/commits/c641f2c615ad"
         }
       }
     },
@@ -71,7 +85,7 @@
       "name": "master"
     }
   },
-  "created_on": "2018-07-25T12:23:21.100810+00:00",
+  "created_on": "2019-02-12T16:48:04.251028+00:00",
   "summary": {
     "raw": "main.tf edited online with Bitbucket",
     "markup": "markdown",
@@ -80,14 +94,14 @@
   },
   "source": {
     "commit": {
-      "hash": "3428957ade18",
+      "hash": "75d1e7c57cd9",
       "type": "commit",
       "links": {
         "self": {
-          "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/commit/3428957ade18"
+          "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/commit/75d1e7c57cd9"
         },
         "html": {
-          "href": "https://bitbucket.org/lkysow/atlantis-example/commits/3428957ade18"
+          "href": "https://bitbucket.org/lkysow/atlantis-example/commits/75d1e7c57cd9"
         }
       }
     },
@@ -109,57 +123,84 @@
       "uuid": "{94189367-116b-436a-9f77-2314b97a6067}"
     },
     "branch": {
-      "name": "lkysow/maintf-edited-online-with-bitbucket-1532521398289"
+      "name": "lkysow/maintf-edited-online-with-bitbucket-1549990080103"
     }
   },
-  "comment_count": 3,
+  "comment_count": 23,
   "state": "OPEN",
   "task_count": 0,
   "participants": [
     {
       "role": "PARTICIPANT",
-      "participated_on": "2018-07-28T00:06:42.255492+00:00",
+      "participated_on": "2019-06-03T13:55:54.065877+00:00",
       "type": "participant",
       "approved": true,
       "user": {
-        "username": "author",
+        "username": "lkysow",
         "display_name": "Luke",
-        "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
+        "uuid": "{bf34a99b-8a11-452c-8fbc-bdffc340e584}",
         "links": {
           "self": {
-            "href": "https://api.bitbucket.org/2.0/users/lkysow"
+            "href": "https://api.bitbucket.org/2.0/users/%7Bbf34a99b-8a11-452c-8fbc-bdffc340e584%7D"
           },
           "html": {
-            "href": "https://bitbucket.org/lkysow/"
+            "href": "https://bitbucket.org/%7Bbf34a99b-8a11-452c-8fbc-bdffc340e584%7D/"
           },
           "avatar": {
-            "href": "https://bitbucket.org/account/lkysow/avatar/"
+            "href": "https://avatar-cdn.atlassian.com/557058%3Adc3817de-68b5-45cd-b81c-5c39d2560090?by=id&sg=TUDovBcAEFksW8FiPnLjf1IV73Y%3D&d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FL-1.svg"
           }
         },
+        "nickname": "Luke",
         "type": "user",
-        "uuid": "{bf34a99b-8a11-452c-8fbc-bdffc340e584}"
+        "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090"
+      }
+    },
+    {
+      "role": "PARTICIPANT",
+      "participated_on": "2019-06-03T13:51:47.350675+00:00",
+      "type": "participant",
+      "approved": false,
+      "user": {
+        "username": "atlantis-bot",
+        "display_name": "Atlantisbot",
+        "uuid": "{73686412-4495-426f-89a7-c69ff1c8d7b8}",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/users/%7B73686412-4495-426f-89a7-c69ff1c8d7b8%7D"
+          },
+          "html": {
+            "href": "https://bitbucket.org/%7B73686412-4495-426f-89a7-c69ff1c8d7b8%7D/"
+          },
+          "avatar": {
+            "href": "https://avatar-cdn.atlassian.com/5b5097035488b9140c078f7f?by=id&sg=vyisLdHfYH10sFOuFCvPgHKn6ds%3D&d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FA-1.png"
+          }
+        },
+        "nickname": "Atlantisbot",
+        "type": "user",
+        "account_id": "5b5097035488b9140c078f7f"
       }
     }
   ],
   "reason": "",
-  "updated_on": "2018-07-28T00:06:42.257659+00:00",
+  "updated_on": "2019-06-03T13:55:54.081581+00:00",
   "author": {
     "username": "lkysow",
     "display_name": "Luke",
-    "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
+    "uuid": "{bf34a99b-8a11-452c-8fbc-bdffc340e584}",
     "links": {
       "self": {
-        "href": "https://api.bitbucket.org/2.0/users/lkysow"
+        "href": "https://api.bitbucket.org/2.0/users/%7Bbf34a99b-8a11-452c-8fbc-bdffc340e584%7D"
       },
       "html": {
-        "href": "https://bitbucket.org/lkysow/"
+        "href": "https://bitbucket.org/%7Bbf34a99b-8a11-452c-8fbc-bdffc340e584%7D/"
       },
       "avatar": {
-        "href": "https://bitbucket.org/account/lkysow/avatar/"
+        "href": "https://avatar-cdn.atlassian.com/557058%3Adc3817de-68b5-45cd-b81c-5c39d2560090?by=id&sg=TUDovBcAEFksW8FiPnLjf1IV73Y%3D&d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FL-1.svg"
       }
     },
+    "nickname": "Luke",
     "type": "user",
-    "uuid": "{bf34a99b-8a11-452c-8fbc-bdffc340e584}"
+    "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090"
   },
   "merge_commit": null,
   "closed_by": null

--- a/server/events/vcs/bitbucketcloud/testdata/pull-approved-multiple.json
+++ b/server/events/vcs/bitbucketcloud/testdata/pull-approved-multiple.json
@@ -1,52 +1,66 @@
 {
+  "rendered": {
+    "description": {
+      "raw": "main.tf edited online with Bitbucket",
+      "markup": "markdown",
+      "html": "<p>main.tf edited online with Bitbucket</p>",
+      "type": "rendered"
+    },
+    "title": {
+      "raw": "main.tf edited online with Bitbucket",
+      "markup": "markdown",
+      "html": "<p>main.tf edited online with Bitbucket</p>",
+      "type": "rendered"
+    }
+  },
   "type": "pullrequest",
   "description": "main.tf edited online with Bitbucket",
   "links": {
     "decline": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/decline"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/decline"
     },
     "commits": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/commits"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/commits"
     },
     "self": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12"
     },
     "comments": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/comments"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/comments"
     },
     "merge": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/merge"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/merge"
     },
     "html": {
-      "href": "https://bitbucket.org/lkysow/atlantis-example/pull-requests/5"
+      "href": "https://bitbucket.org/lkysow/atlantis-example/pull-requests/12"
     },
     "activity": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/activity"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/activity"
     },
     "diff": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/diff"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/diff"
     },
     "approve": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/approve"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/approve"
     },
     "statuses": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/statuses"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/statuses"
     }
   },
   "title": "main.tf edited online with Bitbucket",
   "close_source_branch": true,
   "reviewers": [],
-  "id": 5,
+  "id": 12,
   "destination": {
     "commit": {
-      "hash": "fe607a7f5172",
+      "hash": "c641f2c615ad",
       "type": "commit",
       "links": {
         "self": {
-          "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/commit/fe607a7f5172"
+          "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/commit/c641f2c615ad"
         },
         "html": {
-          "href": "https://bitbucket.org/lkysow/atlantis-example/commits/fe607a7f5172"
+          "href": "https://bitbucket.org/lkysow/atlantis-example/commits/c641f2c615ad"
         }
       }
     },
@@ -71,7 +85,7 @@
       "name": "master"
     }
   },
-  "created_on": "2018-07-25T12:23:21.100810+00:00",
+  "created_on": "2019-02-12T16:48:04.251028+00:00",
   "summary": {
     "raw": "main.tf edited online with Bitbucket",
     "markup": "markdown",
@@ -80,14 +94,14 @@
   },
   "source": {
     "commit": {
-      "hash": "3428957ade18",
+      "hash": "75d1e7c57cd9",
       "type": "commit",
       "links": {
         "self": {
-          "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/commit/3428957ade18"
+          "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/commit/75d1e7c57cd9"
         },
         "html": {
-          "href": "https://bitbucket.org/lkysow/atlantis-example/commits/3428957ade18"
+          "href": "https://bitbucket.org/lkysow/atlantis-example/commits/75d1e7c57cd9"
         }
       }
     },
@@ -109,81 +123,109 @@
       "uuid": "{94189367-116b-436a-9f77-2314b97a6067}"
     },
     "branch": {
-      "name": "lkysow/maintf-edited-online-with-bitbucket-1532521398289"
+      "name": "lkysow/maintf-edited-online-with-bitbucket-1549990080103"
     }
   },
-  "comment_count": 3,
+  "comment_count": 23,
   "state": "OPEN",
   "task_count": 0,
   "participants": [
     {
       "role": "PARTICIPANT",
-      "participated_on": "2018-07-28T00:06:42.255492+00:00",
+      "participated_on": "2019-06-03T13:51:44.122406+00:00",
       "type": "participant",
-      "approved": true,
+      "approved": false,
       "user": {
-        "username": "author",
+        "username": "lkysow",
         "display_name": "Luke",
-        "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
+        "uuid": "{bf34a99b-8a11-452c-8fbc-bdffc340e584}",
         "links": {
           "self": {
-            "href": "https://api.bitbucket.org/2.0/users/lkysow"
+            "href": "https://api.bitbucket.org/2.0/users/%7Bbf34a99b-8a11-452c-8fbc-bdffc340e584%7D"
           },
           "html": {
-            "href": "https://bitbucket.org/lkysow/"
+            "href": "https://bitbucket.org/%7Bbf34a99b-8a11-452c-8fbc-bdffc340e584%7D/"
           },
           "avatar": {
-            "href": "https://bitbucket.org/account/lkysow/avatar/"
+            "href": "https://avatar-cdn.atlassian.com/557058%3Adc3817de-68b5-45cd-b81c-5c39d2560090?by=id&sg=TUDovBcAEFksW8FiPnLjf1IV73Y%3D&d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FL-1.svg"
           }
         },
+        "nickname": "Luke",
         "type": "user",
-        "uuid": "{bf34a99b-8a11-452c-8fbc-bdffc340e584}"
+        "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090"
       }
     },
     {
       "role": "PARTICIPANT",
-      "participated_on": "2018-07-28T00:06:42.255492+00:00",
+      "participated_on": "2019-06-03T13:55:17.622018+00:00",
       "type": "participant",
       "approved": true,
       "user": {
-        "username": "approver",
-        "display_name": "Luke",
-        "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
+        "username": "atlantis-bot",
+        "display_name": "Atlantisbot",
+        "uuid": "{73686412-4495-426f-89a7-c69ff1c8d7b8}",
         "links": {
           "self": {
-            "href": "https://api.bitbucket.org/2.0/users/lkysow"
+            "href": "https://api.bitbucket.org/2.0/users/%7B73686412-4495-426f-89a7-c69ff1c8d7b8%7D"
           },
           "html": {
-            "href": "https://bitbucket.org/lkysow/"
+            "href": "https://bitbucket.org/%7B73686412-4495-426f-89a7-c69ff1c8d7b8%7D/"
           },
           "avatar": {
-            "href": "https://bitbucket.org/account/lkysow/avatar/"
+            "href": "https://avatar-cdn.atlassian.com/5b5097035488b9140c078f7f?by=id&sg=vyisLdHfYH10sFOuFCvPgHKn6ds%3D&d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FA-1.png"
           }
         },
+        "nickname": "Atlantisbot",
         "type": "user",
-        "uuid": "{bf34a99b-8a11-452c-8fbc-bdffc340e584}"
+        "account_id": "5b5097035488b9140c078f7f"
+      }
+    },
+    {
+      "role": "PARTICIPANT",
+      "participated_on": "2019-06-03T13:55:17.622018+00:00",
+      "type": "participant",
+      "approved": true,
+      "user": {
+        "username": "atlantis-bot2",
+        "display_name": "Atlantisbot2",
+        "uuid": "{73686412-4495-426f-89a7-c69ff1c8d7b2}",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/users/%7B73686412-4495-426f-89a7-c69ff1c8d7b2%7D"
+          },
+          "html": {
+            "href": "https://bitbucket.org/%7B73686412-4495-426f-89a7-c69ff1c8d7b2%7D/"
+          },
+          "avatar": {
+            "href": "https://avatar-cdn.atlassian.com/5b5097035488b9140c078f7f?by=id&sg=vyisLdHfYH10sFOuFCvPgHKn6ds%3D&d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FA-1.png"
+          }
+        },
+        "nickname": "Atlantisbot2",
+        "type": "user",
+        "account_id": "5b5097035488b9140c078f72"
       }
     }
   ],
   "reason": "",
-  "updated_on": "2018-07-28T00:06:42.257659+00:00",
+  "updated_on": "2019-06-03T13:55:17.639190+00:00",
   "author": {
     "username": "lkysow",
     "display_name": "Luke",
-    "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
+    "uuid": "{bf34a99b-8a11-452c-8fbc-bdffc340e584}",
     "links": {
       "self": {
-        "href": "https://api.bitbucket.org/2.0/users/lkysow"
+        "href": "https://api.bitbucket.org/2.0/users/%7Bbf34a99b-8a11-452c-8fbc-bdffc340e584%7D"
       },
       "html": {
-        "href": "https://bitbucket.org/lkysow/"
+        "href": "https://bitbucket.org/%7Bbf34a99b-8a11-452c-8fbc-bdffc340e584%7D/"
       },
       "avatar": {
-        "href": "https://bitbucket.org/account/lkysow/avatar/"
+        "href": "https://avatar-cdn.atlassian.com/557058%3Adc3817de-68b5-45cd-b81c-5c39d2560090?by=id&sg=TUDovBcAEFksW8FiPnLjf1IV73Y%3D&d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FL-1.svg"
       }
     },
+    "nickname": "Luke",
     "type": "user",
-    "uuid": "{bf34a99b-8a11-452c-8fbc-bdffc340e584}"
+    "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090"
   },
   "merge_commit": null,
   "closed_by": null

--- a/server/events/vcs/bitbucketcloud/testdata/pull-approved.json
+++ b/server/events/vcs/bitbucketcloud/testdata/pull-approved.json
@@ -1,52 +1,66 @@
 {
+  "rendered": {
+    "description": {
+      "raw": "main.tf edited online with Bitbucket",
+      "markup": "markdown",
+      "html": "<p>main.tf edited online with Bitbucket</p>",
+      "type": "rendered"
+    },
+    "title": {
+      "raw": "main.tf edited online with Bitbucket",
+      "markup": "markdown",
+      "html": "<p>main.tf edited online with Bitbucket</p>",
+      "type": "rendered"
+    }
+  },
   "type": "pullrequest",
   "description": "main.tf edited online with Bitbucket",
   "links": {
     "decline": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/decline"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/decline"
     },
     "commits": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/commits"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/commits"
     },
     "self": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12"
     },
     "comments": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/comments"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/comments"
     },
     "merge": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/merge"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/merge"
     },
     "html": {
-      "href": "https://bitbucket.org/lkysow/atlantis-example/pull-requests/5"
+      "href": "https://bitbucket.org/lkysow/atlantis-example/pull-requests/12"
     },
     "activity": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/activity"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/activity"
     },
     "diff": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/diff"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/diff"
     },
     "approve": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/approve"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/approve"
     },
     "statuses": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/statuses"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/statuses"
     }
   },
   "title": "main.tf edited online with Bitbucket",
   "close_source_branch": true,
   "reviewers": [],
-  "id": 5,
+  "id": 12,
   "destination": {
     "commit": {
-      "hash": "fe607a7f5172",
+      "hash": "c641f2c615ad",
       "type": "commit",
       "links": {
         "self": {
-          "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/commit/fe607a7f5172"
+          "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/commit/c641f2c615ad"
         },
         "html": {
-          "href": "https://bitbucket.org/lkysow/atlantis-example/commits/fe607a7f5172"
+          "href": "https://bitbucket.org/lkysow/atlantis-example/commits/c641f2c615ad"
         }
       }
     },
@@ -57,6 +71,9 @@
         },
         "html": {
           "href": "https://bitbucket.org/lkysow/atlantis-example"
+        },
+        "avatar": {
+          "href": "https://bytebucket.org/ravatar/%7B94189367-116b-436a-9f77-2314b97a6067%7D?ts=default"
         }
       },
       "type": "repository",
@@ -68,7 +85,7 @@
       "name": "master"
     }
   },
-  "created_on": "2018-07-25T12:23:21.100810+00:00",
+  "created_on": "2019-02-12T16:48:04.251028+00:00",
   "summary": {
     "raw": "main.tf edited online with Bitbucket",
     "markup": "markdown",
@@ -77,14 +94,14 @@
   },
   "source": {
     "commit": {
-      "hash": "3428957ade18",
+      "hash": "75d1e7c57cd9",
       "type": "commit",
       "links": {
         "self": {
-          "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/commit/3428957ade18"
+          "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/commit/75d1e7c57cd9"
         },
         "html": {
-          "href": "https://bitbucket.org/lkysow/atlantis-example/commits/3428957ade18"
+          "href": "https://bitbucket.org/lkysow/atlantis-example/commits/75d1e7c57cd9"
         }
       }
     },
@@ -95,6 +112,9 @@
         },
         "html": {
           "href": "https://bitbucket.org/lkysow/atlantis-example"
+        },
+        "avatar": {
+          "href": "https://bytebucket.org/ravatar/%7B94189367-116b-436a-9f77-2314b97a6067%7D?ts=default"
         }
       },
       "type": "repository",
@@ -103,57 +123,84 @@
       "uuid": "{94189367-116b-436a-9f77-2314b97a6067}"
     },
     "branch": {
-      "name": "lkysow/maintf-edited-online-with-bitbucket-1532521398289"
+      "name": "lkysow/maintf-edited-online-with-bitbucket-1549990080103"
     }
   },
-  "comment_count": 3,
+  "comment_count": 23,
   "state": "OPEN",
   "task_count": 0,
   "participants": [
     {
       "role": "PARTICIPANT",
-      "participated_on": "2018-07-28T00:06:42.255492+00:00",
+      "participated_on": "2019-06-03T13:51:44.122406+00:00",
+      "type": "participant",
+      "approved": false,
+      "user": {
+        "username": "lkysow",
+        "display_name": "Luke",
+        "uuid": "{bf34a99b-8a11-452c-8fbc-bdffc340e584}",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/users/%7Bbf34a99b-8a11-452c-8fbc-bdffc340e584%7D"
+          },
+          "html": {
+            "href": "https://bitbucket.org/%7Bbf34a99b-8a11-452c-8fbc-bdffc340e584%7D/"
+          },
+          "avatar": {
+            "href": "https://avatar-cdn.atlassian.com/557058%3Adc3817de-68b5-45cd-b81c-5c39d2560090?by=id&sg=TUDovBcAEFksW8FiPnLjf1IV73Y%3D&d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FL-1.svg"
+          }
+        },
+        "nickname": "Luke",
+        "type": "user",
+        "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090"
+      }
+    },
+    {
+      "role": "PARTICIPANT",
+      "participated_on": "2019-06-03T13:55:17.622018+00:00",
       "type": "participant",
       "approved": true,
       "user": {
-        "username": "approver",
-        "display_name": "Luke",
-        "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
+        "username": "atlantis-bot",
+        "display_name": "Atlantisbot",
+        "uuid": "{73686412-4495-426f-89a7-c69ff1c8d7b8}",
         "links": {
           "self": {
-            "href": "https://api.bitbucket.org/2.0/users/lkysow"
+            "href": "https://api.bitbucket.org/2.0/users/%7B73686412-4495-426f-89a7-c69ff1c8d7b8%7D"
           },
           "html": {
-            "href": "https://bitbucket.org/lkysow/"
+            "href": "https://bitbucket.org/%7B73686412-4495-426f-89a7-c69ff1c8d7b8%7D/"
           },
           "avatar": {
-            "href": "https://bitbucket.org/account/lkysow/avatar/"
+            "href": "https://avatar-cdn.atlassian.com/5b5097035488b9140c078f7f?by=id&sg=vyisLdHfYH10sFOuFCvPgHKn6ds%3D&d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FA-1.png"
           }
         },
+        "nickname": "Atlantisbot",
         "type": "user",
-        "uuid": "{bf34a99b-8a11-452c-8fbc-bdffc340e584}"
+        "account_id": "5b5097035488b9140c078f7f"
       }
     }
   ],
   "reason": "",
-  "updated_on": "2018-07-28T00:06:42.257659+00:00",
+  "updated_on": "2019-06-03T13:55:17.639190+00:00",
   "author": {
     "username": "lkysow",
     "display_name": "Luke",
-    "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
+    "uuid": "{bf34a99b-8a11-452c-8fbc-bdffc340e584}",
     "links": {
       "self": {
-        "href": "https://api.bitbucket.org/2.0/users/lkysow"
+        "href": "https://api.bitbucket.org/2.0/users/%7Bbf34a99b-8a11-452c-8fbc-bdffc340e584%7D"
       },
       "html": {
-        "href": "https://bitbucket.org/lkysow/"
+        "href": "https://bitbucket.org/%7Bbf34a99b-8a11-452c-8fbc-bdffc340e584%7D/"
       },
       "avatar": {
-        "href": "https://bitbucket.org/account/lkysow/avatar/"
+        "href": "https://avatar-cdn.atlassian.com/557058%3Adc3817de-68b5-45cd-b81c-5c39d2560090?by=id&sg=TUDovBcAEFksW8FiPnLjf1IV73Y%3D&d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FL-1.svg"
       }
     },
+    "nickname": "Luke",
     "type": "user",
-    "uuid": "{bf34a99b-8a11-452c-8fbc-bdffc340e584}"
+    "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090"
   },
   "merge_commit": null,
   "closed_by": null

--- a/server/events/vcs/bitbucketcloud/testdata/pull-unapproved.json
+++ b/server/events/vcs/bitbucketcloud/testdata/pull-unapproved.json
@@ -1,52 +1,66 @@
 {
+  "rendered": {
+    "description": {
+      "raw": "main.tf edited online with Bitbucket",
+      "markup": "markdown",
+      "html": "<p>main.tf edited online with Bitbucket</p>",
+      "type": "rendered"
+    },
+    "title": {
+      "raw": "main.tf edited online with Bitbucket",
+      "markup": "markdown",
+      "html": "<p>main.tf edited online with Bitbucket</p>",
+      "type": "rendered"
+    }
+  },
   "type": "pullrequest",
   "description": "main.tf edited online with Bitbucket",
   "links": {
     "decline": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/decline"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/decline"
     },
     "commits": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/commits"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/commits"
     },
     "self": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12"
     },
     "comments": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/comments"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/comments"
     },
     "merge": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/merge"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/merge"
     },
     "html": {
-      "href": "https://bitbucket.org/lkysow/atlantis-example/pull-requests/5"
+      "href": "https://bitbucket.org/lkysow/atlantis-example/pull-requests/12"
     },
     "activity": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/activity"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/activity"
     },
     "diff": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/diff"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/diff"
     },
     "approve": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/approve"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/approve"
     },
     "statuses": {
-      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/5/statuses"
+      "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/pullrequests/12/statuses"
     }
   },
   "title": "main.tf edited online with Bitbucket",
   "close_source_branch": true,
   "reviewers": [],
-  "id": 5,
+  "id": 12,
   "destination": {
     "commit": {
-      "hash": "fe607a7f5172",
+      "hash": "c641f2c615ad",
       "type": "commit",
       "links": {
         "self": {
-          "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/commit/fe607a7f5172"
+          "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/commit/c641f2c615ad"
         },
         "html": {
-          "href": "https://bitbucket.org/lkysow/atlantis-example/commits/fe607a7f5172"
+          "href": "https://bitbucket.org/lkysow/atlantis-example/commits/c641f2c615ad"
         }
       }
     },
@@ -57,6 +71,9 @@
         },
         "html": {
           "href": "https://bitbucket.org/lkysow/atlantis-example"
+        },
+        "avatar": {
+          "href": "https://bytebucket.org/ravatar/%7B94189367-116b-436a-9f77-2314b97a6067%7D?ts=default"
         }
       },
       "type": "repository",
@@ -68,7 +85,7 @@
       "name": "master"
     }
   },
-  "created_on": "2018-07-25T12:23:21.100810+00:00",
+  "created_on": "2019-02-12T16:48:04.251028+00:00",
   "summary": {
     "raw": "main.tf edited online with Bitbucket",
     "markup": "markdown",
@@ -77,14 +94,14 @@
   },
   "source": {
     "commit": {
-      "hash": "3428957ade18",
+      "hash": "75d1e7c57cd9",
       "type": "commit",
       "links": {
         "self": {
-          "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/commit/3428957ade18"
+          "href": "https://api.bitbucket.org/2.0/repositories/lkysow/atlantis-example/commit/75d1e7c57cd9"
         },
         "html": {
-          "href": "https://bitbucket.org/lkysow/atlantis-example/commits/3428957ade18"
+          "href": "https://bitbucket.org/lkysow/atlantis-example/commits/75d1e7c57cd9"
         }
       }
     },
@@ -95,6 +112,9 @@
         },
         "html": {
           "href": "https://bitbucket.org/lkysow/atlantis-example"
+        },
+        "avatar": {
+          "href": "https://bytebucket.org/ravatar/%7B94189367-116b-436a-9f77-2314b97a6067%7D?ts=default"
         }
       },
       "type": "repository",
@@ -103,32 +123,84 @@
       "uuid": "{94189367-116b-436a-9f77-2314b97a6067}"
     },
     "branch": {
-      "name": "lkysow/maintf-edited-online-with-bitbucket-1532521398289"
+      "name": "lkysow/maintf-edited-online-with-bitbucket-1549990080103"
     }
   },
-  "comment_count": 3,
+  "comment_count": 23,
   "state": "OPEN",
   "task_count": 0,
-  "participants": [],
+  "participants": [
+    {
+      "role": "PARTICIPANT",
+      "participated_on": "2019-06-03T13:51:44.122406+00:00",
+      "type": "participant",
+      "approved": false,
+      "user": {
+        "username": "lkysow",
+        "display_name": "Luke",
+        "uuid": "{bf34a99b-8a11-452c-8fbc-bdffc340e584}",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/users/%7Bbf34a99b-8a11-452c-8fbc-bdffc340e584%7D"
+          },
+          "html": {
+            "href": "https://bitbucket.org/%7Bbf34a99b-8a11-452c-8fbc-bdffc340e584%7D/"
+          },
+          "avatar": {
+            "href": "https://avatar-cdn.atlassian.com/557058%3Adc3817de-68b5-45cd-b81c-5c39d2560090?by=id&sg=TUDovBcAEFksW8FiPnLjf1IV73Y%3D&d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FL-1.svg"
+          }
+        },
+        "nickname": "Luke",
+        "type": "user",
+        "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090"
+      }
+    },
+    {
+      "role": "PARTICIPANT",
+      "participated_on": "2019-06-03T13:51:47.350675+00:00",
+      "type": "participant",
+      "approved": false,
+      "user": {
+        "username": "atlantis-bot",
+        "display_name": "Atlantisbot",
+        "uuid": "{73686412-4495-426f-89a7-c69ff1c8d7b8}",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/users/%7B73686412-4495-426f-89a7-c69ff1c8d7b8%7D"
+          },
+          "html": {
+            "href": "https://bitbucket.org/%7B73686412-4495-426f-89a7-c69ff1c8d7b8%7D/"
+          },
+          "avatar": {
+            "href": "https://avatar-cdn.atlassian.com/5b5097035488b9140c078f7f?by=id&sg=vyisLdHfYH10sFOuFCvPgHKn6ds%3D&d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FA-1.png"
+          }
+        },
+        "nickname": "Atlantisbot",
+        "type": "user",
+        "account_id": "5b5097035488b9140c078f7f"
+      }
+    }
+  ],
   "reason": "",
-  "updated_on": "2018-07-28T00:06:42.257659+00:00",
+  "updated_on": "2019-06-03T13:54:09.266101+00:00",
   "author": {
     "username": "lkysow",
     "display_name": "Luke",
-    "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
+    "uuid": "{bf34a99b-8a11-452c-8fbc-bdffc340e584}",
     "links": {
       "self": {
-        "href": "https://api.bitbucket.org/2.0/users/lkysow"
+        "href": "https://api.bitbucket.org/2.0/users/%7Bbf34a99b-8a11-452c-8fbc-bdffc340e584%7D"
       },
       "html": {
-        "href": "https://bitbucket.org/lkysow/"
+        "href": "https://bitbucket.org/%7Bbf34a99b-8a11-452c-8fbc-bdffc340e584%7D/"
       },
       "avatar": {
-        "href": "https://bitbucket.org/account/lkysow/avatar/"
+        "href": "https://avatar-cdn.atlassian.com/557058%3Adc3817de-68b5-45cd-b81c-5c39d2560090?by=id&sg=TUDovBcAEFksW8FiPnLjf1IV73Y%3D&d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FL-1.svg"
       }
     },
+    "nickname": "Luke",
     "type": "user",
-    "uuid": "{bf34a99b-8a11-452c-8fbc-bdffc340e584}"
+    "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090"
   },
   "merge_commit": null,
   "closed_by": null


### PR DESCRIPTION
Bitbucket Cloud changed their APIs to deprecate the username fields.
This broke how we were checking for approvals. Rather than propagate the
UUID field through the PullRequest model, I use the pull request API
response directly while checking approvers.

Fixes #652