### PR TITLE
Configure git to use https instead of ssh.

### DIFF
--- a/server/events/git_cred_writer.go
+++ b/server/events/git_cred_writer.go
@@ -2,13 +2,14 @@ package events
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/runatlantis/atlantis/server/logging"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/logging"
 )
 
 // WriteGitCreds generates a .git-credentials file containing the username and token
@@ -42,10 +43,16 @@ func WriteGitCreds(gitUser string, gitToken string, gitHostname string, home str
 
 	logger.Info("wrote git credentials to %s", credsFile)
 
-	cmd := exec.Command("git", "config", "--global", "credential.helper", "store")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return errors.Wrapf(err, "There was an error running %s: %s", strings.Join(cmd.Args, " "), string(out))
+	credentialCmd := exec.Command("git", "config", "--global", "credential.helper", "store")
+	if out, err := credentialCmd.CombinedOutput(); err != nil {
+		return errors.Wrapf(err, "There was an error running %s: %s", strings.Join(credentialCmd.Args, " "), string(out))
 	}
-	logger.Info("successfully ran %s", strings.Join(cmd.Args, " "))
+	logger.Info("successfully ran %s", strings.Join(credentialCmd.Args, " "))
+
+	urlCmd := exec.Command("git", "config", "--global", fmt.Sprintf("url.https://%s/.insteadOf", gitHostname), fmt.Sprintf("git@%s:", gitHostname))
+	if out, err := urlCmd.CombinedOutput(); err != nil {
+		return errors.Wrapf(err, "There was an error running %s: %s", strings.Join(urlCmd.Args, " "), string(out))
+	}
+	logger.Info("successfully ran %s", strings.Join(urlCmd.Args, " "))
 	return nil
 }

--- a/server/events/git_cred_writer_test.go
+++ b/server/events/git_cred_writer_test.go
@@ -84,7 +84,7 @@ func TestWriteGitCreds_ErrIfCannotWrite(t *testing.T) {
 }
 
 // Test that git is actually configured to use the credentials
-func TestWriteGitCreds_ConfigureGit(t *testing.T) {
+func TestWriteGitCreds_ConfigureGitCredentialHelper(t *testing.T) {
 	tmp, cleanup := TempDir(t)
 	defer cleanup()
 
@@ -93,6 +93,20 @@ func TestWriteGitCreds_ConfigureGit(t *testing.T) {
 
 	expOutput := `store`
 	actOutput, err := exec.Command("git", "config", "--global", "credential.helper").Output()
+	Ok(t, err)
+	Equals(t, expOutput+"\n", string(actOutput))
+}
+
+// Test that git is configured to use https instead of ssh
+func TestWriteGitCreds_ConfigureGitUrlOveride(t *testing.T) {
+	tmp, cleanup := TempDir(t)
+	defer cleanup()
+
+	err := events.WriteGitCreds("user", "token", "hostname", tmp, logger)
+	Ok(t, err)
+
+	expOutput := `git@hostname:`
+	actOutput, err := exec.Command("git", "config", "--global", "url.https://hostname/.insteadof").Output()
 	Ok(t, err)
 	Equals(t, expOutput+"\n", string(actOutput))
 }


### PR DESCRIPTION
In [711](https://github.com/runatlantis/atlantis/pull/711) I implemented write-git-creds and it was suggested that this particular enhancement should be implemented via a separate PR.

However, for that work, it does require the source to be specified as an HTTPS source type. It's relatively trivial to have it work for ssh sources also we just need to run one extra command to configure it which is what this PR adds.
