### PR TITLE
add branch-allowlist repo-config parameter

### DIFF
--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -306,6 +306,9 @@ type ProjectCommandContext struct {
 	// ApplyRequirements is the list of requirements that must be satisfied
 	// before we will run the apply stage.
 	ApplyRequirements []string
+	// BranchAllowlist is the list of base branches that are allowed targets
+	// if `mergeable` is an ApplyRequirement
+	BranchAllowlist []string
 	// AutomergeEnabled is true if automerge is enabled for the repo that this
 	// project is in.
 	AutomergeEnabled bool

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -437,6 +437,7 @@ func (p *DefaultProjectCommandBuilder) buildCtx(ctx *CommandContext,
 	return models.ProjectCommandContext{
 		ApplyCmd:             p.CommentBuilder.BuildApplyComment(projCfg.RepoRelDir, projCfg.Workspace, projCfg.Name),
 		BaseRepo:             ctx.Pull.BaseRepo,
+		BranchAllowlist:      projCfg.BranchAllowlist,
 		EscapedCommentArgs:   p.escapeArgs(commentArgs),
 		AutomergeEnabled:     automergeEnabled,
 		ParallelApplyEnabled: parallelApplyEnabled,

--- a/server/events/project_command_builder_internal_test.go
+++ b/server/events/project_command_builder_internal_test.go
@@ -54,6 +54,7 @@ workflows:
 			expCtx: models.ProjectCommandContext{
 				ApplyCmd:           "atlantis apply -d project1 -w myworkspace",
 				BaseRepo:           baseRepo,
+				BranchAllowlist:    []string{},
 				EscapedCommentArgs: []string{`\f\l\a\g`},
 				AutomergeEnabled:   false,
 				AutoplanEnabled:    true,
@@ -103,6 +104,7 @@ projects:
 			expCtx: models.ProjectCommandContext{
 				ApplyCmd:           "atlantis apply -d project1 -w myworkspace",
 				BaseRepo:           baseRepo,
+				BranchAllowlist:    []string{},
 				EscapedCommentArgs: []string{`\f\l\a\g`},
 				AutomergeEnabled:   true,
 				AutoplanEnabled:    true,
@@ -154,6 +156,7 @@ projects:
 			expCtx: models.ProjectCommandContext{
 				ApplyCmd:           "atlantis apply -d project1 -w myworkspace",
 				BaseRepo:           baseRepo,
+				BranchAllowlist:    []string{},
 				EscapedCommentArgs: []string{`\f\l\a\g`},
 				AutomergeEnabled:   true,
 				AutoplanEnabled:    true,
@@ -163,6 +166,59 @@ projects:
 				Pull:               pull,
 				ProjectName:        "",
 				ApplyRequirements:  []string{"approved", "mergeable"},
+				RepoConfigVersion:  3,
+				RePlanCmd:          "atlantis plan -d project1 -w myworkspace -- flag",
+				RepoRelDir:         "project1",
+				TerraformVersion:   mustVersion("10.0"),
+				User:               models.User{},
+				Verbose:            true,
+				Workspace:          "myworkspace",
+			},
+			expPlanSteps:  []string{"init", "plan"},
+			expApplySteps: []string{"apply"},
+		},
+
+		// Set a global apply req that should be used.
+		"global branch_allowlist": {
+			globalCfg: `
+repos:
+- id: /.*/
+  workflow: default
+  apply_requirements: [mergeable]
+  branch_allowlist: [master]
+workflows:
+  default:
+    plan:
+      steps:
+      - init
+      - plan
+    apply:
+      steps:
+      - apply`,
+			repoCfg: `
+version: 3
+automerge: true
+projects:
+- dir: project1
+  workspace: myworkspace
+  autoplan:
+    enabled: true
+    when_modified: [../modules/**/*.tf]
+  terraform_version: v10.0
+`,
+			expCtx: models.ProjectCommandContext{
+				ApplyCmd:           "atlantis apply -d project1 -w myworkspace",
+				BaseRepo:           baseRepo,
+				BranchAllowlist:    []string{"master"},
+				EscapedCommentArgs: []string{`\f\l\a\g`},
+				AutomergeEnabled:   true,
+				AutoplanEnabled:    true,
+				HeadRepo:           models.Repo{},
+				Log:                nil,
+				PullMergeable:      true,
+				Pull:               pull,
+				ProjectName:        "",
+				ApplyRequirements:  []string{"mergeable"},
 				RepoConfigVersion:  3,
 				RePlanCmd:          "atlantis plan -d project1 -w myworkspace -- flag",
 				RepoRelDir:         "project1",
@@ -213,6 +269,7 @@ projects:
 			expCtx: models.ProjectCommandContext{
 				ApplyCmd:           "atlantis apply -d project1 -w myworkspace",
 				BaseRepo:           baseRepo,
+				BranchAllowlist:    []string{},
 				EscapedCommentArgs: []string{`\f\l\a\g`},
 				AutomergeEnabled:   true,
 				AutoplanEnabled:    true,
@@ -359,6 +416,7 @@ workflows:
 			expCtx: models.ProjectCommandContext{
 				ApplyCmd:           "atlantis apply -d project1 -w myworkspace",
 				BaseRepo:           baseRepo,
+				BranchAllowlist:    []string{},
 				EscapedCommentArgs: []string{`\f\l\a\g`},
 				AutomergeEnabled:   true,
 				AutoplanEnabled:    true,
@@ -414,6 +472,7 @@ projects:
 			expCtx: models.ProjectCommandContext{
 				ApplyCmd:           "atlantis apply -d project1 -w myworkspace",
 				BaseRepo:           baseRepo,
+				BranchAllowlist:    []string{},
 				EscapedCommentArgs: []string{`\f\l\a\g`},
 				AutomergeEnabled:   true,
 				AutoplanEnabled:    true,
@@ -472,6 +531,7 @@ workflows:
 			expCtx: models.ProjectCommandContext{
 				ApplyCmd:           "atlantis apply -d project1 -w myworkspace",
 				BaseRepo:           baseRepo,
+				BranchAllowlist:    []string{},
 				EscapedCommentArgs: []string{`\f\l\a\g`},
 				AutomergeEnabled:   true,
 				AutoplanEnabled:    true,
@@ -514,6 +574,7 @@ projects:
 			expCtx: models.ProjectCommandContext{
 				ApplyCmd:           "atlantis apply -d project1 -w myworkspace",
 				BaseRepo:           baseRepo,
+				BranchAllowlist:    []string{},
 				EscapedCommentArgs: []string{`\f\l\a\g`},
 				AutomergeEnabled:   false,
 				AutoplanEnabled:    true,

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -240,6 +240,17 @@ func (p *DefaultProjectCommandRunner) doApply(ctx models.ProjectCommandContext) 
 			if !ctx.PullMergeable {
 				return "", "Pull request must be mergeable before running apply.", nil
 			}
+			if len(ctx.BranchAllowlist) > 0 {
+				allowed := false
+				for _, branch := range ctx.BranchAllowlist {
+					if branch == ctx.Pull.BaseBranch {
+						allowed = true
+					}
+				}
+				if !allowed {
+					return "", "Base branch must be in branch_allowlist.", nil
+				}
+			}
 		}
 	}
 	// Acquire internal lock for the directory we're going to operate in.

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -214,10 +214,12 @@ func TestDefaultProjectCommandRunner_Apply(t *testing.T) {
 		steps       []valid.Step
 		applyReqs   []string
 
-		expSteps      []string
-		expOut        string
-		expFailure    string
-		pullMergeable bool
+		expSteps        []string
+		expOut          string
+		expFailure      string
+		pullMergeable   bool
+		branchAllowlist []string
+		pull            models.PullRequest
 	}{
 		{
 			description: "normal workflow",
@@ -248,6 +250,16 @@ func TestDefaultProjectCommandRunner_Apply(t *testing.T) {
 			expSteps:      []string{""},
 			expOut:        "",
 			expFailure:    "Pull request must be mergeable before running apply.",
+		},
+		{
+			description:     "mergeable required, branch_allowlist match",
+			steps:           valid.DefaultApplyStage.Steps,
+			pullMergeable:   false,
+			applyReqs:       []string{"mergeable"},
+			pull:            models.PullRequest{BaseBranch: "master"},
+			branchAllowlist: []string{"master"},
+			expSteps:        []string{"apply"},
+			expOut:          "apply",
 		},
 		{
 			description:   "mergeable and approved required",
@@ -325,7 +337,9 @@ func TestDefaultProjectCommandRunner_Apply(t *testing.T) {
 				Steps:             c.steps,
 				Workspace:         "default",
 				ApplyRequirements: c.applyReqs,
+				Pull:              c.pull,
 				RepoRelDir:        ".",
+				BranchAllowlist:   c.branchAllowlist,
 				PullMergeable:     c.pullMergeable,
 			}
 			expEnvs := map[string]string{

--- a/server/events/yaml/parser_validator_test.go
+++ b/server/events/yaml/parser_validator_test.go
@@ -1128,6 +1128,7 @@ workflows:
 						IDRegex:           regexp.MustCompile(".*"),
 						PreWorkflowHooks:  []*valid.PreWorkflowHook{},
 						ApplyRequirements: []string{},
+						BranchAllowlist:   []string{},
 						Workflow: &valid.Workflow{
 							Name: "default",
 							Apply: valid.Stage{

--- a/server/events/yaml/raw/global_cfg.go
+++ b/server/events/yaml/raw/global_cfg.go
@@ -20,6 +20,7 @@ type GlobalCfg struct {
 type Repo struct {
 	ID                   string            `yaml:"id" json:"id"`
 	ApplyRequirements    []string          `yaml:"apply_requirements" json:"apply_requirements"`
+	BranchAllowlist      []string          `yaml:"branch_allowlist" json:"branch_allowlist"`
 	PreWorkflowHooks     []PreWorkflowHook `yaml:"pre_workflow_hooks" json:"pre_workflow_hooks"`
 	Workflow             *string           `yaml:"workflow,omitempty" json:"workflow,omitempty"`
 	AllowedWorkflows     []string          `yaml:"allowed_workflows,omitempty" json:"allowed_workflows,omitempty"`
@@ -182,6 +183,7 @@ func (r Repo) ToValid(workflows map[string]valid.Workflow) valid.Repo {
 		ID:                   id,
 		IDRegex:              idRegex,
 		ApplyRequirements:    r.ApplyRequirements,
+		BranchAllowlist:      r.BranchAllowlist,
 		PreWorkflowHooks:     preWorkflowHooks,
 		Workflow:             workflow,
 		AllowedWorkflows:     r.AllowedWorkflows,

--- a/server/events/yaml/raw/project.go
+++ b/server/events/yaml/raw/project.go
@@ -26,6 +26,7 @@ type Project struct {
 	TerraformVersion  *string   `yaml:"terraform_version,omitempty"`
 	Autoplan          *Autoplan `yaml:"autoplan,omitempty"`
 	ApplyRequirements []string  `yaml:"apply_requirements,omitempty"`
+	BranchAllowlist   []string  `yaml:"branch_allowlist,omitempty"`
 }
 
 func (p Project) Validate() error {
@@ -92,6 +93,7 @@ func (p Project) ToValid() valid.Project {
 	// There are no default apply requirements.
 	v.ApplyRequirements = p.ApplyRequirements
 
+	v.BranchAllowlist = p.BranchAllowlist
 	v.Name = p.Name
 
 	return v

--- a/server/events/yaml/raw/project_test.go
+++ b/server/events/yaml/raw/project_test.go
@@ -27,11 +27,12 @@ func TestProject_UnmarshalYAML(t *testing.T) {
 				TerraformVersion:  nil,
 				Autoplan:          nil,
 				ApplyRequirements: nil,
+				BranchAllowlist:   nil,
 				Name:              nil,
 			},
 		},
 		{
-			description: "all fields set including mergeable apply requirement",
+			description: "all fields set including mergeable apply requirement and branch_allowlist master",
 			input: `
 name: myname
 dir: mydir
@@ -42,7 +43,9 @@ autoplan:
   when_modified: []
   enabled: false
 apply_requirements:
-- mergeable`,
+- mergeable
+branch_allowlist:
+- master`,
 			exp: raw.Project{
 				Name:             String("myname"),
 				Dir:              String("mydir"),
@@ -54,6 +57,7 @@ apply_requirements:
 					Enabled:      Bool(false),
 				},
 				ApplyRequirements: []string{"mergeable"},
+				BranchAllowlist:   []string{"master"},
 			},
 		},
 	}
@@ -124,6 +128,22 @@ func TestProject_Validate(t *testing.T) {
 			input: raw.Project{
 				Dir:               String("."),
 				ApplyRequirements: []string{"mergeable", "approved"},
+			},
+			expErr: "",
+		},
+		{
+			description: "empty branch_allowlist",
+			input: raw.Project{
+				Dir:             String("."),
+				BranchAllowlist: []string{},
+			},
+			expErr: "",
+		},
+		{
+			description: "branch_allowlist with master branch",
+			input: raw.Project{
+				Dir:             String("."),
+				BranchAllowlist: []string{"master"},
 			},
 			expErr: "",
 		},
@@ -235,6 +255,7 @@ func TestProject_ToValid(t *testing.T) {
 					Enabled:      true,
 				},
 				ApplyRequirements: nil,
+				BranchAllowlist:   nil,
 				Name:              nil,
 			},
 		},
@@ -250,6 +271,7 @@ func TestProject_ToValid(t *testing.T) {
 					Enabled:      Bool(false),
 				},
 				ApplyRequirements: []string{"approved"},
+				BranchAllowlist:   []string{"master"},
 				Name:              String("myname"),
 			},
 			exp: valid.Project{
@@ -262,6 +284,7 @@ func TestProject_ToValid(t *testing.T) {
 					Enabled:      false,
 				},
 				ApplyRequirements: []string{"approved"},
+				BranchAllowlist:   []string{"master"},
 				Name:              String("myname"),
 			},
 		},

--- a/server/events/yaml/valid/global_cfg.go
+++ b/server/events/yaml/valid/global_cfg.go
@@ -111,7 +111,7 @@ func NewGlobalCfg(allowRepoCfg bool, mergeableReq bool, approvedReq bool) Global
 
 	allowCustomWorkflows := false
 	if allowRepoCfg {
-		allowedOverrides = []string{ApplyRequirementsKey, WorkflowKey}
+		allowedOverrides = []string{ApplyRequirementsKey, BranchAllowlistKey, WorkflowKey}
 		allowCustomWorkflows = true
 	}
 

--- a/server/events/yaml/valid/global_cfg_test.go
+++ b/server/events/yaml/valid/global_cfg_test.go
@@ -40,6 +40,7 @@ func TestNewGlobalCfg(t *testing.T) {
 			{
 				IDRegex:              regexp.MustCompile(".*"),
 				ApplyRequirements:    []string{},
+				BranchAllowlist:      []string{},
 				Workflow:             &expDefaultWorkflow,
 				AllowedWorkflows:     []string{},
 				AllowedOverrides:     []string{},

--- a/server/events/yaml/valid/global_cfg_test.go
+++ b/server/events/yaml/valid/global_cfg_test.go
@@ -338,6 +338,7 @@ workflows:
 			repoWorkflows: nil,
 			exp: valid.MergedProjectCfg{
 				ApplyRequirements: []string{},
+				BranchAllowlist:   []string{},
 				Workflow: valid.Workflow{
 					Name:  "custom",
 					Apply: valid.DefaultApplyStage,
@@ -371,6 +372,7 @@ repos:
 			repoWorkflows: nil,
 			exp: valid.MergedProjectCfg{
 				ApplyRequirements: []string{"mergeable"},
+				BranchAllowlist:   []string{},
 				Workflow: valid.Workflow{
 					Name:  "default",
 					Apply: valid.DefaultApplyStage,
@@ -401,6 +403,7 @@ repos:
 			repoWorkflows: nil,
 			exp: valid.MergedProjectCfg{
 				ApplyRequirements: []string{"approved", "mergeable"},
+				BranchAllowlist:   []string{},
 				Workflow: valid.Workflow{
 					Name:  "default",
 					Apply: valid.DefaultApplyStage,
@@ -427,6 +430,7 @@ repos:
 			repoWorkflows: nil,
 			exp: valid.MergedProjectCfg{
 				ApplyRequirements: []string{},
+				BranchAllowlist:   []string{},
 				Workflow: valid.Workflow{
 					Name:  "default",
 					Apply: valid.DefaultApplyStage,

--- a/server/events/yaml/valid/global_cfg_test.go
+++ b/server/events/yaml/valid/global_cfg_test.go
@@ -101,7 +101,7 @@ func TestNewGlobalCfg(t *testing.T) {
 
 			if c.allowRepoCfg {
 				exp.Repos[0].AllowCustomWorkflows = Bool(true)
-				exp.Repos[0].AllowedOverrides = []string{"apply_requirements", "workflow"}
+				exp.Repos[0].AllowedOverrides = []string{"apply_requirements", "branch_allowlist", "workflow"}
 			}
 			if c.mergeableReq {
 				exp.Repos[0].ApplyRequirements = append(exp.Repos[0].ApplyRequirements, "mergeable")

--- a/server/events/yaml/valid/repo_cfg.go
+++ b/server/events/yaml/valid/repo_cfg.go
@@ -53,6 +53,7 @@ type Project struct {
 	TerraformVersion  *version.Version
 	Autoplan          Autoplan
 	ApplyRequirements []string
+	BranchAllowlist   []string
 }
 
 // GetName returns the name of the project or an empty string if there is no


### PR DESCRIPTION
### Context

Fixes #1028

### What

This PR should add a `branch_allowlist` parameter to the RepoConfig that comes into effect in combination with the `mergeable` requirement.
In addition to checking if a PR is mergeable it also validates that it targets a set of allowed base branches.
Otherwise one might avoid the mergeable requirement by planning and applying on a non-protected branch.

#### Example
I set `branch_allowlist: [master]` and tried to apply a PR that is targeting the `development` branch. Error message:

<img width="858" alt="image" src="https://user-images.githubusercontent.com/14163614/106357291-827abc00-6305-11eb-8489-71105d93c8fd.png">

Looking forward to all reviews :-)