### PR TITLE
go to the latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
         # We do this instead of setting --default-tf-version because setting
         # that flag starts the download asynchronously so we'd have a race
         # condition.
-        TERRAFORM_VERSION: 0.12.1
+        TERRAFORM_VERSION: 0.12.3
     steps:
     - checkout
     - run: make build-service

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM runatlantis/atlantis-base:v3.0
 LABEL authors="Anubhav Mishra, Luke Kysow"
 
 # install terraform binaries
-ENV DEFAULT_TERRAFORM_VERSION=0.12.1
+ENV DEFAULT_TERRAFORM_VERSION=0.12.2
 
 # In the official Atlantis image we only have the latest of each Terrafrom version.
 RUN AVAILABLE_TERRAFORM_VERSIONS="0.8.8 0.9.11 0.10.8 0.11.14 ${DEFAULT_TERRAFORM_VERSION}" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM runatlantis/atlantis-base:v3.0
 LABEL authors="Anubhav Mishra, Luke Kysow"
 
 # install terraform binaries
-ENV DEFAULT_TERRAFORM_VERSION=0.12.2
+ENV DEFAULT_TERRAFORM_VERSION=0.12.3
 
 # In the official Atlantis image we only have the latest of each Terrafrom version.
 RUN AVAILABLE_TERRAFORM_VERSIONS="0.8.8 0.9.11 0.10.8 0.11.14 ${DEFAULT_TERRAFORM_VERSION}" && \

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -5,7 +5,7 @@
 FROM circleci/golang:1.12
 
 # Install Terraform
-ENV TERRAFORM_VERSION=0.12.1
+ENV TERRAFORM_VERSION=0.12.3
 RUN curl -LOks https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
     sudo mkdir -p /usr/local/bin/tf/versions/${TERRAFORM_VERSION} && \
     sudo unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/local/bin/tf/versions/${TERRAFORM_VERSION} && \


### PR DESCRIPTION
we have some Engineers that are super aggressive in updating their things;

```Initializing the backend...
Error refreshing state: state snapshot was created by Terraform v0.12.2, which is newer than current v0.12.1; upgrade to Terraform v0.12.2 or greater to work with this state```

Thanks