### PR TITLE
Fix test that depends on exact output of git command

### DIFF
--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -224,10 +224,13 @@ func TestClone_CheckoutMergeConflict(t *testing.T) {
 		HeadBranch: "branch",
 		BaseBranch: "master",
 	}, "default")
-	ErrEquals(t, `running git merge -q --no-ff -m atlantis-merge FETCH_HEAD: Auto-merging file
-CONFLICT (add/add): Merge conflict in file
-Automatic merge failed; fix conflicts and then commit the result.
-: exit status 1`, err)
+
+	ErrContains(t, "running git merge -q --no-ff -m atlantis-merge FETCH_HEAD", err)
+	ErrContains(t, "Auto-merging file", err)
+	ErrContains(t, "CONFLICT (add/add)", err)
+	ErrContains(t, "Merge conflict in file", err)
+	ErrContains(t, "Automatic merge failed; fix conflicts and then commit the result.", err)
+	ErrContains(t, "exit status 1", err)
 }
 
 // Test that if the repo is already cloned and is at the right commit, we


### PR DESCRIPTION
When cloning atlantis on a mac with git version 2.23.0 and running `make test-all`, I get the follwing test failure:

```
--- FAIL: TestClone_CheckoutMergeConflict (0.25s)
    working_dir_test.go:227: exp err: "running git merge -q --no-ff -m atlantis-merge FETCH_HEAD: Auto-merging file\nCONFLICT (add/add): Merge conflict in file\nAutomatic merge failed; fix conflicts and then commit the result.\n: exit status 1" but got: "running git merge -q --no-ff -m atlantis-merge FETCH_HEAD: CONFLICT (add/add): Merge conflict in file\nAuto-merging file\nAutomatic merge failed; fix conflicts and then commit the result.\n: exit status 1"
```

Presented more cleanly, you can see that the 2 clauses between `FETCH_HEAD:` and `Automatic merge failed` are flipped
```
Expected:
running git merge -q --no-ff -m atlantis-merge FETCH_HEAD: Auto-merging file\nCONFLICT (add/add): Merge conflict in file\nAutomatic merge failed; fix conflicts and then commit the result.\n: exit status 1
Actual:
running git merge -q --no-ff -m atlantis-merge FETCH_HEAD: CONFLICT (add/add): Merge conflict in file\nAuto-merging file\nAutomatic merge failed; fix conflicts and then commit the result.\n: exit status 1
```

This makes the test slightly more flexible by breaking up the long string in to several smaller substrings