### PR TITLE
GitLab's Merge Requests are using ! not #

### DIFF
--- a/server/events/vcs/gitlab_client.go
+++ b/server/events/vcs/gitlab_client.go
@@ -218,7 +218,7 @@ func (g *GitlabClient) MergePull(pull models.PullRequest) error {
 
 // MarkdownPullLink specifies the string used in a pull request comment to reference another pull request.
 func (g *GitlabClient) MarkdownPullLink(pull models.PullRequest) (string, error) {
-	return fmt.Sprintf("#%d", pull.Num), nil
+	return fmt.Sprintf("!%d", pull.Num), nil
 }
 
 // GetVersion returns the version of the Gitlab server this client is using.

--- a/server/events/vcs/gitlab_client_test.go
+++ b/server/events/vcs/gitlab_client_test.go
@@ -239,7 +239,7 @@ func TestGitlabClient_MarkdownPullLink(t *testing.T) {
 	Ok(t, err)
 	pull := models.PullRequest{Num: 1}
 	s, _ := client.MarkdownPullLink(pull)
-	exp := "#1"
+	exp := "!1"
 	Equals(t, exp, s)
 }
 


### PR DESCRIPTION
fixes #948

Thanks to the ground work from #983, we can now configure GitLab's Merge Request links in the Lock Message correctly, using `!` instead of `#` which refers to issues, not MRs. 