### PR TITLE
chore: correct cast from int to string in error message formatting

### DIFF
--- a/server/events/db/boltdb.go
+++ b/server/events/db/boltdb.go
@@ -147,7 +147,7 @@ func (b *BoltDB) List() ([]models.ProjectLock, error) {
 	for k, v := range locksBytes {
 		var lock models.ProjectLock
 		if err := json.Unmarshal(v, &lock); err != nil {
-			return locks, errors.Wrap(err, fmt.Sprintf("failed to deserialize lock at key %q", string(k)))
+			return locks, errors.Wrap(err, fmt.Sprintf("failed to deserialize lock at key '%d'", k))
 		}
 		locks = append(locks, lock)
 	}


### PR DESCRIPTION
Small behavioral bug that has been around for a while. In the error message we are casting the index to a rune resulting in text characters rather than the numeric string.