### PR TITLE
Fix AzureDevops PR status updates

### DIFF
--- a/server/events/vcs/azuredevops_client.go
+++ b/server/events/vcs/azuredevops_client.go
@@ -195,8 +195,10 @@ func (g *AzureDevopsClient) PullIsMergeable(repo models.Repo, pull models.PullRe
 		// Ignore the Atlantis status, even if its set as a blocker.
 		// This status should not be considered when evaluating if the pull request can be applied.
 		settings := (policyEvaluation.Configuration.Settings).(map[string]interface{})
-		if status, ok := settings["statusName"]; ok && status == "atlantis/apply" {
-			continue
+		if genre, ok := settings["statusGenre"]; ok && genre == "Atlantis Bot/atlantis" {
+			if name, ok := settings["statusName"]; ok && name == "apply" {
+				continue
+			}
 		}
 
 		if *policyEvaluation.Configuration.IsBlocking && *policyEvaluation.Status != azuredevops.PolicyEvaluationApproved {

--- a/server/events/vcs/azuredevops_client_test.go
+++ b/server/events/vcs/azuredevops_client_test.go
@@ -524,4 +524,40 @@ var adMergeSuccess = `{
 					"transitionWorkItems":true,
 					"triggeredByAutoComplete":false
 	}
-}`
+}
+`
+
+func TestAzureDevopsClient_GitStatusContextFromSrc(t *testing.T) {
+	cases := []struct {
+		src      string
+		expGenre string
+		expName  string
+	}{
+		{
+			"atlantis/plan",
+			"Atlantis Bot/atlantis",
+			"plan",
+		},
+		{
+			"atlantis/foo/bar/biz/baz",
+			"Atlantis Bot/atlantis/foo/bar/biz",
+			"baz",
+		},
+		{
+			"foo",
+			"Atlantis Bot",
+			"foo",
+		},
+		{
+			"",
+			"Atlantis Bot",
+			"",
+		},
+	}
+
+	for _, c := range cases {
+		result := vcs.GitStatusContextFromSrc(c.src)
+		Equals(t, &c.expName, result.Name)
+		Equals(t, &c.expGenre, result.Genre)
+	}
+}

--- a/server/events/vcs/azuredevops_client_test.go
+++ b/server/events/vcs/azuredevops_client_test.go
@@ -277,28 +277,65 @@ func TestAzureDevopsClient_GetModifiedFiles(t *testing.T) {
 }
 
 func TestAzureDevopsClient_PullIsMergeable(t *testing.T) {
+	type Policy struct {
+		genre  string
+		name   string
+		status string
+	}
 	cases := []struct {
 		testName     string
 		mergeStatus  string
-		policyStatus string
+		policy       Policy
 		expMergeable bool
 	}{
 		{
 			"merge conflicts",
 			azuredevops.MergeConflicts.String(),
-			"approved",
+			Policy{
+				"Not Atlantis",
+				"foo",
+				"approved",
+			},
 			false,
 		},
 		{
 			"rejected policy status",
 			azuredevops.MergeSucceeded.String(),
-			"rejected",
+			Policy{
+				"Not Atlantis",
+				"foo",
+				"rejected",
+			},
 			false,
 		},
 		{
 			"merge succeeded",
 			azuredevops.MergeSucceeded.String(),
-			"approved",
+			Policy{
+				"Not Atlantis",
+				"foo",
+				"approved",
+			},
+			true,
+		},
+		{
+			"pending policy status",
+			azuredevops.MergeSucceeded.String(),
+			Policy{
+				"Not Atlantis",
+				"foo",
+				"pending",
+			},
+			false,
+		},
+		{
+			"atlantis apply status rejected",
+			azuredevops.MergeSucceeded.String(),
+			Policy{
+				"Atlantis Bot/atlantis",
+				"apply",
+				"rejected",
+			},
 			true,
 		},
 	}
@@ -315,7 +352,9 @@ func TestAzureDevopsClient_PullIsMergeable(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.testName, func(t *testing.T) {
 			pullRequestResponse := strings.Replace(pullRequestBody, `"mergeStatus": "notSet"`, fmt.Sprintf(`"mergeStatus": "%s"`, c.mergeStatus), 1)
-			policyEvaluationsResponse := strings.Replace(policyEvaluationsBody, `"status": "approved"`, fmt.Sprintf(`"status": "%s"`, c.policyStatus), 1)
+			policyEvaluationsResponse := strings.Replace(policyEvaluationsBody, `"status": "approved"`, fmt.Sprintf(`"status": "%s"`, c.policy.status), 1)
+			policyEvaluationsResponse = strings.Replace(policyEvaluationsResponse, `"statusGenre": "Atlantis Bot/atlantis"`, fmt.Sprintf(`"statusGenre": "%s"`, c.policy.genre), 1)
+			policyEvaluationsResponse = strings.Replace(policyEvaluationsResponse, `"statusName": "plan"`, fmt.Sprintf(`"statusName": "%s"`, c.policy.name), 1)
 
 			testServer := httptest.NewTLSServer(
 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/events/vcs/fixtures/azuredevops-policyevaluations.json
+++ b/server/events/vcs/fixtures/azuredevops-policyevaluations.json
@@ -6,7 +6,8 @@
                 "isEnabled": true,
                 "isBlocking": true,
                 "settings": {
-                    "statusName": "pending"
+                    "statusGenre": "Atlantis Bot/atlantis",
+                    "statusName": "plan"
                 }
             },
             "status": "approved"


### PR DESCRIPTION
Fixes #1172

I was on the fence about removing the `Atlantis Bot` from the genre entirely to make the behavior in AzDO closer to the other VCS platforms but ultimately decided against it. Please let me know if you have any thoughts.