### PR TITLE
Update COMMENT_ARGS Docs for Character Escaping

### DIFF
--- a/runatlantis.io/docs/custom-workflows.md
+++ b/runatlantis.io/docs/custom-workflows.md
@@ -337,7 +337,8 @@ Or a custom command
   * `PULL_NUM` - Pull request number or ID, ex. `2`.
   * `PULL_AUTHOR` - Username of the pull request author, ex. `acme-user`.
   * `USER_NAME` - Username of the VCS user running command, ex. `acme-user`. During an autoplan, the user will be the Atlantis API user, ex. `atlantis`.
-  * `COMMENT_ARGS` - Any additional flags passed in the comment on the pull request separated by commas, ex. `atlantis plan -- arg1 arg2` will result in `COMMENT_ARGS=arg1,arg2`.
+  * `COMMENT_ARGS` - Any additional flags passed in the comment on the pull request. Flags are separated by commas and
+  every character is escaped, ex. `atlantis plan -- arg1 arg2` will result in `COMMENT_ARGS=\a\r\g\1,\a\r\g\2`.
 * A custom command will only terminate if all output file descriptors are closed.
 Therefore a custom command can only be sent to the background (e.g. for an SSH tunnel during
 the terraform run) when its output is redirected to a different location. For example, Atlantis


### PR DESCRIPTION
This updates docs for COMMENT_ARGS to account for escaping from https://github.com/runatlantis/atlantis/pull/699. This will address https://github.com/runatlantis/atlantis/issues/832.