### PR TITLE
Ignore casing on log levels

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -700,7 +700,7 @@ func (s *ServerCmd) printErr(err error) {
 
 func isValidLogLevel(level string) bool {
 	for _, logLevel := range ValidLogLevels {
-		if strings.EqualFold(logLevel, level) {
+		if logLevel == level {
 			return true
 		}
 	}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -291,6 +291,9 @@ var intFlags = map[string]intFlag{
 	},
 }
 
+// ValidLogLevels are the valid log levels that can be set
+var ValidLogLevels = []string{"debug", "info", "warn", "error"}
+
 type stringFlag struct {
 	description  string
 	defaultValue string
@@ -494,10 +497,11 @@ func (s *ServerCmd) setDefaults(c *server.UserConfig) {
 }
 
 func (s *ServerCmd) validate(userConfig server.UserConfig) error {
-	logLevel := userConfig.LogLevel
-	if logLevel != "debug" && logLevel != "info" && logLevel != "warn" && logLevel != "error" {
-		return errors.New("invalid log level: not one of debug, info, warn, error")
+	userConfig.LogLevel = strings.ToLower(userConfig.LogLevel)
+	if !isValidLogLevel(userConfig.LogLevel) {
+		return fmt.Errorf("invalid log level: must be one of %v", ValidLogLevels)
 	}
+
 	checkoutStrategy := userConfig.CheckoutStrategy
 	if checkoutStrategy != "branch" && checkoutStrategy != "merge" {
 		return errors.New("invalid checkout strategy: not one of branch or merge")
@@ -692,4 +696,14 @@ func (s *ServerCmd) withErrPrint(f func(*cobra.Command, []string) error) func(*c
 // printErr prints err to stderr using a red terminal colour.
 func (s *ServerCmd) printErr(err error) {
 	fmt.Fprintf(os.Stderr, "%sError: %s%s\n", "\033[31m", err.Error(), "\033[39m")
+}
+
+func isValidLogLevel(level string) bool {
+	for _, logLevel := range ValidLogLevels {
+		if strings.EqualFold(logLevel, level) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -257,13 +257,36 @@ func TestExecute_RepoWhitelistScheme(t *testing.T) {
 }
 
 func TestExecute_ValidateLogLevel(t *testing.T) {
-	t.Log("Should validate log level.")
-	c := setupWithDefaults(map[string]interface{}{
-		LogLevelFlag: "invalid",
-	})
-	err := c.Execute()
-	Assert(t, err != nil, "should be an error")
-	Equals(t, "invalid log level: not one of debug, info, warn, error", err.Error())
+	cases := []struct {
+		description string
+		flags       map[string]interface{}
+		expectError bool
+	}{
+		{
+			"log level is invalid",
+			map[string]interface{}{
+				LogLevelFlag: "invalid",
+			},
+			true,
+		},
+		{
+			"log level is valid uppercase",
+			map[string]interface{}{
+				LogLevelFlag: "DEBUG",
+			},
+			false,
+		},
+	}
+	for _, testCase := range cases {
+		t.Log("Should validate log level when " + testCase.description)
+		c := setupWithDefaults(testCase.flags)
+		err := c.Execute()
+		if testCase.expectError {
+			Assert(t, err != nil, "should be an error")
+		} else {
+			Ok(t, err)
+		}
+	}
 }
 
 func TestExecute_ValidateCheckoutStrategy(t *testing.T) {


### PR DESCRIPTION
Just a small quality of life change when parsing log levels. During our rollout of Atlantis, I had set the log level to `DEBUG` and saw it wasn't a valid option.