### PR TITLE
Add troubleshooting section for https

### DIFF
--- a/runatlantis.io/.vuepress/config.js
+++ b/runatlantis.io/.vuepress/config.js
@@ -86,6 +86,13 @@ module.exports = {
                         'automerging',
                         'security'
                     ]
+                },
+                {
+                    title: 'Troubleshooting',
+                    collapsable: true,
+                    children: [
+                        'troubleshooting-https',
+                    ]
                 }
             ]
         },

--- a/runatlantis.io/docs/README.md
+++ b/runatlantis.io/docs/README.md
@@ -12,4 +12,3 @@ where you can try our [Test Drive](/guide/test-drive.html) or [Run Atlantis Loca
 * [Configuring Atlantis](configuring-atlantis.html)&nbsp;&nbsp;–&nbsp;&nbsp;Configure how Atlantis works for your specific use-cases
 * [Using Atlantis](using-atlantis.html)&nbsp;&nbsp;–&nbsp;&nbsp;How do you use Atlantis?
 * [How Atlantis Works](how-atlantis-works.html)&nbsp;&nbsp;–&nbsp;&nbsp;Internals of what Atlantis is doing
-* [Troubleshooting](troubleshooting.html)&nbsp;&nbsp;–&nbsp;&nbsp;Common solutions to common problems

--- a/runatlantis.io/docs/README.md
+++ b/runatlantis.io/docs/README.md
@@ -12,3 +12,4 @@ where you can try our [Test Drive](/guide/test-drive.html) or [Run Atlantis Loca
 * [Configuring Atlantis](configuring-atlantis.html)&nbsp;&nbsp;–&nbsp;&nbsp;Configure how Atlantis works for your specific use-cases
 * [Using Atlantis](using-atlantis.html)&nbsp;&nbsp;–&nbsp;&nbsp;How do you use Atlantis?
 * [How Atlantis Works](how-atlantis-works.html)&nbsp;&nbsp;–&nbsp;&nbsp;Internals of what Atlantis is doing
+* [Troubleshooting](troubleshooting.html)&nbsp;&nbsp;–&nbsp;&nbsp;Common solutions to common problems

--- a/runatlantis.io/docs/troubleshooting-https.md
+++ b/runatlantis.io/docs/troubleshooting-https.md
@@ -6,7 +6,7 @@ there are a few considerations.
 Atlantis uses the web server from the standard Go library, 
 the method name is [ListenAndServeTLS](https://golang.org/pkg/net/http/#ListenAndServeTLS).
 
-For info, ListenAndServeTLS acts identically to [ListenAndServe](https://golang.org/pkg/net/http/#ListenAndServe),
+`ListenAndServeTLS` acts identically to [ListenAndServe](https://golang.org/pkg/net/http/#ListenAndServe),
 except that it expects HTTPS connections. 
 Additionally, files containing a certificate and matching private key for the server must be provided. 
 If the certificate is signed by a certificate authority, 

--- a/runatlantis.io/docs/troubleshooting-https.md
+++ b/runatlantis.io/docs/troubleshooting-https.md
@@ -1,0 +1,27 @@
+# HTTPS, SSL, TLS
+
+When using a self-signed certificate for Atlantis (with flags `--ssl-cert-file` and `--ssl-key-file`),
+there are a few considerations.
+
+Atlantis uses the web server from the standard Go library, 
+the method name is [ListenAndServeTLS](https://golang.org/pkg/net/http/#ListenAndServeTLS).
+
+For info, ListenAndServeTLS acts identically to [ListenAndServe](https://golang.org/pkg/net/http/#ListenAndServe),
+except that it expects HTTPS connections. 
+Additionally, files containing a certificate and matching private key for the server must be provided. 
+If the certificate is signed by a certificate authority, 
+the certFile should be the concatenation of the server's certificate, any intermediates, and the CA's certificate. 
+
+If you have this error when specifying a TLS cert with a key: 
+```
+[EROR] server.go:413 server: Tls: private key does not match public key
+```
+
+Check that the locally signed certificate is prepended to the self signed certificate.
+A good example is shown at [Seth Vargo terraform implementation of atlantis-on-gke](https://github.com/sethvargo/atlantis-on-gke/blob/master/terraform/tls.tf#L64)
+
+For Go specific TLS resources have a look at the repository by [denji called golang-tls](https://github.com/denji/golang-tls).
+
+For a complete explanation on PKI, read this [article](https://smallstep.com/blog/everything-pki.html).
+
+

--- a/runatlantis.io/docs/troubleshooting-https.md
+++ b/runatlantis.io/docs/troubleshooting-https.md
@@ -17,7 +17,7 @@ If you have this error when specifying a TLS cert with a key:
 [EROR] server.go:413 server: Tls: private key does not match public key
 ```
 
-Check that the locally signed certificate is prepended to the self signed certificate.
+Check that the locally signed certificate authority is prepended to the self signed certificate.
 A good example is shown at [Seth Vargo terraform implementation of atlantis-on-gke](https://github.com/sethvargo/atlantis-on-gke/blob/master/terraform/tls.tf#L64)
 
 For Go specific TLS resources have a look at the repository by [denji called golang-tls](https://github.com/denji/golang-tls).

--- a/runatlantis.io/docs/troubleshooting-https.md
+++ b/runatlantis.io/docs/troubleshooting-https.md
@@ -10,7 +10,7 @@ the method name is [ListenAndServeTLS](https://golang.org/pkg/net/http/#ListenAn
 except that it expects HTTPS connections. 
 Additionally, files containing a certificate and matching private key for the server must be provided. 
 If the certificate is signed by a certificate authority, 
-the certFile should be the concatenation of the server's certificate, any intermediates, and the CA's certificate. 
+the file passed to `--ssl-cert-file` should be the concatenation of the server's certificate, any intermediates, and the CA's certificate. 
 
 If you have this error when specifying a TLS cert with a key: 
 ```


### PR DESCRIPTION
After our discussion on #750 , here is the troubleshooting section.

For info, in order to contribute to the doc, 
I just forked this repo, then `npm install && npm website:dev` and start editing files in `runatlantis.io/` .

It was quite a seamless experience. 👍 

Let me know your thoughts