### PR TITLE
Added support for restricting workflows usage repo-side

### DIFF
--- a/runatlantis.io/docs/access-credentials.md
+++ b/runatlantis.io/docs/access-credentials.md
@@ -57,7 +57,7 @@ Only a single installation per GitHub App is supported at the moment.
 - Record the access token
 
 ### Bitbucket Cloud (bitbucket.org)
-- Create an App Password by following [https://confluence.atlassian.com/bitbucket/app-passwords-828781300.html#Apppasswords-Createanapppassword](https://confluence.atlassian.com/bitbucket/app-passwords-828781300.html#Apppasswords-Createanapppassword)
+- Create an App Password by following [https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/#Create-an-app-password](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/#Create-an-app-password)
 - Label the password "atlantis"
 - Select **Pull requests**: **Read** and **Write** so that Atlantis can read your pull requests and write comments to them
 - Record the access token

--- a/runatlantis.io/docs/server-side-repo-config.md
+++ b/runatlantis.io/docs/server-side-repo-config.md
@@ -40,6 +40,10 @@ repos:
   # its atlantis.yaml file.
   allowed_overrides: [apply_requirements, workflow]
 
+  # allowed_workflows specifies which workflows the repos that match 
+  # are allowed to select.
+  allowed_workflows: [custom]
+
   # allow_custom_workflows defines whether this repo can define its own
   # workflows. If false (default), the repo can only use server-side defined
   # workflows.
@@ -204,6 +208,39 @@ workflows:
       steps:
       - run: another custom command
 ```
+Or, if you want to restrict what workflows each repo has access to, use the `allowed_workflows` 
+key:
+
+```yaml
+# repos.yaml
+# Restrict which workflows repos can select.
+repos:
+- id: /.*/
+  allowed_overrides: [workflow]
+
+- id: /my_repo/
+  allowed_overrides: [workflow]
+  allowed_workflows: [custom1]
+
+# Define your custom workflows.
+workflows:
+  custom1:
+    plan:
+      steps:
+      - init
+      - run: my custom plan command
+    apply:
+      steps:
+      - run: my custom apply command
+
+  custom2:
+    plan:
+      steps:
+      - run: another custom command
+    apply:
+      steps:
+      - run: another custom command
+```
 
 Then each allowed repo can choose one of the workflows in their `atlantis.yaml`
 files:
@@ -310,6 +347,7 @@ If you set a workflow with the key `default`, it will override this.
 | workflow               | string   | none    | no       | A custom workflow.                                                                                                                                                                                                                                                                                       |
 | apply_requirements     | []string | none    | no       | Requirements that must be satisfied before `atlantis apply` can be run. Currently the only supported requirements are `approved` and `mergeable`. See [Apply Requirements](apply-requirements.html) for more details.                                                                                    |
 | allowed_overrides      | []string | none    | no       | A list of restricted keys that `atlantis.yaml` files can override. The only supported keys are `apply_requirements` and `workflow`                                                                                                                                                                       |
+| allowed_workflows      | []string | none    | no       | A list of workflows that `atlantis.yaml` files can select from.                                                                                                                                                                        |
 | allow_custom_workflows | bool     | false   | no       | Whether or not to allow [Custom Workflows](custom-workflows.html).                                                                                                                                                                       |
 
 

--- a/runatlantis.io/guide/testing-locally.md
+++ b/runatlantis.io/guide/testing-locally.md
@@ -164,7 +164,7 @@ TOKEN="{YOUR_TOKEN}"
 ```
 
 ### Bitbucket Cloud (bitbucket.org) Access Token
-- follow [https://confluence.atlassian.com/bitbucket/app-passwords-828781300.html#Apppasswords-Createanapppassword](https://confluence.atlassian.com/bitbucket/app-passwords-828781300.html#Apppasswords-Createanapppassword)
+- follow [https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/#Create-an-app-password](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/#Create-an-app-password)
 - Label the password "atlantis"
 - Select **Pull requests**: **Read** and **Write** so that Atlantis can read your pull requests and write comments to them
 - set the token as an environment variable

--- a/server/events/yaml/parser_validator_test.go
+++ b/server/events/yaml/parser_validator_test.go
@@ -1127,6 +1127,7 @@ workflows:
 								},
 							},
 						},
+						AllowedWorkflows:     []string{},
 						AllowedOverrides:     []string{},
 						AllowCustomWorkflows: Bool(false),
 					},
@@ -1227,6 +1228,7 @@ func TestParserValidator_ParseGlobalCfgJSON(t *testing.T) {
     {
       "id": "/.*/",
       "workflow": "custom",
+      "allowed_workflows": ["custom"],
       "apply_requirements": ["mergeable", "approved"],
       "allowed_overrides": ["workflow", "apply_requirements"],
       "allow_custom_workflows": true
@@ -1260,12 +1262,14 @@ func TestParserValidator_ParseGlobalCfgJSON(t *testing.T) {
 						IDRegex:              regexp.MustCompile(".*"),
 						ApplyRequirements:    []string{"mergeable", "approved"},
 						Workflow:             &customWorkflow,
+						AllowedWorkflows:     []string{"custom"},
 						AllowedOverrides:     []string{"workflow", "apply_requirements"},
 						AllowCustomWorkflows: Bool(true),
 					},
 					{
 						ID:                   "github.com/owner/repo",
 						IDRegex:              nil,
+						AllowedWorkflows:     nil,
 						ApplyRequirements:    nil,
 						AllowedOverrides:     nil,
 						AllowCustomWorkflows: nil,

--- a/server/events/yaml/valid/global_cfg.go
+++ b/server/events/yaml/valid/global_cfg.go
@@ -292,16 +292,6 @@ func (g GlobalCfg) ValidateRepoCfg(rCfg RepoCfg, repoID string) error {
 		}
 	}
 
-	for _, p := range rCfg.Projects {
-		// default is always allowed
-		if p.WorkflowName != nil && len(allowedWorkflows) != 0 && !allowCustomWorkflows {
-			name := *p.WorkflowName
-			if !sliceContainsF(allowedWorkflows, name) && !allowCustomWorkflows {
-				return fmt.Errorf("workflow '%s' is not allowed for this repo", name)
-			}
-		}
-	}
-
 	return nil
 }
 

--- a/server/events/yaml/valid/global_cfg.go
+++ b/server/events/yaml/valid/global_cfg.go
@@ -13,6 +13,7 @@ const MergeableApplyReq = "mergeable"
 const ApprovedApplyReq = "approved"
 const ApplyRequirementsKey = "apply_requirements"
 const WorkflowKey = "workflow"
+const AllowedWorkflowsKey = "allowed_workflows"
 const AllowedOverridesKey = "allowed_overrides"
 const AllowCustomWorkflowsKey = "allow_custom_workflows"
 const DefaultWorkflowName = "default"
@@ -33,6 +34,7 @@ type Repo struct {
 	IDRegex              *regexp.Regexp
 	ApplyRequirements    []string
 	Workflow             *Workflow
+	AllowedWorkflows     []string
 	AllowedOverrides     []string
 	AllowCustomWorkflows *bool
 }
@@ -40,6 +42,7 @@ type Repo struct {
 type MergedProjectCfg struct {
 	ApplyRequirements []string
 	Workflow          Workflow
+	AllowedWorkflows  []string
 	RepoRelDir        string
 	Workspace         string
 	Name              string
@@ -85,6 +88,7 @@ func NewGlobalCfg(allowRepoCfg bool, mergeableReq bool, approvedReq bool) Global
 	// we treat nil slices differently.
 	applyReqs := []string{}
 	allowedOverrides := []string{}
+	allowedWorkflows := []string{}
 	if mergeableReq {
 		applyReqs = append(applyReqs, MergeableApplyReq)
 	}
@@ -104,6 +108,7 @@ func NewGlobalCfg(allowRepoCfg bool, mergeableReq bool, approvedReq bool) Global
 				IDRegex:              regexp.MustCompile(".*"),
 				ApplyRequirements:    applyReqs,
 				Workflow:             &defaultWorkflow,
+				AllowedWorkflows:     allowedWorkflows,
 				AllowedOverrides:     allowedOverrides,
 				AllowCustomWorkflows: &allowCustomWorkflows,
 			},
@@ -202,6 +207,7 @@ func (g GlobalCfg) DefaultProjCfg(log logging.SimpleLogging, repoID string, repo
 // ValidateRepoCfg validates that rCfg for repo with id repoID is valid based
 // on our global config.
 func (g GlobalCfg) ValidateRepoCfg(rCfg RepoCfg, repoID string) error {
+
 	sliceContainsF := func(slc []string, str string) bool {
 		for _, s := range slc {
 			if s == str {
@@ -257,6 +263,41 @@ func (g GlobalCfg) ValidateRepoCfg(rCfg RepoCfg, repoID string) error {
 			name := *p.WorkflowName
 			if !mapContainsF(rCfg.Workflows, name) && !mapContainsF(g.Workflows, name) {
 				return fmt.Errorf("workflow %q is not defined anywhere", name)
+			}
+		}
+	}
+
+	// Check workflow is allowed
+	var allowedWorkflows []string
+	for _, repo := range g.Repos {
+		if repo.IDMatches(repoID) {
+
+			if repo.AllowedWorkflows != nil {
+				allowedWorkflows = repo.AllowedWorkflows
+			}
+		}
+	}
+
+	for _, p := range rCfg.Projects {
+		// default is always allowed
+		if p.WorkflowName != nil && len(allowedWorkflows) != 0 {
+			name := *p.WorkflowName
+			if !sliceContainsF(allowedWorkflows, name) || !allowCustomWorkflows {
+				return fmt.Errorf("workflow '%s' is not allowed for this repo", name)
+			}
+
+			if allowCustomWorkflows {
+				break
+			}
+		}
+	}
+
+	for _, p := range rCfg.Projects {
+		// default is always allowed
+		if p.WorkflowName != nil && len(allowedWorkflows) != 0 && !allowCustomWorkflows {
+			name := *p.WorkflowName
+			if !sliceContainsF(allowedWorkflows, name) && !allowCustomWorkflows {
+				return fmt.Errorf("workflow '%s' is not allowed for this repo", name)
 			}
 		}
 	}


### PR DESCRIPTION
This implements a new option that can be defined server-config side.

The idea is to have a new key: `allowed_workflows.`

Currently, when `workflow` is an allowed override, the workflows that the repo side can choose any of the ser-side defined workflows..

This allows to specify server-side what workflows each repo is allowed to use.

This is particularly useful when certain workflows are associated with certain accounts or credentials set and limiting access to these is desired.