### PR TITLE
Update repo level planning configuration docs

### DIFF
--- a/runatlantis.io/docs/autoplanning.md
+++ b/runatlantis.io/docs/autoplanning.md
@@ -26,7 +26,7 @@ Given the directory structure:
 
 * If `project1/main.tf` were modified, we would run `plan` in `project1`
 * If `modules/module1/main.tf` were modified, we would not automatically run `plan` because we couldn't determine the location of the terraform project
-    * You could use an [atlantis.yaml](repo-level-atlantis-yaml.html#configuring-autoplanning) file to specify which projects to plan when this module changed
+    * You could use an [atlantis.yaml](repo-level-atlantis-yaml.html#configuring-planning) file to specify which projects to plan when this module changed
     * Or you could manually plan with `atlantis plan -d <dir>`
 * If `project1/modules/module1/main.tf` were modified, we would look one level above `project1/modules`
 into `project1/`, see that there was a `main.tf` file and so run plan in `project1/`
@@ -36,4 +36,4 @@ If you would like to customize how Atlantis determines which directory to run in
 or disable it all together you need to create an `atlantis.yaml` file.
 See
 * [Disabling Autoplanning](repo-level-atlantis-yaml.html#disabling-autoplanning)
-* [Configuring Autoplanning](repo-level-atlantis-yaml.html#configuring-autoplanning)
+* [Configuring Planning](repo-level-atlantis-yaml.html#configuring-planning)

--- a/runatlantis.io/docs/repo-level-atlantis-yaml.md
+++ b/runatlantis.io/docs/repo-level-atlantis-yaml.md
@@ -83,8 +83,10 @@ projects:
 This will stop Atlantis automatically running plan when `project1/` is updated
 in a pull request.
 
-### Configuring Autoplanning
+### Configuring Planning
+
 Given the directory structure:
+
 ```
 .
 ├── modules
@@ -97,8 +99,9 @@ Given the directory structure:
 └── project1
     └── main.tf
 ```
-If you wanted Atlantis to autoplan `project1/` whenever any `.tf` file under `module1/`
-changed or any `.tf` or `.tfvars` file under `project1/` changed, you could use the following configuration:
+
+If you want Atlantis to plan `project1/` whenever any `.tf` files under `module1/` change or any `.tf` or `.tfvars` files under `project1/` change you could use the following configuration:
+
 
 ```yaml
 version: 3
@@ -107,9 +110,12 @@ projects:
   autoplan:
     when_modified: ["../modules/**/*.tf", "*.tf*"]
 ```
+
 Note:
 * `when_modified` uses the [`.dockerignore` syntax](https://docs.docker.com/engine/reference/builder/#dockerignore-file)
 * The paths are relative to the project's directory.
+* `when_modified` will be used by both automatic and manually run plans.
+* `when_modified` will continue to work for manually run plans even when autoplan is disabled.
 
 ### Supporting Terraform Workspaces
 ```yaml
@@ -229,5 +235,3 @@ when_modified: ["*.tf"]
 |---------------|---------------|----------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | enabled       | boolean       | `true`         | no       | Whether autoplanning is enabled for this project.                                                                                                                                                                                                                 |
 | when_modified | array[string] | `["**/*.tf*"]` | no       | Uses [.dockerignore](https://docs.docker.com/engine/reference/builder/#dockerignore-file) syntax. If any modified file in the pull request matches, this project will be planned. See [Autoplanning](autoplanning.html). Paths are relative to the project's dir. |
-
-

--- a/runatlantis.io/docs/requirements.md
+++ b/runatlantis.io/docs/requirements.md
@@ -55,7 +55,7 @@ Atlantis supports any Terraform repository structure, for example:
         └── ...
 ```
 With modules, if you want `project1` automatically planned when `module1` is modified
-you need to create an `atlantis.yaml` file. See [atlantis.yaml Use Cases](repo-level-atlantis-yaml.html#configuring-autoplanning) for more details.
+you need to create an `atlantis.yaml` file. See [atlantis.yaml Use Cases](repo-level-atlantis-yaml.html#configuring-planning) for more details.
 
 ###  Terraform Workspaces
 *See [Terraform's docs](https://www.terraform.io/docs/state/workspaces.html) if you are unfamiliar with workspaces.*


### PR DESCRIPTION
This clarifies that the `when_modified` block will be used by both
manual and automatic planning even though it's configured within the
auto planning block. This will help clarify issues like #774.