### PR TITLE
Configure git to use https instead of ssh.

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -229,7 +229,7 @@ var boolFlags = map[string]boolFlag{
 		defaultValue: false,
 	},
 	WriteGitCredsFlag: {
-		description: "Write out a .git-credentials file with the provider user and token to allow authentication with git over HTTPS." +
+		description: "Write out a .git-credentials file with the provider user and token to allow cloning private modules over HTTPS or SSH" +
 			" This does write secrets to disk and should only be enabled in a secure environment.",
 		defaultValue: false,
 	},

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -407,8 +407,8 @@ Values are chosen in this order:
   ```bash
   atlantis server --write-git-creds
   ```
-  Write out a .git-credentials file and configure git-credentials-store. To allow authentication with your git remotes over https. See [here](https://git-scm.com/docs/git-credential-store) for more information.
-
+  Write out a .git-credentials file with the provider user and token to allow
+  cloning private modules over HTTPS or SSH. See [here](https://git-scm.com/docs/git-credential-store) for more information.
   ::: warning SECURITY WARNING
-  Potentially dangerous to enable as this writes your credentials to disk.
+  This does write secrets to disk and should only be enabled in a secure environment.
   :::

--- a/server/events/git_cred_writer.go
+++ b/server/events/git_cred_writer.go
@@ -2,13 +2,14 @@ package events
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/runatlantis/atlantis/server/logging"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/logging"
 )
 
 // WriteGitCreds generates a .git-credentials file containing the username and token
@@ -42,10 +43,16 @@ func WriteGitCreds(gitUser string, gitToken string, gitHostname string, home str
 
 	logger.Info("wrote git credentials to %s", credsFile)
 
-	cmd := exec.Command("git", "config", "--global", "credential.helper", "store")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return errors.Wrapf(err, "There was an error running %s: %s", strings.Join(cmd.Args, " "), string(out))
+	credentialCmd := exec.Command("git", "config", "--global", "credential.helper", "store")
+	if out, err := credentialCmd.CombinedOutput(); err != nil {
+		return errors.Wrapf(err, "There was an error running %s: %s", strings.Join(credentialCmd.Args, " "), string(out))
 	}
-	logger.Info("successfully ran %s", strings.Join(cmd.Args, " "))
+	logger.Info("successfully ran %s", strings.Join(credentialCmd.Args, " "))
+
+	urlCmd := exec.Command("git", "config", "--global", fmt.Sprintf("url.https://%s@%s.insteadOf", gitUser, gitHostname), fmt.Sprintf("ssh://git@%s", gitHostname))
+	if out, err := urlCmd.CombinedOutput(); err != nil {
+		return errors.Wrapf(err, "There was an error running %s: %s", strings.Join(urlCmd.Args, " "), string(out))
+	}
+	logger.Info("successfully ran %s", strings.Join(urlCmd.Args, " "))
 	return nil
 }

--- a/server/events/git_cred_writer_test.go
+++ b/server/events/git_cred_writer_test.go
@@ -84,7 +84,7 @@ func TestWriteGitCreds_ErrIfCannotWrite(t *testing.T) {
 }
 
 // Test that git is actually configured to use the credentials
-func TestWriteGitCreds_ConfigureGit(t *testing.T) {
+func TestWriteGitCreds_ConfigureGitCredentialHelper(t *testing.T) {
 	tmp, cleanup := TempDir(t)
 	defer cleanup()
 
@@ -93,6 +93,20 @@ func TestWriteGitCreds_ConfigureGit(t *testing.T) {
 
 	expOutput := `store`
 	actOutput, err := exec.Command("git", "config", "--global", "credential.helper").Output()
+	Ok(t, err)
+	Equals(t, expOutput+"\n", string(actOutput))
+}
+
+// Test that git is configured to use https instead of ssh
+func TestWriteGitCreds_ConfigureGitUrlOveride(t *testing.T) {
+	tmp, cleanup := TempDir(t)
+	defer cleanup()
+
+	err := events.WriteGitCreds("user", "token", "hostname", tmp, logger)
+	Ok(t, err)
+
+	expOutput := `ssh://git@hostname`
+	actOutput, err := exec.Command("git", "config", "--global", "url.https://user@hostname.insteadof").Output()
 	Ok(t, err)
 	Equals(t, expOutput+"\n", string(actOutput))
 }


### PR DESCRIPTION
Pretty straightforward. Means that when `write-git-creds` is used it'll work for ssh and https sources without any changes needed. This was discussed in #711 