### PR TITLE
Add instructions for Terraform Cloud token permissions

### DIFF
--- a/runatlantis.io/docs/terraform-cloud.md
+++ b/runatlantis.io/docs/terraform-cloud.md
@@ -52,11 +52,14 @@ Using a **Team Token is recommended**, however you can also use a User Token.
 
 ### Team Token
 To generate a team token, click on **Settings** in the top bar, then **Teams** in
-the sidebar, then scroll down to **Team API Token**.
+the sidebar.
+Choose an existing team or create a new one.
+Enable the **Manage Workspaces** permission, then scroll down to **Team API Token**.
 
 ### User Token
 To generate a user token, click on your avatar, then **User Settings**, then
 **Tokens** in the sidebar.
+Ensure the **Manage Workspaces** permission is enabled for this user's team.
 
 ## Passing The Token To Atlantis
 The token can be passed to Atlantis via the `ATLANTIS_TFE_TOKEN` environment variable.


### PR DESCRIPTION
Add instructions for Terraform Cloud token permissions. Without **Manage Workspaces** permission, users get this error:

```
running "/usr/local/bin/terraform init -input=false -no-color -upgrade" in "/home/atlantis/.atlantis/repos/my_org/terraform/79/dev/my_project": exit status 1
Initializing the backend...
Successfully configured the backend "remote"! Terraform will automatically
use this backend unless the backend configuration changes.
Error: No existing workspaces.
Use the "terraform workspace" command to create and select a new workspace.
If the backend already contains existing workspaces, you may need to update
the backend configuration.
```