### PR TITLE
Updates default filter for terragrunt to pick up **/*.hcl

### DIFF
--- a/server/events/yaml/parser_validator_test.go
+++ b/server/events/yaml/parser_validator_test.go
@@ -206,7 +206,7 @@ projects:
 						WorkflowName:     nil,
 						TerraformVersion: nil,
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 							Enabled:      true,
 						},
 						ApplyRequirements: nil,
@@ -229,7 +229,7 @@ projects:
 						Dir:       ".",
 						Workspace: "default",
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 							Enabled:      true,
 						},
 					},
@@ -275,7 +275,7 @@ projects:
 						Dir:       ".",
 						Workspace: "default",
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 							Enabled:      true,
 						},
 					},
@@ -298,7 +298,7 @@ workflows: ~
 						Dir:       ".",
 						Workspace: "default",
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 							Enabled:      true,
 						},
 					},
@@ -326,7 +326,7 @@ workflows:
 						Dir:       ".",
 						Workspace: "default",
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 							Enabled:      true,
 						},
 					},
@@ -361,7 +361,7 @@ workflows:
 						WorkflowName:     String("myworkflow"),
 						TerraformVersion: tfVersion,
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 							Enabled:      true,
 						},
 						ApplyRequirements: []string{"approved"},
@@ -399,7 +399,7 @@ workflows:
 						WorkflowName:     String("myworkflow"),
 						TerraformVersion: tfVersion,
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 							Enabled:      false,
 						},
 						ApplyRequirements: []string{"approved"},
@@ -437,7 +437,7 @@ workflows:
 						WorkflowName:     String("myworkflow"),
 						TerraformVersion: tfVersion,
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 							Enabled:      false,
 						},
 						ApplyRequirements: []string{"mergeable"},
@@ -475,7 +475,7 @@ workflows:
 						WorkflowName:     String("myworkflow"),
 						TerraformVersion: tfVersion,
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 							Enabled:      false,
 						},
 						ApplyRequirements: []string{"mergeable", "approved"},
@@ -589,7 +589,7 @@ projects:
 						Dir:       ".",
 						Workspace: "workspace",
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 							Enabled:      true,
 						},
 					},
@@ -598,7 +598,7 @@ projects:
 						Dir:       ".",
 						Workspace: "workspace",
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 							Enabled:      true,
 						},
 					},
@@ -630,7 +630,7 @@ workflows:
 						Dir:       ".",
 						Workspace: "default",
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 							Enabled:      true,
 						},
 					},
@@ -692,7 +692,7 @@ workflows:
 						Dir:       ".",
 						Workspace: "default",
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 							Enabled:      true,
 						},
 					},
@@ -750,7 +750,7 @@ workflows:
 						Dir:       ".",
 						Workspace: "default",
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 							Enabled:      true,
 						},
 					},
@@ -804,7 +804,7 @@ workflows:
 						Dir:       ".",
 						Workspace: "default",
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 							Enabled:      true,
 						},
 					},

--- a/server/events/yaml/raw/autoplan.go
+++ b/server/events/yaml/raw/autoplan.go
@@ -6,7 +6,7 @@ import (
 
 // DefaultAutoPlanWhenModified is the default element in the when_modified
 // list if none is defined.
-var DefaultAutoPlanWhenModified = []string{"**/*.tf*", "**/terragrunt.hcl"}
+var DefaultAutoPlanWhenModified = []string{"**/*.tf*", "**/*.hcl"}
 
 type Autoplan struct {
 	WhenModified []string `yaml:"when_modified,omitempty"`

--- a/server/events/yaml/raw/autoplan_test.go
+++ b/server/events/yaml/raw/autoplan_test.go
@@ -109,7 +109,7 @@ func TestAutoplan_ToValid(t *testing.T) {
 			input:       raw.Autoplan{},
 			exp: valid.Autoplan{
 				Enabled:      true,
-				WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+				WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 			},
 		},
 		{
@@ -129,7 +129,7 @@ func TestAutoplan_ToValid(t *testing.T) {
 			},
 			exp: valid.Autoplan{
 				Enabled:      false,
-				WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+				WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 			},
 		},
 		{
@@ -139,7 +139,7 @@ func TestAutoplan_ToValid(t *testing.T) {
 			},
 			exp: valid.Autoplan{
 				Enabled:      true,
-				WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+				WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 			},
 		},
 	}

--- a/server/events/yaml/raw/project_test.go
+++ b/server/events/yaml/raw/project_test.go
@@ -231,7 +231,7 @@ func TestProject_ToValid(t *testing.T) {
 				WorkflowName:     nil,
 				TerraformVersion: nil,
 				Autoplan: valid.Autoplan{
-					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+					WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 					Enabled:      true,
 				},
 				ApplyRequirements: nil,
@@ -276,7 +276,7 @@ func TestProject_ToValid(t *testing.T) {
 				Workspace:        "default",
 				TerraformVersion: tfVersionPointEleven,
 				Autoplan: valid.Autoplan{
-					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+					WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 					Enabled:      true,
 				},
 			},
@@ -291,7 +291,7 @@ func TestProject_ToValid(t *testing.T) {
 				Dir:       ".",
 				Workspace: "default",
 				Autoplan: valid.Autoplan{
-					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+					WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 					Enabled:      true,
 				},
 			},
@@ -305,7 +305,7 @@ func TestProject_ToValid(t *testing.T) {
 				Dir:       "a/b/c",
 				Workspace: "default",
 				Autoplan: valid.Autoplan{
-					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+					WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 					Enabled:      true,
 				},
 			},
@@ -319,7 +319,7 @@ func TestProject_ToValid(t *testing.T) {
 				Dir:       "mydir",
 				Workspace: "default",
 				Autoplan: valid.Autoplan{
-					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+					WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 					Enabled:      true,
 				},
 			},
@@ -334,7 +334,7 @@ func TestProject_ToValid(t *testing.T) {
 				Dir:       "mydir",
 				Workspace: "default",
 				Autoplan: valid.Autoplan{
-					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+					WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 					Enabled:      true,
 				},
 			},
@@ -348,7 +348,7 @@ func TestProject_ToValid(t *testing.T) {
 				Dir:       ".",
 				Workspace: "default",
 				Autoplan: valid.Autoplan{
-					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+					WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 					Enabled:      true,
 				},
 			},
@@ -362,7 +362,7 @@ func TestProject_ToValid(t *testing.T) {
 				Dir:       ".",
 				Workspace: "default",
 				Autoplan: valid.Autoplan{
-					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+					WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 					Enabled:      true,
 				},
 			},
@@ -376,7 +376,7 @@ func TestProject_ToValid(t *testing.T) {
 				Dir:       ".",
 				Workspace: "default",
 				Autoplan: valid.Autoplan{
-					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+					WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 					Enabled:      true,
 				},
 			},
@@ -392,7 +392,7 @@ func TestProject_ToValid(t *testing.T) {
 				Dir:       ".",
 				Workspace: "default",
 				Autoplan: valid.Autoplan{
-					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+					WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 					Enabled:      true,
 				},
 			},

--- a/server/events/yaml/raw/repo_cfg_test.go
+++ b/server/events/yaml/raw/repo_cfg_test.go
@@ -377,7 +377,7 @@ func TestConfig_ToValid(t *testing.T) {
 						Dir:       "mydir",
 						Workspace: "default",
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: []string{"**/*.tf*", "**/*.hcl"},
 							Enabled:      true,
 						},
 					},


### PR DESCRIPTION
This updates the default autoplan configuration to mirror the discovery behavior that terraform gets.
We use terragrunt and make use of `.hcl` files like `terragrunt.hcl`, but we also name files like `org.hcl` or `folder.hcl`. We group vars in these files hierarchically and use them like below. 
I can't think of any reason why we wouldn't want to detect changes in all .hcl files, but I'm happy to discuss :D

```
locals {
    org_vars     = read_terragrunt_config(find_in_parent_folders("organization.hcl"))
}
```
