### PR TITLE
Set ApplyDisabled on CommentParser to fix atlantis help output with --apply-disabled set

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -341,6 +341,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		GitlabUser:      userConfig.GitlabUser,
 		BitbucketUser:   userConfig.BitbucketUser,
 		AzureDevopsUser: userConfig.AzureDevopsUser,
+		ApplyDisabled:   userConfig.DisableApply,
 	}
 	defaultTfVersion := terraformClient.DefaultVersion()
 	pendingPlanFinder := &events.DefaultPendingPlanFinder{}


### PR DESCRIPTION
Hi

I realised this weekend while working with the disable apply changes that the `atlantis help` output was not working I have tracked it down to me not passing the property to the CommentParser this PR fixes it