### PR TITLE
Hotfix: server-configuration Gitlab webhook secret command 

### DIFF
--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -305,7 +305,7 @@ Values are chosen in this order:
 
 * ### `--gitlab-webhook-secret`
   ```bash
-  atlantis server --gh-webhook-secret="secret"
+  atlantis server --gitlab-webhook-secret="secret"
   # or (recommended)
   ATLANTIS_GITLAB_WEBHOOK_SECRET='secret' atlantis server
   ```


### PR DESCRIPTION
This PR fixes a typo made in the `server-configuration` page of the Atlantis docs.

The `Gitlab` section contained the `Github` flag, which is now replaced with the Gitlab `--gitlab-webhook-secret` flag.