### PR TITLE
Refactor cmd tests

### DIFF
--- a/server/user_config.go
+++ b/server/user_config.go
@@ -1,6 +1,8 @@
 package server
 
-import "github.com/runatlantis/atlantis/server/logging"
+import (
+	"github.com/runatlantis/atlantis/server/logging"
+)
 
 // UserConfig holds config values passed in by the user.
 // The mapstructure tags correspond to flags in cmd/server.go and are used when


### PR DESCRIPTION
- Remove config/env/flag override tests since we know that the overrides
work
- We'll no longer need to edit the tests now when we add new flags