### PR TITLE
Set Slack parameter AsUser to true

### DIFF
--- a/server/events/webhooks/slack_client.go
+++ b/server/events/webhooks/slack_client.go
@@ -81,6 +81,7 @@ func (d *DefaultSlackClient) ChannelExists(channelName string) (bool, error) {
 func (d *DefaultSlackClient) PostMessage(channel string, applyResult ApplyResult) error {
 	params := slack.NewPostMessageParameters()
 	params.Attachments = d.createAttachments(applyResult)
+	params.AsUser = true
 	params.EscapeText = false
 	_, _, err := d.Slack.PostMessage(channel, "", params)
 	return err

--- a/server/events/webhooks/slack_client_test.go
+++ b/server/events/webhooks/slack_client_test.go
@@ -116,7 +116,7 @@ func TestPostMessage_Success(t *testing.T) {
 			},
 		},
 	}}
-	expParams.AsUser = false
+	expParams.AsUser = true
 	expParams.EscapeText = false
 
 	channel := "somechannel"
@@ -160,7 +160,7 @@ func TestPostMessage_Error(t *testing.T) {
 			},
 		},
 	}}
-	expParams.AsUser = false
+	expParams.AsUser = true
 	expParams.EscapeText = false
 
 	channel := "somechannel"


### PR DESCRIPTION
Set as_user to true for slack post message function so messages to a Slack channel use the bot's name and icon.