### PR TITLE
Make trigger words configurable

### DIFF
--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -36,7 +36,9 @@ const (
 	projectFlagShort   = "p"
 	verboseFlagLong    = "verbose"
 	verboseFlagShort   = ""
-	atlantisExecutable = "atlantis"
+
+	// AtlantisExecutable is the name of the Atlantis executable
+	AtlantisExecutable = "atlantis"
 )
 
 // multiLineRegex is used to ignore multi-line comments since those aren't valid
@@ -69,6 +71,7 @@ type CommentParser struct {
 	GitlabUser      string
 	BitbucketUser   string
 	AzureDevopsUser string
+	TriggerWords    []string
 }
 
 // CommentParseResult describes the result of parsing a comment as a command.
@@ -129,7 +132,7 @@ func (e *CommentParser) Parse(comment string, vcsHost models.VCSHostType) Commen
 	case models.AzureDevops:
 		vcsUser = e.AzureDevopsUser
 	}
-	executableNames := []string{"run", atlantisExecutable, "@" + vcsUser}
+	executableNames := append(e.TriggerWords, "@"+vcsUser)
 	if !e.stringInSlice(args[0], executableNames) {
 		return CommentParseResult{Ignore: true}
 	}
@@ -263,13 +266,13 @@ func (e *CommentParser) BuildPlanComment(repoRelDir string, workspace string, pr
 		}
 		commentFlags = fmt.Sprintf(" -- %s", strings.Join(flagsWithoutQuotes, " "))
 	}
-	return fmt.Sprintf("%s %s%s%s", atlantisExecutable, models.PlanCommand.String(), flags, commentFlags)
+	return fmt.Sprintf("%s %s%s%s", AtlantisExecutable, models.PlanCommand.String(), flags, commentFlags)
 }
 
 // BuildApplyComment builds an apply comment for the specified args.
 func (e *CommentParser) BuildApplyComment(repoRelDir string, workspace string, project string) string {
 	flags := e.buildFlags(repoRelDir, workspace, project)
-	return fmt.Sprintf("%s %s%s", atlantisExecutable, models.ApplyCommand.String(), flags)
+	return fmt.Sprintf("%s %s%s", AtlantisExecutable, models.ApplyCommand.String(), flags)
 }
 
 func (e *CommentParser) buildFlags(repoRelDir string, workspace string, project string) string {

--- a/server/events/matchers/models_pullrequest.go
+++ b/server/events/matchers/models_pullrequest.go
@@ -3,6 +3,7 @@ package matchers
 
 import (
 	"reflect"
+
 	"github.com/petergtz/pegomock"
 	models "github.com/runatlantis/atlantis/server/events/models"
 )

--- a/server/events/matchers/models_repo.go
+++ b/server/events/matchers/models_repo.go
@@ -3,6 +3,7 @@ package matchers
 
 import (
 	"reflect"
+
 	"github.com/petergtz/pegomock"
 	models "github.com/runatlantis/atlantis/server/events/models"
 )

--- a/server/events/matchers/ptr_to_logging_simplelogger.go
+++ b/server/events/matchers/ptr_to_logging_simplelogger.go
@@ -3,6 +3,7 @@ package matchers
 
 import (
 	"reflect"
+
 	"github.com/petergtz/pegomock"
 	logging "github.com/runatlantis/atlantis/server/logging"
 )

--- a/server/events/mock_workingdir_test.go
+++ b/server/events/mock_workingdir_test.go
@@ -4,11 +4,12 @@
 package events
 
 import (
+	"reflect"
+	"time"
+
 	pegomock "github.com/petergtz/pegomock"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	logging "github.com/runatlantis/atlantis/server/logging"
-	"reflect"
-	"time"
 )
 
 type MockWorkingDir struct {

--- a/server/server.go
+++ b/server/server.go
@@ -340,6 +340,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		GitlabUser:      userConfig.GitlabUser,
 		BitbucketUser:   userConfig.BitbucketUser,
 		AzureDevopsUser: userConfig.AzureDevopsUser,
+		TriggerWords:    userConfig.TriggerWord,
 	}
 	defaultTfVersion := terraformClient.DefaultVersion()
 	pendingPlanFinder := &events.DefaultPendingPlanFinder{}

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -60,6 +60,7 @@ type UserConfig struct {
 	TFDownloadURL           string          `mapstructure:"tf-download-url"`
 	TFEHostname             string          `mapstructure:"tfe-hostname"`
 	TFEToken                string          `mapstructure:"tfe-token"`
+	TriggerWord             []string        `mapstructure:"trigger-word"`
 	VCSStatusName           string          `mapstructure:"vcs-status-name"`
 	DefaultTFVersion        string          `mapstructure:"default-tf-version"`
 	Webhooks                []WebhookConfig `mapstructure:"webhooks"`


### PR DESCRIPTION
Fixes #375 

@lkysow thanks for the directional input; I have made the initial changes to make trigger words configurable.

One Issue I have encountered is that the tests have started to fail for non-obvious reasons, in seemingly unrelated code paths:

<details>
<summary><code>make test</code></summary>

```
?   	github.com/runatlantis/atlantis	[no test files]
ok  	github.com/runatlantis/atlantis/cmd	(cached)
--- FAIL: TestPost_GitlabCommentNotWhitelisted (0.00s)
    events_controller_test.go:186: when the event is a gitlab comment from a repo that isn't whitelisted we comment with an error
    events_controller_test.go:205: [403 != 200]
        
        exp: (int) 403
        ******
        got: (int) 200
        
--- FAIL: TestPost_GitlabCommentNotWhitelistedWithSilenceErrors (0.00s)
    events_controller_test.go:214: when the event is a gitlab comment from a repo that isn't whitelisted and we are silencing errors, do not comment with an error
    events_controller_test.go:234: [403 != 200]
        
        exp: (int) 403
        ******
        got: (int) 200
        
--- FAIL: TestPost_GithubCommentNotWhitelisted (0.00s)
    events_controller_test.go:243: when the event is a github comment from a repo that isn't whitelisted we comment with an error
    events_controller_test.go:263: [403 != 200]
        
        exp: (int) 403
        ******
        got: (int) 200
        
--- FAIL: TestPost_GithubCommentNotWhitelistedWithSilenceErrors (0.00s)
    events_controller_test.go:272: when the event is a github comment from a repo that isn't whitelisted and we are silencing errors, do not comment with an error
    events_controller_test.go:293: [403 != 200]
        
        exp: (int) 403
        ******
        got: (int) 200
        
FAIL
FAIL	github.com/runatlantis/atlantis/server	1.461s
2020/07/24 18:07:03-0700 [EROR] runatlantis/atlantis#1: PANIC: panic test - if you're seeing this in a test failure this isn't the failing test
/Users/gkontridze/Development/github.com/runatlantis/atlantis/vendor/github.com/petergtz/pegomock/dsl.go:513 (0x19fde92)
	(*ongoingStubbing).ThenPanic.func1: func([]Param) ReturnValues { panic(v) })
/Users/gkontridze/Development/github.com/runatlantis/atlantis/vendor/github.com/petergtz/pegomock/dsl.go:366 (0x19fbae3)
	(*Stubbing).Invoke: return stubbing.callbackSequence[stubbing.sequencePointer](params)
/Users/gkontridze/Development/github.com/runatlantis/atlantis/vendor/github.com/petergtz/pegomock/dsl.go:273 (0x19fb160)
	(*mockedMethod).Invoke: return stubbing.Invoke(params)
/Users/gkontridze/Development/github.com/runatlantis/atlantis/vendor/github.com/petergtz/pegomock/dsl.go:72 (0x19f8de9)
	(*GenericMock).Invoke: return genericMock.getOrCreateMockedMethod(methodName).Invoke(params)
/Users/gkontridze/Development/github.com/runatlantis/atlantis/server/events/mocks/mock_github_pull_getter.go:35 (0x1a4777f)
	(*MockGithubPullGetter).GetPullRequest: result := pegomock.GetGenericMockFrom(mock).Invoke("GetPullRequest", params, []reflect.Type{reflect.TypeOf((**github.PullRequest)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
/Users/gkontridze/Development/github.com/runatlantis/atlantis/server/events/command_runner.go:453 (0x1a09e33)
	(*DefaultCommandRunner).getGithubData: ghPull, err := c.GithubPullGetter.GetPullRequest(baseRepo, pullNum)
/Users/gkontridze/Development/github.com/runatlantis/atlantis/server/events/command_runner.go:219 (0x1a084f0)
	(*DefaultCommandRunner).RunCommentCommand: pull, headRepo, err = c.getGithubData(baseRepo, pullNum)
/Users/gkontridze/Development/github.com/runatlantis/atlantis/server/events/command_runner_test.go:102 (0x1a68df1)
	TestRunCommentCommand_LogPanics: ch.RunCommentCommand(fixtures.GithubRepo, &fixtures.GithubRepo, nil, fixtures.User, 1, &events.CommentCommand{Name: models.PlanCommand})
/usr/local/Cellar/go/1.14.5/libexec/src/testing/testing.go:991 (0x110eb8b)
	tRunner: fn(t)
/usr/local/Cellar/go/1.14.5/libexec/src/runtime/asm_amd64.s:1373 (0x1068640)
	goexit: BYTE	$0x90	// NOP

2020/07/24 18:07:04-0700 [EROR] runatlantis/atlantis#1: Atlantis not configured to support GitHub
2020/07/24 18:07:04-0700 [EROR] runatlantis/atlantis#1: Atlantis not configured to support GitLab
2020/07/24 18:07:04-0700 [EROR] runatlantis/atlantis#1: Making pull request API call to GitHub: err
2020/07/24 18:07:04-0700 [EROR] runatlantis/atlantis#1: Making merge request API call to GitLab: err
2020/07/24 18:07:04-0700 [EROR] runatlantis/atlantis#1: Extracting required fields from comment data: err
2020/07/24 18:07:04-0700 [INFO] runatlantis/atlantis#1: Command was run on a fork pull request which is disallowed
2020/07/24 18:07:04-0700 [INFO] runatlantis/atlantis#1: Command was run on closed pull request
2020/07/24 18:07:04-0700 [EROR] runatlantis/atlantis#1: Failed to delete locks by pull err
2020/07/24 18:07:04-0700 [INFO] runatlantis/atlantis#1: Deleting plans because there were errors and automerge requires all plans succeed
2020/07/24 18:07:04-0700 [INFO] runatlantis/atlantis#1: Pull request mergeable status: false
2020/07/24 18:07:04-0700 [INFO] runatlantis/atlantis#1: Automerging pull request
2020/07/24 18:07:04-0700 [INFO] runatlantis/atlantis#1: Pull request mergeable status: false
2020/07/24 18:07:04-0700 [INFO] runatlantis/atlantis#1: Not automerging because project at dir ".", workspace "default" has status "plan_discarded"
2020/07/24 18:07:05-0700 [EROR] runatlantis/atlantis#1: PANIC: panic test - if you're seeing this in a test failure this isn't the failing test
/Users/gkontridze/Development/github.com/runatlantis/atlantis/vendor/github.com/petergtz/pegomock/dsl.go:513 (0x19fde92)
	(*ongoingStubbing).ThenPanic.func1: func([]Param) ReturnValues { panic(v) })
/Users/gkontridze/Development/github.com/runatlantis/atlantis/vendor/github.com/petergtz/pegomock/dsl.go:366 (0x19fbae3)
	(*Stubbing).Invoke: return stubbing.callbackSequence[stubbing.sequencePointer](params)
/Users/gkontridze/Development/github.com/runatlantis/atlantis/vendor/github.com/petergtz/pegomock/dsl.go:273 (0x19fb160)
	(*mockedMethod).Invoke: return stubbing.Invoke(params)
/Users/gkontridze/Development/github.com/runatlantis/atlantis/vendor/github.com/petergtz/pegomock/dsl.go:72 (0x19f8de9)
	(*GenericMock).Invoke: return genericMock.getOrCreateMockedMethod(methodName).Invoke(params)
/Users/gkontridze/Development/github.com/runatlantis/atlantis/server/events/mocks/mock_github_pull_getter.go:35 (0x1a4777f)
	(*MockGithubPullGetter).GetPullRequest: result := pegomock.GetGenericMockFrom(mock).Invoke("GetPullRequest", params, []reflect.Type{reflect.TypeOf((**github.PullRequest)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
/Users/gkontridze/Development/github.com/runatlantis/atlantis/server/events/command_runner.go:453 (0x1a09e33)
	(*DefaultCommandRunner).getGithubData: ghPull, err := c.GithubPullGetter.GetPullRequest(baseRepo, pullNum)
/Users/gkontridze/Development/github.com/runatlantis/atlantis/server/events/command_runner.go:219 (0x1a084f0)
	(*DefaultCommandRunner).RunCommentCommand: pull, headRepo, err = c.getGithubData(baseRepo, pullNum)
/Users/gkontridze/Development/github.com/runatlantis/atlantis/server/events/command_runner_test.go:358 (0x1a7003e)
	TestRunCommentCommand_DrainNotOngoing: ch.RunCommentCommand(fixtures.GithubRepo, &fixtures.GithubRepo, nil, fixtures.User, fixtures.Pull.Num, nil)
/usr/local/Cellar/go/1.14.5/libexec/src/testing/testing.go:991 (0x110eb8b)
	tRunner: fn(t)
/usr/local/Cellar/go/1.14.5/libexec/src/runtime/asm_amd64.s:1373 (0x1068640)
	goexit: BYTE	$0x90	// NOP

2020/07/24 18:07:05-0700 [EROR] runatlantis/atlantis#1: PANIC: panic test - if you're seeing this in a test failure this isn't the failing test
/Users/gkontridze/Development/github.com/runatlantis/atlantis/vendor/github.com/petergtz/pegomock/dsl.go:513 (0x19fde92)
	(*ongoingStubbing).ThenPanic.func1: func([]Param) ReturnValues { panic(v) })
/Users/gkontridze/Development/github.com/runatlantis/atlantis/vendor/github.com/petergtz/pegomock/dsl.go:366 (0x19fbae3)
	(*Stubbing).Invoke: return stubbing.callbackSequence[stubbing.sequencePointer](params)
/Users/gkontridze/Development/github.com/runatlantis/atlantis/vendor/github.com/petergtz/pegomock/dsl.go:273 (0x19fb160)
	(*mockedMethod).Invoke: return stubbing.Invoke(params)
/Users/gkontridze/Development/github.com/runatlantis/atlantis/vendor/github.com/petergtz/pegomock/dsl.go:72 (0x19f8de9)
	(*GenericMock).Invoke: return genericMock.getOrCreateMockedMethod(methodName).Invoke(params)
/Users/gkontridze/Development/github.com/runatlantis/atlantis/server/events/mocks/mock_project_command_builder.go:34 (0x1a4a6b5)
	(*MockProjectCommandBuilder).BuildAutoplanCommands: result := pegomock.GetGenericMockFrom(mock).Invoke("BuildAutoplanCommands", params, []reflect.Type{reflect.TypeOf((*[]models.ProjectCommandContext)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
/Users/gkontridze/Development/github.com/runatlantis/atlantis/server/events/command_runner.go:134 (0x1a05b75)
	(*DefaultCommandRunner).RunAutoplanCommand: projectCmds, err := c.ProjectCommandBuilder.BuildAutoplanCommands(ctx)
/Users/gkontridze/Development/github.com/runatlantis/atlantis/server/events/command_runner_test.go:375 (0x1a706ed)
	TestRunAutoplanCommand_DrainNotOngoing: ch.RunAutoplanCommand(fixtures.GithubRepo, fixtures.GithubRepo, fixtures.Pull, fixtures.User)
/usr/local/Cellar/go/1.14.5/libexec/src/testing/testing.go:991 (0x110eb8b)
	tRunner: fn(t)
/usr/local/Cellar/go/1.14.5/libexec/src/runtime/asm_amd64.s:1373 (0x1068640)
	goexit: BYTE	$0x90	// NOP

--- FAIL: TestParse_HelpResponse (0.00s)
    comment_parser_test.go:59: [```cmake
        atlantis
        Terraform Pull Request Automation
        
        Usage:
          atlantis <command> [options] -- [terraform options]
        
        Examples:
          # run plan in the root directory passing the -target flag to terraform
          atlantis plan -d . -- -target=resource
        
          # apply all unapplied plans from this pull request
          atlantis apply
        
          # apply the plan for the root directory and staging workspace
          atlantis apply -d . -w staging
        
        Commands:
          plan     Runs 'terraform plan' for the changes in this pull request.
                   To plan a specific project, use the -d, -w and -p flags.
          apply    Runs 'terraform apply' on all unapplied plans from this pull request.
                   To only apply a specific plan, use the -d, -w and -p flags.
          unlock   Removes all atlantis locks and discards all plans for this PR.
                   To unlock a specific plan you can use the Atlantis UI.
          help     View help.
        
        Flags:
          -h, --help   help for atlantis
        
        Use "atlantis [command] --help" for more information about a command.
        ``` != ]
        
        exp: (string) (len=987) "```cmake\natlantis\nTerraform Pull Request Automation\n\nUsage:\n  atlantis <command> [options] -- [terraform options]\n\nExamples:\n  # run plan in the root directory passing the -target flag to terraform\n  atlantis plan -d . -- -target=resource\n\n  # apply all unapplied plans from this pull request\n  atlantis apply\n\n  # apply the plan for the root directory and staging workspace\n  atlantis apply -d . -w staging\n\nCommands:\n  plan     Runs 'terraform plan' for the changes in this pull request.\n           To plan a specific project, use the -d, -w and -p flags.\n  apply    Runs 'terraform apply' on all unapplied plans from this pull request.\n           To only apply a specific plan, use the -d, -w and -p flags.\n  unlock   Removes all atlantis locks and discards all plans for this PR.\n           To unlock a specific plan you can use the Atlantis UI.\n  help     View help.\n\nFlags:\n  -h, --help   help for atlantis\n\nUse \"atlantis [command] --help\" for more information about a command.\n```"
        ******
        got: (string) ""
        
--- FAIL: TestParse_UnusedArguments (0.00s)
    comment_parser_test.go:64: if there are unused flags we return an error
    --- FAIL: TestParse_UnusedArguments/atlantis_plan_-d_._arg (0.00s)
        comment_parser_test.go:124: [```
            Error: unknown argument(s) – arg.
            Usage of plan:
              -d, --dir string         Which directory to run plan in relative to root of repo,
                                       ex. 'child/dir'.
              -p, --project string     Which project to run plan for. Refers to the name of the
                                       project configured in atlantis.yaml. Cannot be used at
                                       same time as workspace or dir flags.
                  --verbose            Append Atlantis log to comment.
              -w, --workspace string   Switch to this Terraform workspace before planning.
            ``` != ]
            
            exp: (string) (len=554) "```\nError: unknown argument(s) – arg.\nUsage of plan:\n  -d, --dir string         Which directory to run plan in relative to root of repo,\n                           ex. 'child/dir'.\n  -p, --project string     Which project to run plan for. Refers to the name of the\n                           project configured in atlantis.yaml. Cannot be used at\n                           same time as workspace or dir flags.\n      --verbose            Append Atlantis log to comment.\n  -w, --workspace string   Switch to this Terraform workspace before planning.\n```"
            ******
            got: (string) ""
            
    --- FAIL: TestParse_UnusedArguments/atlantis_plan_arg_-d_. (0.00s)
        comment_parser_test.go:124: [```
            Error: unknown argument(s) – arg.
            Usage of plan:
              -d, --dir string         Which directory to run plan in relative to root of repo,
                                       ex. 'child/dir'.
              -p, --project string     Which project to run plan for. Refers to the name of the
                                       project configured in atlantis.yaml. Cannot be used at
                                       same time as workspace or dir flags.
                  --verbose            Append Atlantis log to comment.
              -w, --workspace string   Switch to this Terraform workspace before planning.
            ``` != ]
            
            exp: (string) (len=554) "```\nError: unknown argument(s) – arg.\nUsage of plan:\n  -d, --dir string         Which directory to run plan in relative to root of repo,\n                           ex. 'child/dir'.\n  -p, --project string     Which project to run plan for. Refers to the name of the\n                           project configured in atlantis.yaml. Cannot be used at\n                           same time as workspace or dir flags.\n      --verbose            Append Atlantis log to comment.\n  -w, --workspace string   Switch to this Terraform workspace before planning.\n```"
            ******
            got: (string) ""
            
    --- FAIL: TestParse_UnusedArguments/atlantis_plan_arg (0.00s)
        comment_parser_test.go:124: [```
            Error: unknown argument(s) – arg.
            Usage of plan:
              -d, --dir string         Which directory to run plan in relative to root of repo,
                                       ex. 'child/dir'.
              -p, --project string     Which project to run plan for. Refers to the name of the
                                       project configured in atlantis.yaml. Cannot be used at
                                       same time as workspace or dir flags.
                  --verbose            Append Atlantis log to comment.
              -w, --workspace string   Switch to this Terraform workspace before planning.
            ``` != ]
            
            exp: (string) (len=554) "```\nError: unknown argument(s) – arg.\nUsage of plan:\n  -d, --dir string         Which directory to run plan in relative to root of repo,\n                           ex. 'child/dir'.\n  -p, --project string     Which project to run plan for. Refers to the name of the\n                           project configured in atlantis.yaml. Cannot be used at\n                           same time as workspace or dir flags.\n      --verbose            Append Atlantis log to comment.\n  -w, --workspace string   Switch to this Terraform workspace before planning.\n```"
            ******
            got: (string) ""
            
    --- FAIL: TestParse_UnusedArguments/atlantis_plan_arg_arg2 (0.00s)
        comment_parser_test.go:124: [```
            Error: unknown argument(s) – arg arg2.
            Usage of plan:
              -d, --dir string         Which directory to run plan in relative to root of repo,
                                       ex. 'child/dir'.
              -p, --project string     Which project to run plan for. Refers to the name of the
                                       project configured in atlantis.yaml. Cannot be used at
                                       same time as workspace or dir flags.
                  --verbose            Append Atlantis log to comment.
              -w, --workspace string   Switch to this Terraform workspace before planning.
            ``` != ]
            
            exp: (string) (len=559) "```\nError: unknown argument(s) – arg arg2.\nUsage of plan:\n  -d, --dir string         Which directory to run plan in relative to root of repo,\n                           ex. 'child/dir'.\n  -p, --project string     Which project to run plan for. Refers to the name of the\n                           project configured in atlantis.yaml. Cannot be used at\n                           same time as workspace or dir flags.\n      --verbose            Append Atlantis log to comment.\n  -w, --workspace string   Switch to this Terraform workspace before planning.\n```"
            ******
            got: (string) ""
            
    --- FAIL: TestParse_UnusedArguments/atlantis_plan_-d_._arg_-w_kjj_arg2 (0.00s)
        comment_parser_test.go:124: [```
            Error: unknown argument(s) – arg arg2.
            Usage of plan:
              -d, --dir string         Which directory to run plan in relative to root of repo,
                                       ex. 'child/dir'.
              -p, --project string     Which project to run plan for. Refers to the name of the
                                       project configured in atlantis.yaml. Cannot be used at
                                       same time as workspace or dir flags.
                  --verbose            Append Atlantis log to comment.
              -w, --workspace string   Switch to this Terraform workspace before planning.
            ``` != ]
            
            exp: (string) (len=559) "```\nError: unknown argument(s) – arg arg2.\nUsage of plan:\n  -d, --dir string         Which directory to run plan in relative to root of repo,\n                           ex. 'child/dir'.\n  -p, --project string     Which project to run plan for. Refers to the name of the\n                           project configured in atlantis.yaml. Cannot be used at\n                           same time as workspace or dir flags.\n      --verbose            Append Atlantis log to comment.\n  -w, --workspace string   Switch to this Terraform workspace before planning.\n```"
            ******
            got: (string) ""
            
    --- FAIL: TestParse_UnusedArguments/atlantis_apply_-d_._arg (0.00s)
        comment_parser_test.go:124: [```
            Error: unknown argument(s) – arg.
            Usage of apply:
              -d, --dir string         Apply the plan for this directory, relative to root of
                                       repo, ex. 'child/dir'.
              -p, --project string     Apply the plan for this project. Refers to the name of
                                       the project configured in atlantis.yaml. Cannot be used
                                       at same time as workspace or dir flags.
                  --verbose            Append Atlantis log to comment.
              -w, --workspace string   Apply the plan for this Terraform workspace.
            ``` != ]
            
            exp: (string) (len=554) "```\nError: unknown argument(s) – arg.\nUsage of apply:\n  -d, --dir string         Apply the plan for this directory, relative to root of\n                           repo, ex. 'child/dir'.\n  -p, --project string     Apply the plan for this project. Refers to the name of\n                           the project configured in atlantis.yaml. Cannot be used\n                           at same time as workspace or dir flags.\n      --verbose            Append Atlantis log to comment.\n  -w, --workspace string   Apply the plan for this Terraform workspace.\n```"
            ******
            got: (string) ""
            
    --- FAIL: TestParse_UnusedArguments/atlantis_apply_arg_arg2 (0.00s)
        comment_parser_test.go:124: [```
            Error: unknown argument(s) – arg arg2.
            Usage of apply:
              -d, --dir string         Apply the plan for this directory, relative to root of
                                       repo, ex. 'child/dir'.
              -p, --project string     Apply the plan for this project. Refers to the name of
                                       the project configured in atlantis.yaml. Cannot be used
                                       at same time as workspace or dir flags.
                  --verbose            Append Atlantis log to comment.
              -w, --workspace string   Apply the plan for this Terraform workspace.
            ``` != ]
            
            exp: (string) (len=559) "```\nError: unknown argument(s) – arg arg2.\nUsage of apply:\n  -d, --dir string         Apply the plan for this directory, relative to root of\n                           repo, ex. 'child/dir'.\n  -p, --project string     Apply the plan for this project. Refers to the name of\n                           the project configured in atlantis.yaml. Cannot be used\n                           at same time as workspace or dir flags.\n      --verbose            Append Atlantis log to comment.\n  -w, --workspace string   Apply the plan for this Terraform workspace.\n```"
            ******
            got: (string) ""
            
    --- FAIL: TestParse_UnusedArguments/atlantis_apply_arg_arg2_--_useful (0.00s)
        comment_parser_test.go:124: [```
            Error: unknown argument(s) – arg arg2.
            Usage of apply:
              -d, --dir string         Apply the plan for this directory, relative to root of
                                       repo, ex. 'child/dir'.
              -p, --project string     Apply the plan for this project. Refers to the name of
                                       the project configured in atlantis.yaml. Cannot be used
                                       at same time as workspace or dir flags.
                  --verbose            Append Atlantis log to comment.
              -w, --workspace string   Apply the plan for this Terraform workspace.
            ``` != ]
            
            exp: (string) (len=559) "```\nError: unknown argument(s) – arg arg2.\nUsage of apply:\n  -d, --dir string         Apply the plan for this directory, relative to root of\n                           repo, ex. 'child/dir'.\n  -p, --project string     Apply the plan for this project. Refers to the name of\n                           the project configured in atlantis.yaml. Cannot be used\n                           at same time as workspace or dir flags.\n      --verbose            Append Atlantis log to comment.\n  -w, --workspace string   Apply the plan for this Terraform workspace.\n```"
            ******
            got: (string) ""
            
    --- FAIL: TestParse_UnusedArguments/atlantis_apply_arg_arg2_-- (0.00s)
        comment_parser_test.go:124: [```
            Error: unknown argument(s) – arg arg2.
            Usage of apply:
              -d, --dir string         Apply the plan for this directory, relative to root of
                                       repo, ex. 'child/dir'.
              -p, --project string     Apply the plan for this project. Refers to the name of
                                       the project configured in atlantis.yaml. Cannot be used
                                       at same time as workspace or dir flags.
                  --verbose            Append Atlantis log to comment.
              -w, --workspace string   Apply the plan for this Terraform workspace.
            ``` != ]
            
            exp: (string) (len=559) "```\nError: unknown argument(s) – arg arg2.\nUsage of apply:\n  -d, --dir string         Apply the plan for this directory, relative to root of\n                           repo, ex. 'child/dir'.\n  -p, --project string     Apply the plan for this project. Refers to the name of\n                           the project configured in atlantis.yaml. Cannot be used\n                           at same time as workspace or dir flags.\n      --verbose            Append Atlantis log to comment.\n  -w, --workspace string   Apply the plan for this Terraform workspace.\n```"
            ******
            got: (string) ""
            
--- FAIL: TestParse_UnknownShorthandFlag (0.00s)
    comment_parser_test.go:133: [`Usage of unlock:`
        
         ```cmake
        atlantis unlock	
        
          Unlocks the entire PR and discards all plans in this PR.
          Arguments or flags are not supported at the moment.
          If you need to unlock a specific project please use the atlantis UI.
        ``` != ]
        
        exp: (string) (len=235) "`Usage of unlock:`\n\n ```cmake\natlantis unlock\t\n\n  Unlocks the entire PR and discards all plans in this PR.\n  Arguments or flags are not supported at the moment.\n  If you need to unlock a specific project please use the atlantis UI.\n```"
        ******
        got: (string) ""
        
--- FAIL: TestParse_InvalidCommand (0.00s)
    comment_parser_test.go:156: given a comment with an invalid atlantis command, should return a warning.
    comment_parser_test.go:166: For comment "atlantis paln" expected CommentResponse=="```\nError: unknown command \"paln\".\nRun 'atlantis --help' for usage.\n```" but got ""
--- FAIL: TestParse_SubcommandUsage (0.00s)
    comment_parser_test.go:172: given a comment asking for the usage of a subcommand should return help
    comment_parser_test.go:183: For comment "atlantis plan -h" expected CommentResponse "" to contain "Usage of plan"
--- FAIL: TestParse_InvalidFlags (0.00s)
    comment_parser_test.go:191: given a comment with a valid atlantis command but invalid flags, should return a warning and the proper usage
    comment_parser_test.go:216: For comment "atlantis plan -e" expected CommentResponse "" to contain "Error: unknown shorthand flag: 'e' in -e"
--- FAIL: TestParse_RelativeDirPath (0.00s)
    comment_parser_test.go:224: if -d is used with a relative path, should return an error
    comment_parser_test.go:239: For comment "atlantis plan -d .." expected CommentResponse "" to contain "Error: using a relative path"
--- FAIL: TestParse_Multiline (0.00s)
    --- FAIL: TestParse_Multiline/atlantis_plan_ (0.00s)
        comment_parser_test.go:257: [events.CommentCommand != <nil pointer>]
            
            exp: (*events.CommentCommand)(0xc00068e060)(command="plan" verbose=false dir="" workspace="" project="" flags="")
            ******
            got: (*events.CommentCommand)(<nil>)
            
    --- FAIL: TestParse_Multiline/atlantis_plan__ (0.00s)
        comment_parser_test.go:257: [events.CommentCommand != <nil pointer>]
            
            exp: (*events.CommentCommand)(0xc00068e120)(command="plan" verbose=false dir="" workspace="" project="" flags="")
            ******
            got: (*events.CommentCommand)(<nil>)
            
    --- FAIL: TestParse_Multiline/atlantis_plan__#01 (0.00s)
        comment_parser_test.go:257: [events.CommentCommand != <nil pointer>]
            
            exp: (*events.CommentCommand)(0xc00068e1e0)(command="plan" verbose=false dir="" workspace="" project="" flags="")
            ******
            got: (*events.CommentCommand)(<nil>)
            
    --- FAIL: TestParse_Multiline/atlantis_plan____ (0.00s)
        comment_parser_test.go:257: [events.CommentCommand != <nil pointer>]
            
            exp: (*events.CommentCommand)(0xc00068e2a0)(command="plan" verbose=false dir="" workspace="" project="" flags="")
            ******
            got: (*events.CommentCommand)(<nil>)
            
--- FAIL: TestParse_InvalidWorkspace (0.00s)
    comment_parser_test.go:270: if -w is used with '..' or '/', should return an error
    comment_parser_test.go:284: For comment "atlantis plan -w .." expected CommentResponse "" to contain "Error: invalid workspace"
--- FAIL: TestParse_UsingProjectAtSameTimeAsWorkspaceOrDir (0.00s)
    --- FAIL: TestParse_UsingProjectAtSameTimeAsWorkspaceOrDir/atlantis_plan_-w_workspace_-p_project (0.00s)
        comment_parser_test.go:299: For comment "atlantis plan -w workspace -p project" expected CommentResponse "" to contain "Error: cannot use -p/--project at same time as -d/--dir or -w/--workspace"
    --- FAIL: TestParse_UsingProjectAtSameTimeAsWorkspaceOrDir/atlantis_plan_-d_dir_-p_project (0.00s)
        comment_parser_test.go:299: For comment "atlantis plan -d dir -p project" expected CommentResponse "" to contain "Error: cannot use -p/--project at same time as -d/--dir or -w/--workspace"
    --- FAIL: TestParse_UsingProjectAtSameTimeAsWorkspaceOrDir/atlantis_plan_-d_dir_-w_workspace_-p_project (0.00s)
        comment_parser_test.go:299: For comment "atlantis plan -d dir -w workspace -p project" expected CommentResponse "" to contain "Error: cannot use -p/--project at same time as -d/--dir or -w/--workspace"
--- FAIL: TestParse_Parsing (0.00s)
    --- FAIL: TestParse_Parsing/atlantis_plan_ (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1aa2aab]

goroutine 185 [running]:
testing.tRunner.func1.1(0x1bfa4e0, 0x27f9230)
	/usr/local/Cellar/go/1.14.5/libexec/src/testing/testing.go:940 +0x2f5
testing.tRunner.func1(0xc000481e60)
	/usr/local/Cellar/go/1.14.5/libexec/src/testing/testing.go:943 +0x3f9
panic(0x1bfa4e0, 0x27f9230)
	/usr/local/Cellar/go/1.14.5/libexec/src/runtime/panic.go:969 +0x166
github.com/runatlantis/atlantis/server/events_test.TestParse_Parsing.func1(0xc000481e60)
	/Users/gkontridze/Development/github.com/runatlantis/atlantis/server/events/comment_parser_test.go:529 +0x18b
testing.tRunner(0xc000481e60, 0xc00031f380)
	/usr/local/Cellar/go/1.14.5/libexec/src/testing/testing.go:991 +0xdc
created by testing.(*T).Run
	/usr/local/Cellar/go/1.14.5/libexec/src/testing/testing.go:1042 +0x357
FAIL	github.com/runatlantis/atlantis/server/events	1.443s
ok  	github.com/runatlantis/atlantis/server/events/db	(cached)
ok  	github.com/runatlantis/atlantis/server/events/locking	(cached)
?   	github.com/runatlantis/atlantis/server/events/matchers	[no test files]
ok  	github.com/runatlantis/atlantis/server/events/models	(cached)
?   	github.com/runatlantis/atlantis/server/events/models/fixtures	[no test files]
ok  	github.com/runatlantis/atlantis/server/events/runtime	(cached)
ok  	github.com/runatlantis/atlantis/server/events/terraform	(cached)
ok  	github.com/runatlantis/atlantis/server/events/vcs	(cached)
ok  	github.com/runatlantis/atlantis/server/events/vcs/bitbucketcloud	(cached)
ok  	github.com/runatlantis/atlantis/server/events/vcs/bitbucketserver	(cached)
ok  	github.com/runatlantis/atlantis/server/events/vcs/common	(cached)
?   	github.com/runatlantis/atlantis/server/events/vcs/fixtures	[no test files]
ok  	github.com/runatlantis/atlantis/server/events/webhooks	(cached)
ok  	github.com/runatlantis/atlantis/server/events/yaml	(cached)
ok  	github.com/runatlantis/atlantis/server/events/yaml/raw	(cached)
ok  	github.com/runatlantis/atlantis/server/events/yaml/valid	(cached)
ok  	github.com/runatlantis/atlantis/server/logging	(cached) [no tests to run]
ok  	github.com/runatlantis/atlantis/server/recovery	(cached) [no tests to run]
?   	github.com/runatlantis/atlantis/testdrive	[no test files]
FAIL
make: *** [Makefile:36: test] Error 1
```
</details>

Do you have any insight as to what might be happening? I will try to take a look again soon.