### PR TITLE
Update go-github, empty automerge commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/go-playground/locales v0.12.1 // indirect
 	github.com/go-playground/universal-translator v0.16.0 // indirect
 	github.com/go-test/deep v1.0.3
-	github.com/google/go-github/v28 v28.0.0
+	github.com/google/go-github/v31 v31.0.0
 	github.com/google/uuid v0.0.0-20161128191214-064e2069ce9c // indirect
 	github.com/gorilla/context v0.0.0-20160226214623-1ea25387ff6f // indirect
 	github.com/gorilla/mux v1.6.2

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,7 @@ github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-github/v28 v28.0.0 h1:+UjHI4+1W/vsXR4jJBWt0ZA74XHbvt5yBAvsf1M3bgM=
 github.com/google/go-github/v28 v28.0.0/go.mod h1:+5GboIspo7F0NG2qsvfYh7en6F3EK37uyqv+c35AR3s=
+github.com/google/go-github/v31 v31.0.0/go.mod h1:NQPZol8/1sMoWYGN2yaALIBytu17gAWfhbweiEed3pM=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -309,7 +309,9 @@ func (g *GithubClient) MergePull(pull models.PullRequest) error {
 		pull.BaseRepo.Owner,
 		pull.BaseRepo.Name,
 		pull.Num,
-		common.AutomergeCommitMsg,
+		// NOTE: Using the emtpy string here causes GitHub to autogenerate
+		// the commit message as it normally would.
+		"",
 		options)
 	if err != nil {
 		return errors.Wrap(err, "merging pull request")

--- a/server/events/vcs/github_client_test.go
+++ b/server/events/vcs/github_client_test.go
@@ -597,7 +597,7 @@ func TestGithubClient_MergePullHandlesError(t *testing.T) {
 					case "/api/v3/repos/owner/repo/pulls/1/merge":
 						body, err := ioutil.ReadAll(r.Body)
 						Ok(t, err)
-						exp := "{\"commit_message\":\"[Atlantis] Automatically merging after successful apply\",\"merge_method\":\"merge\"}\n"
+						exp := "{\"commit_message\":\"\",\"merge_method\":\"merge\"}\n"
 						Equals(t, exp, string(body))
 						var resp string
 						if c.code == 200 {
@@ -722,8 +722,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 							MergeMethod   string `json:"merge_method"`
 						}
 						expBody := bodyJSON{
-							CommitMessage: "[Atlantis] Automatically merging after successful apply",
-							MergeMethod:   c.expMethod,
+							MergeMethod: c.expMethod,
 						}
 						expBytes, err := json.Marshal(expBody)
 						Ok(t, err)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -109,9 +109,9 @@ github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
-# github.com/google/go-github/v28 v28.0.0
+# github.com/google/go-github/v31 v31.0.0
 ## explicit
-github.com/google/go-github/v28/github
+github.com/google/go-github/v31/github
 # github.com/google/go-querystring v1.0.0
 github.com/google/go-querystring/query
 # github.com/google/uuid v0.0.0-20161128191214-064e2069ce9c


### PR DESCRIPTION
Using an empty auto-merge commit will cause GitHub to autogenerate its
own commit message like would happen when using the UI.

Closes #845, Deprecates #939 