### PR TITLE
Small refactoring to azure devops support

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -36,8 +36,8 @@ import (
 // 3. Add your flag's description etc. to the stringFlags, intFlags, or boolFlags slices.
 const (
 	// Flag names.
-	ADBasicPasswordFlag        = "azuredevops-basic-password" // nolint: gosec
-	ADBasicUserFlag            = "azuredevops-basic-user"
+	ADWebhookPasswordFlag      = "azuredevops-webhook-password" // nolint: gosec
+	ADWebhookUserFlag          = "azuredevops-webhook-user"
 	ADTokenFlag                = "azuredevops-token" // nolint: gosec
 	ADUserFlag                 = "azuredevops-user"
 	AllowForkPRsFlag           = "allow-fork-prs"
@@ -90,23 +90,23 @@ const (
 )
 
 var stringFlags = map[string]stringFlag{
-	ADBasicPasswordFlag: {
-		description: "Azure Devops basic authentication password for inbound webhooks " +
-			"(see https://docs.microsoft.com/en-us/azure/devops/service-hooks/authorize?view=azure-devops)." +
-			" SECURITY WARNING: If not specified, Atlantis won't be able to validate that the incoming webhook call came from your Azure Devops org. " +
-			"This means that an attacker could spoof calls to Atlantis and cause it to perform malicious actions. " +
-			"Should be specified via the ATLANTIS_AZUREDEVOPS_BASIC_PASSWORD environment variable.",
-		defaultValue: "",
-	},
-	ADBasicUserFlag: {
-		description:  "Azure Devops basic authentication username for inbound webhooks.",
-		defaultValue: "",
-	},
 	ADTokenFlag: {
-		description: "Azure Devops token of API user. Can also be specified via the ATLANTIS_DO_TOKEN environment variable.",
+		description: "Azure DevOps token of API user. Can also be specified via the ATLANTIS_AZUREDEVOPS_TOKEN environment variable.",
 	},
 	ADUserFlag: {
-		description: "Azure Devops username of API user.",
+		description: "Azure DevOps username of API user.",
+	},
+	ADWebhookPasswordFlag: {
+		description: "Azure DevOps basic HTTP authentication password for inbound webhooks " +
+			"(see https://docs.microsoft.com/en-us/azure/devops/service-hooks/authorize?view=azure-devops)." +
+			" SECURITY WARNING: If not specified, Atlantis won't be able to validate that the incoming webhook call came from your Azure DevOps org. " +
+			"This means that an attacker could spoof calls to Atlantis and cause it to perform malicious actions. " +
+			"Should be specified via the ATLANTIS_AZUREDEVOPS_WEBHOOK_PASSWORD environment variable.",
+		defaultValue: "",
+	},
+	ADWebhookUserFlag: {
+		description:  "Azure DevOps basic HTTP authentication username for inbound webhooks.",
+		defaultValue: "",
 	},
 	AtlantisURLFlag: {
 		description: "URL that Atlantis can be reached at. Defaults to http://$(hostname):$port where $port is from --" + PortFlag + ". Supports a base path ex. https://example.com/basepath.",
@@ -590,8 +590,8 @@ func (s *ServerCmd) securityWarnings(userConfig *server.UserConfig) {
 	if userConfig.BitbucketUser != "" && userConfig.BitbucketBaseURL == DefaultBitbucketBaseURL && !s.SilenceOutput {
 		s.Logger.Warn("Bitbucket Cloud does not support webhook secrets. This could allow attackers to spoof requests from Bitbucket. Ensure you are whitelisting Bitbucket IPs")
 	}
-	if (userConfig.AzureDevopsWebhookBasicUser == "" || userConfig.AzureDevopsWebhookBasicPassword == "") && !s.SilenceOutput {
-		s.Logger.Warn("no Azure Devops webhook basic user and password set. This could allow attackers to spoof requests from Azure Devops.")
+	if (userConfig.AzureDevopsWebhookUser == "" || userConfig.AzureDevopsWebhookPassword == "") && !s.SilenceOutput {
+		s.Logger.Warn("no Azure DevOps webhook user and password set. This could allow attackers to spoof requests from Azure DevOps.")
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,8 @@ require (
 	github.com/imdario/mergo v0.3.5 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/magiconair/properties v1.7.3 // indirect
+	github.com/mcdafydd/go-azuredevops v0.8.4
+	github.com/microcosm-cc/bluemonday v1.0.1
 	github.com/mitchellh/colorstring v0.0.0-20150917214807-8631ce90f286
 	github.com/mitchellh/go-homedir v1.0.0
 	github.com/mitchellh/mapstructure v0.0.0-20170523030023-d0303fe80992 // indirect

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,9 @@ github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/mcdafydd/go-azuredevops v0.8.4 h1:MVQgoF2xep/7mMPRrv0u6+nCbFSrMTImnwv4kwUlkok=
+github.com/mcdafydd/go-azuredevops v0.8.4/go.mod h1:1RwqgbF/Afc2o/BLKsRy3dD/nNFQF0YqroNp0CkP4i0=
+github.com/microcosm-cc/bluemonday v1.0.1 h1:SIYunPjnlXcW+gVfvm0IlSeR5U3WZUOLfVmqg85Go44=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/mitchellh/colorstring v0.0.0-20150917214807-8631ce90f286 h1:KHyL+3mQOF9sPfs26lsefckcFNDcIZtiACQiECzIUkw=
 github.com/mitchellh/colorstring v0.0.0-20150917214807-8631ce90f286/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
@@ -264,6 +267,7 @@ golang.org/x/net v0.0.0-20181029044818-c44066c5c816/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20181106065722-10aee1819953/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181108082009-03003ca0c849/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd h1:HuTn7WObtcDo9uEEU7rEqL0jYthdXAmZ6PP+meazmaU=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -274,6 +278,8 @@ golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAG
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890 h1:uESlIz09WIHT2I+pasSXcpLYqYK8wHcdCetU3VuMBJE=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a h1:tImsplftrFpALCYumobsd0K86vlAs/eXGFms2txfJfA=
+golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/perf v0.0.0-20180704124530-6e6d33e29852/go.mod h1:JLpeXjPJfIyPr5TlbXLkXWLhP8nz10XfvxElABhCtcw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/runatlantis.io/.vuepress/components/HomeCustom.vue
+++ b/runatlantis.io/.vuepress/components/HomeCustom.vue
@@ -129,7 +129,7 @@
                   Fargate, etc.
                 </li>
                 <li><img class="checkmark" src="/checkmark.svg">Listens for
-                  webhooks from GitHub/GitLab/Bitbucket/Azure Devops.
+                  webhooks from GitHub/GitLab/Bitbucket/Azure DevOps.
                 </li>
                 <li><img class="checkmark" src="/checkmark.svg">Runs terraform
                   commands remotely and comments back with their output.

--- a/runatlantis.io/docs/access-credentials.md
+++ b/runatlantis.io/docs/access-credentials.md
@@ -1,5 +1,5 @@
 # Git Host Access Credentials
-This page describes how to create credentials for your Git host (GitHub, GitLab, Bitbucket, or Azure Devops)
+This page describes how to create credentials for your Git host (GitHub, GitLab, Bitbucket, or Azure DevOps)
 
 that Atlantis will use to make API calls.
 [[toc]]
@@ -20,7 +20,7 @@ generate an access token. Read on for the instructions for your specific Git hos
 * [GitLab](#gitlab)
 * [Bitbucket Cloud (bitbucket.org)](#bitbucket-cloud-bitbucket-org)
 * [Bitbucket Server (aka Stash)](#bitbucket-server-aka-stash)
-* [Azure Devops](#azure-devops)
+* [Azure DevOps](#azure-devops)
 
 ### GitHub
 - Create a Personal Access Token by following: [https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/#creating-a-token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/#creating-a-token)
@@ -50,13 +50,12 @@ Your Atlantis user must also have "Write permissions" (for repos in an organizat
 - Give the token **Read** Project permissions and **Write** Pull request permissions
 - Click **Create** and record the access token
 
-### Azure Devops
+### Azure DevOps
 - Create a Personal access token by following [https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops)
 - Label the password "atlantis"
 - The minimum scopes required for this token are:
-  - Code (Read)
+  - Code (Read & Write)
   - Code (Status)
-  - Work Items (Read & write)
 - Record the access token
 
 ## Next Steps

--- a/runatlantis.io/docs/apply-requirements.md
+++ b/runatlantis.io/docs/apply-requirements.md
@@ -49,7 +49,7 @@ Each VCS provider has different rules around who can approve:
 * **Bitbucket Cloud (bitbucket.org)** – A user can approve their own pull request but
   Atlantis does not count that as an approval and requires an approval from at least one user that
   is not the author of the pull request
-* **Azure Devops** – **All builtin groups include the "Contribute to pull requests"** permission and can approve a pull request
+* **Azure DevOps** – **All builtin groups include the "Contribute to pull requests"** permission and can approve a pull request
 
 :::tip Tip
 If you want to require **certain people** to approve the pull request, look at the
@@ -121,8 +121,8 @@ merge. We don't check anything else because Bitbucket's API doesn't support it.
 If you need a specific check, please
 [open an issue](https://github.com/runatlantis/atlantis/issues/new).
 
-#### Azure Devops
-In Azure Devops, all pull requests are mergeable unless there is a conflict. You can set a pull request to "Complete" right away, or set "Auto-Complete", which will merge after all branch policies are met. See [Review code with pull requests](https://docs.microsoft.com/en-us/azure/devops/repos/git/pull-requests?view=azure-devops).
+#### Azure DevOps
+In Azure DevOps, all pull requests are mergeable unless there is a conflict. You can set a pull request to "Complete" right away, or set "Auto-Complete", which will merge after all branch policies are met. See [Review code with pull requests](https://docs.microsoft.com/en-us/azure/devops/repos/git/pull-requests?view=azure-devops).
 
 [Branch policies](https://docs.microsoft.com/en-us/azure/devops/repos/git/branch-policies?view=azure-devops) can:
 * Require a minimum number of reviewers
@@ -132,7 +132,7 @@ In Azure Devops, all pull requests are mergeable unless there is a conflict. You
 * Require a specfic merge strategy (squash, rebase, etc.)
 
 ::: warning
-At this time, the Azure Devops client only supports merging using the default 'no fast-forward' strategy. Make sure your branch policies permit this type of merge.
+At this time, the Azure DevOps client only supports merging using the default 'no fast-forward' strategy. Make sure your branch policies permit this type of merge.
 :::
 
 ## Setting Apply Requirements
@@ -201,4 +201,4 @@ request can run the actual `atlantis apply` command.
 * For more information on GitHub pull request reviews and approvals see: [https://help.github.com/articles/about-pull-request-reviews/](https://help.github.com/articles/about-pull-request-reviews/)
 * For more information on GitLab merge request reviews and approvals (only supported on GitLab Enterprise) see: [https://docs.gitlab.com/ee/user/project/merge_requests/merge_request_approvals.html](https://docs.gitlab.com/ee/user/project/merge_requests/merge_request_approvals.html).
 * For more information on Bitbucket pull request reviews and approvals see: [https://confluence.atlassian.com/bitbucket/pull-requests-and-code-review-223220593.html](https://confluence.atlassian.com/bitbucket/pull-requests-and-code-review-223220593.html)
-* For more information on Azure Devops pull request reviews and approvals see: [https://docs.microsoft.com/en-us/azure/devops/repos/git/pull-requests-overview?view=azure-devops](https://docs.microsoft.com/en-us/azure/devops/repos/git/pull-requests-overview?view=azure-devops)
+* For more information on Azure DevOps pull request reviews and approvals see: [https://docs.microsoft.com/en-us/azure/devops/repos/git/pull-requests-overview?view=azure-devops](https://docs.microsoft.com/en-us/azure/devops/repos/git/pull-requests-overview?view=azure-devops)

--- a/runatlantis.io/docs/configuring-webhooks.md
+++ b/runatlantis.io/docs/configuring-webhooks.md
@@ -85,7 +85,7 @@ If you're using GitLab, navigate to your project's home page in GitLab
 - Click **Save**<img src="../guide/images/bitbucket-server-webhook.png" alt="Bitbucket Webhook" style="max-height: 500px;">
 - See [Next Steps](#next-steps)
 
-## Azure Devops
+## Azure DevOps
 Webhooks are installed at the [team project](https://docs.microsoft.com/en-us/azure/devops/organizations/projects/about-projects?view=azure-devops) level, but may be restricted to only fire based on events pertaining to [specific repos](https://docs.microsoft.com/en-us/azure/devops/service-hooks/services/webhooks?view=azure-devops) within the team project.
 
 - Navigate anywhere within a team project, ie: `https://dev.azure.com/orgName/projectName/_git/repoName`

--- a/runatlantis.io/docs/deployment.md
+++ b/runatlantis.io/docs/deployment.md
@@ -17,7 +17,7 @@ Atlantis [Docker image](https://hub.docker.com/r/runatlantis/atlantis/).
 ### Routing
 Atlantis and your Git host need to be able to route and communicate with one another. Your Git host needs to be able to send webhooks to Atlantis and Atlantis needs to be able to make API calls to your Git host.
 If you're using 
-a public Git host like GitHub.com, GitLab.com, Bitbucket.org, or Dev.azure.com then you'll need to
+a public Git host like github.com, gitlab.com, bitbucket.org, or dev.azure.com then you'll need to
 expose Atlantis to the internet.
 
 If you're using a private Git host like GitHub Enterprise, GitLab Enterprise or
@@ -100,15 +100,15 @@ up upgrading Atlantis by accident!
 for your Terraform repos. See [Repo Whitelist](server-configuration.html#repo-whitelist) for more details.
 3. If you're using GitHub:
     1. Replace `<YOUR_GITHUB_USER>` with the username of your Atlantis GitHub user without the `@`.
-    2. Delete all the `ATLANTIS_GITLAB_*`, `ATLANTIS_BITBUCKET_*`, and `ATLANTIS_ADS_*` environment variables.
+    2. Delete all the `ATLANTIS_GITLAB_*`, `ATLANTIS_BITBUCKET_*`, and `ATLANTIS_AZUREDEVOPS_*` environment variables.
 4. If you're using GitLab:
     1. Replace `<YOUR_GITLAB_USER>` with the username of your Atlantis GitLab user without the `@`.
     2. Delete all the `ATLANTIS_GH_*`, `ATLANTIS_BITBUCKET_*`, and `ATLANTIS_AZUREDEVOPS_*` environment variables.
 5. If you're using Bitbucket:
     1. Replace `<YOUR_BITBUCKET_USER>` with the username of your Atlantis Bitbucket user without the `@`.
     2. Delete all the `ATLANTIS_GH_*`, `ATLANTIS_GITLAB_*`, and `ATLANTIS_AZUREDEVOPS_*` environment variables.
-6. If you're using Azure Devops:
-    1. Replace `<YOUR_AZUREDEVOPS_USER>` with the username of your Atlantis Azure Devops user without the `@`.
+6. If you're using Azure DevOps:
+    1. Replace `<YOUR_AZUREDEVOPS_USER>` with the username of your Atlantis Azure DevOps user without the `@`.
     2. Delete all the `ATLANTIS_GH_*`, `ATLANTIS_GITLAB_*`, and `ATLANTIS_BITBUCKET_*` environment variables.
 
 #### StatefulSet Manifest
@@ -184,25 +184,25 @@ spec:
               key: token
         ### End Bitbucket Config ###
 
-        ### Azure Devops Config ###
+        ### Azure DevOps Config ###
         - name: ATLANTIS_AZUREDEVOPS_USER
-          value: <YOUR_AZUREDEVOPS_USER> # 6i. If you're using Azure Devops replace <YOUR_AZUREDEVOPS_USER> with the username of your Atlantis Azure Devops user without the `@`.
+          value: <YOUR_AZUREDEVOPS_USER> # 6i. If you're using Azure DevOps replace <YOUR_AZUREDEVOPS_USER> with the username of your Atlantis Azure DevOps user without the `@`.
         - name: ATLANTIS_AZUREDEVOPS_TOKEN
           valueFrom:
             secretKeyRef:
               name: atlantis-vcs
               key: token
-        - name: ATLANTIS_AZUREDEVOPS_BASIC_USER
+        - name: ATLANTIS_AZUREDEVOPS_WEBHOOK_USER
           valueFrom:
             secretKeyRef:
               name: atlantis-vcs
               key: basic-user
-        - name: ATLANTIS_AZUREDEVOPS_BASIC_PASS
+        - name: ATLANTIS_AZUREDEVOPS_WEBHOOK_PASSWORD
           valueFrom:
             secretKeyRef:
               name: atlantis-vcs
               key: basic-password
-        ### End Azure Devops Config ###
+        ### End Azure DevOps Config ###
 
         - name: ATLANTIS_DATA_DIR
           value: /atlantis
@@ -332,25 +332,25 @@ spec:
               key: token
         ### End Bitbucket Config ###
 
-        ### Azure Devops Config ###
+        ### Azure DevOps Config ###
         - name: ATLANTIS_AZUREDEVOPS_USER
-          value: <YOUR_AZUREDEVOPS_USER> # 6i. If you're using Azure Devops replace <YOUR_AZUREDEVOPS_USER> with the username of your Atlantis Azure Devops user without the `@`.
+          value: <YOUR_AZUREDEVOPS_USER> # 6i. If you're using Azure DevOps replace <YOUR_AZUREDEVOPS_USER> with the username of your Atlantis Azure DevOps user without the `@`.
         - name: ATLANTIS_AZUREDEVOPS_TOKEN
           valueFrom:
             secretKeyRef:
               name: atlantis-vcs
               key: token
-        - name: ATLANTIS_AZUREDEVOPS_BASIC_USER
+        - name: ATLANTIS_AZUREDEVOPS_WEBHOOK_USER
           valueFrom:
             secretKeyRef:
               name: atlantis-vcs
               key: basic-user
-        - name: ATLANTIS_AZUREDEVOPS_BASIC_PASS
+        - name: ATLANTIS_AZUREDEVOPS_WEBHOOK_PASSWORD
           valueFrom:
             secretKeyRef:
               name: atlantis-vcs
               key: basic-password
-        ### End Azure Devops Config ###
+        ### End Azure DevOps Config ###
 
         - name: ATLANTIS_PORT
           value: "4141" # Kubernetes sets an ATLANTIS_PORT variable so we need to override.
@@ -527,7 +527,7 @@ atlantis server \
 --repo-whitelist="$REPO_WHITELIST"
 ```
 
-##### Azure Devops
+##### Azure DevOps
 
 A certificate and private key are required if using Basic authentication for webhooks.
 
@@ -536,8 +536,8 @@ atlantis server \
 --atlantis-url="$URL" \
 --azuredevops-user="$USERNAME" \
 --azuredevops-token="$TOKEN" \
---azuredevops-basic-user="$ATLANTIS_AZUREDEVOPS_BASIC_USER" \
---azuredevops-basic-password="$ATLANTIS_AZUREDEVOPS_BASIC_PASS" \
+--azuredevops-webhook-user="$ATLANTIS_AZUREDEVOPS_WEBHOOK_USER" \
+--azuredevops-webhook-password="$ATLANTIS_AZUREDEVOPS_WEBHOOK_PASSWORD" \
 --repo-whitelist="$REPO_WHITELIST"
 --ssl-cert-file=file.crt
 --ssl-key-file=file.key

--- a/runatlantis.io/docs/installation-guide.md
+++ b/runatlantis.io/docs/installation-guide.md
@@ -3,7 +3,7 @@ This guide is for installing a **production-ready** instance of Atlantis onto yo
 infrastructure:
 1. First, ensure your Terraform setup meets the Atlantis **requirements**
     * See [Requirements](requirements.html)
-1. Create **access credentials** for your Git host (GitHub, GitLab, Bitbucket, Azure Devops)
+1. Create **access credentials** for your Git host (GitHub, GitLab, Bitbucket, Azure DevOps)
     * See [Generating Git Host Access Credentials](access-credentials.html)
 1. Create a **webhook secret** so Atlantis can validate webhooks
     * See [Creating a Webhook Secret](webhook-secrets.html)

--- a/runatlantis.io/docs/requirements.md
+++ b/runatlantis.io/docs/requirements.md
@@ -11,7 +11,7 @@ Atlantis integrates with the following Git hosts:
 * GitLab (public, private or enterprise)
 * Bitbucket Cloud aka bitbucket.org (public or private)
 * Bitbucket Server aka Stash
-* Azure Devops
+* Azure DevOps
 
 ## Terraform State
 Atlantis supports all backend types **except for local state**. We don't support local state

--- a/runatlantis.io/docs/security.md
+++ b/runatlantis.io/docs/security.md
@@ -53,11 +53,11 @@ Even with the `--repo-whitelist` flag set, without a webhook secret, attackers c
 Webhook secrets ensure that the webhook requests are actually coming from your VCS provider (GitHub or GitLab).
 
 :::tip Tip
-If you are using Azure Devops, instead of webhook secrets add a [basic username and password](#azure devops basic authentication)
+If you are using Azure DevOps, instead of webhook secrets add a [basic username and password](#azure devops basic authentication)
 :::
 
-### Azure Devops Basic Authentication
-Azure Devops supports sending a basic authentication header in all webhook events. This requires using an HTTPS URL for your webhook location.
+### Azure DevOps Basic Authentication
+Azure DevOps supports sending a basic authentication header in all webhook events. This requires using an HTTPS URL for your webhook location.
 
 ### SSL/HTTPS
 If you're using webhook secrets but your traffic is over HTTP then the webhook secrets

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -98,37 +98,37 @@ Values are chosen in this order:
   Automatically merge pull requests after all plans have been successfully applied.
   Defaults to `false`. See [Automerging](automerging.html) for more details.
 
-* ### `--azuredevops-basic-password`
+* ### `--azuredevops-webhook-password`
   ```bash
-  atlantis server --azuredevops-basic-password="password123"
+  atlantis server --azuredevops-webhook-password="password123"
   ```
-  Azure Devops basic authentication password for inbound webhooks (see
+  Azure DevOps basic authentication password for inbound webhooks (see
   https://docs.microsoft.com/en-us/azure/devops/service-hooks/authorize?view=azure-devops).
   SECURITY WARNING: If not specified, Atlantis won't be able to validate that the
-  incoming webhook call came from your Azure Devops org. This means that an
+  incoming webhook call came from your Azure DevOps org. This means that an
   attacker could spoof calls to Atlantis and cause it to perform malicious
   actions. Should be specified via the ATLANTIS_AZUREDEVOPS_BASIC_AUTH environment
   variable.
 
-* ### `--azuredevops-basic-user`
+* ### `--azuredevops-webhook-user`
   ```bash
-  atlantis server --azuredevops-basic-user="username@example.com"
+  atlantis server --azuredevops-webhook-user="username@example.com"
   ```
-  Azure Devops basic authentication username for inbound webhooks. Can also be specified via the ATLANTIS_AZUREDEVOPS_BASIC_USER
+  Azure DevOps basic authentication username for inbound webhooks. Can also be specified via the ATLANTIS_AZUREDEVOPS_WEBHOOK_USER
   environment variable.
 
 * ### `--azuredevops-token`
   ```bash
   atlantis server --azuredevops-token="username@example.com"
   ```
-  Azure Devops token of API user. Can also be specified via the ATLANTIS_AZUREDEVOPS_TOKEN
+  Azure DevOps token of API user. Can also be specified via the ATLANTIS_AZUREDEVOPS_TOKEN
   environment variable.
 
 * ### `--azuredevops-user`
   ```bash
   atlantis server --azuredevops-user="username@example.com"
   ```
-  Azure Devops username of API user.
+  Azure DevOps username of API user.
 
 * ### `--bitbucket-base-url`
   ```bash
@@ -340,8 +340,8 @@ Values are chosen in this order:
   * Format is `{hostname}/{owner}/{repo}`, ex. `github.com/runatlantis/atlantis`
   * `*` matches any characters, ex. `github.com/runatlantis/*` will match all repos in the runatlantis organization
   * For Bitbucket Server: `{hostname}` is the domain without scheme and port, `{owner}` is the name of the project (not the key), and `{repo}` is the repo name
-  * For Azure Devops the whitelist takes one of two forms: `{owner}.visualstudio.com/{project}/{repo}` or `dev.azure.com/{owner}/{project}/{repo}
-  * Microsoft is in the process of changing Azure Devops to the latter form, so it may be safest to always specify both formats in your repo whitelist for each repository until the change is complete.
+  * For Azure DevOps the whitelist takes one of two forms: `{owner}.visualstudio.com/{project}/{repo}` or `dev.azure.com/{owner}/{project}/{repo}
+  * Microsoft is in the process of changing Azure DevOps to the latter form, so it may be safest to always specify both formats in your repo whitelist for each repository until the change is complete.
 
   Examples:
   * Whitelist `myorg/repo1` and `myorg/repo2` on `github.com`
@@ -350,7 +350,7 @@ Values are chosen in this order:
     * `--repo-whitelist='github.com/myorg/*'`
   * Whitelist all repos in my GitHub Enterprise installation
     * `--repo-whitelist='github.yourcompany.com/*'`
-  * Whitelist all repos under `myorg` project `myproject` on Azure Devops
+  * Whitelist all repos under `myorg` project `myproject` on Azure DevOps
     * `--repo-whitelist='myorg.visualstudio.com/myproject/*,dev.azure.com/myorg/myproject/*'`
   * Whitelist all repositories
     * `--repo-whitelist='*'`

--- a/runatlantis.io/docs/webhook-secrets.md
+++ b/runatlantis.io/docs/webhook-secrets.md
@@ -13,7 +13,7 @@ security.
 :::
 
 ::: tip NOTE
-Azure Devops uses Basic authentication for webhooks rather than webhook secrets.
+Azure DevOps uses Basic authentication for webhooks rather than webhook secrets.
 :::
 
 ::: warning

--- a/runatlantis.io/guide/testing-locally.md
+++ b/runatlantis.io/guide/testing-locally.md
@@ -262,7 +262,7 @@ atlantis server \
 --repo-whitelist="$REPO_WHITELIST"
 ```
 
-##### Azure Devops
+##### Azure DevOps
 
 A certificate and private key are required if using Basic authentication for webhooks.
 
@@ -271,8 +271,8 @@ atlantis server \
 --atlantis-url="$URL" \
 --azuredevops-user="$USERNAME" \
 --azuredevops-token="$TOKEN" \
---azuredevops-basic-user="$ATLANTIS_AZUREDEVOPS_BASIC_USER" \
---azuredevops-basic-password="$ATLANTIS_AZUREDEVOPS_BASIC_PASS" \
+--azuredevops-webhook-user="$ATLANTIS_AZUREDEVOPS_WEBHOOK_USER" \
+--azuredevops-webhook-password="$ATLANTIS_AZUREDEVOPS_WEBHOOK_PASSWORD" \
 --repo-whitelist="$REPO_WHITELIST"
 --ssl-cert-file=file.crt
 --ssl-key-file=file.key

--- a/server/azuredevops_request_validator.go
+++ b/server/azuredevops_request_validator.go
@@ -10,7 +10,7 @@ import (
 
 //go:generate pegomock generate -m --use-experimental-model-gen --package mocks -o mocks/mock_azuredevops_request_validator.go AzureDevopsRequestValidator
 
-// AzureDevopsRequestValidator handles checking if Azure Devops requests
+// AzureDevopsRequestValidator handles checking if Azure DevOps requests
 // contain a valid Basic authentication username and password.
 type AzureDevopsRequestValidator interface {
 	// Validate returns the JSON payload of the request.
@@ -21,7 +21,7 @@ type AzureDevopsRequestValidator interface {
 	Validate(r *http.Request, user []byte, pass []byte) ([]byte, error)
 }
 
-// DefaultAzureDevopsRequestValidator handles checking if Azure Devops
+// DefaultAzureDevopsRequestValidator handles checking if Azure DevOps
 // requests contain the correct Basic auth username and password.
 type DefaultAzureDevopsRequestValidator struct{}
 

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -367,11 +367,11 @@ func (c *DefaultCommandRunner) getGitlabData(baseRepo models.Repo, pullNum int) 
 
 func (c *DefaultCommandRunner) getAzureDevopsData(baseRepo models.Repo, pullNum int) (models.PullRequest, models.Repo, error) {
 	if c.AzureDevopsPullGetter == nil {
-		return models.PullRequest{}, models.Repo{}, errors.New("atlantis not configured to support Azure Devops")
+		return models.PullRequest{}, models.Repo{}, errors.New("atlantis not configured to support Azure DevOps")
 	}
 	adPull, err := c.AzureDevopsPullGetter.GetPullRequest(baseRepo, pullNum)
 	if err != nil {
-		return models.PullRequest{}, models.Repo{}, errors.Wrap(err, "making pull request API call to Azure Devops")
+		return models.PullRequest{}, models.Repo{}, errors.Wrap(err, "making pull request API call to Azure DevOps")
 	}
 	pull, _, headRepo, err := c.EventParser.ParseAzureDevopsPull(adPull)
 	if err != nil {

--- a/server/events/event_parser_test.go
+++ b/server/events/event_parser_test.go
@@ -1077,7 +1077,7 @@ func TestGetBitbucketServerEventType(t *testing.T) {
 }
 
 func TestParseAzureDevopsRepo(t *testing.T) {
-	// this should  be successful
+	// this should be successful
 	repo := ADRepo
 	repo.ParentRepository = nil
 	r, err := parser.ParseAzureDevopsRepo(&repo)
@@ -1094,7 +1094,7 @@ func TestParseAzureDevopsRepo(t *testing.T) {
 		},
 	}, r)
 
-	// this should  be successful
+	// this should be successful
 	repo = ADRepo
 	repo.WebURL = nil
 	r, err = parser.ParseAzureDevopsRepo(&repo)

--- a/server/events/models/models_test.go
+++ b/server/events/models/models_test.go
@@ -105,7 +105,7 @@ func TestNewRepo_FullNameWrongFormat(t *testing.T) {
 	}
 }
 
-// If the clone url doesn't end with .git, and VCS is not Azure Devops, it is appended
+// If the clone url doesn't end with .git, and VCS is not Azure DevOps, it is appended
 func TestNewRepo_MissingDotGit(t *testing.T) {
 	repo, err := models.NewRepo(models.BitbucketCloud, "owner/repo", "https://bitbucket.org/owner/repo", "u", "p")
 	Ok(t, err)

--- a/server/events/vcs/azuredevops_client_test.go
+++ b/server/events/vcs/azuredevops_client_test.go
@@ -276,7 +276,7 @@ func TestAzureDevopsClient_PullIsMergeable(t *testing.T) {
 		},
 	}
 
-	// Use a real Azure Devops json response and edit the mergeable_state field.
+	// Use a real Azure DevOps json response and edit the mergeable_state field.
 	jsBytes, err := ioutil.ReadFile("fixtures/azuredevops-pr.json")
 	Ok(t, err)
 	json := string(jsBytes)
@@ -359,7 +359,7 @@ func TestAzureDevopsClient_PullIsApproved(t *testing.T) {
 		},
 	}
 
-	// Use a real Azure Devops json response and edit the mergeable_state field.
+	// Use a real Azure DevOps json response and edit the mergeable_state field.
 	jsBytes, err := ioutil.ReadFile("fixtures/azuredevops-pr.json")
 	Ok(t, err)
 	json := string(jsBytes)
@@ -410,7 +410,7 @@ func TestAzureDevopsClient_PullIsApproved(t *testing.T) {
 }
 
 func TestAzureDevopsClient_GetPullRequest(t *testing.T) {
-	// Use a real Azure Devops json response and edit the mergeable_state field.
+	// Use a real Azure DevOps json response and edit the mergeable_state field.
 	jsBytes, err := ioutil.ReadFile("fixtures/azuredevops-pr.json")
 	Ok(t, err)
 	response := string(jsBytes)

--- a/server/locks_controller.go
+++ b/server/locks_controller.go
@@ -51,6 +51,7 @@ func (l *LocksController) GetLock(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	owner, repo := models.SplitRepoFullName(lock.Project.RepoFullName)
 	viewData := LockDetailData{
 		LockKeyEncoded:  id,
 		LockKey:         idUnencoded,
@@ -59,17 +60,9 @@ func (l *LocksController) GetLock(w http.ResponseWriter, r *http.Request) {
 		Workspace:       lock.Workspace,
 		AtlantisVersion: l.AtlantisVersion,
 		CleanedBasePath: l.AtlantisURL.Path,
+		RepoOwner:       owner,
+		RepoName:        repo,
 	}
-	var owner, project, repo string
-	if lock.Pull.BaseRepo.VCSHost.Type == models.AzureDevops {
-		owner, project, repo = vcs.SplitAzureDevopsRepoFullName(lock.Project.RepoFullName)
-	} else {
-		owner, repo = models.SplitRepoFullName(lock.Project.RepoFullName)
-		project = ""
-	}
-	viewData.RepoOwner = owner
-	viewData.RepoProject = project
-	viewData.RepoName = repo
 
 	err = l.LockDetailTemplate.Execute(w, viewData)
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -378,8 +378,8 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		SupportedVCSHosts:               supportedVCSHosts,
 		VCSClient:                       vcsClient,
 		BitbucketWebhookSecret:          []byte(userConfig.BitbucketWebhookSecret),
-		AzureDevopsWebhookBasicUser:     []byte(userConfig.AzureDevopsWebhookBasicUser),
-		AzureDevopsWebhookBasicPassword: []byte(userConfig.AzureDevopsWebhookBasicPassword),
+		AzureDevopsWebhookBasicUser:     []byte(userConfig.AzureDevopsWebhookUser),
+		AzureDevopsWebhookBasicPassword: []byte(userConfig.AzureDevopsWebhookPassword),
 		AzureDevopsRequestValidator:     &DefaultAzureDevopsRequestValidator{},
 	}
 	return &Server{

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -6,34 +6,34 @@ import "github.com/runatlantis/atlantis/server/logging"
 // The mapstructure tags correspond to flags in cmd/server.go and are used when
 // the config is parsed from a YAML file.
 type UserConfig struct {
-	AllowForkPRs                    bool   `mapstructure:"allow-fork-prs"`
-	AllowRepoConfig                 bool   `mapstructure:"allow-repo-config"`
-	AtlantisURL                     string `mapstructure:"atlantis-url"`
-	Automerge                       bool   `mapstructure:"automerge"`
-	AzureDevopsToken                string `mapstructure:"azuredevops-token"`
-	AzureDevopsUser                 string `mapstructure:"azuredevops-user"`
-	AzureDevopsWebhookBasicPassword string `mapstructure:"azuredevops-basic-password"`
-	AzureDevopsWebhookBasicUser     string `mapstructure:"azuredevops-basic-user"`
-	BitbucketBaseURL                string `mapstructure:"bitbucket-base-url"`
-	BitbucketToken                  string `mapstructure:"bitbucket-token"`
-	BitbucketUser                   string `mapstructure:"bitbucket-user"`
-	BitbucketWebhookSecret          string `mapstructure:"bitbucket-webhook-secret"`
-	CheckoutStrategy                string `mapstructure:"checkout-strategy"`
-	DataDir                         string `mapstructure:"data-dir"`
-	DisableApplyAll                 bool   `mapstructure:"disable-apply-all"`
-	GithubHostname                  string `mapstructure:"gh-hostname"`
-	GithubToken                     string `mapstructure:"gh-token"`
-	GithubUser                      string `mapstructure:"gh-user"`
-	GithubWebhookSecret             string `mapstructure:"gh-webhook-secret"`
-	GitlabHostname                  string `mapstructure:"gitlab-hostname"`
-	GitlabToken                     string `mapstructure:"gitlab-token"`
-	GitlabUser                      string `mapstructure:"gitlab-user"`
-	GitlabWebhookSecret             string `mapstructure:"gitlab-webhook-secret"`
-	LogLevel                        string `mapstructure:"log-level"`
-	Port                            int    `mapstructure:"port"`
-	RepoConfig                      string `mapstructure:"repo-config"`
-	RepoConfigJSON                  string `mapstructure:"repo-config-json"`
-	RepoWhitelist                   string `mapstructure:"repo-whitelist"`
+	AllowForkPRs               bool   `mapstructure:"allow-fork-prs"`
+	AllowRepoConfig            bool   `mapstructure:"allow-repo-config"`
+	AtlantisURL                string `mapstructure:"atlantis-url"`
+	Automerge                  bool   `mapstructure:"automerge"`
+	AzureDevopsToken           string `mapstructure:"azuredevops-token"`
+	AzureDevopsUser            string `mapstructure:"azuredevops-user"`
+	AzureDevopsWebhookPassword string `mapstructure:"azuredevops-webhook-password"`
+	AzureDevopsWebhookUser     string `mapstructure:"azuredevops-webhook-user"`
+	BitbucketBaseURL           string `mapstructure:"bitbucket-base-url"`
+	BitbucketToken             string `mapstructure:"bitbucket-token"`
+	BitbucketUser              string `mapstructure:"bitbucket-user"`
+	BitbucketWebhookSecret     string `mapstructure:"bitbucket-webhook-secret"`
+	CheckoutStrategy           string `mapstructure:"checkout-strategy"`
+	DataDir                    string `mapstructure:"data-dir"`
+	DisableApplyAll            bool   `mapstructure:"disable-apply-all"`
+	GithubHostname             string `mapstructure:"gh-hostname"`
+	GithubToken                string `mapstructure:"gh-token"`
+	GithubUser                 string `mapstructure:"gh-user"`
+	GithubWebhookSecret        string `mapstructure:"gh-webhook-secret"`
+	GitlabHostname             string `mapstructure:"gitlab-hostname"`
+	GitlabToken                string `mapstructure:"gitlab-token"`
+	GitlabUser                 string `mapstructure:"gitlab-user"`
+	GitlabWebhookSecret        string `mapstructure:"gitlab-webhook-secret"`
+	LogLevel                   string `mapstructure:"log-level"`
+	Port                       int    `mapstructure:"port"`
+	RepoConfig                 string `mapstructure:"repo-config"`
+	RepoConfigJSON             string `mapstructure:"repo-config-json"`
+	RepoWhitelist              string `mapstructure:"repo-whitelist"`
 	// RequireApproval is whether to require pull request approval before
 	// allowing terraform apply's to be run.
 	RequireApproval bool `mapstructure:"require-approval"`

--- a/server/web_templates.go
+++ b/server/web_templates.go
@@ -113,7 +113,6 @@ type LockDetailData struct {
 	LockKeyEncoded  string
 	LockKey         string
 	RepoOwner       string
-	RepoProject     string
 	RepoName        string
 	PullRequestLink string
 	LockedBy        string


### PR DESCRIPTION
* flags
  * `azuredevops-basic-password` => `azuredevops-webhook-password` (to keep consistent with other webhook flags)
  * `azuredevops-basic-user` => `azuredevops-webhook-user`
* Capitalize `O` in `DevOps`
* remove regex validation of azuredevops repos since it was broken and also I didn't think it provided any value since if the repo wasn't in the right format it would fail later
* removed the `project` field from the lock view data since it wasn't being used

cc @mcdafydd 