### PR TITLE
TF cloud support with branches as workspace

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
-*
-!docker-entrypoint.sh
-!atlantis
+# *
+# !docker-entrypoint.sh
+# !atlantis

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,13 @@
 # The runatlantis/atlantis-base is created by docker-base/Dockerfile.
+FROM  circleci/golang:1.13 as builder
+ENV GOFLAGS=-mod=vendor
+WORKDIR /atlantis
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+COPY . .
+RUN make build-service
+
 FROM runatlantis/atlantis-base:v3.2
 LABEL authors="Anubhav Mishra, Luke Kysow"
 
@@ -20,7 +29,7 @@ RUN AVAILABLE_TERRAFORM_VERSIONS="0.8.8 0.9.11 0.10.8 0.11.14 ${DEFAULT_TERRAFOR
     ln -s /usr/local/bin/tf/versions/${DEFAULT_TERRAFORM_VERSION}/terraform /usr/local/bin/terraform
 
 # copy binary
-COPY atlantis /usr/local/bin/atlantis
+COPY --from=builder /atlantis/atlantis /usr/local/bin/atlantis
 
 # copy docker entrypoint
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -97,7 +97,8 @@ func (p *DefaultProjectCommandBuilder) BuildApplyCommands(ctx *CommandContext, c
 // modified in this ctx.
 func (p *DefaultProjectCommandBuilder) buildPlanAllCommands(ctx *CommandContext, commentFlags []string, verbose bool) ([]models.ProjectCommandContext, error) {
 	// Need to lock the workspace we're about to clone to.
-	workspace := DefaultWorkspace
+	workspace := ctx.Pull.BaseBranch
+
 	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.BaseRepo.FullName, ctx.Pull.Num, workspace)
 	if err != nil {
 		ctx.Log.Warn("workspace was locked")
@@ -151,7 +152,7 @@ func (p *DefaultProjectCommandBuilder) buildPlanAllCommands(ctx *CommandContext,
 		ctx.Log.Info("automatically determined that there were %d projects modified in this pull request: %s", len(modifiedProjects), modifiedProjects)
 		for _, mp := range modifiedProjects {
 			ctx.Log.Debug("determining config for project at dir: %q", mp.Path)
-			pCfg := p.GlobalCfg.DefaultProjCfg(ctx.Log, ctx.BaseRepo.ID(), mp.Path, DefaultWorkspace)
+			pCfg := p.GlobalCfg.DefaultProjCfg(ctx.Log, ctx.BaseRepo.ID(), mp.Path, ctx.Pull.BaseBranch)
 			projCtxs = append(projCtxs, p.buildCtx(ctx, models.PlanCommand, pCfg, commentFlags, DefaultAutomergeEnabled, verbose, repoDir))
 		}
 	}
@@ -162,7 +163,7 @@ func (p *DefaultProjectCommandBuilder) buildPlanAllCommands(ctx *CommandContext,
 // buildProjectPlanCommand builds a plan context for a single project.
 // cmd must be for only one project.
 func (p *DefaultProjectCommandBuilder) buildProjectPlanCommand(ctx *CommandContext, cmd *CommentCommand) (models.ProjectCommandContext, error) {
-	workspace := DefaultWorkspace
+	workspace := ctx.Pull.BaseBranch
 	if cmd.Workspace != "" {
 		workspace = cmd.Workspace
 	}
@@ -224,7 +225,7 @@ func (p *DefaultProjectCommandBuilder) buildApplyAllCommands(ctx *CommandContext
 // buildProjectApplyCommand builds an apply command for the single project
 // identified by cmd.
 func (p *DefaultProjectCommandBuilder) buildProjectApplyCommand(ctx *CommandContext, cmd *CommentCommand) (models.ProjectCommandContext, error) {
-	workspace := DefaultWorkspace
+	workspace := ctx.Pull.BaseBranch
 	if cmd.Workspace != "" {
 		workspace = cmd.Workspace
 	}


### PR DESCRIPTION
Regarding Feature Request: Autoplan based on pull request destination branch #431

I'm having a working prototype using terraform cloud. 

Looking for a way to implement it in a clean way without too many iteration loop. @lkysow 

Planning to add:

1. Repo + server config ATLANTIS_TFE_PREFIX_ENABLED
1. Repo + server config ATLANTIS_USE_BRANCH_AS_WORKSPACE
1. BONUS: Repo + server config ATLANTIS_BRANCH_MAP
1. BONUS: Repo + server config ATLANTIS_BRANCH_MAP_DEFAULT

### ATLANTIS_TFE_PREFIX_ENABLED

Boolean that enables using TFE/C with prefix. Basically writing a file /.terraform/environment with the workspace durint init. (Found no other way to do it in automation)

### ATLANTIS_USE_BRANCH_AS_WORKSPACE

Boolean to use the destination branch as a workspace  #431 
(I've tested it with TF Cloud against develop and master environment) And it is working flawlessly

I also think this would need some sanitizing when handling a destination branch like feature/added_something

### ATLANTIS_BRANCH_MAP

General Idea to have something like 
[
"develop" = "staging",
"master" = "production"
]

To ensure user can remap dest. branch to dest. env.

### ATLANTIS_BRANCH_MAP_DEFAULT

That would solve the problem of someone opening a PR against a feature or release branch or any other branch than the one described in the MAP.

Ideas, comments, feedback would be very appreciated here. :D 