### PR TITLE
Fix parse URL tests

### DIFF
--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -610,7 +610,7 @@ func TestExecute_BitbucketServerBaseURLScheme(t *testing.T) {
 		RepoWhitelistFlag:    "*",
 		BitbucketBaseURLFlag: "://mydomain.com",
 	})
-	ErrEquals(t, "error parsing --bitbucket-webhook-secret flag value \"://mydomain.com\": parse ://mydomain.com: missing protocol scheme", c.Execute())
+	ErrEquals(t, "error parsing --bitbucket-webhook-secret flag value \"://mydomain.com\": parse \"://mydomain.com\": missing protocol scheme", c.Execute())
 }
 
 // Port should be retained on base url.

--- a/server/events/models/models_test.go
+++ b/server/events/models/models_test.go
@@ -35,7 +35,7 @@ func TestNewRepo_EmptyCloneURL(t *testing.T) {
 
 func TestNewRepo_InvalidCloneURL(t *testing.T) {
 	_, err := models.NewRepo(models.Github, "owner/repo", ":", "u", "p")
-	ErrEquals(t, "invalid clone url: parse :.git: missing protocol scheme", err)
+	ErrEquals(t, "invalid clone url: parse \":.git\": missing protocol scheme", err)
 }
 
 func TestNewRepo_CloneURLWrongRepo(t *testing.T) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -217,7 +217,7 @@ func TestParseAtlantisURL(t *testing.T) {
 		// Must be valid URL.
 		{
 			In:     "::",
-			ExpErr: "parse ::: missing protocol scheme",
+			ExpErr: "parse \"::\": missing protocol scheme",
 		},
 
 		// Must be absolute.


### PR DESCRIPTION
Resolves #985. This assumes the test failures are harmless and can safely be updated to match the new error output. The tests now pass locally.