### PR TITLE
Update lint version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ node_modules/
 helm/test-values.yaml
 *.swp
 golangci-lint
+atlantis

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ lint: ## Run linter locally
 	golangci-lint run
 
 check-lint: ## Run linter in CI/CD. If running locally use 'lint'
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b ./bin v1.24.0
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b ./bin v1.23.8
 	./bin/golangci-lint run -j 4
 
 check-fmt: ## Fail if not formatted


### PR DESCRIPTION
This is an alternative to #990 .

It seems like there are some OOM issues in `v1.24.0` of golanglint-ci. This still updates our golanglint-ci version, but only up a more stable version.

ref issue: https://github.com/golangci/golangci-lint/issues/994