### PR TITLE
NewRepo() encodes spaces in clone URLs.

### DIFF
--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -97,6 +97,7 @@ func NewRepo(vcsHostType VCSHostType, repoFullName string, cloneURL string, vcsU
 
 	// We url encode because we're using them in a URL and weird characters can
 	// mess up git.
+	cloneURL = strings.Replace(cloneURL, " ", "%20", -1)
 	escapedVCSUser := url.QueryEscape(vcsUser)
 	escapedVCSToken := url.QueryEscape(vcsToken)
 	auth := fmt.Sprintf("%s:%s@", escapedVCSUser, escapedVCSToken)

--- a/server/events/models/models_test.go
+++ b/server/events/models/models_test.go
@@ -66,6 +66,19 @@ func TestNewRepo_CloneURLBitbucketServer(t *testing.T) {
 	}, repo)
 }
 
+// If the clone URL contains a space, NewRepo() should encode it
+func TestNewRepo_CloneURLContainsSpace(t *testing.T) {
+	repo, err := models.NewRepo(models.AzureDevops, "owner/project space/repo", "https://dev.azure.com/owner/project space/repo", "u", "p")
+	Ok(t, err)
+	Equals(t, repo.CloneURL, "https://u:p@dev.azure.com/owner/project%20space/repo")
+	Equals(t, repo.SanitizedCloneURL, "https://u:<redacted>@dev.azure.com/owner/project%20space/repo")
+
+	repo, err = models.NewRepo(models.BitbucketCloud, "owner/repo space", "https://bitbucket.org/owner/repo space", "u", "p")
+	Ok(t, err)
+	Equals(t, repo.CloneURL, "https://u:p@bitbucket.org/owner/repo%20space.git")
+	Equals(t, repo.SanitizedCloneURL, "https://u:<redacted>@bitbucket.org/owner/repo%20space.git")
+}
+
 func TestNewRepo_FullNameWrongFormat(t *testing.T) {
 	cases := []struct {
 		repoFullName string


### PR DESCRIPTION
Changes NewRepo() to encode any spaces in clone URLs.