### PR TITLE
Include plan change summary for successful plans that use the "wrapped" template

### DIFF
--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -241,7 +241,7 @@ var planSuccessUnwrappedTmpl = template.Must(template.New("").Parse(
 		"{{ if .HasDiverged }}\n\n:warning: The branch we're merging into is ahead, it is recommended to pull new commits first.{{end}}"))
 
 var planSuccessWrappedTmpl = template.Must(template.New("").Parse(
-	"<details><summary>Show Output</summary>\n\n" +
+	"Change Summary: `{{.ChangeSummary}}`\n<details><summary>Show Output</summary>\n\n" +
 		"```diff\n" +
 		"{{.TerraformOutput}}\n" +
 		"```\n\n" +

--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -135,6 +135,7 @@ func TestRenderProjectResults(t *testing.T) {
 				{
 					PlanSuccess: &models.PlanSuccess{
 						TerraformOutput: "terraform-output",
+						ChangeSummary:   "Plan: 1 to add, 2 to change, 3 to destroy.",
 						LockURL:         "lock-url",
 						RePlanCmd:       "atlantis plan -d path -w workspace",
 						ApplyCmd:        "atlantis apply -d path -w workspace",
@@ -170,6 +171,7 @@ $$$
 				{
 					PlanSuccess: &models.PlanSuccess{
 						TerraformOutput: "terraform-output",
+						ChangeSummary:   "Plan: 1 to add, 2 to change, 3 to destroy.",
 						LockURL:         "lock-url",
 						RePlanCmd:       "atlantis plan -d path -w workspace",
 						ApplyCmd:        "atlantis apply -d path -w workspace",
@@ -208,6 +210,7 @@ $$$
 				{
 					PlanSuccess: &models.PlanSuccess{
 						TerraformOutput: "terraform-output",
+						ChangeSummary:   "Plan: 1 to add, 2 to change, 3 to destroy.",
 						LockURL:         "lock-url",
 						RePlanCmd:       "atlantis plan -d path -w workspace",
 						ApplyCmd:        "atlantis apply -d path -w workspace",
@@ -285,6 +288,7 @@ $$$
 					RepoRelDir: "path",
 					PlanSuccess: &models.PlanSuccess{
 						TerraformOutput: "terraform-output",
+						ChangeSummary:   "Plan: 1 to add, 2 to change, 3 to destroy.",
 						LockURL:         "lock-url",
 						ApplyCmd:        "atlantis apply -d path -w workspace",
 						RePlanCmd:       "atlantis plan -d path -w workspace",
@@ -295,6 +299,7 @@ $$$
 					RepoRelDir:  "path2",
 					ProjectName: "projectname",
 					PlanSuccess: &models.PlanSuccess{
+						ChangeSummary:   "Plan: 1 to add, 2 to change, 3 to destroy.",
 						TerraformOutput: "terraform-output2",
 						LockURL:         "lock-url2",
 						ApplyCmd:        "atlantis apply -d path2 -w workspace",
@@ -421,6 +426,7 @@ $$$
 					RepoRelDir: "path",
 					PlanSuccess: &models.PlanSuccess{
 						TerraformOutput: "terraform-output",
+						ChangeSummary:   "Plan: 1 to add, 2 to change, 3 to destroy.",
 						LockURL:         "lock-url",
 						ApplyCmd:        "atlantis apply -d path -w workspace",
 						RePlanCmd:       "atlantis plan -d path -w workspace",
@@ -607,6 +613,7 @@ func TestRenderProjectResultsDisableApplyAll(t *testing.T) {
 				{
 					PlanSuccess: &models.PlanSuccess{
 						TerraformOutput: "terraform-output",
+						ChangeSummary:   "Plan: 1 to add, 2 to change, 3 to destroy.",
 						LockURL:         "lock-url",
 						RePlanCmd:       "atlantis plan -d path -w workspace",
 						ApplyCmd:        "atlantis apply -d path -w workspace",
@@ -638,6 +645,7 @@ $$$
 				{
 					PlanSuccess: &models.PlanSuccess{
 						TerraformOutput: "terraform-output",
+						ChangeSummary:   "Plan: 1 to add, 2 to change, 3 to destroy.",
 						LockURL:         "lock-url",
 						RePlanCmd:       "atlantis plan -d path -w workspace",
 						ApplyCmd:        "atlantis apply -d path -w workspace",
@@ -672,6 +680,7 @@ $$$
 					RepoRelDir: "path",
 					PlanSuccess: &models.PlanSuccess{
 						TerraformOutput: "terraform-output",
+						ChangeSummary:   "Plan: 1 to add, 2 to change, 3 to destroy.",
 						LockURL:         "lock-url",
 						ApplyCmd:        "atlantis apply -d path -w workspace",
 						RePlanCmd:       "atlantis plan -d path -w workspace",
@@ -683,6 +692,7 @@ $$$
 					ProjectName: "projectname",
 					PlanSuccess: &models.PlanSuccess{
 						TerraformOutput: "terraform-output2",
+						ChangeSummary:   "Plan: 1 to add, 2 to change, 3 to destroy.",
 						LockURL:         "lock-url2",
 						ApplyCmd:        "atlantis apply -d path2 -w workspace",
 						RePlanCmd:       "atlantis plan -d path2 -w workspace",
@@ -953,6 +963,7 @@ func TestRenderProjectResults_WrapSingleProject(t *testing.T) {
 							Workspace:  "default",
 							PlanSuccess: &models.PlanSuccess{
 								TerraformOutput: c.Output,
+								ChangeSummary: "Plan: 1 to add, 2 to change, 3 to destroy.",
 								LockURL:         "lock-url",
 								RePlanCmd:       "replancmd",
 								ApplyCmd:        "applycmd",
@@ -976,6 +987,7 @@ func TestRenderProjectResults_WrapSingleProject(t *testing.T) {
 						if c.ShouldWrap {
 							exp = `Ran Plan for dir: $.$ workspace: $default$
 
+` + "Change Summary: `Plan: 1 to add, 2 to change, 3 to destroy.`" + `
 <details><summary>Show Output</summary>
 
 $$$diff
@@ -1101,6 +1113,7 @@ func TestRenderProjectResults_MultiProjectPlanWrapped(t *testing.T) {
 				Workspace:  "staging",
 				PlanSuccess: &models.PlanSuccess{
 					TerraformOutput: tfOut,
+					ChangeSummary:   "Plan: 1 to add, 2 to change, 3 to destroy.",
 					LockURL:         "staging-lock-url",
 					ApplyCmd:        "staging-apply-cmd",
 					RePlanCmd:       "staging-replan-cmd",
@@ -1111,6 +1124,7 @@ func TestRenderProjectResults_MultiProjectPlanWrapped(t *testing.T) {
 				Workspace:  "production",
 				PlanSuccess: &models.PlanSuccess{
 					TerraformOutput: tfOut,
+					ChangeSummary:   "Plan: 1 to add, 2 to change, 3 to destroy.",
 					LockURL:         "production-lock-url",
 					ApplyCmd:        "production-apply-cmd",
 					RePlanCmd:       "production-replan-cmd",
@@ -1124,6 +1138,7 @@ func TestRenderProjectResults_MultiProjectPlanWrapped(t *testing.T) {
 1. dir: $.$ workspace: $production$
 
 ### 1. dir: $.$ workspace: $staging$
+` + "Change Summary: `Plan: 1 to add, 2 to change, 3 to destroy.`" + `
 <details><summary>Show Output</summary>
 
 $$$diff
@@ -1139,6 +1154,7 @@ $$$
 
 ---
 ### 2. dir: $.$ workspace: $production$
+` + "Change Summary: `Plan: 1 to add, 2 to change, 3 to destroy.`" + `
 <details><summary>Show Output</summary>
 
 $$$diff
@@ -1231,6 +1247,7 @@ func TestRenderProjectResults_PlansDeleted(t *testing.T) {
 						Workspace:  "production",
 						PlanSuccess: &models.PlanSuccess{
 							TerraformOutput: "tf out",
+							ChangeSummary:   "Plan: 1 to add, 2 to change, 3 to destroy.",
 							LockURL:         "lock-url",
 							RePlanCmd:       "re-plan cmd",
 							ApplyCmd:        "apply cmd",

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -430,6 +430,9 @@ func (p ProjectResult) IsSuccessful() bool {
 type PlanSuccess struct {
 	// TerraformOutput is the output from Terraform of running plan.
 	TerraformOutput string
+	// The last line of a successful terraform plan output that summarizes the changes
+	// e.g. Plan: 0 to add, 1 to change, 0 to destroy.
+	ChangeSummary string
 	// LockURL is the full URL to the lock held by this plan.
 	LockURL string
 	// RePlanCmd is the command that users should run to re-plan this project.

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -174,6 +174,7 @@ func (p *DefaultProjectCommandRunner) doPlan(ctx models.ProjectCommandContext) (
 	return &models.PlanSuccess{
 		LockURL:         p.LockURLGenerator.GenerateLockURL(lockAttempt.LockKey),
 		TerraformOutput: strings.Join(outputs, "\n"),
+		ChangeSummary:   outputs[len(outputs)-2],
 		RePlanCmd:       ctx.RePlanCmd,
 		ApplyCmd:        ctx.ApplyCmd,
 		HasDiverged:     hasDiverged,

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -171,10 +172,19 @@ func (p *DefaultProjectCommandRunner) doPlan(ctx models.ProjectCommandContext) (
 		return nil, "", fmt.Errorf("%s\n%s", err, strings.Join(outputs, "\n"))
 	}
 
+	var summary string
+	for _, line := range outputs {
+		matched, _ := regexp.MatchString("(^Plan:|^No changes\\.).*", line)
+		if matched {
+			summary = line
+			break
+		}
+	}
+
 	return &models.PlanSuccess{
 		LockURL:         p.LockURLGenerator.GenerateLockURL(lockAttempt.LockKey),
 		TerraformOutput: strings.Join(outputs, "\n"),
-		ChangeSummary:   outputs[len(outputs)-2],
+		ChangeSummary:   summary,
 		RePlanCmd:       ctx.RePlanCmd,
 		ApplyCmd:        ctx.ApplyCmd,
 		HasDiverged:     hasDiverged,


### PR DESCRIPTION
Fixes #1223 

Unit tests passed. I did not have things set up to run all end-to-end tests with an actual atlantis and github and terraform, but I expect the output to look like:

### 1. project: `the_project` dir: `projects/the_project` workspace: `default`
Change Summary: `Plan: 1 to add, 2 to change, 3 to destroy.`
<details><summary>Show Output</summary></details>

Edit: Looks like there are some integration tests that need to be updated