### PR TITLE
Further parse Gitlab MergeRequest Update events

### DIFF
--- a/server/events/event_parser.go
+++ b/server/events/event_parser.go
@@ -175,6 +175,12 @@ type EventParsing interface {
 		pull models.PullRequest, pullEventType models.PullRequestEventType,
 		baseRepo models.Repo, headRepo models.Repo, user models.User, err error)
 
+	// ParseGitlabMergeRequestUpdateEvent dives deeper into Gitlab merge request update events to check
+	// if Atlantis should handle events or not. Atlantis should ignore events which dont change the MR content
+	// We assume that 1 event carries multiple events, so firstly need to check for events triggering Atlantis planning
+	// Default 'unknown' event to 'models.UpdatedPullEvent'
+	ParseGitlabMergeRequestUpdateEvent(event gitlab.MergeEvent) models.PullRequestEventType
+
 	// ParseGitlabMergeRequestCommentEvent parses GitLab merge request comment
 	// events.
 	// baseRepo is the repo the merge request will be merged into.
@@ -515,6 +521,36 @@ func (e *EventParser) ParseGithubRepo(ghRepo *github.Repository) (models.Repo, e
 	return models.NewRepo(models.Github, ghRepo.GetFullName(), ghRepo.GetCloneURL(), e.GithubUser, e.GithubToken)
 }
 
+// ParseGitlabMergeRequestUpdateEvent dives deeper into Gitlab merge request update events
+func (e *EventParser) ParseGitlabMergeRequestUpdateEvent(event gitlab.MergeEvent) models.PullRequestEventType {
+	// New commit to opened MR
+	if len(event.ObjectAttributes.OldRev) > 0 {
+		return models.UpdatedPullEvent
+	}
+
+	// Update Assignee
+	if len(event.Changes.Assignees.Previous) > 0 || len(event.Changes.Assignees.Current) > 0 {
+		return models.OtherPullEvent
+	}
+
+	// Update Description
+	if len(event.Changes.Description.Previous) > 0 || len(event.Changes.Description.Current) > 0 {
+		return models.OtherPullEvent
+	}
+
+	// Update Labels
+	if len(event.Changes.Labels.Previous) > 0 || len(event.Changes.Labels.Current) > 0 {
+		return models.OtherPullEvent
+	}
+
+	//Update Title
+	if len(event.Changes.Title.Previous) > 0 || len(event.Changes.Title.Current) > 0 {
+		return models.OtherPullEvent
+	}
+
+	return models.UpdatedPullEvent
+}
+
 // ParseGitlabMergeRequestEvent parses GitLab merge request events.
 // pull is the parsed merge request.
 // See EventParsing for return value docs.
@@ -550,7 +586,7 @@ func (e *EventParser) ParseGitlabMergeRequestEvent(event gitlab.MergeEvent) (pul
 	case "open":
 		eventType = models.OpenedPullEvent
 	case "update":
-		eventType = models.UpdatedPullEvent
+		eventType = e.ParseGitlabMergeRequestUpdateEvent(event)
 	case "merge", "close":
 		eventType = models.ClosedPullEvent
 	default:

--- a/server/events/event_parser_test.go
+++ b/server/events/event_parser_test.go
@@ -429,6 +429,57 @@ func TestParseGitlabMergeEvent_Subgroup(t *testing.T) {
 	Equals(t, models.User{Username: "lkysow"}, actUser)
 }
 
+func TestParseGitlabMergeEvent_Update_ActionType(t *testing.T) {
+	cases := []struct {
+		filename string
+		exp      models.PullRequestEventType
+	}{
+		{
+			filename: "gitlab-merge-request-event-update-title.json",
+			exp:      models.OtherPullEvent,
+		},
+		{
+			filename: "gitlab-merge-request-event-update-new-commit.json",
+			exp:      models.UpdatedPullEvent,
+		},
+		{
+			filename: "gitlab-merge-request-event-update-labels.json",
+			exp:      models.OtherPullEvent,
+		},
+		{
+			filename: "gitlab-merge-request-event-update-description.json",
+			exp:      models.OtherPullEvent,
+		},
+		{
+			filename: "gitlab-merge-request-event-update-assignee.json",
+			exp:      models.OtherPullEvent,
+		},
+		{
+			filename: "gitlab-merge-request-event-update-mixed.json",
+			exp:      models.OtherPullEvent,
+		},
+		{
+			filename: "gitlab-merge-request-event-update-target-branch.json",
+			exp:      models.UpdatedPullEvent,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.filename, func(t *testing.T) {
+			path := filepath.Join("testdata", c.filename)
+			bytes, err := ioutil.ReadFile(path)
+			Ok(t, err)
+
+			var event *gitlab.MergeEvent
+			err = json.Unmarshal(bytes, &event)
+			Ok(t, err)
+			_, evType, _, _, _, err := parser.ParseGitlabMergeRequestEvent(*event)
+			Ok(t, err)
+			Equals(t, c.exp, evType)
+		})
+	}
+}
+
 func TestParseGitlabMergeEvent_ActionType(t *testing.T) {
 	cases := []struct {
 		action string
@@ -437,10 +488,6 @@ func TestParseGitlabMergeEvent_ActionType(t *testing.T) {
 		{
 			action: "open",
 			exp:    models.OpenedPullEvent,
-		},
-		{
-			action: "update",
-			exp:    models.UpdatedPullEvent,
 		},
 		{
 			action: "merge",

--- a/server/events/mocks/mock_event_parsing.go
+++ b/server/events/mocks/mock_event_parsing.go
@@ -4,14 +4,13 @@
 package mocks
 
 import (
-	"reflect"
-	"time"
-
 	github "github.com/google/go-github/v31/github"
 	azuredevops "github.com/mcdafydd/go-azuredevops/azuredevops"
 	pegomock "github.com/petergtz/pegomock"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	go_gitlab "github.com/xanzy/go-gitlab"
+	"reflect"
+	"time"
 )
 
 type MockEventParsing struct {
@@ -170,6 +169,21 @@ func (mock *MockEventParsing) ParseGitlabMergeRequestEvent(event go_gitlab.Merge
 		}
 	}
 	return ret0, ret1, ret2, ret3, ret4, ret5
+}
+
+func (mock *MockEventParsing) ParseGitlabMergeRequestUpdateEvent(event go_gitlab.MergeEvent) models.PullRequestEventType {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockEventParsing().")
+	}
+	params := []pegomock.Param{event}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("ParseGitlabMergeRequestUpdateEvent", params, []reflect.Type{reflect.TypeOf((*models.PullRequestEventType)(nil)).Elem()})
+	var ret0 models.PullRequestEventType
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(models.PullRequestEventType)
+		}
+	}
+	return ret0
 }
 
 func (mock *MockEventParsing) ParseGitlabMergeRequestCommentEvent(event go_gitlab.MergeCommentEvent) (models.Repo, models.Repo, models.User, error) {
@@ -619,6 +633,33 @@ func (c *MockEventParsing_ParseGitlabMergeRequestEvent_OngoingVerification) GetC
 }
 
 func (c *MockEventParsing_ParseGitlabMergeRequestEvent_OngoingVerification) GetAllCapturedArguments() (_param0 []go_gitlab.MergeEvent) {
+	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(params) > 0 {
+		_param0 = make([]go_gitlab.MergeEvent, len(c.methodInvocations))
+		for u, param := range params[0] {
+			_param0[u] = param.(go_gitlab.MergeEvent)
+		}
+	}
+	return
+}
+
+func (verifier *VerifierMockEventParsing) ParseGitlabMergeRequestUpdateEvent(event go_gitlab.MergeEvent) *MockEventParsing_ParseGitlabMergeRequestUpdateEvent_OngoingVerification {
+	params := []pegomock.Param{event}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "ParseGitlabMergeRequestUpdateEvent", params, verifier.timeout)
+	return &MockEventParsing_ParseGitlabMergeRequestUpdateEvent_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockEventParsing_ParseGitlabMergeRequestUpdateEvent_OngoingVerification struct {
+	mock              *MockEventParsing
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockEventParsing_ParseGitlabMergeRequestUpdateEvent_OngoingVerification) GetCapturedArguments() go_gitlab.MergeEvent {
+	event := c.GetAllCapturedArguments()
+	return event[len(event)-1]
+}
+
+func (c *MockEventParsing_ParseGitlabMergeRequestUpdateEvent_OngoingVerification) GetAllCapturedArguments() (_param0 []go_gitlab.MergeEvent) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]go_gitlab.MergeEvent, len(c.methodInvocations))

--- a/server/events/testdata/gitlab-merge-request-event-update-assignee.json
+++ b/server/events/testdata/gitlab-merge-request-event-update-assignee.json
@@ -1,0 +1,156 @@
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {
+    "name": "Quan Hoang",
+    "username": "quan.hoang",
+    "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/255/avatar.png",
+    "email": "hdquan@pm.me"
+  },
+  "project": {
+    "id": 910,
+    "name": "Test Gitlab Webhook",
+    "description": "",
+    "web_url": "https://gitlab.com/quan.hoang/atlantis-example",
+    "avatar_url": null,
+    "git_ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "git_http_url": "https://gitlab.com/quan.hoang/atlantis-example.git",
+    "namespace": "Quan Hoang",
+    "visibility_level": 0,
+    "path_with_namespace": "quan.hoang/atlantis-example",
+    "default_branch": "master",
+    "ci_config_path": null,
+    "homepage": "https://gitlab.com/quan.hoang/atlantis-example",
+    "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "http_url": "https://gitlab.com/quan.hoang/atlantis-example.git"
+  },
+  "object_attributes": {
+    "assignee_id": 255,
+    "author_id": 255,
+    "created_at": "2020-12-08 04:04:23 UTC",
+    "description": "New description",
+    "head_pipeline_id": null,
+    "id": 41728,
+    "iid": 3,
+    "last_edited_at": "2020-12-08 04:05:16 UTC",
+    "last_edited_by_id": 255,
+    "merge_commit_sha": null,
+    "merge_error": null,
+    "merge_params": {
+      "force_remove_source_branch": "1"
+    },
+    "merge_status": "can_be_merged",
+    "merge_user_id": null,
+    "merge_when_pipeline_succeeds": false,
+    "milestone_id": null,
+    "source_branch": "get-event-payload",
+    "source_project_id": 910,
+    "state_id": 1,
+    "target_branch": "master",
+    "target_project_id": 910,
+    "time_estimate": 0,
+    "title": "Add new file",
+    "updated_at": "2020-12-08 04:05:58 UTC",
+    "updated_by_id": 255,
+    "url": "https://gitlab.com/quan.hoang/atlantis-example/-/merge_requests/3",
+    "source": {
+      "id": 910,
+      "name": "Test Gitlab Webhook",
+      "description": "",
+      "web_url": "https://gitlab.com/quan.hoang/atlantis-example",
+      "avatar_url": null,
+      "git_ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "git_http_url": "https://gitlab.com/quan.hoang/atlantis-example.git",
+      "namespace": "Quan Hoang",
+      "visibility_level": 0,
+      "path_with_namespace": "quan.hoang/atlantis-example",
+      "default_branch": "master",
+      "ci_config_path": null,
+      "homepage": "https://gitlab.com/quan.hoang/atlantis-example",
+      "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "http_url": "https://gitlab.com/quan.hoang/atlantis-example.git"
+    },
+    "target": {
+      "id": 910,
+      "name": "Test Gitlab Webhook",
+      "description": "",
+      "web_url": "https://gitlab.com/quan.hoang/atlantis-example",
+      "avatar_url": null,
+      "git_ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "git_http_url": "https://gitlab.com/quan.hoang/atlantis-example.git",
+      "namespace": "Quan Hoang",
+      "visibility_level": 0,
+      "path_with_namespace": "quan.hoang/atlantis-example",
+      "default_branch": "master",
+      "ci_config_path": null,
+      "homepage": "https://gitlab.com/quan.hoang/atlantis-example",
+      "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "http_url": "https://gitlab.com/quan.hoang/atlantis-example.git"
+    },
+    "last_commit": {
+      "id": "1ca7e340460796fe3eb17e2ea1b383ac4a1c95b7",
+      "message": "Add abc.txt\n",
+      "title": "Add abc.txt",
+      "timestamp": "2020-12-08T11:03:29+07:00",
+      "url": "https://gitlab.com/quan.hoang/atlantis-example/-/commit/1ca7e340460796fe3eb17e2ea1b383ac4a1c95b7",
+      "author": {
+        "name": "Quan Hoang",
+        "email": "hdquan@pm.me"
+      }
+    },
+    "work_in_progress": false,
+    "total_time_spent": 0,
+    "human_total_time_spent": null,
+    "human_time_estimate": null,
+    "assignee_ids": [
+      255,
+      19
+    ],
+    "state": "opened",
+    "action": "update"
+  },
+  "labels": [
+    {
+      "id": 340,
+      "title": "aaaa",
+      "color": "#0033CC",
+      "project_id": 910,
+      "created_at": "2020-12-08 04:05:34 UTC",
+      "updated_at": "2020-12-08 04:05:34 UTC",
+      "template": false,
+      "description": null,
+      "type": "ProjectLabel",
+      "group_id": null
+    }
+  ],
+  "changes": {
+    "assignees": {
+      "previous": [],
+      "current": [
+        {
+          "name": "Quan Hoang",
+          "username": "quan.hoang",
+          "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/255/avatar.png",
+          "email": "hdquan@pm.me"
+        }
+      ]
+    }
+  },
+  "repository": {
+    "name": "Test Gitlab Webhook",
+    "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "description": "",
+    "homepage": "https://gitlab.com/quan.hoang/atlantis-example"
+  },
+  "assignees": [
+    {
+      "name": "Quan Hoang",
+      "username": "quan.hoang",
+      "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/255/avatar.png",
+      "email": "hdquan@pm.me"
+    }
+  ]
+}

--- a/server/events/testdata/gitlab-merge-request-event-update-description.json
+++ b/server/events/testdata/gitlab-merge-request-event-update-description.json
@@ -1,0 +1,133 @@
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {
+    "name": "Quan Hoang",
+    "username": "quan.hoang",
+    "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/255/avatar.png",
+    "email": "hdquan@pm.me"
+  },
+  "project": {
+    "id": 910,
+    "name": "Test Gitlab Webhook",
+    "description": "",
+    "web_url": "https://gitlab.com/quan.hoang/atlantis-example",
+    "avatar_url": null,
+    "git_ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "git_http_url": "https://gitlab.com/quan.hoang/atlantis-example.git",
+    "namespace": "Quan Hoang",
+    "visibility_level": 0,
+    "path_with_namespace": "quan.hoang/atlantis-example",
+    "default_branch": "master",
+    "ci_config_path": null,
+    "homepage": "https://gitlab.com/quan.hoang/atlantis-example",
+    "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "http_url": "https://gitlab.com/quan.hoang/atlantis-example.git"
+  },
+  "object_attributes": {
+    "assignee_id": null,
+    "author_id": 255,
+    "created_at": "2020-12-08 04:04:23 UTC",
+    "description": "New description",
+    "head_pipeline_id": null,
+    "id": 41728,
+    "iid": 3,
+    "last_edited_at": "2020-12-08 04:05:16 UTC",
+    "last_edited_by_id": 255,
+    "merge_commit_sha": null,
+    "merge_error": null,
+    "merge_params": {
+      "force_remove_source_branch": "1"
+    },
+    "merge_status": "can_be_merged",
+    "merge_user_id": null,
+    "merge_when_pipeline_succeeds": false,
+    "milestone_id": null,
+    "source_branch": "get-event-payload",
+    "source_project_id": 910,
+    "state_id": 1,
+    "target_branch": "master",
+    "target_project_id": 910,
+    "time_estimate": 0,
+    "title": "Add new file",
+    "updated_at": "2020-12-08 04:05:16 UTC",
+    "updated_by_id": 255,
+    "url": "https://gitlab.com/quan.hoang/atlantis-example/-/merge_requests/3",
+    "source": {
+      "id": 910,
+      "name": "Test Gitlab Webhook",
+      "description": "",
+      "web_url": "https://gitlab.com/quan.hoang/atlantis-example",
+      "avatar_url": null,
+      "git_ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "git_http_url": "https://gitlab.com/quan.hoang/atlantis-example.git",
+      "namespace": "Quan Hoang",
+      "visibility_level": 0,
+      "path_with_namespace": "quan.hoang/atlantis-example",
+      "default_branch": "master",
+      "ci_config_path": null,
+      "homepage": "https://gitlab.com/quan.hoang/atlantis-example",
+      "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "http_url": "https://gitlab.com/quan.hoang/atlantis-example.git"
+    },
+    "target": {
+      "id": 910,
+      "name": "Test Gitlab Webhook",
+      "description": "",
+      "web_url": "https://gitlab.com/quan.hoang/atlantis-example",
+      "avatar_url": null,
+      "git_ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "git_http_url": "https://gitlab.com/quan.hoang/atlantis-example.git",
+      "namespace": "Quan Hoang",
+      "visibility_level": 0,
+      "path_with_namespace": "quan.hoang/atlantis-example",
+      "default_branch": "master",
+      "ci_config_path": null,
+      "homepage": "https://gitlab.com/quan.hoang/atlantis-example",
+      "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "http_url": "https://gitlab.com/quan.hoang/atlantis-example.git"
+    },
+    "last_commit": {
+      "id": "1ca7e340460796fe3eb17e2ea1b383ac4a1c95b7",
+      "message": "Add abc.txt\n",
+      "title": "Add abc.txt",
+      "timestamp": "2020-12-08T11:03:29+07:00",
+      "url": "https://gitlab.com/quan.hoang/atlantis-example/-/commit/1ca7e340460796fe3eb17e2ea1b383ac4a1c95b7",
+      "author": {
+        "name": "Quan Hoang",
+        "email": "hdquan@pm.me"
+      }
+    },
+    "work_in_progress": false,
+    "total_time_spent": 0,
+    "human_total_time_spent": null,
+    "human_time_estimate": null,
+    "assignee_ids": [],
+    "state": "opened",
+    "action": "update"
+  },
+  "labels": [],
+  "changes": {
+    "description": {
+      "previous": "description",
+      "current": "New description"
+    },
+    "last_edited_at": {
+      "previous": "2020-12-08 04:04:56 UTC",
+      "current": "2020-12-08 04:05:16 UTC"
+    },
+    "updated_at": {
+      "previous": "2020-12-08 04:04:56 UTC",
+      "current": "2020-12-08 04:05:16 UTC"
+    }
+  },
+  "repository": {
+    "name": "Test Gitlab Webhook",
+    "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "description": "",
+    "homepage": "https://gitlab.com/quan.hoang/atlantis-example"
+  }
+}

--- a/server/events/testdata/gitlab-merge-request-event-update-labels.json
+++ b/server/events/testdata/gitlab-merge-request-event-update-labels.json
@@ -1,0 +1,151 @@
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {
+    "name": "Quan Hoang",
+    "username": "quan.hoang",
+    "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/255/avatar.png",
+    "email": "hdquan@pm.me"
+  },
+  "project": {
+    "id": 910,
+    "name": "Test Gitlab Webhook",
+    "description": "",
+    "web_url": "https://gitlab.com/quan.hoang/atlantis-example",
+    "avatar_url": null,
+    "git_ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "git_http_url": "https://gitlab.com/quan.hoang/atlantis-example.git",
+    "namespace": "Quan Hoang",
+    "visibility_level": 0,
+    "path_with_namespace": "quan.hoang/atlantis-example",
+    "default_branch": "master",
+    "ci_config_path": null,
+    "homepage": "https://gitlab.com/quan.hoang/atlantis-example",
+    "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "http_url": "https://gitlab.com/quan.hoang/atlantis-example.git"
+  },
+  "object_attributes": {
+    "assignee_id": null,
+    "author_id": 255,
+    "created_at": "2020-12-08 04:04:23 UTC",
+    "description": "New description",
+    "head_pipeline_id": null,
+    "id": 41728,
+    "iid": 3,
+    "last_edited_at": "2020-12-08 04:05:16 UTC",
+    "last_edited_by_id": 255,
+    "merge_commit_sha": null,
+    "merge_error": null,
+    "merge_params": {
+      "force_remove_source_branch": "1"
+    },
+    "merge_status": "can_be_merged",
+    "merge_user_id": null,
+    "merge_when_pipeline_succeeds": false,
+    "milestone_id": null,
+    "source_branch": "get-event-payload",
+    "source_project_id": 910,
+    "state_id": 1,
+    "target_branch": "master",
+    "target_project_id": 910,
+    "time_estimate": 0,
+    "title": "Add new file",
+    "updated_at": "2020-12-08 04:05:16 UTC",
+    "updated_by_id": 255,
+    "url": "https://gitlab.com/quan.hoang/atlantis-example/-/merge_requests/3",
+    "source": {
+      "id": 910,
+      "name": "Test Gitlab Webhook",
+      "description": "",
+      "web_url": "https://gitlab.com/quan.hoang/atlantis-example",
+      "avatar_url": null,
+      "git_ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "git_http_url": "https://gitlab.com/quan.hoang/atlantis-example.git",
+      "namespace": "Quan Hoang",
+      "visibility_level": 0,
+      "path_with_namespace": "quan.hoang/atlantis-example",
+      "default_branch": "master",
+      "ci_config_path": null,
+      "homepage": "https://gitlab.com/quan.hoang/atlantis-example",
+      "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "http_url": "https://gitlab.com/quan.hoang/atlantis-example.git"
+    },
+    "target": {
+      "id": 910,
+      "name": "Test Gitlab Webhook",
+      "description": "",
+      "web_url": "https://gitlab.com/quan.hoang/atlantis-example",
+      "avatar_url": null,
+      "git_ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "git_http_url": "https://gitlab.com/quan.hoang/atlantis-example.git",
+      "namespace": "Quan Hoang",
+      "visibility_level": 0,
+      "path_with_namespace": "quan.hoang/atlantis-example",
+      "default_branch": "master",
+      "ci_config_path": null,
+      "homepage": "https://gitlab.com/quan.hoang/atlantis-example",
+      "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "http_url": "https://gitlab.com/quan.hoang/atlantis-example.git"
+    },
+    "last_commit": {
+      "id": "1ca7e340460796fe3eb17e2ea1b383ac4a1c95b7",
+      "message": "Add abc.txt\n",
+      "title": "Add abc.txt",
+      "timestamp": "2020-12-08T11:03:29+07:00",
+      "url": "https://gitlab.com/quan.hoang/atlantis-example/-/commit/1ca7e340460796fe3eb17e2ea1b383ac4a1c95b7",
+      "author": {
+        "name": "Quan Hoang",
+        "email": "hdquan@pm.me"
+      }
+    },
+    "work_in_progress": false,
+    "total_time_spent": 0,
+    "human_total_time_spent": null,
+    "human_time_estimate": null,
+    "assignee_ids": [],
+    "state": "opened",
+    "action": "update"
+  },
+  "labels": [
+    {
+      "id": 340,
+      "title": "aaaa",
+      "color": "#0033CC",
+      "project_id": 910,
+      "created_at": "2020-12-08 04:05:34 UTC",
+      "updated_at": "2020-12-08 04:05:34 UTC",
+      "template": false,
+      "description": null,
+      "type": "ProjectLabel",
+      "group_id": null
+    }
+  ],
+  "changes": {
+    "labels": {
+      "previous": [],
+      "current": [
+        {
+          "id": 340,
+          "title": "aaaa",
+          "color": "#0033CC",
+          "project_id": 910,
+          "created_at": "2020-12-08 04:05:34 UTC",
+          "updated_at": "2020-12-08 04:05:34 UTC",
+          "template": false,
+          "description": null,
+          "type": "ProjectLabel",
+          "group_id": null
+        }
+      ]
+    }
+  },
+  "repository": {
+    "name": "Test Gitlab Webhook",
+    "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "description": "",
+    "homepage": "https://gitlab.com/quan.hoang/atlantis-example"
+  }
+}

--- a/server/events/testdata/gitlab-merge-request-event-update-mixed.json
+++ b/server/events/testdata/gitlab-merge-request-event-update-mixed.json
@@ -1,0 +1,178 @@
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {
+    "name": "Quan Hoang",
+    "username": "quan.hoang",
+    "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/255/avatar.png",
+    "email": "hdquan@pm.me"
+  },
+  "project": {
+    "id": 910,
+    "name": "Test Gitlab Webhook",
+    "description": "",
+    "web_url": "https://gitlab.com/quan.hoang/atlantis-example",
+    "avatar_url": null,
+    "git_ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "git_http_url": "https://gitlab.com/quan.hoang/atlantis-example.git",
+    "namespace": "Quan Hoang",
+    "visibility_level": 0,
+    "path_with_namespace": "quan.hoang/atlantis-example",
+    "default_branch": "master",
+    "ci_config_path": null,
+    "homepage": "https://gitlab.com/quan.hoang/atlantis-example",
+    "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "http_url": "https://gitlab.com/quan.hoang/atlantis-example.git"
+  },
+  "object_attributes": {
+    "assignee_id": 255,
+    "author_id": 255,
+    "created_at": "2020-12-08 04:04:23 UTC",
+    "description": "New description aaaa",
+    "head_pipeline_id": null,
+    "id": 41728,
+    "iid": 3,
+    "last_edited_at": "2020-12-08 04:11:57 UTC",
+    "last_edited_by_id": 255,
+    "merge_commit_sha": null,
+    "merge_error": null,
+    "merge_params": {
+      "force_remove_source_branch": "1"
+    },
+    "merge_status": "can_be_merged",
+    "merge_user_id": null,
+    "merge_when_pipeline_succeeds": false,
+    "milestone_id": null,
+    "source_branch": "get-event-payload",
+    "source_project_id": 910,
+    "state_id": 1,
+    "target_branch": "master",
+    "target_project_id": 910,
+    "time_estimate": 0,
+    "title": "Add new file (another time)",
+    "updated_at": "2020-12-08 04:11:57 UTC",
+    "updated_by_id": 255,
+    "url": "https://gitlab.com/quan.hoang/atlantis-example/-/merge_requests/3",
+    "source": {
+      "id": 910,
+      "name": "Test Gitlab Webhook",
+      "description": "",
+      "web_url": "https://gitlab.com/quan.hoang/atlantis-example",
+      "avatar_url": null,
+      "git_ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "git_http_url": "https://gitlab.com/quan.hoang/atlantis-example.git",
+      "namespace": "Quan Hoang",
+      "visibility_level": 0,
+      "path_with_namespace": "quan.hoang/atlantis-example",
+      "default_branch": "master",
+      "ci_config_path": null,
+      "homepage": "https://gitlab.com/quan.hoang/atlantis-example",
+      "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "http_url": "https://gitlab.com/quan.hoang/atlantis-example.git"
+    },
+    "target": {
+      "id": 910,
+      "name": "Test Gitlab Webhook",
+      "description": "",
+      "web_url": "https://gitlab.com/quan.hoang/atlantis-example",
+      "avatar_url": null,
+      "git_ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "git_http_url": "https://gitlab.com/quan.hoang/atlantis-example.git",
+      "namespace": "Quan Hoang",
+      "visibility_level": 0,
+      "path_with_namespace": "quan.hoang/atlantis-example",
+      "default_branch": "master",
+      "ci_config_path": null,
+      "homepage": "https://gitlab.com/quan.hoang/atlantis-example",
+      "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "http_url": "https://gitlab.com/quan.hoang/atlantis-example.git"
+    },
+    "last_commit": {
+      "id": "1ca7e340460796fe3eb17e2ea1b383ac4a1c95b7",
+      "message": "Add abc.txt\n",
+      "title": "Add abc.txt",
+      "timestamp": "2020-12-08T11:03:29+07:00",
+      "url": "https://gitlab.com/quan.hoang/atlantis-example/-/commit/1ca7e340460796fe3eb17e2ea1b383ac4a1c95b7",
+      "author": {
+        "name": "Quan Hoang",
+        "email": "hdquan@pm.me"
+      }
+    },
+    "work_in_progress": false,
+    "total_time_spent": 0,
+    "human_total_time_spent": null,
+    "human_time_estimate": null,
+    "assignee_ids": [
+      255
+    ],
+    "state": "opened",
+    "action": "update"
+  },
+  "labels": [
+    {
+      "id": 340,
+      "title": "aaaa",
+      "color": "#0033CC",
+      "project_id": 910,
+      "created_at": "2020-12-08 04:05:34 UTC",
+      "updated_at": "2020-12-08 04:05:34 UTC",
+      "template": false,
+      "description": null,
+      "type": "ProjectLabel",
+      "group_id": null
+    }
+  ],
+  "changes": {
+    "description": {
+      "previous": "New description",
+      "current": "New description aaaa"
+    },
+    "last_edited_at": {
+      "previous": "2020-12-08 04:05:16 UTC",
+      "current": "2020-12-08 04:11:57 UTC"
+    },
+    "title": {
+      "previous": "Add new file",
+      "current": "Add new file (another time)"
+    },
+    "updated_at": {
+      "previous": "2020-12-08 04:07:34 UTC",
+      "current": "2020-12-08 04:11:57 UTC"
+    },
+    "assignees": {
+      "previous": [
+        {
+          "name": "Quan Hoang",
+          "username": "quan.hoang",
+          "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/255/avatar.png",
+          "email": "hdquan@pm.me"
+        }
+      ],
+      "current": [
+        {
+          "name": "Quan Hoang",
+          "username": "quan.hoang",
+          "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/255/avatar.png",
+          "email": "hdquan@pm.me"
+        }
+      ]
+    }
+  },
+  "repository": {
+    "name": "Test Gitlab Webhook",
+    "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "description": "",
+    "homepage": "https://gitlab.com/quan.hoang/atlantis-example"
+  },
+  "assignees": [
+    {
+      "name": "Quan Hoang",
+      "username": "quan.hoang",
+      "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/255/avatar.png",
+      "email": "hdquan@pm.me"
+    }
+  ]
+}

--- a/server/events/testdata/gitlab-merge-request-event-update-new-commit.json
+++ b/server/events/testdata/gitlab-merge-request-event-update-new-commit.json
@@ -1,0 +1,149 @@
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {
+    "name": "Quan Hoang",
+    "username": "quan.hoang",
+    "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/255/avatar.png",
+    "email": "hdquan@pm.me"
+  },
+  "project": {
+    "id": 910,
+    "name": "Test Gitlab Webhook",
+    "description": "",
+    "web_url": "https://gitlab.com/quan.hoang/atlantis-example",
+    "avatar_url": null,
+    "git_ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "git_http_url": "https://gitlab.com/quan.hoang/atlantis-example.git",
+    "namespace": "Quan Hoang",
+    "visibility_level": 0,
+    "path_with_namespace": "quan.hoang/atlantis-example",
+    "default_branch": "master",
+    "ci_config_path": null,
+    "homepage": "https://gitlab.com/quan.hoang/atlantis-example",
+    "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "http_url": "https://gitlab.com/quan.hoang/atlantis-example.git"
+  },
+  "object_attributes": {
+    "assignee_id": 255,
+    "author_id": 255,
+    "created_at": "2020-12-08 04:04:23 UTC",
+    "description": "New description aaaa",
+    "head_pipeline_id": null,
+    "id": 41728,
+    "iid": 3,
+    "last_edited_at": "2020-12-08 04:11:57 UTC",
+    "last_edited_by_id": 255,
+    "merge_commit_sha": null,
+    "merge_error": null,
+    "merge_params": {
+      "force_remove_source_branch": "1"
+    },
+    "merge_status": "unchecked",
+    "merge_user_id": null,
+    "merge_when_pipeline_succeeds": false,
+    "milestone_id": null,
+    "source_branch": "get-event-payload",
+    "source_project_id": 910,
+    "state_id": 1,
+    "target_branch": "master",
+    "target_project_id": 910,
+    "time_estimate": 0,
+    "title": "Add new file (another time)",
+    "updated_at": "2020-12-08 04:15:39 UTC",
+    "updated_by_id": 255,
+    "url": "https://gitlab.com/quan.hoang/atlantis-example/-/merge_requests/3",
+    "source": {
+      "id": 910,
+      "name": "Test Gitlab Webhook",
+      "description": "",
+      "web_url": "https://gitlab.com/quan.hoang/atlantis-example",
+      "avatar_url": null,
+      "git_ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "git_http_url": "https://gitlab.com/quan.hoang/atlantis-example.git",
+      "namespace": "Quan Hoang",
+      "visibility_level": 0,
+      "path_with_namespace": "quan.hoang/atlantis-example",
+      "default_branch": "master",
+      "ci_config_path": null,
+      "homepage": "https://gitlab.com/quan.hoang/atlantis-example",
+      "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "http_url": "https://gitlab.com/quan.hoang/atlantis-example.git"
+    },
+    "target": {
+      "id": 910,
+      "name": "Test Gitlab Webhook",
+      "description": "",
+      "web_url": "https://gitlab.com/quan.hoang/atlantis-example",
+      "avatar_url": null,
+      "git_ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "git_http_url": "https://gitlab.com/quan.hoang/atlantis-example.git",
+      "namespace": "Quan Hoang",
+      "visibility_level": 0,
+      "path_with_namespace": "quan.hoang/atlantis-example",
+      "default_branch": "master",
+      "ci_config_path": null,
+      "homepage": "https://gitlab.com/quan.hoang/atlantis-example",
+      "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "http_url": "https://gitlab.com/quan.hoang/atlantis-example.git"
+    },
+    "last_commit": {
+      "id": "5ff66a1f7404deee915b50998c340e96d995f048",
+      "message": "New commit\n",
+      "title": "New commit",
+      "timestamp": "2020-12-08T11:15:30+07:00",
+      "url": "https://gitlab.com/quan.hoang/atlantis-example/-/commit/5ff66a1f7404deee915b50998c340e96d995f048",
+      "author": {
+        "name": "Quan Hoang",
+        "email": "hdquan@pm.me"
+      }
+    },
+    "work_in_progress": false,
+    "total_time_spent": 0,
+    "human_total_time_spent": null,
+    "human_time_estimate": null,
+    "assignee_ids": [
+      255
+    ],
+    "state": "opened",
+    "action": "update",
+    "oldrev": "1ca7e340460796fe3eb17e2ea1b383ac4a1c95b7"
+  },
+  "labels": [
+    {
+      "id": 340,
+      "title": "aaaa",
+      "color": "#0033CC",
+      "project_id": 910,
+      "created_at": "2020-12-08 04:05:34 UTC",
+      "updated_at": "2020-12-08 04:05:34 UTC",
+      "template": false,
+      "description": null,
+      "type": "ProjectLabel",
+      "group_id": null
+    }
+  ],
+  "changes": {
+    "updated_at": {
+      "previous": "2020-12-08 04:11:57 UTC",
+      "current": "2020-12-08 04:15:39 UTC"
+    }
+  },
+  "repository": {
+    "name": "Test Gitlab Webhook",
+    "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "description": "",
+    "homepage": "https://gitlab.com/quan.hoang/atlantis-example"
+  },
+  "assignees": [
+    {
+      "name": "Quan Hoang",
+      "username": "quan.hoang",
+      "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/255/avatar.png",
+      "email": "hdquan@pm.me"
+    }
+  ]
+}

--- a/server/events/testdata/gitlab-merge-request-event-update-target-branch.json
+++ b/server/events/testdata/gitlab-merge-request-event-update-target-branch.json
@@ -1,0 +1,149 @@
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {
+    "name": "Quan Hoang",
+    "username": "quan.hoang",
+    "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/255/avatar.png",
+    "email": "hdquan@pm.me"
+  },
+  "project": {
+    "id": 910,
+    "name": "Test Gitlab Webhook",
+    "description": "",
+    "web_url": "https://gitlab.com/quan.hoang/atlantis-example",
+    "avatar_url": null,
+    "git_ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "git_http_url": "https://gitlab.com/quan.hoang/atlantis-example.git",
+    "namespace": "Quan Hoang",
+    "visibility_level": 0,
+    "path_with_namespace": "quan.hoang/atlantis-example",
+    "default_branch": "master",
+    "ci_config_path": null,
+    "homepage": "https://gitlab.com/quan.hoang/atlantis-example",
+    "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "http_url": "https://gitlab.com/quan.hoang/atlantis-example.git"
+  },
+  "object_attributes": {
+    "assignee_id": 19,
+    "author_id": 255,
+    "created_at": "2020-12-08 04:04:23 UTC",
+    "description": "New description",
+    "head_pipeline_id": null,
+    "id": 41728,
+    "iid": 3,
+    "last_edited_at": "2020-12-08 04:05:16 UTC",
+    "last_edited_by_id": 255,
+    "merge_commit_sha": null,
+    "merge_error": null,
+    "merge_params": {
+      "force_remove_source_branch": "1"
+    },
+    "merge_status": "unchecked",
+    "merge_user_id": null,
+    "merge_when_pipeline_succeeds": false,
+    "milestone_id": null,
+    "source_branch": "get-event-payload",
+    "source_project_id": 910,
+    "state_id": 1,
+    "target_branch": "demo-1",
+    "target_project_id": 910,
+    "time_estimate": 0,
+    "title": "Add new file",
+    "updated_at": "2020-12-08 04:07:12 UTC",
+    "updated_by_id": 255,
+    "url": "https://gitlab.com/quan.hoang/atlantis-example/-/merge_requests/3",
+    "source": {
+      "id": 910,
+      "name": "Test Gitlab Webhook",
+      "description": "",
+      "web_url": "https://gitlab.com/quan.hoang/atlantis-example",
+      "avatar_url": null,
+      "git_ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "git_http_url": "https://gitlab.com/quan.hoang/atlantis-example.git",
+      "namespace": "Quan Hoang",
+      "visibility_level": 0,
+      "path_with_namespace": "quan.hoang/atlantis-example",
+      "default_branch": "master",
+      "ci_config_path": null,
+      "homepage": "https://gitlab.com/quan.hoang/atlantis-example",
+      "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "http_url": "https://gitlab.com/quan.hoang/atlantis-example.git"
+    },
+    "target": {
+      "id": 910,
+      "name": "Test Gitlab Webhook",
+      "description": "",
+      "web_url": "https://gitlab.com/quan.hoang/atlantis-example",
+      "avatar_url": null,
+      "git_ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "git_http_url": "https://gitlab.com/quan.hoang/atlantis-example.git",
+      "namespace": "Quan Hoang",
+      "visibility_level": 0,
+      "path_with_namespace": "quan.hoang/atlantis-example",
+      "default_branch": "master",
+      "ci_config_path": null,
+      "homepage": "https://gitlab.com/quan.hoang/atlantis-example",
+      "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "http_url": "https://gitlab.com/quan.hoang/atlantis-example.git"
+    },
+    "last_commit": {
+      "id": "1ca7e340460796fe3eb17e2ea1b383ac4a1c95b7",
+      "message": "Add abc.txt\n",
+      "title": "Add abc.txt",
+      "timestamp": "2020-12-08T11:03:29+07:00",
+      "url": "https://gitlab.com/quan.hoang/atlantis-example/-/commit/1ca7e340460796fe3eb17e2ea1b383ac4a1c95b7",
+      "author": {
+        "name": "Quan Hoang",
+        "email": "hdquan@pm.me"
+      }
+    },
+    "work_in_progress": false,
+    "total_time_spent": 0,
+    "human_total_time_spent": null,
+    "human_time_estimate": null,
+    "assignee_ids": [
+      19,
+      255
+    ],
+    "state": "opened",
+    "action": "update"
+  },
+  "labels": [
+    {
+      "id": 340,
+      "title": "aaaa",
+      "color": "#0033CC",
+      "project_id": 910,
+      "created_at": "2020-12-08 04:05:34 UTC",
+      "updated_at": "2020-12-08 04:05:34 UTC",
+      "template": false,
+      "description": null,
+      "type": "ProjectLabel",
+      "group_id": null
+    }
+  ],
+  "changes": {
+    "merge_status": {
+      "previous": "can_be_merged",
+      "current": "unchecked"
+    }
+  },
+  "repository": {
+    "name": "Test Gitlab Webhook",
+    "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "description": "",
+    "homepage": "https://gitlab.com/quan.hoang/atlantis-example"
+  },
+  "assignees": [
+    {
+      "name": "Quan Hoang",
+      "username": "quan.hoang",
+      "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/255/avatar.png",
+      "email": "hdquan@pm.me"
+    }
+  ]
+}

--- a/server/events/testdata/gitlab-merge-request-event-update-title.json
+++ b/server/events/testdata/gitlab-merge-request-event-update-title.json
@@ -1,0 +1,141 @@
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {
+    "name": "Quan Hoang",
+    "username": "quan.hoang",
+    "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/255/avatar.png",
+    "email": "hdquan@pm.me"
+  },
+  "project": {
+    "id": 910,
+    "name": "Test Gitlab Webhook",
+    "description": "",
+    "web_url": "https://gitlab.com/quan.hoang/atlantis-example",
+    "avatar_url": null,
+    "git_ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "git_http_url": "https://gitlab.com/quan.hoang/atlantis-example.git",
+    "namespace": "Quan Hoang",
+    "visibility_level": 0,
+    "path_with_namespace": "quan.hoang/atlantis-example",
+    "default_branch": "master",
+    "ci_config_path": null,
+    "homepage": "https://gitlab.com/quan.hoang/atlantis-example",
+    "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "http_url": "https://gitlab.com/quan.hoang/atlantis-example.git"
+  },
+  "object_attributes": {
+    "assignee_id": null,
+    "author_id": 255,
+    "created_at": "2020-12-08 04:04:23 UTC",
+    "description": "description",
+    "head_pipeline_id": null,
+    "id": 41728,
+    "iid": 3,
+    "last_edited_at": "2020-12-08 04:04:56 UTC",
+    "last_edited_by_id": 255,
+    "merge_commit_sha": null,
+    "merge_error": null,
+    "merge_params": {
+      "force_remove_source_branch": "1"
+    },
+    "merge_status": "can_be_merged",
+    "merge_user_id": null,
+    "merge_when_pipeline_succeeds": false,
+    "milestone_id": null,
+    "source_branch": "get-event-payload",
+    "source_project_id": 910,
+    "state_id": 1,
+    "target_branch": "master",
+    "target_project_id": 910,
+    "time_estimate": 0,
+    "title": "Add new file",
+    "updated_at": "2020-12-08 04:04:56 UTC",
+    "updated_by_id": 255,
+    "url": "https://gitlab.com/quan.hoang/atlantis-example/-/merge_requests/3",
+    "source": {
+      "id": 910,
+      "name": "Test Gitlab Webhook",
+      "description": "",
+      "web_url": "https://gitlab.com/quan.hoang/atlantis-example",
+      "avatar_url": null,
+      "git_ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "git_http_url": "https://gitlab.com/quan.hoang/atlantis-example.git",
+      "namespace": "Quan Hoang",
+      "visibility_level": 0,
+      "path_with_namespace": "quan.hoang/atlantis-example",
+      "default_branch": "master",
+      "ci_config_path": null,
+      "homepage": "https://gitlab.com/quan.hoang/atlantis-example",
+      "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "http_url": "https://gitlab.com/quan.hoang/atlantis-example.git"
+    },
+    "target": {
+      "id": 910,
+      "name": "Test Gitlab Webhook",
+      "description": "",
+      "web_url": "https://gitlab.com/quan.hoang/atlantis-example",
+      "avatar_url": null,
+      "git_ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "git_http_url": "https://gitlab.com/quan.hoang/atlantis-example.git",
+      "namespace": "Quan Hoang",
+      "visibility_level": 0,
+      "path_with_namespace": "quan.hoang/atlantis-example",
+      "default_branch": "master",
+      "ci_config_path": null,
+      "homepage": "https://gitlab.com/quan.hoang/atlantis-example",
+      "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "ssh_url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+      "http_url": "https://gitlab.com/quan.hoang/atlantis-example.git"
+    },
+    "last_commit": {
+      "id": "1ca7e340460796fe3eb17e2ea1b383ac4a1c95b7",
+      "message": "Add abc.txt\n",
+      "title": "Add abc.txt",
+      "timestamp": "2020-12-08T11:03:29+07:00",
+      "url": "https://gitlab.com/quan.hoang/atlantis-example/-/commit/1ca7e340460796fe3eb17e2ea1b383ac4a1c95b7",
+      "author": {
+        "name": "Quan Hoang",
+        "email": "hdquan@pm.me"
+      }
+    },
+    "work_in_progress": false,
+    "total_time_spent": 0,
+    "human_total_time_spent": null,
+    "human_time_estimate": null,
+    "assignee_ids": [],
+    "state": "opened",
+    "action": "update"
+  },
+  "labels": [],
+  "changes": {
+    "last_edited_at": {
+      "previous": null,
+      "current": "2020-12-08 04:04:56 UTC"
+    },
+    "last_edited_by_id": {
+      "previous": null,
+      "current": 255
+    },
+    "title": {
+      "previous": "Add abc.txt",
+      "current": "Add new file"
+    },
+    "updated_at": {
+      "previous": "2020-12-08 04:04:23 UTC",
+      "current": "2020-12-08 04:04:56 UTC"
+    },
+    "updated_by_id": {
+      "previous": null,
+      "current": 255
+    }
+  },
+  "repository": {
+    "name": "Test Gitlab Webhook",
+    "url": "git@gitlab.com:quan.hoang/atlantis-example.git",
+    "description": "",
+    "homepage": "https://gitlab.com/quan.hoang/atlantis-example"
+  }
+}


### PR DESCRIPTION
This MR further parses Gitlab MergeRequest Update event to see if Atlantis should handle the update or just ignoring it. With current implementation of gitlab sdk used in Atlantis. We could ignore events such as assignee/description/title/labels changing