### PR TITLE
Update security.md

### DIFF
--- a/runatlantis.io/docs/security.md
+++ b/runatlantis.io/docs/security.md
@@ -56,3 +56,7 @@ Webhook secrets ensure that the webhook requests are actually coming from your V
 If you're using webhook secrets but your traffic is over HTTP then the webhook secrets
 could be stolen. Enable SSL/HTTPS using the `--ssl-cert-file` and `--ssl-key-file`
 flags.
+
+### Arbitrary command injection on comments
+Any user with the ability to comment on the merge request can run any Linux command available to the Linux Atlantis User. Be certain that the Atlantis user is secured as much as possible from running damaging commands.
+Example: terraform plan -- -var=$(rm -rf /) 


### PR DESCRIPTION
Arbitrary commands don't need to be embedded in terraform. One can run any command or set of commands from inside a terraform variable using the notation I show in my example. The Atlantis user itself should only be able run a small set of commands. I would suggest the permissions be limited to running terraform, reading and writing only to the data-dir, and only when the source is the git repository, and the other pieces of code used to interact with the Pull Request. I don't know how you would build this into the Altantis application, but if you would like, I can come up with an sh script to limit what I think are major vulnerabilities. 