### PR TITLE
Ignore Github draft PRs

### DIFF
--- a/server/events/event_parser.go
+++ b/server/events/event_parser.go
@@ -425,6 +425,10 @@ func (e *EventParser) ParseGithubPullEvent(pullEvent *github.PullRequestEvent) (
 		switch pullEvent.GetAction() {
 		case "opened":
 			pullEventType = models.OpenedPullEvent
+		case "ready_for_review":
+			// when an author takes a PR out of 'draft' state a 'ready_for_review'
+			// event is triggered. We want atlantis to treat this as a freshly opened PR
+			pullEventType = models.OpenedPullEvent
 		case "synchronize":
 			pullEventType = models.UpdatedPullEvent
 		case "closed":

--- a/server/events/event_parser.go
+++ b/server/events/event_parser.go
@@ -416,15 +416,22 @@ func (e *EventParser) ParseGithubPullEvent(pullEvent *github.PullRequestEvent) (
 		err = errors.New("sender.login is null")
 		return
 	}
-	switch pullEvent.GetAction() {
-	case "opened":
-		pullEventType = models.OpenedPullEvent
-	case "synchronize":
-		pullEventType = models.UpdatedPullEvent
-	case "closed":
-		pullEventType = models.ClosedPullEvent
-	default:
+
+	if pullEvent.GetPullRequest().GetDraft() {
+		// if the PR is in draft state we don't care about the action type
+		// we can set the type to Other and ignore the PR
 		pullEventType = models.OtherPullEvent
+	} else {
+		switch pullEvent.GetAction() {
+		case "opened":
+			pullEventType = models.OpenedPullEvent
+		case "synchronize":
+			pullEventType = models.UpdatedPullEvent
+		case "closed":
+			pullEventType = models.ClosedPullEvent
+		default:
+			pullEventType = models.OtherPullEvent
+		}
 	}
 	user = models.User{Username: senderUsername}
 	return

--- a/server/events/event_parser_test.go
+++ b/server/events/event_parser_test.go
@@ -131,6 +131,14 @@ func TestParseGithubPullEvent(t *testing.T) {
 	_, _, _, _, _, err = parser.ParseGithubPullEvent(&testEvent)
 	ErrEquals(t, "sender.login is null", err)
 
+	// verify that draft PRs are treated as 'other' events
+	testEvent = deepcopy.Copy(PullEvent).(github.PullRequestEvent)
+	draftPR := true
+	testEvent.PullRequest.Draft = &draftPR
+	_, evType, _, _, _, err := parser.ParseGithubPullEvent(&testEvent)
+	Ok(t, err)
+	Equals(t, models.OtherPullEvent, evType)
+
 	actPull, evType, actBaseRepo, actHeadRepo, actUser, err := parser.ParseGithubPullEvent(&PullEvent)
 	Ok(t, err)
 	expBaseRepo := models.Repo{

--- a/server/events/event_parser_test.go
+++ b/server/events/event_parser_test.go
@@ -131,14 +131,6 @@ func TestParseGithubPullEvent(t *testing.T) {
 	_, _, _, _, _, err = parser.ParseGithubPullEvent(&testEvent)
 	ErrEquals(t, "sender.login is null", err)
 
-	// verify that draft PRs are treated as 'other' events
-	testEvent = deepcopy.Copy(PullEvent).(github.PullRequestEvent)
-	draftPR := true
-	testEvent.PullRequest.Draft = &draftPR
-	_, evType, _, _, _, err := parser.ParseGithubPullEvent(&testEvent)
-	Ok(t, err)
-	Equals(t, models.OtherPullEvent, evType)
-
 	actPull, evType, actBaseRepo, actHeadRepo, actUser, err := parser.ParseGithubPullEvent(&PullEvent)
 	Ok(t, err)
 	expBaseRepo := models.Repo{
@@ -166,6 +158,16 @@ func TestParseGithubPullEvent(t *testing.T) {
 	}, actPull)
 	Equals(t, models.OpenedPullEvent, evType)
 	Equals(t, models.User{Username: "user"}, actUser)
+}
+
+func TestParseGithubPullEventFromDraft(t *testing.T) {
+	// verify that draft PRs are treated as 'other' events
+	testEvent := deepcopy.Copy(PullEvent).(github.PullRequestEvent)
+	draftPR := true
+	testEvent.PullRequest.Draft = &draftPR
+	_, evType, _, _, _, err := parser.ParseGithubPullEvent(&testEvent)
+	Ok(t, err)
+	Equals(t, models.OtherPullEvent, evType)
 }
 
 func TestParseGithubPullEvent_EventType(t *testing.T) {

--- a/server/events/event_parser_test.go
+++ b/server/events/event_parser_test.go
@@ -215,6 +215,10 @@ func TestParseGithubPullEvent_EventType(t *testing.T) {
 			action: "reopened",
 			exp:    models.OtherPullEvent,
 		},
+		{
+			action: "ready_for_review",
+			exp:    models.OpenedPullEvent,
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Related to #491. This change would classify any pull request event coming from draft PRs as an 'OtherPullEvent'. As a result Atlantis will ignore the PR until it is ready for review, at which point new events would be classified as before. 