### PR TITLE
revert openshift docs, change ATLANTIS_DATA_DIR to HOME

### DIFF
--- a/runatlantis.io/docs/deployment.md
+++ b/runatlantis.io/docs/deployment.md
@@ -16,7 +16,7 @@ Atlantis [Docker image](https://hub.docker.com/r/runatlantis/atlantis/).
 
 ### Routing
 Atlantis and your Git host need to be able to route and communicate with one another. Your Git host needs to be able to send webhooks to Atlantis and Atlantis needs to be able to make API calls to your Git host.
-If you're using 
+If you're using
 a public Git host like github.com, gitlab.com, bitbucket.org, or dev.azure.com then you'll need to
 expose Atlantis to the internet.
 
@@ -485,19 +485,10 @@ containers:
           key: token
 ```
 
-       
 ### OpenShift
 The Helm chart and Kubernetes manifests above are compatible with OpenShift, however you need to run
-with an additional environment variable: `ATLANTIS_DATA_DIR=/home/atlantis`. This is required because
+with an additional environment variable: `HOME=/home/atlantis`. This is required because
 OpenShift runs Docker images with random user id's that use `/` as their home directory.
-
-If you are deploying Atlantis as a StatefulSet, you will also want to change the `atlantis-data`
-volume mount from `/atlantis` to `/home/atlantis`, matching the `ATLANTIS_DATA_DIR`.
-```
-volumeMounts:
-- name: atlantis-data
-  mountPath: /home/atlantis
-```
 
 ### AWS Fargate
 If you'd like to run Atlantis on [AWS Fargate](https://aws.amazon.com/fargate/)


### PR DESCRIPTION
This should address https://github.com/runatlantis/atlantis/issues/824 by reverting back to the original docs for OpenShift but setting `HOME=/home/atlantis` instead of `ATLANTIS_DATA_DIR=/home/atlantis`.

May need further discussion to determine if this is all that is needed.