### PR TITLE
Use regex to filter filenames

### DIFF
--- a/server/events/project_finder.go
+++ b/server/events/project_finder.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/runatlantis/atlantis/server/events/yaml/valid"
@@ -147,11 +148,14 @@ func (p *DefaultProjectFinder) DetermineProjectsViaConfig(log *logging.SimpleLog
 // filterToTerraform filters non-terraform files from files.
 func (p *DefaultProjectFinder) filterToTerraform(files []string) []string {
 	var filtered []string
+	fileNameRe, _ := regexp.Compile(`^.*(\.tf|\.tfvars)$`)
+
 	for _, fileName := range files {
-		if !p.shouldIgnore(fileName) && (strings.Contains(fileName, ".tf") || filepath.Base(fileName) == "terragrunt.hcl") {
+		if !p.shouldIgnore(fileName) && (fileNameRe.MatchString(fileName) || filepath.Base(fileName) == "terragrunt.hcl") {
 			filtered = append(filtered, fileName)
 		}
 	}
+
 	return filtered
 }
 

--- a/server/events/project_finder_test.go
+++ b/server/events/project_finder_test.go
@@ -120,7 +120,7 @@ func TestDetermineProjects(t *testing.T) {
 		},
 		{
 			"Should ignore non .tf files and return an empty list",
-			[]string{"non-tf"},
+			[]string{"non-tf", "non.tf.suffix"},
 			nil,
 			nestedModules1,
 		},


### PR DESCRIPTION
I ran into an issue where I have a directory of templates I use that I name `foo.tf.template`. I found that Atlantis was running against this directory and failing, which was unexpected behaviour.

This is because we're just checking if `.tf` is contained within a filename, rather than checking if it's the suffix of the filename.

Instead, we can use regex to ensure that we're only filtering on actual Terraform files, inclusive of `.tf` and `.tfvars` suffixes.

There are obviously some alternative ways I could get around this: rename my templates to `foo.template` without the `.tf`.

I also really liked the idea of a `.atlantisignore` file previously cited[1], but it was rejected in favour of explicitly defining exactly
which directories to run it in. We have a large number of directories so this wasn't appealing to me.

I felt this behaviour was sufficiently unexpected that it was worth making a more explicit filter.

[1] https://github.com/runatlantis/atlantis/issues/26