### PR TITLE
Set TF_APPEND_USER_AGENT

### DIFF
--- a/server/events/terraform/terraform_client.go
+++ b/server/events/terraform/terraform_client.go
@@ -261,6 +261,8 @@ func (c *DefaultClient) prepCmd(log *logging.SimpleLogger, v *version.Version, w
 	// We add custom variables so that if `extra_args` is specified with env
 	// vars then they'll be substituted.
 	envVars := []string{
+		// Pass user-agent for Terraform and provider calls.
+		"TF_APPEND_USER_AGENT=Atlantis/1.0",
 		// Will de-emphasize specific commands to run in output.
 		"TF_IN_AUTOMATION=true",
 		// Cache plugins so terraform init runs faster.


### PR DESCRIPTION
This is used for Terraform HTTP interactions (registry, etc) as well as inside providers for their API calls. See https://github.com/hashicorp/terraform/blob/49597c3c21e0362d10c04a9961644ef04a6aead9/httpclient/useragent.go#L14

The version number is unimportant unless you would like to set one. Mostly I just wanted to send the Atlantis product identifier.