### PR TITLE
Release locks when closing draft PRs

### DIFF
--- a/server/events/event_parser.go
+++ b/server/events/event_parser.go
@@ -418,9 +418,13 @@ func (e *EventParser) ParseGithubPullEvent(pullEvent *github.PullRequestEvent) (
 	}
 
 	if pullEvent.GetPullRequest().GetDraft() {
-		// if the PR is in draft state we don't care about the action type
-		// we can set the type to Other and ignore the PR
-		pullEventType = models.OtherPullEvent
+		// if the PR is in draft state we do not initiate actions proactively however,
+		// we must still clean up locks in the event of a user initiated plan
+		if pullEvent.GetAction() == "closed" {
+			pullEventType = models.ClosedPullEvent
+		} else {
+			pullEventType = models.OtherPullEvent
+		}
 	} else {
 		switch pullEvent.GetAction() {
 		case "opened":


### PR DESCRIPTION
If plan is run manually in a draft PR, the PR may hold locks. If the draft PR is then closed, without first marking it Ready For Review, the locks are left in place. To resolve this, we can process closing draft PRs in the same way as non-draft PRs.

Also collapses draft event parsing test into normal event parsing. Previous test did not actually test different event types.