### PR TITLE
Fixed Azure URL parameter for WriteGitCreds

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -193,7 +193,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 			}
 		}
 		if userConfig.AzureDevopsUser != "" {
-			if err := events.WriteGitCreds(userConfig.AzureDevopsUser, userConfig.AzureDevopsToken, "https://dev.azure.com/", home, logger); err != nil {
+			if err := events.WriteGitCreds(userConfig.AzureDevopsUser, userConfig.AzureDevopsToken, "dev.azure.com", home, logger); err != nil {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
The AzureDevopsUser, AzureDevopsToken, and the AzureDevopsURL are combined
to create the .git-credentials file.
When supplying the full FQDN, https://dev.azure.com, https://
is written twice to the .git-credentials file.