### PR TITLE
Bump terraform version to 0.12.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
         # We do this instead of setting --default-tf-version because setting
         # that flag starts the download asynchronously so we'd have a race
         # condition.
-        TERRAFORM_VERSION: 0.12.15
+        TERRAFORM_VERSION: 0.12.16
     steps:
     - checkout
     - run: make build-service

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM runatlantis/atlantis-base:v3.1
 LABEL authors="Anubhav Mishra, Luke Kysow"
 
 # install terraform binaries
-ENV DEFAULT_TERRAFORM_VERSION=0.12.15
+ENV DEFAULT_TERRAFORM_VERSION=0.12.16
 
 # In the official Atlantis image we only have the latest of each Terrafrom version.
 RUN AVAILABLE_TERRAFORM_VERSIONS="0.8.8 0.9.11 0.10.8 0.11.14 ${DEFAULT_TERRAFORM_VERSION}" && \

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -5,7 +5,7 @@
 FROM circleci/golang:1.13
 
 # Install Terraform
-ENV TERRAFORM_VERSION=0.12.15
+ENV TERRAFORM_VERSION=0.12.16
 RUN curl -LOks https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
     sudo mkdir -p /usr/local/bin/tf/versions/${TERRAFORM_VERSION} && \
     sudo unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/local/bin/tf/versions/${TERRAFORM_VERSION} && \


### PR DESCRIPTION
The GitLab autobump action is taking a bit too long.