### PR TITLE
Update approved requirement documentation to be consistent

### DIFF
--- a/runatlantis.io/docs/apply-requirements.md
+++ b/runatlantis.io/docs/apply-requirements.md
@@ -5,7 +5,7 @@
 Atlantis allows you to require certain conditions be satisfied **before** an `atlantis apply`
 command can be run:
 
-* [Approved](#approved) – requires pull requests to be approved by at least one user
+* [Approved](#approved) – requires pull requests to be approved by at least one user other than the author
 * [Mergeable](#mergeable) – requires pull requests to be able to be merged
 
 ## What Happens If The Requirement Is Not Met?

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -234,7 +234,7 @@ func (p *DefaultProjectCommandRunner) doApply(ctx models.ProjectCommandContext) 
 				return "", "", errors.Wrap(err, "checking if pull request was approved")
 			}
 			if !approved {
-				return "", "Pull request must be approved before running apply.", nil
+				return "", "Pull request must be approved by at least one person other than the author before running apply.", nil
 			}
 		case raw.MergeableApplyRequirement:
 			if !ctx.PullMergeable {

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -162,7 +162,7 @@ func TestDefaultProjectCommandRunner_ApplyNotApproved(t *testing.T) {
 	When(mockApproved.PullIsApproved(ctx.BaseRepo, ctx.Pull)).ThenReturn(false, nil)
 
 	res := runner.Apply(ctx)
-	Equals(t, "Pull request must be approved before running apply.", res.Failure)
+	Equals(t, "Pull request must be approved by at least one person other than the author before running apply.", res.Failure)
 }
 
 // Test that if mergeable is required and the PR isn't mergeable we give an error.


### PR DESCRIPTION
Cherrypicks commit from https://github.com/runatlantis/atlantis/pull/988 and closes https://github.com/runatlantis/atlantis/pull/988.

## Context

Azure DevOps also allows users to approve their own requests, but there isn't much value in checking if this occurred before running an apply (similar to BitBucket).

The current Atlantis documentation seems to hint that the `approved` requirement means that someone _else_ has to approve the pull request, but the error message and documentation doesn't quite highlight this.

The apply requirement itself does call this out: https://www.runatlantis.io/docs/apply-requirements.html#supported-requirements.

## Change

This change updates the error message that is returned from Atlantis so that it's clear that more than just a single approval is needed. Also updates the documentation on the site itself for consistency.
