### PR TITLE
Add Option to globally disable apply

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -276,11 +276,11 @@ var boolFlags = map[string]boolFlag{
 		defaultValue: false,
 	},
 	DisableApplyAllFlag: {
-		description:  "Disable \"atlantis apply\" command so a specific project/workspace/directory has to be specified for applies.",
+		description:  "Disable \"atlantis apply\" command without any flags (i.e. apply all). A specific project/workspace/directory has to be specified for applies.",
 		defaultValue: false,
 	},
 	DisableApplyFlag: {
-		description:  "Globally disable \"atlantis apply\" command",
+		description:  "Disable all \"atlantis apply\" command regardless of which flags are passed with it.",
 		defaultValue: false,
 	},
 	DisableAutoplanFlag: {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -53,6 +53,7 @@ const (
 	DataDirFlag                = "data-dir"
 	DefaultTFVersionFlag       = "default-tf-version"
 	DisableApplyAllFlag        = "disable-apply-all"
+	DisableApplyFlag           = "disable-apply"
 	DisableAutoplanFlag        = "disable-autoplan"
 	DisableMarkdownFoldingFlag = "disable-markdown-folding"
 	GHHostnameFlag             = "gh-hostname"
@@ -276,6 +277,10 @@ var boolFlags = map[string]boolFlag{
 	},
 	DisableApplyAllFlag: {
 		description:  "Disable \"atlantis apply\" command so a specific project/workspace/directory has to be specified for applies.",
+		defaultValue: false,
+	},
+	DisableApplyFlag: {
+		description:  "Globally disable \"atlantis apply\" command",
 		defaultValue: false,
 	},
 	DisableAutoplanFlag: {

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -65,7 +65,7 @@ var testFlags = map[string]interface{}{
 	DataDirFlag:                "/path",
 	DefaultTFVersionFlag:       "v0.11.0",
 	DisableApplyAllFlag:        true,
-	DisableApplyFlag:           false,
+	DisableApplyFlag:           true,
 	DisableMarkdownFoldingFlag: true,
 	GHHostnameFlag:             "ghhostname",
 	GHTokenFlag:                "token",

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -65,6 +65,7 @@ var testFlags = map[string]interface{}{
 	DataDirFlag:                "/path",
 	DefaultTFVersionFlag:       "v0.11.0",
 	DisableApplyAllFlag:        true,
+	DisableApplyFlag:           false,
 	DisableMarkdownFoldingFlag: true,
 	GHHostnameFlag:             "ghhostname",
 	GHTokenFlag:                "token",

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -159,6 +159,7 @@ Values are chosen in this order:
   Bitbucket username of API user.
 
 * ### `--bitbucket-webhook-secret`
+* ### `--bitbucket-webhook-secret`
   ```bash
   atlantis server --bitbucket-webhook-secret="secret"
   # or (recommended)
@@ -201,6 +202,12 @@ Values are chosen in this order:
   Terraform version to default to. Will download to `<data-dir>/bin/terraform<version>`
   if not in `PATH`. See [Terraform Versions](terraform-versions.html) for more details.
 
+* ### `--disable-apply`
+  ```bash
+  atlantis server --disable-apply
+  ```
+  Disable all \"atlantis apply\" commands, regardless of which flags are passed with it.
+  
 * ### `--disable-apply-all`
   ```bash
   atlantis server --disable-apply-all

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -159,7 +159,6 @@ Values are chosen in this order:
   Bitbucket username of API user.
 
 * ### `--bitbucket-webhook-secret`
-* ### `--bitbucket-webhook-secret`
   ```bash
   atlantis server --bitbucket-webhook-secret="secret"
   # or (recommended)

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -199,6 +199,16 @@ func TestRunCommentCommand_DisableApplyAllDisabled(t *testing.T) {
 	vcsClient.VerifyWasCalledOnce().CreateComment(fixtures.GithubRepo, modelPull.Num, "**Error:** Running `atlantis apply` without flags is disabled. You must specify which project to apply via the `-d <dir>`, `-w <workspace>` or `-p <project name>` flags.", "apply")
 }
 
+func TestRunCommentCommand_ApplyDisabled(t *testing.T) {
+	t.Log("if \"atlantis apply\" is run and this is disabled globally atlantis should" +
+		" comment saying that this is not allowed")
+	vcsClient := setup(t)
+	ch.DisableApply = true
+	modelPull := models.PullRequest{State: models.OpenPullState}
+	ch.RunCommentCommand(fixtures.GithubRepo, nil, nil, fixtures.User, modelPull.Num, &events.CommentCommand{Name: models.ApplyCommand})
+	vcsClient.VerifyWasCalledOnce().CreateComment(fixtures.GithubRepo, modelPull.Num, "**Error:** Running `atlantis apply` is disabled.", "apply")
+}
+
 func TestRunCommentCommand_DisableDisableAutoplan(t *testing.T) {
 	t.Log("if \"DisableAutoplan is true\" are disabled and we are silencing return and do not comment with error")
 	setup(t)

--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -16,19 +16,16 @@ package events
 import (
 	"bytes"
 	"fmt"
+	"github.com/flynn-archive/go-shlex"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/events/yaml"
+	"github.com/spf13/pflag"
 	"io/ioutil"
 	"net/url"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"text/template"
-
-	"github.com/Masterminds/sprig"
-
-	"github.com/flynn-archive/go-shlex"
-	"github.com/runatlantis/atlantis/server/events/models"
-	"github.com/runatlantis/atlantis/server/events/yaml"
-	"github.com/spf13/pflag"
 )
 
 const (
@@ -337,7 +334,7 @@ func (e *CommentParser) errMarkdown(errMsg string, command string, flagSet *pfla
 
 func (e *CommentParser) HelpComment(applyDisabled bool) string {
 	buf := &bytes.Buffer{}
-	var tmpl = template.Must(template.New("").Funcs(sprig.TxtFuncMap()).Parse(helpCommentTemplate))
+	var tmpl = template.Must(template.New("").Parse(helpCommentTemplate))
 	if err := tmpl.Execute(buf, struct {
 		ApplyDisabled bool
 	}{
@@ -358,20 +355,24 @@ Usage:
 
 Examples:
   # run plan in the root directory passing the -target flag to terraform
-  atlantis plan -d . -- -target=resource{{if not .ApplyDisabled}}
+  atlantis plan -d . -- -target=resource
+  {{- if not .ApplyDisabled }}
 
   # apply all unapplied plans from this pull request
   atlantis apply
 
   # apply the plan for the root directory and staging workspace
-  atlantis apply -d . -w staging{{end}}
+  atlantis apply -d . -w staging
+{{- end }}
 
 Commands:
   plan     Runs 'terraform plan' for the changes in this pull request.
            To plan a specific project, use the -d, -w and -p flags.
-{{if not .ApplyDisabled}}  apply    Runs 'terraform apply' on all unapplied plans from this pull request.
+{{- if not .ApplyDisabled }}
+  apply    Runs 'terraform apply' on all unapplied plans from this pull request.
            To only apply a specific plan, use the -d, -w and -p flags.
-{{end}}  unlock   Removes all atlantis locks and discards all plans for this PR.
+{{- end }}
+  unlock   Removes all atlantis locks and discards all plans for this PR.
            To unlock a specific plan you can use the Atlantis UI.
   help     View help.
 

--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -16,13 +16,14 @@ package events
 import (
 	"bytes"
 	"fmt"
-	"github.com/Masterminds/sprig"
 	"io/ioutil"
 	"net/url"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"text/template"
+
+	"github.com/Masterminds/sprig"
 
 	"github.com/flynn-archive/go-shlex"
 	"github.com/runatlantis/atlantis/server/events/models"
@@ -337,7 +338,7 @@ func (e *CommentParser) errMarkdown(errMsg string, command string, flagSet *pfla
 func (e *CommentParser) HelpComment(applyDisabled bool) string {
 	buf := &bytes.Buffer{}
 	var tmpl = template.Must(template.New("").Funcs(sprig.TxtFuncMap()).Parse(helpCommentTemplate))
-	if err := tmpl.Execute(buf,struct {
+	if err := tmpl.Execute(buf, struct {
 		ApplyDisabled bool
 	}{
 		ApplyDisabled: applyDisabled,

--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -799,38 +799,3 @@ var UnlockUsage = "`Usage of unlock:`\n\n ```cmake\n" +
   Arguments or flags are not supported at the moment.
   If you need to unlock a specific project please use the atlantis UI.` +
 	"\n```"
-
-func TestCommentParser_helpComment(t *testing.T) {
-	type fields struct {
-		GithubUser      string
-		GitlabUser      string
-		BitbucketUser   string
-		AzureDevopsUser string
-		ApplyDisabled   bool
-	}
-	type args struct {
-		applyDisabled bool
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   string
-	}{
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			e := &events.CommentParser{
-				GithubUser:      tt.fields.GithubUser,
-				GitlabUser:      tt.fields.GitlabUser,
-				BitbucketUser:   tt.fields.BitbucketUser,
-				AzureDevopsUser: tt.fields.AzureDevopsUser,
-				ApplyDisabled:   tt.fields.ApplyDisabled,
-			}
-			if got := e.HelpComment(tt.args.applyDisabled); got != tt.want {
-				t.Errorf("helpComment() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}

--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -658,13 +658,13 @@ func TestBuildPlanApplyComment(t *testing.T) {
 	}
 }
 
-func TestCommentParser_HelpComment(t *testing.T){
+func TestCommentParser_HelpComment(t *testing.T) {
 	cases := []struct {
-		applyDisabled  bool
-		expectResult         string
+		applyDisabled bool
+		expectResult  string
 	}{
 		{
-			applyDisabled:  false,
+			applyDisabled: false,
 			expectResult: "```cmake\n" +
 				`atlantis
 Terraform Pull Request Automation
@@ -698,7 +698,7 @@ Use "atlantis [command] --help" for more information about a command.` +
 				"\n```",
 		},
 		{
-			applyDisabled:  true,
+			applyDisabled: true,
 			expectResult: "```cmake\n" +
 				`atlantis
 Terraform Pull Request Automation

--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -38,6 +38,7 @@ type MarkdownRenderer struct {
 	// If we're not configured with a GitLab client, this will be false.
 	GitlabSupportsCommonMark bool
 	DisableApplyAll          bool
+	DisableApply             bool
 	DisableMarkdownFolding   bool
 }
 
@@ -48,6 +49,7 @@ type commonData struct {
 	Log             string
 	PlansDeleted    bool
 	DisableApplyAll bool
+	DisableApply    bool
 }
 
 // errData is data about an error response.
@@ -71,6 +73,7 @@ type resultData struct {
 type planSuccessData struct {
 	models.PlanSuccess
 	PlanWasDeleted bool
+	DisableApply   bool
 }
 
 type projectResultTmplData struct {
@@ -89,7 +92,8 @@ func (m *MarkdownRenderer) Render(res CommandResult, cmdName models.CommandName,
 		Verbose:         verbose,
 		Log:             log,
 		PlansDeleted:    res.PlansDeleted,
-		DisableApplyAll: m.DisableApplyAll,
+		DisableApplyAll: m.DisableApplyAll || m.DisableApply,
+		DisableApply:    m.DisableApply,
 	}
 	if res.Error != nil {
 		return m.renderTemplate(unwrappedErrWithLogTmpl, errData{res.Error.Error(), common})
@@ -132,9 +136,9 @@ func (m *MarkdownRenderer) renderProjectResults(results []models.ProjectResult, 
 			})
 		} else if result.PlanSuccess != nil {
 			if m.shouldUseWrappedTmpl(vcsHost, result.PlanSuccess.TerraformOutput) {
-				resultData.Rendered = m.renderTemplate(planSuccessWrappedTmpl, planSuccessData{PlanSuccess: *result.PlanSuccess, PlanWasDeleted: common.PlansDeleted})
+				resultData.Rendered = m.renderTemplate(planSuccessWrappedTmpl, planSuccessData{PlanSuccess: *result.PlanSuccess, PlanWasDeleted: common.PlansDeleted, DisableApply: common.DisableApply})
 			} else {
-				resultData.Rendered = m.renderTemplate(planSuccessUnwrappedTmpl, planSuccessData{PlanSuccess: *result.PlanSuccess, PlanWasDeleted: common.PlansDeleted})
+				resultData.Rendered = m.renderTemplate(planSuccessUnwrappedTmpl, planSuccessData{PlanSuccess: *result.PlanSuccess, PlanWasDeleted: common.PlansDeleted, DisableApply: common.DisableApply})
 			}
 			numPlanSuccesses++
 		} else if result.ApplySuccess != "" {
@@ -251,8 +255,9 @@ var planSuccessWrappedTmpl = template.Must(template.New("").Parse(
 
 // planNextSteps are instructions appended after successful plans as to what
 // to do next.
-var planNextSteps = "{{ if .PlanWasDeleted }}This plan was not saved because one or more projects failed and automerge requires all plans pass.{{ else }}* :arrow_forward: To **apply** this plan, comment:\n" +
-	"    * `{{.ApplyCmd}}`\n" +
+var planNextSteps = "{{ if .PlanWasDeleted }}This plan was not saved because one or more projects failed and automerge requires all plans pass.{{ else }}" +
+	"{{if ne .DisableApply true }}* :arrow_forward: To **apply** this plan, comment:\n" +
+	"    * `{{.ApplyCmd}}`\n{{end}}" +
 	"* :put_litter_in_its_place: To **delete** this plan click [here]({{.LockURL}})\n" +
 	"* :repeat: To **plan** this project again, comment:\n" +
 	"    * `{{.RePlanCmd}}`{{end}}"

--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -256,7 +256,7 @@ var planSuccessWrappedTmpl = template.Must(template.New("").Parse(
 // planNextSteps are instructions appended after successful plans as to what
 // to do next.
 var planNextSteps = "{{ if .PlanWasDeleted }}This plan was not saved because one or more projects failed and automerge requires all plans pass.{{ else }}" +
-	"{{if ne .DisableApply true }}* :arrow_forward: To **apply** this plan, comment:\n" +
+	"{{ if not .DisableApply }}* :arrow_forward: To **apply** this plan, comment:\n" +
 	"    * `{{.ApplyCmd}}`\n{{end}}" +
 	"* :put_litter_in_its_place: To **delete** this plan click [here]({{.LockURL}})\n" +
 	"* :repeat: To **plan** this project again, comment:\n" +

--- a/server/events/mocks/mock_comment_parsing.go
+++ b/server/events/mocks/mock_comment_parsing.go
@@ -26,7 +26,7 @@ func NewMockCommentParsing(options ...pegomock.Option) *MockCommentParsing {
 func (mock *MockCommentParsing) SetFailHandler(fh pegomock.FailHandler) { mock.fail = fh }
 func (mock *MockCommentParsing) FailHandler() pegomock.FailHandler      { return mock.fail }
 
-func (mock *MockCommentParsing) Parse(comment string, vcsHost models.VCSHostType) events.CommentParseResult {
+func (mock *MockCommentParsing) Parse(comment string, vcsHost models.VCSHostType, applyDisabled bool) events.CommentParseResult {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockCommentParsing().")
 	}

--- a/server/events/mocks/mock_comment_parsing.go
+++ b/server/events/mocks/mock_comment_parsing.go
@@ -26,7 +26,7 @@ func NewMockCommentParsing(options ...pegomock.Option) *MockCommentParsing {
 func (mock *MockCommentParsing) SetFailHandler(fh pegomock.FailHandler) { mock.fail = fh }
 func (mock *MockCommentParsing) FailHandler() pegomock.FailHandler      { return mock.fail }
 
-func (mock *MockCommentParsing) Parse(comment string, vcsHost models.VCSHostType, applyDisabled bool) events.CommentParseResult {
+func (mock *MockCommentParsing) Parse(comment string, vcsHost models.VCSHostType) events.CommentParseResult {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockCommentParsing().")
 	}

--- a/server/events_controller.go
+++ b/server/events_controller.go
@@ -404,7 +404,7 @@ func (e *EventsController) HandleGitlabCommentEvent(w http.ResponseWriter, event
 }
 
 func (e *EventsController) handleCommentEvent(w http.ResponseWriter, baseRepo models.Repo, maybeHeadRepo *models.Repo, maybePull *models.PullRequest, user models.User, pullNum int, comment string, vcsHost models.VCSHostType, applyDisabled bool) {
-	parseResult := e.CommentParser.Parse(comment, vcsHost, applyDisabled)
+	parseResult := e.CommentParser.Parse(comment, vcsHost)
 	if parseResult.Ignore {
 		truncated := comment
 		truncateLen := 40

--- a/server/events_controller.go
+++ b/server/events_controller.go
@@ -261,7 +261,7 @@ func (e *EventsController) HandleGithubCommentEvent(w http.ResponseWriter, event
 
 	// We pass in nil for maybeHeadRepo because the head repo data isn't
 	// available in the GithubIssueComment event.
-	e.handleCommentEvent(w, baseRepo, nil, nil, user, pullNum, event.Comment.GetBody(), models.Github, e.ApplyDisabled)
+	e.handleCommentEvent(w, baseRepo, nil, nil, user, pullNum, event.Comment.GetBody(), models.Github)
 }
 
 // HandleBitbucketCloudCommentEvent handles comment events from Bitbucket.
@@ -271,7 +271,7 @@ func (e *EventsController) HandleBitbucketCloudCommentEvent(w http.ResponseWrite
 		e.respond(w, logging.Error, http.StatusBadRequest, "Error parsing pull data: %s %s=%s", err, bitbucketCloudRequestIDHeader, reqID)
 		return
 	}
-	e.handleCommentEvent(w, baseRepo, &headRepo, &pull, user, pull.Num, comment, models.BitbucketCloud, e.ApplyDisabled)
+	e.handleCommentEvent(w, baseRepo, &headRepo, &pull, user, pull.Num, comment, models.BitbucketCloud)
 }
 
 // HandleBitbucketServerCommentEvent handles comment events from Bitbucket.
@@ -281,7 +281,7 @@ func (e *EventsController) HandleBitbucketServerCommentEvent(w http.ResponseWrit
 		e.respond(w, logging.Error, http.StatusBadRequest, "Error parsing pull data: %s %s=%s", err, bitbucketCloudRequestIDHeader, reqID)
 		return
 	}
-	e.handleCommentEvent(w, baseRepo, &headRepo, &pull, user, pull.Num, comment, models.BitbucketCloud, e.ApplyDisabled)
+	e.handleCommentEvent(w, baseRepo, &headRepo, &pull, user, pull.Num, comment, models.BitbucketCloud)
 }
 
 func (e *EventsController) handleBitbucketCloudPullRequestEvent(w http.ResponseWriter, eventType string, body []byte, reqID string) {
@@ -400,10 +400,10 @@ func (e *EventsController) HandleGitlabCommentEvent(w http.ResponseWriter, event
 		e.respond(w, logging.Error, http.StatusBadRequest, "Error parsing webhook: %s", err)
 		return
 	}
-	e.handleCommentEvent(w, baseRepo, &headRepo, nil, user, event.MergeRequest.IID, event.ObjectAttributes.Note, models.Gitlab, e.ApplyDisabled)
+	e.handleCommentEvent(w, baseRepo, &headRepo, nil, user, event.MergeRequest.IID, event.ObjectAttributes.Note, models.Gitlab)
 }
 
-func (e *EventsController) handleCommentEvent(w http.ResponseWriter, baseRepo models.Repo, maybeHeadRepo *models.Repo, maybePull *models.PullRequest, user models.User, pullNum int, comment string, vcsHost models.VCSHostType, applyDisabled bool) {
+func (e *EventsController) handleCommentEvent(w http.ResponseWriter, baseRepo models.Repo, maybeHeadRepo *models.Repo, maybePull *models.PullRequest, user models.User, pullNum int, comment string, vcsHost models.VCSHostType) {
 	parseResult := e.CommentParser.Parse(comment, vcsHost)
 	if parseResult.Ignore {
 		truncated := comment
@@ -491,7 +491,7 @@ func (e *EventsController) HandleAzureDevopsPullRequestCommentedEvent(w http.Res
 		e.respond(w, logging.Error, http.StatusBadRequest, "Error parsing pull request repository field: %s; %s", err, azuredevopsReqID)
 		return
 	}
-	e.handleCommentEvent(w, baseRepo, nil, nil, user, resource.PullRequest.GetPullRequestID(), string(strippedComment), models.AzureDevops, e.ApplyDisabled)
+	e.handleCommentEvent(w, baseRepo, nil, nil, user, resource.PullRequest.GetPullRequestID(), string(strippedComment), models.AzureDevops)
 }
 
 // HandleAzureDevopsPullRequestEvent will delete any locks associated with the pull

--- a/server/events_controller_test.go
+++ b/server/events_controller_test.go
@@ -162,7 +162,7 @@ func TestPost_GitlabCommentInvalidCommand(t *testing.T) {
 	req, _ := http.NewRequest("GET", "", bytes.NewBuffer(nil))
 	req.Header.Set(gitlabHeader, "value")
 	When(gl.ParseAndValidate(req, secret)).ThenReturn(gitlab.MergeCommentEvent{}, nil)
-	When(cp.Parse("", models.Gitlab)).ThenReturn(events.CommentParseResult{Ignore: true})
+	When(cp.Parse("", models.Gitlab, false)).ThenReturn(events.CommentParseResult{Ignore: true})
 	w := httptest.NewRecorder()
 	e.Post(w, req)
 	responseContains(t, w, http.StatusOK, "Ignoring non-command comment: \"\"")
@@ -176,7 +176,7 @@ func TestPost_GithubCommentInvalidCommand(t *testing.T) {
 	event := `{"action": "created"}`
 	When(v.Validate(req, secret)).ThenReturn([]byte(event), nil)
 	When(p.ParseGithubIssueCommentEvent(matchers.AnyPtrToGithubIssueCommentEvent())).ThenReturn(models.Repo{}, models.User{}, 1, nil)
-	When(cp.Parse("", models.Github)).ThenReturn(events.CommentParseResult{Ignore: true})
+	When(cp.Parse("", models.Github, false)).ThenReturn(events.CommentParseResult{Ignore: true})
 	w := httptest.NewRecorder()
 	e.Post(w, req)
 	responseContains(t, w, http.StatusOK, "Ignoring non-command comment: \"\"")
@@ -303,7 +303,7 @@ func TestPost_GitlabCommentResponse(t *testing.T) {
 	req, _ := http.NewRequest("GET", "", bytes.NewBuffer(nil))
 	req.Header.Set(gitlabHeader, "value")
 	When(gl.ParseAndValidate(req, secret)).ThenReturn(gitlab.MergeCommentEvent{}, nil)
-	When(cp.Parse("", models.Gitlab)).ThenReturn(events.CommentParseResult{CommentResponse: "a comment"})
+	When(cp.Parse("", models.Gitlab, false)).ThenReturn(events.CommentParseResult{CommentResponse: "a comment"})
 	w := httptest.NewRecorder()
 	e.Post(w, req)
 	vcsClient.VerifyWasCalledOnce().CreateComment(models.Repo{}, 0, "a comment", "")
@@ -320,7 +320,7 @@ func TestPost_GithubCommentResponse(t *testing.T) {
 	baseRepo := models.Repo{}
 	user := models.User{}
 	When(p.ParseGithubIssueCommentEvent(matchers.AnyPtrToGithubIssueCommentEvent())).ThenReturn(baseRepo, user, 1, nil)
-	When(cp.Parse("", models.Github)).ThenReturn(events.CommentParseResult{CommentResponse: "a comment"})
+	When(cp.Parse("", models.Github, false)).ThenReturn(events.CommentParseResult{CommentResponse: "a comment"})
 	w := httptest.NewRecorder()
 
 	e.Post(w, req)
@@ -352,7 +352,7 @@ func TestPost_GithubCommentSuccess(t *testing.T) {
 	user := models.User{}
 	cmd := events.CommentCommand{}
 	When(p.ParseGithubIssueCommentEvent(matchers.AnyPtrToGithubIssueCommentEvent())).ThenReturn(baseRepo, user, 1, nil)
-	When(cp.Parse("", models.Github)).ThenReturn(events.CommentParseResult{Command: &cmd})
+	When(cp.Parse("", models.Github, false)).ThenReturn(events.CommentParseResult{Command: &cmd})
 	w := httptest.NewRecorder()
 	e.Post(w, req)
 	responseContains(t, w, http.StatusOK, "Processing...")
@@ -472,6 +472,7 @@ func TestPost_AzureDevopsPullRequestIgnoreEvent(t *testing.T) {
 	e := server.EventsController{
 		TestingMode:                     true,
 		Logger:                          logging.NewNoopLogger(),
+		ApplyDisabled:                   false,
 		AzureDevopsWebhookBasicUser:     user,
 		AzureDevopsWebhookBasicPassword: secret,
 		AzureDevopsRequestValidator:     v,

--- a/server/events_controller_test.go
+++ b/server/events_controller_test.go
@@ -162,7 +162,7 @@ func TestPost_GitlabCommentInvalidCommand(t *testing.T) {
 	req, _ := http.NewRequest("GET", "", bytes.NewBuffer(nil))
 	req.Header.Set(gitlabHeader, "value")
 	When(gl.ParseAndValidate(req, secret)).ThenReturn(gitlab.MergeCommentEvent{}, nil)
-	When(cp.Parse("", models.Gitlab, false)).ThenReturn(events.CommentParseResult{Ignore: true})
+	When(cp.Parse("", models.Gitlab)).ThenReturn(events.CommentParseResult{Ignore: true})
 	w := httptest.NewRecorder()
 	e.Post(w, req)
 	responseContains(t, w, http.StatusOK, "Ignoring non-command comment: \"\"")
@@ -176,7 +176,7 @@ func TestPost_GithubCommentInvalidCommand(t *testing.T) {
 	event := `{"action": "created"}`
 	When(v.Validate(req, secret)).ThenReturn([]byte(event), nil)
 	When(p.ParseGithubIssueCommentEvent(matchers.AnyPtrToGithubIssueCommentEvent())).ThenReturn(models.Repo{}, models.User{}, 1, nil)
-	When(cp.Parse("", models.Github, false)).ThenReturn(events.CommentParseResult{Ignore: true})
+	When(cp.Parse("", models.Github)).ThenReturn(events.CommentParseResult{Ignore: true})
 	w := httptest.NewRecorder()
 	e.Post(w, req)
 	responseContains(t, w, http.StatusOK, "Ignoring non-command comment: \"\"")
@@ -303,7 +303,7 @@ func TestPost_GitlabCommentResponse(t *testing.T) {
 	req, _ := http.NewRequest("GET", "", bytes.NewBuffer(nil))
 	req.Header.Set(gitlabHeader, "value")
 	When(gl.ParseAndValidate(req, secret)).ThenReturn(gitlab.MergeCommentEvent{}, nil)
-	When(cp.Parse("", models.Gitlab, false)).ThenReturn(events.CommentParseResult{CommentResponse: "a comment"})
+	When(cp.Parse("", models.Gitlab)).ThenReturn(events.CommentParseResult{CommentResponse: "a comment"})
 	w := httptest.NewRecorder()
 	e.Post(w, req)
 	vcsClient.VerifyWasCalledOnce().CreateComment(models.Repo{}, 0, "a comment", "")
@@ -320,7 +320,7 @@ func TestPost_GithubCommentResponse(t *testing.T) {
 	baseRepo := models.Repo{}
 	user := models.User{}
 	When(p.ParseGithubIssueCommentEvent(matchers.AnyPtrToGithubIssueCommentEvent())).ThenReturn(baseRepo, user, 1, nil)
-	When(cp.Parse("", models.Github, false)).ThenReturn(events.CommentParseResult{CommentResponse: "a comment"})
+	When(cp.Parse("", models.Github)).ThenReturn(events.CommentParseResult{CommentResponse: "a comment"})
 	w := httptest.NewRecorder()
 
 	e.Post(w, req)
@@ -352,7 +352,7 @@ func TestPost_GithubCommentSuccess(t *testing.T) {
 	user := models.User{}
 	cmd := events.CommentCommand{}
 	When(p.ParseGithubIssueCommentEvent(matchers.AnyPtrToGithubIssueCommentEvent())).ThenReturn(baseRepo, user, 1, nil)
-	When(cp.Parse("", models.Github, false)).ThenReturn(events.CommentParseResult{Command: &cmd})
+	When(cp.Parse("", models.Github)).ThenReturn(events.CommentParseResult{Command: &cmd})
 	w := httptest.NewRecorder()
 	e.Post(w, req)
 	responseContains(t, w, http.StatusOK, "Processing...")

--- a/server/server.go
+++ b/server/server.go
@@ -252,6 +252,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		GitlabSupportsCommonMark: gitlabClient.SupportsCommonMark(),
 		DisableApplyAll:          userConfig.DisableApplyAll,
 		DisableMarkdownFolding:   userConfig.DisableMarkdownFolding,
+		DisableApply:             userConfig.DisableApply,
 	}
 
 	boltdb, err := db.New(userConfig.DataDir)
@@ -369,6 +370,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		SilenceForkPRErrorsFlag:  config.SilenceForkPRErrorsFlag,
 		SilenceVCSStatusNoPlans:  userConfig.SilenceVCSStatusNoPlans,
 		DisableApplyAll:          userConfig.DisableApplyAll,
+		DisableApply:             userConfig.DisableApply,
 		DisableAutoplan:          userConfig.DisableAutoplan,
 		ParallelPoolSize:         userConfig.ParallelPoolSize,
 		ProjectCommandBuilder: &events.DefaultProjectCommandBuilder{
@@ -438,6 +440,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		Parser:                          eventParser,
 		CommentParser:                   commentParser,
 		Logger:                          logger,
+		ApplyDisabled:                   userConfig.DisableApply,
 		GithubWebhookSecret:             []byte(userConfig.GithubWebhookSecret),
 		GithubRequestValidator:          &DefaultGithubRequestValidator{},
 		GitlabRequestParserValidator:    &DefaultGitlabRequestParserValidator{},

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -23,6 +23,7 @@ type UserConfig struct {
 	CheckoutStrategy           string `mapstructure:"checkout-strategy"`
 	DataDir                    string `mapstructure:"data-dir"`
 	DisableApplyAll            bool   `mapstructure:"disable-apply-all"`
+	DisableApply               bool   `mapstructure:"disable-apply"`
 	DisableAutoplan            bool   `mapstructure:"disable-autoplan"`
 	DisableMarkdownFolding     bool   `mapstructure:"disable-markdown-folding"`
 	GithubHostname             string `mapstructure:"gh-hostname"`


### PR DESCRIPTION
Implement a new server flag that will disable the ability to run `atlantis apply`, as suggested in #1219