### PR TITLE
Fix GraphQL URL for Github Enterprise

### DIFF
--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -61,7 +61,9 @@ func NewGithubClient(hostname string, user string, pass string, logger *logging.
 			return nil, errors.Wrapf(err, "Invalid github hostname trying to parse %s", baseURL)
 		}
 		client.BaseURL = base
-		graphqlURL = fmt.Sprintf("https://%s/graphql", hostname)
+		// Github Enterprise uses a slightly different endpoint format for GraphQL.
+		// https://developer.github.com/enterprise/2.20/v4/guides/forming-calls/#the-graphql-endpoint
+		graphqlURL = fmt.Sprintf("https://%s/api/graphql", hostname)
 		_, err = url.Parse(graphqlURL)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Invalid GraphQL github hostname trying to parse %s", graphqlURL)

--- a/server/events/vcs/github_client_internal_test.go
+++ b/server/events/vcs/github_client_internal_test.go
@@ -31,4 +31,6 @@ func TestNewGithubClient_NonGithub(t *testing.T) {
 	client, err := NewGithubClient("example.com", "user", "pass", nil)
 	Ok(t, err)
 	Equals(t, "https://example.com/api/v3/", client.client.BaseURL.String())
+	// If possible in the future, test the GraphQL client's URL as well. But at the
+	// moment the shurcooL library doesn't expose it.
 }

--- a/server/events/vcs/github_client_test.go
+++ b/server/events/vcs/github_client_test.go
@@ -165,7 +165,7 @@ func TestGithubClient_PaginatesComments(t *testing.T) {
 	testServer := httptest.NewTLSServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch r.Method + " " + r.RequestURI {
-			case "POST /graphql":
+			case "POST /api/graphql":
 				defer r.Body.Close() // nolint: errcheck
 				body, err := ioutil.ReadAll(r.Body)
 				if err != nil {
@@ -260,7 +260,7 @@ func TestGithubClient_HideOldComments(t *testing.T) {
 			case "GET /api/v3/repos/owner/repo/issues/123/comments?direction=asc&sort=created":
 				w.Write([]byte(issueResp)) // nolint: errcheck
 				return
-			case "POST /graphql":
+			case "POST /api/graphql":
 				if accept, has := r.Header["Accept"]; !has || accept[0] != "application/vnd.github.queen-beryl-preview+json" {
 					t.Error("missing preview header")
 					http.Error(w, "bad request", http.StatusBadRequest)


### PR DESCRIPTION
Partially addresses #1009, but doesn't fix it entirely. The 406 response
is still a puzzler.