### PR TITLE
vcs/github_client: add logging around github API calls

### DIFF
--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -102,7 +102,7 @@ func (g *GithubClient) GetModifiedFiles(repo models.Repo, pull models.PullReques
 		if nextPage != 0 {
 			opts.Page = nextPage
 		}
-		g.logger.Debug("making github listfiles API call")
+		g.logger.Debug("making github API call to pull requests listfiles")
 		pageFiles, resp, err := g.client.PullRequests.ListFiles(g.ctx, repo.Owner, repo.Name, pull.Num, &opts)
 		if err != nil {
 			return files, err
@@ -135,7 +135,7 @@ func (g *GithubClient) CreateComment(repo models.Repo, pullNum int, comment stri
 
 	comments := common.SplitComment(comment, maxCommentLength, sepEnd, sepStart)
 	for _, c := range comments {
-		g.logger.Debug("making github createcomment API call")
+		g.logger.Debug("making github API call to issues createcomment")
 		_, _, err := g.client.Issues.CreateComment(g.ctx, repo.Owner, repo.Name, pullNum, &github.IssueComment{Body: &c})
 		if err != nil {
 			return err
@@ -148,7 +148,7 @@ func (g *GithubClient) HidePrevPlanComments(repo models.Repo, pullNum int) error
 	var allComments []*github.IssueComment
 	nextPage := 0
 	for {
-		g.logger.Debug("making github listcomments API call")
+		g.logger.Debug("making github API call to issues listcomments")
 		comments, resp, err := g.client.Issues.ListComments(g.ctx, repo.Owner, repo.Name, pullNum, &github.IssueListCommentsOptions{
 			Sort:        "created",
 			Direction:   "asc",
@@ -216,7 +216,7 @@ func (g *GithubClient) PullIsApproved(repo models.Repo, pull models.PullRequest)
 		if nextPage != 0 {
 			opts.Page = nextPage
 		}
-		g.logger.Debug("making github listreviews API call")
+		g.logger.Debug("making github API call to pull requests listreviews")
 		pageReviews, resp, err := g.client.PullRequests.ListReviews(g.ctx, repo.Owner, repo.Name, pull.Num, &opts)
 		if err != nil {
 			return false, errors.Wrap(err, "getting reviews")
@@ -289,7 +289,7 @@ func (g *GithubClient) UpdateStatus(repo models.Repo, pull models.PullRequest, s
 func (g *GithubClient) MergePull(pull models.PullRequest) error {
 	// Users can set their repo to disallow certain types of merging.
 	// We detect which types aren't allowed and use the type that is.
-	g.logger.Debug("making github get repositories API call")
+	g.logger.Debug("making github API call to get repositories")
 	repo, _, err := g.client.Repositories.Get(g.ctx, pull.BaseRepo.Owner, pull.BaseRepo.Name)
 	if err != nil {
 		return errors.Wrap(err, "fetching repo info")
@@ -312,7 +312,7 @@ func (g *GithubClient) MergePull(pull models.PullRequest) error {
 	options := &github.PullRequestOptions{
 		MergeMethod: method,
 	}
-	g.logger.Debug("making github merge pullrequsts API call")
+	g.logger.Debug("making github API call to pull requests merge")
 	mergeResult, _, err := g.client.PullRequests.Merge(
 		g.ctx,
 		pull.BaseRepo.Owner,

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/events/vcs/common"
+	"github.com/runatlantis/atlantis/server/logging"
 
 	"github.com/Laisky/graphql"
 	"github.com/google/go-github/v28/github"
@@ -38,10 +39,11 @@ type GithubClient struct {
 	client         *github.Client
 	v4MutateClient *graphql.Client
 	ctx            context.Context
+	logger         *logging.SimpleLogger
 }
 
 // NewGithubClient returns a valid GitHub client.
-func NewGithubClient(hostname string, user string, pass string) (*GithubClient, error) {
+func NewGithubClient(hostname string, user string, pass string, logger *logging.SimpleLogger) (*GithubClient, error) {
 	tp := github.BasicAuthTransport{
 		Username: strings.TrimSpace(user),
 		Password: strings.TrimSpace(pass),
@@ -84,6 +86,7 @@ func NewGithubClient(hostname string, user string, pass string) (*GithubClient, 
 		client:         client,
 		v4MutateClient: v4MutateClient,
 		ctx:            context.Background(),
+		logger:         logger,
 	}, nil
 }
 

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -102,7 +102,7 @@ func (g *GithubClient) GetModifiedFiles(repo models.Repo, pull models.PullReques
 		if nextPage != 0 {
 			opts.Page = nextPage
 		}
-		g.logger.Debug("making github API call to pull requests listfiles")
+		g.logger.Debug("GET /repos/%v/%v/pulls/%d/files", repo.Owner, repo.Name, pull.Num)
 		pageFiles, resp, err := g.client.PullRequests.ListFiles(g.ctx, repo.Owner, repo.Name, pull.Num, &opts)
 		if err != nil {
 			return files, err
@@ -135,7 +135,7 @@ func (g *GithubClient) CreateComment(repo models.Repo, pullNum int, comment stri
 
 	comments := common.SplitComment(comment, maxCommentLength, sepEnd, sepStart)
 	for _, c := range comments {
-		g.logger.Debug("making github API call to issues createcomment")
+		g.logger.Debug("POST /repos/%v/%v/issues/%d/comments", repo.Owner, repo.Name, pullNum)
 		_, _, err := g.client.Issues.CreateComment(g.ctx, repo.Owner, repo.Name, pullNum, &github.IssueComment{Body: &c})
 		if err != nil {
 			return err
@@ -148,7 +148,7 @@ func (g *GithubClient) HidePrevPlanComments(repo models.Repo, pullNum int) error
 	var allComments []*github.IssueComment
 	nextPage := 0
 	for {
-		g.logger.Debug("making github API call to issues listcomments")
+		g.logger.Debug("GET /repos/%v/%v/issues/%d/comments", repo.Owner, repo.Name, pullNum)
 		comments, resp, err := g.client.Issues.ListComments(g.ctx, repo.Owner, repo.Name, pullNum, &github.IssueListCommentsOptions{
 			Sort:        "created",
 			Direction:   "asc",
@@ -216,7 +216,7 @@ func (g *GithubClient) PullIsApproved(repo models.Repo, pull models.PullRequest)
 		if nextPage != 0 {
 			opts.Page = nextPage
 		}
-		g.logger.Debug("making github API call to pull requests listreviews")
+		g.logger.Debug("GET /repos/%v/%v/pulls/%d/reviews", repo.Owner, repo.Name, pull.Num)
 		pageReviews, resp, err := g.client.PullRequests.ListReviews(g.ctx, repo.Owner, repo.Name, pull.Num, &opts)
 		if err != nil {
 			return false, errors.Wrap(err, "getting reviews")
@@ -289,7 +289,7 @@ func (g *GithubClient) UpdateStatus(repo models.Repo, pull models.PullRequest, s
 func (g *GithubClient) MergePull(pull models.PullRequest) error {
 	// Users can set their repo to disallow certain types of merging.
 	// We detect which types aren't allowed and use the type that is.
-	g.logger.Debug("making github API call to get repositories")
+	g.logger.Debug("GET /repos/%v/%v", pull.BaseRepo.Owner, pull.BaseRepo.Name)
 	repo, _, err := g.client.Repositories.Get(g.ctx, pull.BaseRepo.Owner, pull.BaseRepo.Name)
 	if err != nil {
 		return errors.Wrap(err, "fetching repo info")
@@ -312,7 +312,7 @@ func (g *GithubClient) MergePull(pull models.PullRequest) error {
 	options := &github.PullRequestOptions{
 		MergeMethod: method,
 	}
-	g.logger.Debug("making github API call to pull requests merge")
+	g.logger.Debug("PUT /repos/%v/%v/pulls/%d/merge", repo.Owner, repo.Name, pull.Num)
 	mergeResult, _, err := g.client.PullRequests.Merge(
 		g.ctx,
 		pull.BaseRepo.Owner,

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -102,6 +102,7 @@ func (g *GithubClient) GetModifiedFiles(repo models.Repo, pull models.PullReques
 		if nextPage != 0 {
 			opts.Page = nextPage
 		}
+		g.logger.Debug("making github listfiles API call")
 		pageFiles, resp, err := g.client.PullRequests.ListFiles(g.ctx, repo.Owner, repo.Name, pull.Num, &opts)
 		if err != nil {
 			return files, err
@@ -134,6 +135,7 @@ func (g *GithubClient) CreateComment(repo models.Repo, pullNum int, comment stri
 
 	comments := common.SplitComment(comment, maxCommentLength, sepEnd, sepStart)
 	for _, c := range comments {
+		g.logger.Debug("making github createcomment API call")
 		_, _, err := g.client.Issues.CreateComment(g.ctx, repo.Owner, repo.Name, pullNum, &github.IssueComment{Body: &c})
 		if err != nil {
 			return err
@@ -146,6 +148,7 @@ func (g *GithubClient) HidePrevPlanComments(repo models.Repo, pullNum int) error
 	var allComments []*github.IssueComment
 	nextPage := 0
 	for {
+		g.logger.Debug("making github listcomments API call")
 		comments, resp, err := g.client.Issues.ListComments(g.ctx, repo.Owner, repo.Name, pullNum, &github.IssueListCommentsOptions{
 			Sort:        "created",
 			Direction:   "asc",
@@ -213,6 +216,7 @@ func (g *GithubClient) PullIsApproved(repo models.Repo, pull models.PullRequest)
 		if nextPage != 0 {
 			opts.Page = nextPage
 		}
+		g.logger.Debug("making github listreviews API call")
 		pageReviews, resp, err := g.client.PullRequests.ListReviews(g.ctx, repo.Owner, repo.Name, pull.Num, &opts)
 		if err != nil {
 			return false, errors.Wrap(err, "getting reviews")
@@ -285,6 +289,7 @@ func (g *GithubClient) UpdateStatus(repo models.Repo, pull models.PullRequest, s
 func (g *GithubClient) MergePull(pull models.PullRequest) error {
 	// Users can set their repo to disallow certain types of merging.
 	// We detect which types aren't allowed and use the type that is.
+	g.logger.Debug("making github get repositories API call")
 	repo, _, err := g.client.Repositories.Get(g.ctx, pull.BaseRepo.Owner, pull.BaseRepo.Name)
 	if err != nil {
 		return errors.Wrap(err, "fetching repo info")
@@ -307,6 +312,7 @@ func (g *GithubClient) MergePull(pull models.PullRequest) error {
 	options := &github.PullRequestOptions{
 		MergeMethod: method,
 	}
+	g.logger.Debug("making github merge pullrequsts API call")
 	mergeResult, _, err := g.client.PullRequests.Merge(
 		g.ctx,
 		pull.BaseRepo.Owner,

--- a/server/events/vcs/github_client_internal_test.go
+++ b/server/events/vcs/github_client_internal_test.go
@@ -16,20 +16,19 @@ package vcs
 import (
 	"testing"
 
-	"github.com/runatlantis/atlantis/server/logging"
 	. "github.com/runatlantis/atlantis/testing"
 )
 
 // If the hostname is github.com, should use normal BaseURL.
 func TestNewGithubClient_GithubCom(t *testing.T) {
-	client, err := NewGithubClient("github.com", "user", "pass", logging.NewNoopLogger())
+	client, err := NewGithubClient("github.com", "user", "pass", nil)
 	Ok(t, err)
 	Equals(t, "https://api.github.com/", client.client.BaseURL.String())
 }
 
 // If the hostname is a non-github hostname should use the right BaseURL.
 func TestNewGithubClient_NonGithub(t *testing.T) {
-	client, err := NewGithubClient("example.com", "user", "pass", logging.NewNoopLogger())
+	client, err := NewGithubClient("example.com", "user", "pass", nil)
 	Ok(t, err)
 	Equals(t, "https://example.com/api/v3/", client.client.BaseURL.String())
 }

--- a/server/events/vcs/github_client_internal_test.go
+++ b/server/events/vcs/github_client_internal_test.go
@@ -16,19 +16,20 @@ package vcs
 import (
 	"testing"
 
+	"github.com/runatlantis/atlantis/server/logging"
 	. "github.com/runatlantis/atlantis/testing"
 )
 
 // If the hostname is github.com, should use normal BaseURL.
 func TestNewGithubClient_GithubCom(t *testing.T) {
-	client, err := NewGithubClient("github.com", "user", "pass")
+	client, err := NewGithubClient("github.com", "user", "pass", logging.NewNoopLogger())
 	Ok(t, err)
 	Equals(t, "https://api.github.com/", client.client.BaseURL.String())
 }
 
 // If the hostname is a non-github hostname should use the right BaseURL.
 func TestNewGithubClient_NonGithub(t *testing.T) {
-	client, err := NewGithubClient("example.com", "user", "pass")
+	client, err := NewGithubClient("example.com", "user", "pass", logging.NewNoopLogger())
 	Ok(t, err)
 	Equals(t, "https://example.com/api/v3/", client.client.BaseURL.String())
 }

--- a/server/events/vcs/github_client_test.go
+++ b/server/events/vcs/github_client_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/events/vcs"
-	"github.com/runatlantis/atlantis/server/logging"
 	. "github.com/runatlantis/atlantis/testing"
 
 	"github.com/shurcooL/githubv4"
@@ -60,7 +59,7 @@ func TestGithubClient_GetModifiedFiles(t *testing.T) {
 
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
-	client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", logging.NewNoopLogger())
+	client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", nil)
 	Ok(t, err)
 	defer disableSSLVerification()()
 
@@ -115,7 +114,7 @@ func TestGithubClient_GetModifiedFilesMovedFile(t *testing.T) {
 
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
-	client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", logging.NewNoopLogger())
+	client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", nil)
 	Ok(t, err)
 	defer disableSSLVerification()()
 
@@ -209,7 +208,7 @@ func TestGithubClient_PaginatesComments(t *testing.T) {
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
 
-	client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", logging.NewNoopLogger())
+	client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", nil)
 	Ok(t, err)
 	defer disableSSLVerification()()
 
@@ -295,7 +294,7 @@ func TestGithubClient_HideOldComments(t *testing.T) {
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
 
-	client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", logging.NewNoopLogger())
+	client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", nil)
 	Ok(t, err)
 	defer disableSSLVerification()()
 
@@ -359,7 +358,7 @@ func TestGithubClient_UpdateStatus(t *testing.T) {
 
 			testServerURL, err := url.Parse(testServer.URL)
 			Ok(t, err)
-			client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", logging.NewNoopLogger())
+			client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", nil)
 			Ok(t, err)
 			defer disableSSLVerification()()
 
@@ -445,7 +444,7 @@ func TestGithubClient_PullIsApproved(t *testing.T) {
 
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
-	client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", logging.NewNoopLogger())
+	client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", nil)
 	Ok(t, err)
 	defer disableSSLVerification()()
 
@@ -536,7 +535,7 @@ func TestGithubClient_PullIsMergeable(t *testing.T) {
 				}))
 			testServerURL, err := url.Parse(testServer.URL)
 			Ok(t, err)
-			client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", logging.NewNoopLogger())
+			client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", nil)
 			Ok(t, err)
 			defer disableSSLVerification()()
 
@@ -618,7 +617,7 @@ func TestGithubClient_MergePullHandlesError(t *testing.T) {
 
 			testServerURL, err := url.Parse(testServer.URL)
 			Ok(t, err)
-			client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", logging.NewNoopLogger())
+			client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", nil)
 			Ok(t, err)
 			defer disableSSLVerification()()
 
@@ -741,7 +740,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 
 			testServerURL, err := url.Parse(testServer.URL)
 			Ok(t, err)
-			client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", logging.NewNoopLogger())
+			client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", nil)
 			Ok(t, err)
 			defer disableSSLVerification()()
 
@@ -766,7 +765,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 }
 
 func TestGithubClient_MarkdownPullLink(t *testing.T) {
-	client, err := vcs.NewGithubClient("hostname", "user", "pass", logging.NewNoopLogger())
+	client, err := vcs.NewGithubClient("hostname", "user", "pass", nil)
 	Ok(t, err)
 	pull := models.PullRequest{Num: 1}
 	s, _ := client.MarkdownPullLink(pull)

--- a/server/events/vcs/github_client_test.go
+++ b/server/events/vcs/github_client_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/events/vcs"
+	"github.com/runatlantis/atlantis/server/logging"
 	. "github.com/runatlantis/atlantis/testing"
 
 	"github.com/shurcooL/githubv4"
@@ -59,7 +60,7 @@ func TestGithubClient_GetModifiedFiles(t *testing.T) {
 
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
-	client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass")
+	client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", logging.NewNoopLogger())
 	Ok(t, err)
 	defer disableSSLVerification()()
 
@@ -114,7 +115,7 @@ func TestGithubClient_GetModifiedFilesMovedFile(t *testing.T) {
 
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
-	client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass")
+	client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", logging.NewNoopLogger())
 	Ok(t, err)
 	defer disableSSLVerification()()
 
@@ -208,7 +209,7 @@ func TestGithubClient_PaginatesComments(t *testing.T) {
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
 
-	client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass")
+	client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", logging.NewNoopLogger())
 	Ok(t, err)
 	defer disableSSLVerification()()
 
@@ -294,7 +295,7 @@ func TestGithubClient_HideOldComments(t *testing.T) {
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
 
-	client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass")
+	client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", logging.NewNoopLogger())
 	Ok(t, err)
 	defer disableSSLVerification()()
 
@@ -358,7 +359,7 @@ func TestGithubClient_UpdateStatus(t *testing.T) {
 
 			testServerURL, err := url.Parse(testServer.URL)
 			Ok(t, err)
-			client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass")
+			client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", logging.NewNoopLogger())
 			Ok(t, err)
 			defer disableSSLVerification()()
 
@@ -444,7 +445,7 @@ func TestGithubClient_PullIsApproved(t *testing.T) {
 
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
-	client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass")
+	client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", logging.NewNoopLogger())
 	Ok(t, err)
 	defer disableSSLVerification()()
 
@@ -535,7 +536,7 @@ func TestGithubClient_PullIsMergeable(t *testing.T) {
 				}))
 			testServerURL, err := url.Parse(testServer.URL)
 			Ok(t, err)
-			client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass")
+			client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", logging.NewNoopLogger())
 			Ok(t, err)
 			defer disableSSLVerification()()
 
@@ -617,7 +618,7 @@ func TestGithubClient_MergePullHandlesError(t *testing.T) {
 
 			testServerURL, err := url.Parse(testServer.URL)
 			Ok(t, err)
-			client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass")
+			client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", logging.NewNoopLogger())
 			Ok(t, err)
 			defer disableSSLVerification()()
 
@@ -740,7 +741,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 
 			testServerURL, err := url.Parse(testServer.URL)
 			Ok(t, err)
-			client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass")
+			client, err := vcs.NewGithubClient(testServerURL.Host, "user", "pass", logging.NewNoopLogger())
 			Ok(t, err)
 			defer disableSSLVerification()()
 
@@ -765,7 +766,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 }
 
 func TestGithubClient_MarkdownPullLink(t *testing.T) {
-	client, err := vcs.NewGithubClient("hostname", "user", "pass")
+	client, err := vcs.NewGithubClient("hostname", "user", "pass", logging.NewNoopLogger())
 	Ok(t, err)
 	pull := models.PullRequest{Num: 1}
 	s, _ := client.MarkdownPullLink(pull)

--- a/server/server.go
+++ b/server/server.go
@@ -120,7 +120,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	if userConfig.GithubUser != "" {
 		supportedVCSHosts = append(supportedVCSHosts, models.Github)
 		var err error
-		githubClient, err = vcs.NewGithubClient(userConfig.GithubHostname, userConfig.GithubUser, userConfig.GithubToken)
+		githubClient, err = vcs.NewGithubClient(userConfig.GithubHostname, userConfig.GithubUser, userConfig.GithubToken, logger)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR adds debug level logging to indicate when Atlantis is making github API calls. This will be helpful when we approach GH rate limits and want some visibility into when + why calls are made.