### PR TITLE
Improve working dir lock error formatting

### DIFF
--- a/server/events/working_dir_locker.go
+++ b/server/events/working_dir_locker.go
@@ -83,7 +83,7 @@ func (d *DefaultWorkingDirLocker) TryLock(repoFullName string, pullNum int, work
 	for _, l := range d.locks {
 		if l == pullKey || l == workspaceKey {
 			return func() {}, fmt.Errorf("The %s workspace is currently locked by another"+
-				" command that is running for this pull request." + "\n" +
+				" command that is running for this pull request."+"\n"+
 				"Wait until the previous command is complete and try again.", workspace)
 		}
 	}

--- a/server/events/working_dir_locker.go
+++ b/server/events/working_dir_locker.go
@@ -63,9 +63,9 @@ func (d *DefaultWorkingDirLocker) TryLockPull(repoFullName string, pullNum int) 
 	pullKey := d.pullKey(repoFullName, pullNum)
 	for _, l := range d.locks {
 		if l == pullKey || strings.HasPrefix(l, pullKey+"/") {
-			return func() {}, fmt.Errorf("the Atlantis working dir is currently locked by another" +
-				" command that is running for this pull request–" +
-				"wait until the previous command is complete and try again")
+			return func() {}, fmt.Errorf("The Atlantis working dir is currently locked by another" +
+				" command that is running for this pull request." + "\n" +
+				"Wait until the previous command is complete and try again.")
 		}
 	}
 	d.locks = append(d.locks, pullKey)
@@ -82,9 +82,9 @@ func (d *DefaultWorkingDirLocker) TryLock(repoFullName string, pullNum int, work
 	workspaceKey := d.workspaceKey(repoFullName, pullNum, workspace)
 	for _, l := range d.locks {
 		if l == pullKey || l == workspaceKey {
-			return func() {}, fmt.Errorf("the %s workspace is currently locked by another"+
-				" command that is running for this pull request–"+
-				"wait until the previous command is complete and try again", workspace)
+			return func() {}, fmt.Errorf("The %s workspace is currently locked by another"+
+				" command that is running for this pull request." + "\n" +
+				"Wait until the previous command is complete and try again.", workspace)
 		}
 	}
 	d.locks = append(d.locks, workspaceKey)

--- a/server/events/working_dir_locker.go
+++ b/server/events/working_dir_locker.go
@@ -64,7 +64,7 @@ func (d *DefaultWorkingDirLocker) TryLockPull(repoFullName string, pullNum int) 
 	for _, l := range d.locks {
 		if l == pullKey || strings.HasPrefix(l, pullKey+"/") {
 			return func() {}, fmt.Errorf("The Atlantis working dir is currently locked by another" +
-				" command that is running for this pull request." + "\n" +
+				" command that is running for this pull request.\n" +
 				"Wait until the previous command is complete and try again.")
 		}
 	}

--- a/server/events/working_dir_locker.go
+++ b/server/events/working_dir_locker.go
@@ -83,7 +83,7 @@ func (d *DefaultWorkingDirLocker) TryLock(repoFullName string, pullNum int, work
 	for _, l := range d.locks {
 		if l == pullKey || l == workspaceKey {
 			return func() {}, fmt.Errorf("The %s workspace is currently locked by another"+
-				" command that is running for this pull request."+"\n"+
+				" command that is running for this pull request.\n"+
 				"Wait until the previous command is complete and try again.", workspace)
 		}
 	}

--- a/server/events/working_dir_locker_test.go
+++ b/server/events/working_dir_locker_test.go
@@ -33,7 +33,7 @@ func TestTryLock(t *testing.T) {
 	// Now another lock for the same repo, workspace, and pull should fail
 	_, err = locker.TryLock(repo, 1, workspace)
 	ErrEquals(t, "The default workspace is currently locked by another"+
-		" command that is running for this pull request." + "\n" +
+		" command that is running for this pull request."+"\n"+
 		"Wait until the previous command is complete and try again.", err)
 
 	// Unlock should work.

--- a/server/events/working_dir_locker_test.go
+++ b/server/events/working_dir_locker_test.go
@@ -33,7 +33,7 @@ func TestTryLock(t *testing.T) {
 	// Now another lock for the same repo, workspace, and pull should fail
 	_, err = locker.TryLock(repo, 1, workspace)
 	ErrEquals(t, "The default workspace is currently locked by another"+
-		" command that is running for this pull request."+"\n"+
+		" command that is running for this pull request.\n"+
 		"Wait until the previous command is complete and try again.", err)
 
 	// Unlock should work.

--- a/server/events/working_dir_locker_test.go
+++ b/server/events/working_dir_locker_test.go
@@ -32,9 +32,9 @@ func TestTryLock(t *testing.T) {
 
 	// Now another lock for the same repo, workspace, and pull should fail
 	_, err = locker.TryLock(repo, 1, workspace)
-	ErrEquals(t, "the default workspace is currently locked by another"+
-		" command that is running for this pull request–"+
-		"wait until the previous command is complete and try again", err)
+	ErrEquals(t, "The default workspace is currently locked by another"+
+		" command that is running for this pull request." + "\n" +
+		"Wait until the previous command is complete and try again.", err)
 
 	// Unlock should work.
 	unlockFn()


### PR DESCRIPTION
Improves working dir lock error formatting by adding some punctuation and line breaks to the messages that are sent back to git. 