### PR TITLE
Fix bug responding to draft pr updates

### DIFF
--- a/server/events/event_parser.go
+++ b/server/events/event_parser.go
@@ -418,29 +418,28 @@ func (e *EventParser) ParseGithubPullEvent(pullEvent *github.PullRequestEvent) (
 		return
 	}
 
-	if pullEvent.GetPullRequest().GetDraft() {
-		// Even if the PR is in draft state users can manually run plan or may
-		// be using the -allow-draft-prs flag. If so then we need to ensure locks are cleaned up.
-		if pullEvent.GetAction() == "closed" {
-			pullEventType = models.ClosedPullEvent
-		} else if !e.AllowDraftPRs {
-			pullEventType = models.OtherPullEvent
-		}
-	} else {
-		switch pullEvent.GetAction() {
-		case "opened":
-			pullEventType = models.OpenedPullEvent
-		case "ready_for_review":
-			// when an author takes a PR out of 'draft' state a 'ready_for_review'
-			// event is triggered. We want atlantis to treat this as a freshly opened PR
-			pullEventType = models.OpenedPullEvent
-		case "synchronize":
-			pullEventType = models.UpdatedPullEvent
-		case "closed":
-			pullEventType = models.ClosedPullEvent
-		default:
-			pullEventType = models.OtherPullEvent
-		}
+	action := pullEvent.GetAction()
+	// If it's a draft PR we ignore it for auto-planning if configured to do so
+	// however it's still possible for users to run plan on it manually via a
+	// comment so if any draft PR is closed we still need to check if we need
+	// to delete its locks.
+	if pullEvent.GetPullRequest().GetDraft() && pullEvent.GetAction() != "closed" && !e.AllowDraftPRs {
+		action = "other"
+	}
+
+	switch action {
+	case "opened":
+		pullEventType = models.OpenedPullEvent
+	case "ready_for_review":
+		// when an author takes a PR out of 'draft' state a 'ready_for_review'
+		// event is triggered. We want atlantis to treat this as a freshly opened PR
+		pullEventType = models.OpenedPullEvent
+	case "synchronize":
+		pullEventType = models.UpdatedPullEvent
+	case "closed":
+		pullEventType = models.ClosedPullEvent
+	default:
+		pullEventType = models.OtherPullEvent
 	}
 	user = models.User{Username: senderUsername}
 	return

--- a/server/events/event_parser_test.go
+++ b/server/events/event_parser_test.go
@@ -248,12 +248,18 @@ func TestParseGithubPullEvent_EventType(t *testing.T) {
 			_, actType, _, _, _, err := parser.ParseGithubPullEvent(&event)
 			Ok(t, err)
 			Equals(t, c.exp, actType)
-			// Test draft parsing
+			// Test draft parsing when draft PRs disabled
 			draftPR := true
 			event.PullRequest.Draft = &draftPR
 			_, draftEvType, _, _, _, err := parser.ParseGithubPullEvent(&event)
 			Ok(t, err)
 			Equals(t, c.draftExp, draftEvType)
+			// Test draft parsing when draft PRs are enabled.
+			draftParser := parser
+			draftParser.AllowDraftPRs = true
+			_, draftEvType, _, _, _, err = draftParser.ParseGithubPullEvent(&event)
+			Ok(t, err)
+			Equals(t, c.exp, draftEvType)
 		})
 	}
 }


### PR DESCRIPTION
Previously any update to a draft PR other than "closed" would default to
being an "open" event due to a bug in the parsing logic.

FIxes https://github.com/runatlantis/atlantis/issues/1194