### PR TITLE
Add reference to terragrunt-atlantis-config in the Terragrunt docs

### DIFF
--- a/runatlantis.io/docs/custom-workflows.md
+++ b/runatlantis.io/docs/custom-workflows.md
@@ -204,6 +204,10 @@ Atlantis will need to have the `terragrunt` binary in its PATH.
 If you're using Docker you can build your own image, see [Customization](/docs/deployment.html#customization).
 :::
 
+If you don't want to create/manage the repo's `atlantis.yaml` file yourself, you can use the tool [terragrunt-atlantis-config](https://github.com/transcend-io/terragrunt-atlantis-config) to generate it.
+
+The `terragrunt-atlantis-config` tool is a community project and not maintained by the Atlantis team.
+
 ### Running custom commands
 Atlantis supports running completely custom commands. In this example, we want to run
 a script after every `apply`:

--- a/runatlantis.io/docs/repo-level-atlantis-yaml.md
+++ b/runatlantis.io/docs/repo-level-atlantis-yaml.md
@@ -149,7 +149,7 @@ See [Custom Workflow Use Cases: Custom init/plan/apply Commands](custom-workflow
 
 ### Terragrunt
 
-Terragrunt declares it's module dependencies explicitly, so it is possible to generate an `atlantis.yaml` file by examining all the dependencies in your project.
+Terragrunt declares its module dependencies explicitly, so it is possible to generate an `atlantis.yaml` file by examining all the dependencies in your project.
 
 To take advantage of this, you can use the tool [terragrunt-atlantis-config](https://github.com/transcend-io/terragrunt-atlantis-config).
 

--- a/runatlantis.io/docs/repo-level-atlantis-yaml.md
+++ b/runatlantis.io/docs/repo-level-atlantis-yaml.md
@@ -148,11 +148,6 @@ See [Custom Workflow Use Cases: Adding extra arguments to Terraform commands](cu
 See [Custom Workflow Use Cases: Custom init/plan/apply Commands](custom-workflows.html#custom-init-plan-apply-commands)
 
 ### Terragrunt
-
-Terragrunt declares its module dependencies explicitly, so it is possible to generate an `atlantis.yaml` file by examining all the dependencies in your project.
-
-To take advantage of this, you can use the tool [terragrunt-atlantis-config](https://github.com/transcend-io/terragrunt-atlantis-config).
-
 See [Custom Workflow Use Cases: Terragrunt](custom-workflows.html#terragrunt)
 
 ### Running custom commands

--- a/runatlantis.io/docs/repo-level-atlantis-yaml.md
+++ b/runatlantis.io/docs/repo-level-atlantis-yaml.md
@@ -148,6 +148,11 @@ See [Custom Workflow Use Cases: Adding extra arguments to Terraform commands](cu
 See [Custom Workflow Use Cases: Custom init/plan/apply Commands](custom-workflows.html#custom-init-plan-apply-commands)
 
 ### Terragrunt
+
+Terragrunt declares it's module dependencies explicitly, so it is possible to generate an `atlantis.yaml` file by examining all the dependencies in your project.
+
+To take advantage of this, you can use the tool [terragrunt-atlantis-config](https://github.com/transcend-io/terragrunt-atlantis-config).
+
 See [Custom Workflow Use Cases: Terragrunt](custom-workflows.html#terragrunt)
 
 ### Running custom commands


### PR DESCRIPTION
This is a pretty shameless plug of my own library, so no worries at all if you don't feel comfortable adding this reference here.

`terragrunt-atlantis-config` is a tool that I have been using in production for a number of months now with a lot of success, and know of at least a few other companies who have benefited from using it as well.