### PR TITLE
Log apply start at info level

### DIFF
--- a/server/events/runtime/apply_step_runner.go
+++ b/server/events/runtime/apply_step_runner.go
@@ -36,6 +36,7 @@ func (a *ApplyStepRunner) Run(ctx models.ProjectCommandContext, extraArgs []stri
 		return "", errors.Wrap(err, "unable to read planfile")
 	}
 
+	ctx.Log.Info("starting apply")
 	var out string
 	if a.isRemotePlan(contents) {
 		args := append(append([]string{"apply", "-input=false", "-no-color"}, extraArgs...), ctx.EscapedCommentArgs...)


### PR DESCRIPTION
Logging the start of an apply at the info level will be helpful in measuring the time it takes to apply.

Some of our applies are taking a long time when deleting AWS resources. We would like to be able to measure the time it takes to apply a PR with our logging platform so that our SRE team can know when to suggest a project be broken up into smaller projects.