### PR TITLE
Add arm64 (Linux) binary releases.

### DIFF
--- a/scripts/binary-release.sh
+++ b/scripts/binary-release.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # define architecture we want to build
-XC_ARCH=${XC_ARCH:-"386 amd64 arm"}
+XC_ARCH=${XC_ARCH:-"386 amd64 arm arm64"}
 XC_OS=${XC_OS:-linux darwin}
-XC_EXCLUDE_OSARCH="!darwin/arm !darwin/386"
+XC_EXCLUDE_OSARCH="!darwin/arm !darwin/386 !darwin/arm64"
 
 # clean up
 echo "-> running clean up...."


### PR DESCRIPTION
Hashicorp has recently added arm64 builds with their recent 0.14
release:  https://www.hashicorp.com/blog/announcing-hashicorp-terraform-0-14-general-availability

> Terraform 0.14 also adds official support for Linux ARM64 builds.
> We’ve gone further and added Linux ARM64 support in the latest 0.13.x releases.

Similarly, recent versions of popular providers are also published with
arm64 builds.

This change updates the build script in order to produce an arm64
binary.

This would be useful, for example, for running in the cloud with one of
Amazon graviton2 instance types, or at a smaller scale on a Raspberry Pi
3 (or newer).