### PR TITLE
Fix to allow modified files to be excluded

### DIFF
--- a/server/events/project_finder.go
+++ b/server/events/project_finder.go
@@ -87,7 +87,20 @@ func (p *DefaultProjectFinder) DetermineProjectsViaConfig(log *logging.SimpleLog
 		// relative to the repo root.
 		var whenModifiedRelToRepoRoot []string
 		for _, wm := range project.Autoplan.WhenModified {
-			whenModifiedRelToRepoRoot = append(whenModifiedRelToRepoRoot, filepath.Join(project.Dir, wm))
+			exclusion := false
+			wm = strings.TrimSpace(wm)
+			if wm == "" {
+				continue
+			}
+			if wm[0] == '!' {
+				wm = wm[1:]
+				exclusion = true
+			}
+			wmRelPath := filepath.Join(project.Dir, wm)
+			if exclusion {
+				wmRelPath = "!" + wmRelPath
+			}
+			whenModifiedRelToRepoRoot = append(whenModifiedRelToRepoRoot, wmRelPath)
 		}
 		pm, err := fileutils.NewPatternMatcher(whenModifiedRelToRepoRoot)
 		if err != nil {

--- a/server/events/project_finder.go
+++ b/server/events/project_finder.go
@@ -89,10 +89,7 @@ func (p *DefaultProjectFinder) DetermineProjectsViaConfig(log *logging.SimpleLog
 		for _, wm := range project.Autoplan.WhenModified {
 			exclusion := false
 			wm = strings.TrimSpace(wm)
-			if wm == "" {
-				continue
-			}
-			if wm[0] == '!' {
+			if wm != "" && wm[0] == '!' {
 				wm = wm[1:]
 				exclusion = true
 			}

--- a/server/events/project_finder_test.go
+++ b/server/events/project_finder_test.go
@@ -396,6 +396,38 @@ func TestDefaultProjectFinder_DetermineProjectsViaConfig(t *testing.T) {
 			modified:     []string{"project2/terraform.tfvars"},
 			expProjPaths: []string{"project2"},
 		},
+		{
+			description: "all files excluded",
+			config: valid.RepoCfg{
+				Projects: []valid.Project{
+					{
+						Dir: "project1",
+						Autoplan: valid.Autoplan{
+							Enabled:      true,
+							WhenModified: []string{"*.tf", "!exclude-me.tf"},
+						},
+					},
+				},
+			},
+			modified:     []string{"project1/exclude-me.tf"},
+			expProjPaths: nil,
+		},
+		{
+			description: "some files excluded and others included",
+			config: valid.RepoCfg{
+				Projects: []valid.Project{
+					{
+						Dir: "project1",
+						Autoplan: valid.Autoplan{
+							Enabled:      true,
+							WhenModified: []string{"*.tf", "!exclude-me.tf"},
+						},
+					},
+				},
+			},
+			modified:     []string{"project1/exclude-me.tf", "project1/include-me.tf"},
+			expProjPaths: []string{"project1"},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
I noticed that setting `when_modified` to something like `["*.tf", "!exclude-me.tf]` with a modified list of `exclude-me.tf` still resulted in a plan automatically running. This PR allows files to be excluded using `.dockerignore`'s exclusion syntax, i.e. prepending a `!` to the path.