### PR TITLE
Pass atlantis/apply when there are no plans

### DIFF
--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -150,11 +150,14 @@ func (c *DefaultCommandRunner) RunAutoplanCommand(baseRepo models.Repo, headRepo
 	if len(projectCmds) == 0 {
 		log.Info("determined there was no project to run plan in")
 		if !c.SilenceVCSStatusNoPlans {
-			// If there were no projects modified, we set a successful commit status
-			// with 0/0 projects planned successfully because some users require
+			// If there were no projects modified, we set successful commit statuses
+			// with 0/0 projects planned/applied successfully because some users require
 			// the Atlantis status to be passing for all pull requests.
 			ctx.Log.Debug("setting VCS status to success with no projects found")
 			if err := c.CommitStatusUpdater.UpdateCombinedCount(baseRepo, pull, models.SuccessCommitStatus, models.PlanCommand, 0, 0); err != nil {
+				ctx.Log.Warn("unable to update commit status: %s", err)
+			}
+			if err := c.CommitStatusUpdater.UpdateCombinedCount(baseRepo, pull, models.SuccessCommitStatus, models.ApplyCommand, 0, 0); err != nil {
 				ctx.Log.Warn("unable to update commit status: %s", err)
 			}
 		}


### PR DESCRIPTION
When a pull request has no Terraform changes at all, Atlantis passes the atlantis/plan check, but it doesn't pass the atlantis/apply check. This means that while it's possible to enable the atlantis/plan check as required in the branch protection settings, it's not possible to do the same for atlantis/apply (otherwise for PRs with no Terraform changes you have to run a no-op `atlantis apply`). The fix is simple: pass both checks in the case of no Terraform changes.