### PR TITLE
Fix bug when redefining default workflow

### DIFF
--- a/server/events/yaml/parser_validator_test.go
+++ b/server/events/yaml/parser_validator_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	version "github.com/hashicorp/go-version"
+	"github.com/hashicorp/go-version"
 	"github.com/runatlantis/atlantis/server/events/yaml"
 	"github.com/runatlantis/atlantis/server/events/yaml/valid"
 	. "github.com/runatlantis/atlantis/testing"
@@ -1073,6 +1073,57 @@ repos:
 				},
 				Workflows: map[string]valid.Workflow{
 					"default": defaultCfg.Workflows["default"],
+				},
+			},
+		},
+		"redefine default workflow": {
+			input: `
+workflows:
+  default:
+    plan:
+      steps:
+      - run: custom
+    apply:
+     steps: []
+`,
+			exp: valid.GlobalCfg{
+				Repos: []valid.Repo{
+					{
+						IDRegex:           regexp.MustCompile(".*"),
+						ApplyRequirements: []string{},
+						Workflow: &valid.Workflow{
+							Name: "default",
+							Apply: valid.Stage{
+								Steps: nil,
+							},
+							Plan: valid.Stage{
+								Steps: []valid.Step{
+									{
+										StepName:   "run",
+										RunCommand: "custom",
+									},
+								},
+							},
+						},
+						AllowedOverrides:     []string{},
+						AllowCustomWorkflows: Bool(false),
+					},
+				},
+				Workflows: map[string]valid.Workflow{
+					"default": {
+						Name: "default",
+						Apply: valid.Stage{
+							Steps: nil,
+						},
+						Plan: valid.Stage{
+							Steps: []valid.Step{
+								{
+									StepName:   "run",
+									RunCommand: "custom",
+								},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/server/events/yaml/raw/global_cfg.go
+++ b/server/events/yaml/raw/global_cfg.go
@@ -60,7 +60,14 @@ func (g GlobalCfg) Validate() error {
 func (g GlobalCfg) ToValid(defaultCfg valid.GlobalCfg) valid.GlobalCfg {
 	workflows := make(map[string]valid.Workflow)
 	for k, v := range g.Workflows {
-		workflows[k] = v.ToValid(k)
+		validatedWorkflow := v.ToValid(k)
+		workflows[k] = validatedWorkflow
+		if k == valid.DefaultWorkflowName {
+			// Handle the special case where they're redefining the default
+			// workflow. In this case, our default repo config references
+			// the "old" default workflow and so needs to be redefined.
+			defaultCfg.Repos[0].Workflow = &validatedWorkflow
+		}
 	}
 	// Merge in defaults without overriding.
 	for k, v := range defaultCfg.Workflows {


### PR DESCRIPTION
Previously, given the config:
```
  workflows:
    default:
      ...
```
We wouldn't actually use the redefined default workfow in our always
existing first repo config. This would mean that the redefined default
was never used unless users explicitly set workflow: default in the
repos array.

Fixes #860