### PR TITLE
Fix >= 0.12.0 version detection for versions with prereleases

### DIFF
--- a/server/events/runtime/plan_step_runner.go
+++ b/server/events/runtime/plan_step_runner.go
@@ -192,7 +192,7 @@ func (p *PlanStepRunner) buildPlanCmd(ctx models.ProjectCommandContext, extraArg
 // actually used in the configuration. Since there's no way for us to detect
 // if the configuration is using those variables, we don't set them.
 func (p *PlanStepRunner) tfVars(ctx models.ProjectCommandContext, tfVersion *version.Version) []string {
-	if vTwelveAndUp.Check(tfVersion) {
+	if tfVersion.GreaterThanOrEqual(version.Must(version.NewVersion("0.12.0"))) {
 		return nil
 	}
 
@@ -298,8 +298,6 @@ func (p *PlanStepRunner) runRemotePlan(
 	}
 	return output, err
 }
-
-var vTwelveAndUp = MustConstraint(">=0.12-a")
 
 // remoteOpsErr01114 is the error terraform plan will return if this project is
 // using TFE remote operations in TF 0.11.14.


### PR DESCRIPTION
Resolves #1276 

As outlined in https://github.com/hashicorp/go-version/issues/59 go-version Constraints explicitly disallow matches with prerelease versions specified. Most of our other usage of Constraint tend to be for detection of older versions of terraform so there is probably no sense in a global update of these comparisons. In the future it is a good idea for us to opt for the explicit version comparison functions provided by the library.