### PR TITLE
Hide previous comments when they are split

### DIFF
--- a/server/events/vcs/github_client_test.go
+++ b/server/events/vcs/github_client_test.go
@@ -244,7 +244,9 @@ func TestGithubClient_HideOldComments(t *testing.T) {
 	{"node_id": "4", "body": "asdasdasd\nasdasdasd", "user": {"login": "user"}},
 	{"node_id": "5", "body": "asd\nplan\nasd", "user": {"login": "user"}},
 	{"node_id": "6", "body": "asd plan\nasd", "user": {"login": "user"}},
-	{"node_id": "7", "body": "asdasdasd", "user": {"login": "user"}}
+	{"node_id": "7", "body": "asdasdasd", "user": {"login": "user"}},
+	{"node_id": "8", "body": "asd plan\nasd", "user": {"login": "user"}},
+	{"node_id": "9", "body": "Continued from previous comment\nasd", "user": {"login": "user"}}
 ]`
 	minimizeResp := "{}"
 	type graphQLCall struct {
@@ -313,8 +315,9 @@ func TestGithubClient_HideOldComments(t *testing.T) {
 		123,
 	)
 	Ok(t, err)
-	Equals(t, 1, len(gotMinimizeCalls))
+	Equals(t, 3, len(gotMinimizeCalls))
 	Equals(t, "6", gotMinimizeCalls[0].Variables.Input.SubjectID)
+	Equals(t, "9", gotMinimizeCalls[2].Variables.Input.SubjectID)
 	Equals(t, githubv4.ReportedContentClassifiersOutdated, gotMinimizeCalls[0].Variables.Input.Classifier)
 }
 


### PR DESCRIPTION
Since the v0.12 Atlantis can hide the previous "plan" comments.
But when a comment is split into several comments due to his size, only the first part of the plan is hidden.

Related to https://github.com/runatlantis/atlantis/issues/1021