### PR TITLE
feat: Add ability to set pr status context with --status-name flag

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -72,6 +72,7 @@ const (
 	SlackTokenFlag             = "slack-token"
 	SSLCertFileFlag            = "ssl-cert-file"
 	SSLKeyFileFlag             = "ssl-key-file"
+	StatusName                 = "status-name"
 	TFEHostnameFlag            = "tfe-hostname"
 	TFETokenFlag               = "tfe-token"
 	WriteGitCredsFlag          = "write-git-creds"
@@ -87,6 +88,7 @@ const (
 	DefaultLogLevel         = "info"
 	DefaultPort             = 4141
 	DefaultTFEHostname      = "app.terraform.io"
+	DefaultStatusName       = "atlantis"
 )
 
 var stringFlags = map[string]stringFlag{
@@ -201,6 +203,10 @@ var stringFlags = map[string]stringFlag{
 	},
 	SSLKeyFileFlag: {
 		description: fmt.Sprintf("File containing x509 private key matching --%s.", SSLCertFileFlag),
+	},
+	StatusName: {
+		description:  "Name used for updating the pull request status.",
+		defaultValue: DefaultStatusName,
 	},
 	TFEHostnameFlag: {
 		description:  "Hostname of your Terraform Enterprise installation. If using Terraform Cloud no need to set.",
@@ -453,6 +459,9 @@ func (s *ServerCmd) setDefaults(c *server.UserConfig) {
 	}
 	if c.Port == 0 {
 		c.Port = DefaultPort
+	}
+	if c.StatusName == "" {
+		c.StatusName = DefaultStatusName
 	}
 	if c.TFEHostname == "" {
 		c.TFEHostname = DefaultTFEHostname

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -392,6 +392,7 @@ func TestExecute_Defaults(t *testing.T) {
 	Equals(t, "", passedConfig.SlackToken)
 	Equals(t, "", passedConfig.SSLCertFile)
 	Equals(t, "", passedConfig.SSLKeyFile)
+	Equals(t, "atlantis", passedConfig.StatusName)
 	Equals(t, "app.terraform.io", passedConfig.TFEHostname)
 	Equals(t, "", passedConfig.TFEToken)
 	Equals(t, false, passedConfig.WriteGitCreds)

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -720,6 +720,7 @@ write-git-creds: true
 		"TFE_HOSTNAME":                 "override-my-hostname",
 		"TFE_TOKEN":                    "override-my-token",
 		"WRITE_GIT_CREDS":              "false",
+		"STATUS_NAME":                  "override-status-name",
 	} {
 		os.Setenv("ATLANTIS_"+name, value) // nolint: errcheck
 	}
@@ -763,6 +764,7 @@ write-git-creds: true
 	Equals(t, "override-my-hostname", passedConfig.TFEHostname)
 	Equals(t, "override-my-token", passedConfig.TFEToken)
 	Equals(t, false, passedConfig.WriteGitCreds)
+	Equals(t, "override-status-name", passedConfig.StatusName)
 }
 
 func TestExecute_FlagConfigOverride(t *testing.T) {
@@ -800,6 +802,7 @@ require-mergeable: true
 slack-token: slack-token
 ssl-cert-file: cert-file
 ssl-key-file: key-file
+status-name: status-name
 tfe-hostname: my-hostname
 tfe-token: my-token
 write-git-creds: true
@@ -839,6 +842,7 @@ write-git-creds: true
 		cmd.SlackTokenFlag:             "override-slack-token",
 		cmd.SSLCertFileFlag:            "override-cert-file",
 		cmd.SSLKeyFileFlag:             "override-key-file",
+		cmd.StatusName:                 "override-status-name",
 		cmd.TFEHostnameFlag:            "override-my-hostname",
 		cmd.TFETokenFlag:               "override-my-token",
 		cmd.WriteGitCredsFlag:          false,
@@ -876,6 +880,7 @@ write-git-creds: true
 	Equals(t, "override-slack-token", passedConfig.SlackToken)
 	Equals(t, "override-cert-file", passedConfig.SSLCertFile)
 	Equals(t, "override-key-file", passedConfig.SSLKeyFile)
+	Equals(t, "override-status-name", passedConfig.StatusName)
 	Equals(t, "override-my-hostname", passedConfig.TFEHostname)
 	Equals(t, "override-my-token", passedConfig.TFEToken)
 	Equals(t, false, passedConfig.WriteGitCreds)
@@ -918,6 +923,7 @@ func TestExecute_FlagEnvVarOverride(t *testing.T) {
 		"SLACK_TOKEN":                  "slack-token",
 		"SSL_CERT_FILE":                "cert-file",
 		"SSL_KEY_FILE":                 "key-file",
+		"STATUS_NAME":                  "status-name",
 		"TFE_HOSTNAME":                 "my-hostname",
 		"TFE_TOKEN":                    "my-token",
 		"WRITE_GIT_CREDS":              "true",
@@ -965,6 +971,7 @@ func TestExecute_FlagEnvVarOverride(t *testing.T) {
 		cmd.SlackTokenFlag:             "override-slack-token",
 		cmd.SSLCertFileFlag:            "override-cert-file",
 		cmd.SSLKeyFileFlag:             "override-key-file",
+		cmd.StatusName:                 "override-status-name",
 		cmd.TFEHostnameFlag:            "override-my-hostname",
 		cmd.TFETokenFlag:               "override-my-token",
 		cmd.WriteGitCredsFlag:          false,
@@ -1004,6 +1011,7 @@ func TestExecute_FlagEnvVarOverride(t *testing.T) {
 	Equals(t, "override-slack-token", passedConfig.SlackToken)
 	Equals(t, "override-cert-file", passedConfig.SSLCertFile)
 	Equals(t, "override-key-file", passedConfig.SSLKeyFile)
+	Equals(t, "override-status-name", passedConfig.StatusName)
 	Equals(t, "override-my-hostname", passedConfig.TFEHostname)
 	Equals(t, "override-my-token", passedConfig.TFEToken)
 	Equals(t, false, passedConfig.WriteGitCreds)

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/xanzy/go-gitlab v0.20.2-0.20190819195750-b1d195859ad0
 	golang.org/x/build v0.0.0-20190111050920-041ab4dc3f9d // indirect
 	golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5
+	golang.org/x/tools v0.0.0-20191113232020-e2727e816f5a // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.20.2
 	gopkg.in/russross/blackfriday.v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -413,7 +413,11 @@ golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0 h1:Dh6fw+p6FyRl5x/FvNswO1ji0lIGzm3KP8Y9VkS9PTE=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/tools v0.0.0-20191113232020-e2727e816f5a h1:3IG7HNvPBDvrxpnTWA6zpeNCS5ydX6cdt6oOiGlC8qg=
+golang.org/x/tools v0.0.0-20191113232020-e2727e816f5a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181030000543-1d582fd0359e/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181220000619-583d854617af/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -421,7 +421,15 @@ Values are chosen in this order:
   atlantis server --ssl-cert-file="/etc/ssl/private/my-cert.key"
   ```
   File containing x509 private key matching `--ssl-cert-file`.
- 
+
+* ### `--status-name`
+  ```bash
+  atlantis server --status-name="atlantis-dev"
+  ```
+  Application name to use when updating a pull request status.
+
+  This is useful when running multiple Atlantis servers against a single repository.
+
 * ### `--tfe-hostname`
   ```bash
   atlantis server --tfe-hostname="my-terraform-enterprise.company.com"

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -62,7 +62,7 @@ func setup(t *testing.T) *vcsmocks.MockClient {
 		ThenReturn(pullLogger)
 	ch = events.DefaultCommandRunner{
 		VCSClient:                vcsClient,
-		CommitStatusUpdater:      &events.DefaultCommitStatusUpdater{vcsClient},
+		CommitStatusUpdater:      &events.DefaultCommitStatusUpdater{vcsClient, "atlantis"},
 		EventParser:              eventParsing,
 		MarkdownRenderer:         &events.MarkdownRenderer{},
 		GithubPullGetter:         githubGetter,

--- a/server/events/commit_status_updater.go
+++ b/server/events/commit_status_updater.go
@@ -40,10 +40,11 @@ type CommitStatusUpdater interface {
 // DefaultCommitStatusUpdater implements CommitStatusUpdater.
 type DefaultCommitStatusUpdater struct {
 	Client vcs.Client
+	StatusName string
 }
 
 func (d *DefaultCommitStatusUpdater) UpdateCombined(repo models.Repo, pull models.PullRequest, status models.CommitStatus, command models.CommandName) error {
-	src := fmt.Sprintf("atlantis/%s", command.String())
+	src := fmt.Sprintf("%s/%s", d.StatusName, command.String())
 	var descripWords string
 	switch status {
 	case models.PendingCommitStatus:
@@ -58,7 +59,7 @@ func (d *DefaultCommitStatusUpdater) UpdateCombined(repo models.Repo, pull model
 }
 
 func (d *DefaultCommitStatusUpdater) UpdateCombinedCount(repo models.Repo, pull models.PullRequest, status models.CommitStatus, command models.CommandName, numSuccess int, numTotal int) error {
-	src := fmt.Sprintf("atlantis/%s", command.String())
+	src := fmt.Sprintf("%s/%s", d.StatusName, command.String())
 	cmdVerb := "planned"
 	if command == models.ApplyCommand {
 		cmdVerb = "applied"
@@ -71,7 +72,7 @@ func (d *DefaultCommitStatusUpdater) UpdateProject(ctx models.ProjectCommandCont
 	if projectID == "" {
 		projectID = fmt.Sprintf("%s/%s", ctx.RepoRelDir, ctx.Workspace)
 	}
-	src := fmt.Sprintf("atlantis/%s: %s", cmdName.String(), projectID)
+	src := fmt.Sprintf("%s/%s: %s", d.StatusName, cmdName.String(), projectID)
 	var descripWords string
 	switch status {
 	case models.PendingCommitStatus:

--- a/server/events/commit_status_updater.go
+++ b/server/events/commit_status_updater.go
@@ -39,7 +39,7 @@ type CommitStatusUpdater interface {
 
 // DefaultCommitStatusUpdater implements CommitStatusUpdater.
 type DefaultCommitStatusUpdater struct {
-	Client vcs.Client
+	Client     vcs.Client
 	StatusName string
 }
 

--- a/server/events/commit_status_updater_test.go
+++ b/server/events/commit_status_updater_test.go
@@ -66,7 +66,7 @@ func TestUpdateCombined(t *testing.T) {
 		t.Run(c.expDescrip, func(t *testing.T) {
 			RegisterMockTestingT(t)
 			client := mocks.NewMockClient()
-			s := events.DefaultCommitStatusUpdater{Client: client}
+			s := events.DefaultCommitStatusUpdater{Client: client, StatusName: "atlantis"}
 			err := s.UpdateCombined(models.Repo{}, models.PullRequest{}, c.status, c.command)
 			Ok(t, err)
 
@@ -132,11 +132,11 @@ func TestUpdateCombinedCount(t *testing.T) {
 		t.Run(c.expDescrip, func(t *testing.T) {
 			RegisterMockTestingT(t)
 			client := mocks.NewMockClient()
-			s := events.DefaultCommitStatusUpdater{Client: client}
+			s := events.DefaultCommitStatusUpdater{Client: client, StatusName: "atlantis-test"}
 			err := s.UpdateCombinedCount(models.Repo{}, models.PullRequest{}, c.status, c.command, c.numSuccess, c.numTotal)
 			Ok(t, err)
 
-			expSrc := fmt.Sprintf("atlantis/%s", c.command)
+			expSrc := fmt.Sprintf("%s/%s", s.StatusName, c.command)
 			client.VerifyWasCalledOnce().UpdateStatus(models.Repo{}, models.PullRequest{}, c.status, expSrc, c.expDescrip, "")
 		})
 	}
@@ -169,7 +169,7 @@ func TestDefaultCommitStatusUpdater_UpdateProjectSrc(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.expSrc, func(t *testing.T) {
 			client := mocks.NewMockClient()
-			s := events.DefaultCommitStatusUpdater{Client: client}
+			s := events.DefaultCommitStatusUpdater{Client: client, StatusName: "atlantis"}
 			err := s.UpdateProject(models.ProjectCommandContext{
 				ProjectName: c.projectName,
 				RepoRelDir:  c.repoRelDir,
@@ -227,7 +227,7 @@ func TestDefaultCommitStatusUpdater_UpdateProject(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.expDescrip, func(t *testing.T) {
 			client := mocks.NewMockClient()
-			s := events.DefaultCommitStatusUpdater{Client: client}
+			s := events.DefaultCommitStatusUpdater{Client: client, StatusName: "atlantis"}
 			err := s.UpdateProject(models.ProjectCommandContext{
 				RepoRelDir: ".",
 				Workspace:  "default",

--- a/server/events/matchers/models_pullrequest.go
+++ b/server/events/matchers/models_pullrequest.go
@@ -3,6 +3,7 @@ package matchers
 
 import (
 	"reflect"
+
 	"github.com/petergtz/pegomock"
 	models "github.com/runatlantis/atlantis/server/events/models"
 )

--- a/server/events/matchers/models_repo.go
+++ b/server/events/matchers/models_repo.go
@@ -3,6 +3,7 @@ package matchers
 
 import (
 	"reflect"
+
 	"github.com/petergtz/pegomock"
 	models "github.com/runatlantis/atlantis/server/events/models"
 )

--- a/server/events/matchers/ptr_to_logging_simplelogger.go
+++ b/server/events/matchers/ptr_to_logging_simplelogger.go
@@ -3,6 +3,7 @@ package matchers
 
 import (
 	"reflect"
+
 	"github.com/petergtz/pegomock"
 	logging "github.com/runatlantis/atlantis/server/logging"
 )

--- a/server/events/mock_workingdir_test.go
+++ b/server/events/mock_workingdir_test.go
@@ -4,11 +4,12 @@
 package events
 
 import (
+	"reflect"
+	"time"
+
 	pegomock "github.com/petergtz/pegomock"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	logging "github.com/runatlantis/atlantis/server/logging"
-	"reflect"
-	"time"
 )
 
 type MockWorkingDir struct {

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -14,10 +14,11 @@
 package events_test
 
 import (
-	"github.com/hashicorp/go-version"
-	"github.com/runatlantis/atlantis/server/events/runtime"
 	"os"
 	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/runatlantis/atlantis/server/events/runtime"
 
 	. "github.com/petergtz/pegomock"
 	"github.com/runatlantis/atlantis/server/events"

--- a/server/events/runtime/env_step_runner.go
+++ b/server/events/runtime/env_step_runner.go
@@ -1,8 +1,9 @@
 package runtime
 
 import (
-	"github.com/runatlantis/atlantis/server/events/models"
 	"strings"
+
+	"github.com/runatlantis/atlantis/server/events/models"
 )
 
 // EnvStepRunner set environment variables.

--- a/server/server.go
+++ b/server/server.go
@@ -205,7 +205,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		return nil, errors.Wrap(err, "initializing webhooks")
 	}
 	vcsClient := vcs.NewClientProxy(githubClient, gitlabClient, bitbucketCloudClient, bitbucketServerClient, azuredevopsClient)
-	commitStatusUpdater := &events.DefaultCommitStatusUpdater{StatusName: userConfig.StatusName, Client: vcsClient}
+	commitStatusUpdater := &events.DefaultCommitStatusUpdater{Client: vcsClient, StatusName: userConfig.StatusName}
 	terraformClient, err := terraform.NewClient(
 		logger,
 		userConfig.DataDir,

--- a/server/server.go
+++ b/server/server.go
@@ -205,7 +205,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		return nil, errors.Wrap(err, "initializing webhooks")
 	}
 	vcsClient := vcs.NewClientProxy(githubClient, gitlabClient, bitbucketCloudClient, bitbucketServerClient, azuredevopsClient)
-	commitStatusUpdater := &events.DefaultCommitStatusUpdater{Client: vcsClient}
+	commitStatusUpdater := &events.DefaultCommitStatusUpdater{StatusName: userConfig.StatusName, Client: vcsClient}
 	terraformClient, err := terraform.NewClient(
 		logger,
 		userConfig.DataDir,

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -44,6 +44,7 @@ type UserConfig struct {
 	SlackToken             string          `mapstructure:"slack-token"`
 	SSLCertFile            string          `mapstructure:"ssl-cert-file"`
 	SSLKeyFile             string          `mapstructure:"ssl-key-file"`
+	StatusName             string          `mapstructure:"status-name"`
 	TFEHostname            string          `mapstructure:"tfe-hostname"`
 	TFEToken               string          `mapstructure:"tfe-token"`
 	DefaultTFVersion       string          `mapstructure:"default-tf-version"`


### PR DESCRIPTION
Hi 👋 
# Background

I recently commented on #249 with regards to using multiple Atlantis servers against a single repo.

I have a reasonably good setup with an Atlantis server running in a "dev" account and one in a "prd" account (due to no access to a management account or ability to allow cross-account trusted roles). This works well, I can set my dev server to allow applying mergable changes and my prd server allows applying only approved changes with automerging. 

# The Problem

The PR status gets updated with "atlantis/{plan, apply, ...}" from both servers which makes it difficult to know which server had issues with, or is running a plan / apply and can cause some confusion.

# The Solution

A `--status-name` allows users to override the name used in PR status contexts per server.

Example `--status-name atlantis-noprod` results in:
<img width="971" alt="Screenshot 2019-11-14 at 11 05 46 AM" src="https://user-images.githubusercontent.com/57101177/68853164-39732380-06d1-11ea-92ba-c2ffd7ca9999.png">

As always, feedback or recommendation is greatly welcome and appreciated!

Thanks,

Tim