### PR TITLE
Add ability to skip cloning if no Terraform is modified

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -72,6 +72,7 @@ const (
 	SilenceForkPRErrorsFlag    = "silence-fork-pr-errors"
 	SilenceVCSStatusNoPlans    = "silence-vcs-status-no-plans"
 	SilenceWhitelistErrorsFlag = "silence-whitelist-errors"
+	SkipCloneNoTF              = "skip-clone-no-tf"
 	SlackTokenFlag             = "slack-token"
 	SSLCertFileFlag            = "ssl-cert-file"
 	SSLKeyFileFlag             = "ssl-key-file"
@@ -272,6 +273,10 @@ var boolFlags = map[string]boolFlag{
 	},
 	SilenceWhitelistErrorsFlag: {
 		description:  "Silences the posting of whitelist error comments.",
+		defaultValue: false,
+	},
+	SkipCloneNoTF: {
+		description:  "Skips cloning the PR repo if Terraform files are not modified in the PR.",
 		defaultValue: false,
 	},
 	DisableMarkdownFoldingFlag: {

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -82,6 +82,7 @@ var testFlags = map[string]interface{}{
 	SilenceForkPRErrorsFlag:    true,
 	SilenceWhitelistErrorsFlag: true,
 	SilenceVCSStatusNoPlans:    true,
+	SkipCloneNoTF:              true,
 	SlackTokenFlag:             "slack-token",
 	SSLCertFileFlag:            "cert-file",
 	SSLKeyFileFlag:             "key-file",

--- a/server/events/project_command_builder_internal_test.go
+++ b/server/events/project_command_builder_internal_test.go
@@ -571,6 +571,7 @@ projects:
 				PendingPlanFinder: &DefaultPendingPlanFinder{},
 				CommentBuilder:    &CommentParser{},
 				GlobalCfg:         globalCfg,
+				SkipCloneNoTF:     false,
 			}
 
 			// We run a test for each type of command.

--- a/server/events/project_finder.go
+++ b/server/events/project_finder.go
@@ -132,12 +132,10 @@ func (p *DefaultProjectFinder) DetermineProjectsViaConfig(log *logging.SimpleLog
 	return projects, nil
 }
 
+// TerraformWasModified indicates whether any Terraform files are included in the modifiedFiles parameter
 func (p *DefaultProjectFinder) TerraformWasModified(log *logging.SimpleLogger, modifiedFiles []string) bool {
 	modifiedTerraformFiles := p.filterToTerraform(modifiedFiles)
-	if len(modifiedTerraformFiles) == 0 {
-		return false
-	}
-	return true
+	return len(modifiedTerraformFiles) > 0
 }
 
 // filterToTerraform filters non-terraform files from files.

--- a/server/events/project_finder.go
+++ b/server/events/project_finder.go
@@ -136,9 +136,8 @@ func (p *DefaultProjectFinder) TerraformWasModified(log *logging.SimpleLogger, m
 	modifiedTerraformFiles := p.filterToTerraform(modifiedFiles)
 	if len(modifiedTerraformFiles) == 0 {
 		return false
-	} else {
-		return true
 	}
+	return true
 }
 
 // filterToTerraform filters non-terraform files from files.

--- a/server/events/project_finder.go
+++ b/server/events/project_finder.go
@@ -38,6 +38,8 @@ type ProjectFinder interface {
 	// based on modifiedFiles and the repo's config.
 	// absRepoDir is the path to the cloned repo on disk.
 	DetermineProjectsViaConfig(log *logging.SimpleLogger, modifiedFiles []string, config valid.RepoCfg, absRepoDir string) ([]valid.Project, error)
+	// TerraformWasModified indicates whether any of the modified files are Terraform files
+	TerraformWasModified(log *logging.SimpleLogger, modifiedFiles []string) bool
 }
 
 // DefaultProjectFinder implements ProjectFinder.
@@ -128,6 +130,15 @@ func (p *DefaultProjectFinder) DetermineProjectsViaConfig(log *logging.SimpleLog
 		}
 	}
 	return projects, nil
+}
+
+func (p *DefaultProjectFinder) TerraformWasModified(log *logging.SimpleLogger, modifiedFiles []string) bool {
+	modifiedTerraformFiles := p.filterToTerraform(modifiedFiles)
+	if len(modifiedTerraformFiles) == 0 {
+		return false
+	} else {
+		return true
+	}
 }
 
 // filterToTerraform filters non-terraform files from files.

--- a/server/events_controller_e2e_test.go
+++ b/server/events_controller_e2e_test.go
@@ -464,6 +464,7 @@ func setupE2E(t *testing.T, repoDir string) (server.EventsController, *vcsmocks.
 			PendingPlanFinder: &events.DefaultPendingPlanFinder{},
 			CommentBuilder:    commentParser,
 			GlobalCfg:         globalCfg,
+			SkipCloneNoTF:     false,
 		},
 		DB:                boltdb,
 		PendingPlanFinder: &events.DefaultPendingPlanFinder{},

--- a/server/server.go
+++ b/server/server.go
@@ -329,6 +329,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 			GlobalCfg:         globalCfg,
 			PendingPlanFinder: pendingPlanFinder,
 			CommentBuilder:    commentParser,
+			SkipCloneNoTF:     userConfig.SkipCloneNoTF,
 		},
 		ProjectCommandRunner: &events.DefaultProjectCommandRunner{
 			Locker:           projectLocker,

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -48,6 +48,7 @@ type UserConfig struct {
 	// are found.
 	SilenceVCSStatusNoPlans bool            `mapstructure:"silence-vcs-status-no-plans"`
 	SilenceWhitelistErrors  bool            `mapstructure:"silence-whitelist-errors"`
+	SkipCloneNoTF           bool            `mapstructure:"skip-clone-no-tf"`
 	SlackToken              string          `mapstructure:"slack-token"`
 	SSLCertFile             string          `mapstructure:"ssl-cert-file"`
 	SSLKeyFile              string          `mapstructure:"ssl-key-file"`


### PR DESCRIPTION
Related to #967. Adds `skip-clone-no-tf` flag to control this behavior. I'm not sure if this will exactly satisfy the requirements in the ticket since it does not inspect atlantis.yaml but should be a step in the right direction

A couple benefits to this addition:
* not specific to any VCS platform
* improved performance for non-TF PRs - would help Atlantis scale with larger amounts of non-TF PRs
* prevents certain Atlantis errors on non-TF PRs by avoiding the need for the lock in those situations (`workspace is currently locked by another command that is running for this pull request`)

Let me know if I'm missing anything or if this is helpful