### PR TITLE
Bring back clobbered hide-prev-commentds fix

### DIFF
--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -73,7 +73,7 @@ func NewGithubClient(hostname string, credentials GithubCredentials, logger *log
 		if err != nil {
 			return nil, err
 		}
-		graphqlURL = fmt.Sprintf("https://%s/graphql", apiURL.Host)
+		graphqlURL = fmt.Sprintf("https://%s/api/graphql", apiURL.Host)
 	}
 
 	// shurcooL's githubv4 library has a client ctor, but it doesn't support schema

--- a/server/events/vcs/github_client_test.go
+++ b/server/events/vcs/github_client_test.go
@@ -165,7 +165,7 @@ func TestGithubClient_PaginatesComments(t *testing.T) {
 	testServer := httptest.NewTLSServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch r.Method + " " + r.RequestURI {
-			case "POST /graphql":
+			case "POST /api/graphql":
 				defer r.Body.Close() // nolint: errcheck
 				body, err := ioutil.ReadAll(r.Body)
 				if err != nil {
@@ -262,7 +262,7 @@ func TestGithubClient_HideOldComments(t *testing.T) {
 			case "GET /api/v3/repos/owner/repo/issues/123/comments?direction=asc&sort=created":
 				w.Write([]byte(issueResp)) // nolint: errcheck
 				return
-			case "POST /graphql":
+			case "POST /api/graphql":
 				if accept, has := r.Header["Accept"]; !has || accept[0] != "application/vnd.github.queen-beryl-preview+json" {
 					t.Error("missing preview header")
 					http.Error(w, "bad request", http.StatusBadRequest)


### PR DESCRIPTION
Bring back change from https://github.com/runatlantis/atlantis/commit/2f074727e295b2d82a8712bdc0c5a5750f3d939c#diff-e348084f0b7562996b0bd5d429158e53
that was clobbered.