### PR TITLE
add .hcl to supported file filter

### DIFF
--- a/runatlantis.io/docs/custom-workflows.md
+++ b/runatlantis.io/docs/custom-workflows.md
@@ -136,21 +136,43 @@ Atlantis supports running custom commands in place of the default Atlantis
 commands. We can use this functionality to enable
 [Terragrunt](https://github.com/gruntwork-io/terragrunt).
 
+You can either use your repo's `atlantis.yaml` file or the Atlantis server's `repos.yaml` file.
+
 Given a directory structure:
 ```
 .
-├── live
-│   ├── prod
-│   │   └── terraform.tfvars     # OR terragrunt.hcl for terragrunt 0.19+ 
-│   └── staging
-│       └── terraform.tfvars
-└── modules
-    └── ...
+└── live
+    ├── prod
+    │   └── terragrunt.hcl
+    └── staging
+        └── terragrunt.cl
 ```
 
-You would define a custom workflow:
+If using the server `repos.yaml` file, you would use the following config:
+
 ```yaml
-# repos.yaml or atlantis.yaml
+# repos.yaml
+repos:
+- id: "/.*/"
+  workflow: terragrunt
+workflows:
+  terragrunt:
+    plan:
+      steps:
+      - run: terragrunt plan -no-color -out=$PLANFILE
+    apply:
+      steps:
+      - run: terragrunt apply -no-color $PLANFILE
+```
+
+If using the repo's `atlantis.yaml` file you would use the following config:
+```yaml
+version: 3
+projects:
+- dir: live/staging
+  workflow: terragrunt
+- dir: live/prod
+  workflow: terragrunt
 workflows:
   terragrunt:
     plan:
@@ -161,15 +183,8 @@ workflows:
       - run: terragrunt apply -no-color $PLANFILE
 ```
 
-Which you would then reference in your repo-level `atlantis.yaml`:
-```yaml
-version: 3
-projects:
-- dir: live/staging
-  workflow: terragrunt
-- dir: live/prod
-  workflow: terragrunt
-```
+**NOTE:** If using the repo's `atlantis.yaml` file, you will need to specify each directory that is a Terragrunt project.
+
 
 ::: warning
 Atlantis will need to have the `terragrunt` binary in its PATH.

--- a/runatlantis.io/docs/custom-workflows.md
+++ b/runatlantis.io/docs/custom-workflows.md
@@ -141,7 +141,7 @@ Given a directory structure:
 .
 ├── live
 │   ├── prod
-│   │   └── terraform.tfvars
+│   │   └── terraform.tfvars     # OR terragrunt.hcl for terragrunt 0.19+ 
 │   └── staging
 │       └── terraform.tfvars
 └── modules
@@ -175,6 +175,41 @@ projects:
 Atlantis will need to have the `terragrunt` binary in its PATH.
 If you're using Docker you can build your own image, see [Customization](/docs/deployment.html#customization).
 :::
+
+#### Terragrunt Autoplan Configuration
+Since many Terragrunt projects have numerous nested folders where project files reside, 
+updating your repo-level `atlantis.yaml` to include every possible path can be tedious.
+
+Instead, you can use a server-side repo config like this to enable autoplanning of your Terragrunt projects:
+
+```json
+{
+  "repos": [
+    {
+      "id": "/.*/",
+      "workflow": "terragrunt"
+    }
+  ],
+  "workflows": {
+    "terragrunt": {
+      "plan": {
+        "steps": [
+          {
+            "run": "terragrunt plan -no-color -out=$PLANFILE"
+          }
+        ]
+      },
+      "apply": {
+        "steps": [
+          {
+            "run": "terragrunt apply -no-color $PLANFILE"
+          }
+        ]
+      }
+    }
+  }
+}
+```
 
 ### Running custom commands
 Atlantis supports running completely custom commands. In this example, we want to run

--- a/runatlantis.io/docs/custom-workflows.md
+++ b/runatlantis.io/docs/custom-workflows.md
@@ -182,33 +182,18 @@ updating your repo-level `atlantis.yaml` to include every possible path can be t
 
 Instead, you can use a server-side repo config like this to enable autoplanning of your Terragrunt projects:
 
-```json
-{
-  "repos": [
-    {
-      "id": "/.*/",
-      "workflow": "terragrunt"
-    }
-  ],
-  "workflows": {
-    "terragrunt": {
-      "plan": {
-        "steps": [
-          {
-            "run": "terragrunt plan -no-color -out=$PLANFILE"
-          }
-        ]
-      },
-      "apply": {
-        "steps": [
-          {
-            "run": "terragrunt apply -no-color $PLANFILE"
-          }
-        ]
-      }
-    }
-  }
-}
+```yaml
+repos:
+- id: "/.*/"
+  workflow: terragrunt
+workflows:
+  terragrunt:
+    plan:
+      steps:
+      - run: terragrunt plan -no-color -out=$PLANFILE
+    apply:
+      steps:
+      - run: terragrunt apply -no-color $PLANFILE
 ```
 
 ### Running custom commands

--- a/runatlantis.io/docs/custom-workflows.md
+++ b/runatlantis.io/docs/custom-workflows.md
@@ -191,26 +191,6 @@ Atlantis will need to have the `terragrunt` binary in its PATH.
 If you're using Docker you can build your own image, see [Customization](/docs/deployment.html#customization).
 :::
 
-#### Terragrunt Autoplan Configuration
-Since many Terragrunt projects have numerous nested folders where project files reside, 
-updating your repo-level `atlantis.yaml` to include every possible path can be tedious.
-
-Instead, you can use a server-side repo config like this to enable autoplanning of your Terragrunt projects:
-
-```yaml
-repos:
-- id: "/.*/"
-  workflow: terragrunt
-workflows:
-  terragrunt:
-    plan:
-      steps:
-      - run: terragrunt plan -no-color -out=$PLANFILE
-    apply:
-      steps:
-      - run: terragrunt apply -no-color $PLANFILE
-```
-
 ### Running custom commands
 Atlantis supports running completely custom commands. In this example, we want to run
 a script after every `apply`:

--- a/server/events/project_finder.go
+++ b/server/events/project_finder.go
@@ -123,7 +123,7 @@ func (p *DefaultProjectFinder) filterToTerraform(files []string) []string {
 	for _, fileName := range files {
 		// Filter out tfstate files since they usually checked in by accident
 		// and regardless, they don't affect a plan.
-		if !p.isStatefile(fileName) && (strings.Contains(fileName, ".tf") || strings.Contains(fileName, "terragrunt.hcl")) {
+		if !p.isStatefile(fileName) && (strings.Contains(fileName, ".tf") || fileName == "terragrunt.hcl") {
 			filtered = append(filtered, fileName)
 		}
 	}

--- a/server/events/project_finder.go
+++ b/server/events/project_finder.go
@@ -51,7 +51,7 @@ func (p *DefaultProjectFinder) DetermineProjects(log *logging.SimpleLogger, modi
 	if len(modifiedTerraformFiles) == 0 {
 		return projects
 	}
-	log.Info("filtered modified files to %d .tf files: %v",
+	log.Info("filtered modified files to %d .tf or terragrunt.hcl files: %v",
 		len(modifiedTerraformFiles), modifiedTerraformFiles)
 
 	var dirs []string
@@ -123,7 +123,7 @@ func (p *DefaultProjectFinder) filterToTerraform(files []string) []string {
 	for _, fileName := range files {
 		// Filter out tfstate files since they usually checked in by accident
 		// and regardless, they don't affect a plan.
-		if !p.isStatefile(fileName) && (strings.Contains(fileName, ".tf") || strings.Contains(fileName, ".hcl")) {
+		if !p.isStatefile(fileName) && (strings.Contains(fileName, ".tf") || strings.Contains(fileName, "terragrunt.hcl")) {
 			filtered = append(filtered, fileName)
 		}
 	}

--- a/server/events/project_finder.go
+++ b/server/events/project_finder.go
@@ -123,7 +123,7 @@ func (p *DefaultProjectFinder) filterToTerraform(files []string) []string {
 	for _, fileName := range files {
 		// Filter out tfstate files since they usually checked in by accident
 		// and regardless, they don't affect a plan.
-		if !p.isStatefile(fileName) && (strings.Contains(fileName, ".tf") || fileName == "terragrunt.hcl") {
+		if !p.isStatefile(fileName) && (strings.Contains(fileName, ".tf") || filepath.Base(fileName) == "terragrunt.hcl") {
 			filtered = append(filtered, fileName)
 		}
 	}

--- a/server/events/project_finder.go
+++ b/server/events/project_finder.go
@@ -123,7 +123,7 @@ func (p *DefaultProjectFinder) filterToTerraform(files []string) []string {
 	for _, fileName := range files {
 		// Filter out tfstate files since they usually checked in by accident
 		// and regardless, they don't affect a plan.
-		if !p.isStatefile(fileName) && strings.Contains(fileName, ".tf") {
+		if !p.isStatefile(fileName) && (strings.Contains(fileName, ".tf") || strings.Contains(fileName, ".hcl")) {
 			filtered = append(filtered, fileName)
 		}
 	}

--- a/server/events/project_finder_test.go
+++ b/server/events/project_finder_test.go
@@ -189,6 +189,12 @@ func TestDetermineProjects(t *testing.T) {
 			[]string{},
 			"",
 		},
+		{
+			"Should not ignore terragrunt.hcl files",
+			[]string{"terragrunt.hcl"},
+			[]string{"."},
+			nestedModules2,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {

--- a/server/events/project_finder_test.go
+++ b/server/events/project_finder_test.go
@@ -195,6 +195,12 @@ func TestDetermineProjects(t *testing.T) {
 			[]string{"."},
 			nestedModules2,
 		},
+		{
+			"Should find terragrunt.hcl file inside a nested directory",
+			[]string{"project1/terragrunt.hcl"},
+			[]string{"project1"},
+			nestedModules1,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {


### PR DESCRIPTION
Quick fix for https://github.com/runatlantis/atlantis/issues/728 until [this](https://github.com/runatlantis/atlantis/issues/728#issuecomment-521312535) is implemented.

Allows for using Atlantis with Terragrunt 0.19 style `terragrunt.hcl` config.

All tests passing.