### PR TITLE
Add the option to automatically unlock a repo after a plan has been run

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -54,6 +54,7 @@ const (
 	DefaultTFVersionFlag       = "default-tf-version"
 	DisableApplyAllFlag        = "disable-apply-all"
 	DisableApplyFlag           = "disable-apply"
+	UnlockAfterPlanFlag        = "unlock-after-plan"
 	DisableAutoplanFlag        = "disable-autoplan"
 	DisableMarkdownFoldingFlag = "disable-markdown-folding"
 	GHHostnameFlag             = "gh-hostname"
@@ -285,6 +286,10 @@ var boolFlags = map[string]boolFlag{
 	},
 	DisableApplyFlag: {
 		description:  "Disable all \"atlantis apply\" command regardless of which flags are passed with it.",
+		defaultValue: false,
+	},
+	UnlockAfterPlanFlag: {
+		description:  "Unlock the repo and discard plans after running a plan",
 		defaultValue: false,
 	},
 	DisableAutoplanFlag: {

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -66,6 +66,7 @@ var testFlags = map[string]interface{}{
 	DefaultTFVersionFlag:       "v0.11.0",
 	DisableApplyAllFlag:        true,
 	DisableApplyFlag:           true,
+	UnlockAfterPlanFlag:        true,
 	DisableMarkdownFoldingFlag: true,
 	GHHostnameFlag:             "ghhostname",
 	GHTokenFlag:                "token",

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -218,7 +218,7 @@ Values are chosen in this order:
   ```bash
   atlantis server --unlock-after-plan
   ```
-  Removes all logs on a given repo after a plan has been run.
+  Removes all locks on a given repo after a plan has been run.
 
 * ### `--disable-autoplan`
   ```bash

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -214,6 +214,12 @@ Values are chosen in this order:
   Disable \"atlantis apply\" command so a specific project/workspace/directory has to
   be specified for applies.
 
+* ### `--unlock-after-plan`
+  ```bash
+  atlantis server --unlock-after-plan
+  ```
+  Removes all logs on a given repo after a plan has been run.
+
 * ### `--disable-autoplan`
   ```bash
   atlantis server --disable-autoplan

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -77,6 +77,7 @@ type DefaultCommandRunner struct {
 	CommitStatusUpdater      CommitStatusUpdater
 	DisableApplyAll          bool
 	DisableApply             bool
+	UnlockAfterPlan          bool
 	DisableAutoplan          bool
 	EventParser              EventParsing
 	MarkdownRenderer         *MarkdownRenderer
@@ -347,6 +348,15 @@ func (c *DefaultCommandRunner) RunCommentCommand(baseRepo models.Repo, maybeHead
 	if cmd.Name == models.ApplyCommand && c.automergeEnabled(ctx, projectCmds) {
 		c.automerge(ctx, pullStatus)
 	}
+
+	if c.UnlockAfterPlan && cmd.Name == models.PlanCommand {
+		ctx.Log.Info("Unlocking project %v  as UnlockAfterPlan is set", baseRepo.FullName)
+		err := c.DeleteLockCommand.DeleteLocksByPull(baseRepo.FullName, pullNum)
+		if err != nil {
+			log.Err("failed to delete locks by pull %s", err.Error())
+		}
+	}
+
 }
 
 func (c *DefaultCommandRunner) updateCommitStatus(ctx *CommandContext, cmd models.CommandName, pullStatus models.PullStatus) {

--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -16,16 +16,17 @@ package events
 import (
 	"bytes"
 	"fmt"
-	"github.com/flynn-archive/go-shlex"
-	"github.com/runatlantis/atlantis/server/events/models"
-	"github.com/runatlantis/atlantis/server/events/yaml"
-	"github.com/spf13/pflag"
 	"io/ioutil"
 	"net/url"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"text/template"
+
+	"github.com/flynn-archive/go-shlex"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/events/yaml"
+	"github.com/spf13/pflag"
 )
 
 const (

--- a/server/events/matchers/models_pullrequest.go
+++ b/server/events/matchers/models_pullrequest.go
@@ -3,6 +3,7 @@ package matchers
 
 import (
 	"reflect"
+
 	"github.com/petergtz/pegomock"
 	models "github.com/runatlantis/atlantis/server/events/models"
 )

--- a/server/events/matchers/models_repo.go
+++ b/server/events/matchers/models_repo.go
@@ -3,6 +3,7 @@ package matchers
 
 import (
 	"reflect"
+
 	"github.com/petergtz/pegomock"
 	models "github.com/runatlantis/atlantis/server/events/models"
 )

--- a/server/events/matchers/ptr_to_logging_simplelogger.go
+++ b/server/events/matchers/ptr_to_logging_simplelogger.go
@@ -3,6 +3,7 @@ package matchers
 
 import (
 	"reflect"
+
 	"github.com/petergtz/pegomock"
 	logging "github.com/runatlantis/atlantis/server/logging"
 )

--- a/server/events/mock_workingdir_test.go
+++ b/server/events/mock_workingdir_test.go
@@ -4,11 +4,12 @@
 package events
 
 import (
+	"reflect"
+	"time"
+
 	pegomock "github.com/petergtz/pegomock"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	logging "github.com/runatlantis/atlantis/server/logging"
-	"reflect"
-	"time"
 )
 
 type MockWorkingDir struct {

--- a/server/server.go
+++ b/server/server.go
@@ -383,6 +383,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		SilenceVCSStatusNoPlans:  userConfig.SilenceVCSStatusNoPlans,
 		DisableApplyAll:          userConfig.DisableApplyAll,
 		DisableApply:             userConfig.DisableApply,
+		UnlockAfterPlan:          userConfig.UnlockAfterPlan,
 		DisableAutoplan:          userConfig.DisableAutoplan,
 		ParallelPoolSize:         userConfig.ParallelPoolSize,
 		ProjectCommandBuilder: &events.DefaultProjectCommandBuilder{

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -24,6 +24,7 @@ type UserConfig struct {
 	DataDir                    string `mapstructure:"data-dir"`
 	DisableApplyAll            bool   `mapstructure:"disable-apply-all"`
 	DisableApply               bool   `mapstructure:"disable-apply"`
+	UnlockAfterPlan            bool   `mapstructure:"unlock-after-plan"`
 	DisableAutoplan            bool   `mapstructure:"disable-autoplan"`
 	DisableMarkdownFolding     bool   `mapstructure:"disable-markdown-folding"`
 	GithubHostname             string `mapstructure:"gh-hostname"`


### PR DESCRIPTION
This new option is designed to be used when apply is disabled, there is no reason to  hold a lock/plan in this configuration