### PR TITLE
Detect remote ops for TF >= 0.12.0

### DIFF
--- a/server/events/runtime/plan_step_runner.go
+++ b/server/events/runtime/plan_step_runner.go
@@ -64,7 +64,7 @@ func (p *PlanStepRunner) isRemoteOpsErr(output string, err error) bool {
 	if err == nil {
 		return false
 	}
-	return strings.Contains(output, remoteOpsErr)
+	return strings.Contains(output, remoteOpsErr01114) || strings.Contains(output, remoteOpsErr012)
 }
 
 // remotePlan runs a terraform plan command compatible with TFE remote
@@ -298,12 +298,22 @@ func (p *PlanStepRunner) runRemotePlan(
 
 var vTwelveAndUp = MustConstraint(">=0.12-a")
 
-// remoteOpsErr is the error terraform plan will return if this project is
-// using TFE remote operations.
-var remoteOpsErr = `Error: Saving a generated plan is currently not supported!
+// remoteOpsErr01114 is the error terraform plan will return if this project is
+// using TFE remote operations in TF 0.11.14.
+var remoteOpsErr01114 = `Error: Saving a generated plan is currently not supported!
 
 The "remote" backend does not support saving the generated execution
 plan locally at this time.
+
+`
+
+// remoteOpsErr012 is the error terraform plan will return if this project is
+// using TFE remote operations in TF 0.12.{0-4}. Later versions haven't been
+// released yet at this time.
+var remoteOpsErr012 = `Error: Saving a generated plan is currently not supported
+
+The "remote" backend does not support saving the generated execution plan
+locally at this time.
 
 `
 


### PR DESCRIPTION
The error message we use to detect remote ops changed between 0.11.14
and 0.12.0. Recognize this new error message.

Fixes #704