### PR TITLE
Add generic POST webhook for atlantis apply

### DIFF
--- a/server/events/webhooks/post.go
+++ b/server/events/webhooks/post.go
@@ -1,0 +1,49 @@
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Modified hereafter by contributors to runatlantis/atlantis.
+
+package webhooks
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+
+	"github.com/runatlantis/atlantis/server/logging"
+)
+
+type HttpClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Sends POST requests webhooks to url.
+type PostWebhook struct {
+	Url    string
+	Client HttpClient
+}
+
+func NewPost(url string) *PostWebhook {
+	return &PostWebhook{Url: url, Client: &http.Client{}}
+}
+
+// Send sends the webhook to the specified url
+func (p *PostWebhook) Send(log *logging.SimpleLogger, applyResult ApplyResult) error {
+	requestJSON, err := json.Marshal(applyResult)
+	if err != nil {
+		return err
+	}
+
+	req, _ := http.NewRequest("POST", p.Url, bytes.NewBuffer(requestJSON))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := p.Client.Do(req)
+
+	defer resp.Body.Close()
+	return err
+}

--- a/server/events/webhooks/post_test.go
+++ b/server/events/webhooks/post_test.go
@@ -1,0 +1,53 @@
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Modified hereafter by contributors to runatlantis/atlantis.
+
+package webhooks_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/events/webhooks"
+	"github.com/runatlantis/atlantis/server/logging"
+	. "github.com/runatlantis/atlantis/testing"
+)
+
+func TestSend_PostMessage(t *testing.T) {
+	t.Log("Sending a hook should send a request")
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			Assert(t, req.URL.String() == "/", "wrong path")
+
+			var bodyBytes []byte
+			bodyBytes, _ = ioutil.ReadAll(req.Body)
+			var result webhooks.ApplyResult
+			err := json.Unmarshal([]byte(bodyBytes), &result)
+			Ok(t, err)
+
+			Assert(t, result.Workspace == "production", "wrong data")
+		}))
+	defer server.Close()
+
+	hook := webhooks.PostWebhook{
+		Client: server.Client(),
+		Url:    server.URL,
+	}
+	result := webhooks.ApplyResult{
+		Workspace: "production",
+	}
+
+	err := hook.Send(logging.NewNoopLogger(), result)
+	Ok(t, err)
+}

--- a/server/events/webhooks/slack_test.go
+++ b/server/events/webhooks/slack_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/runatlantis/atlantis/testing"
 )
 
-func TestSend_PostMessage(t *testing.T) {
+func TestSend_SlackMessage(t *testing.T) {
 	t.Log("Sending a hook with a matching regex should call PostMessage")
 	RegisterMockTestingT(t)
 	client := mocks.NewMockSlackClient()
@@ -46,7 +46,7 @@ func TestSend_PostMessage(t *testing.T) {
 	client.VerifyWasCalledOnce().PostMessage(channel, result)
 }
 
-func TestSend_NoopSuccess(t *testing.T) {
+func TestSend_SlackNoopSuccess(t *testing.T) {
 	t.Log("Sending a hook with a non-matching regex should succeed")
 	RegisterMockTestingT(t)
 	client := mocks.NewMockSlackClient()

--- a/server/events/webhooks/webhooks.go
+++ b/server/events/webhooks/webhooks.go
@@ -23,7 +23,10 @@ import (
 	"github.com/runatlantis/atlantis/server/logging"
 )
 
-const SlackKind = "slack"
+const (
+	SlackKind string = "slack"
+	PostKind         = "post"
+)
 const ApplyEvent = "apply"
 
 //go:generate pegomock generate -m --use-experimental-model-gen --package mocks -o mocks/mock_sender.go Sender
@@ -54,6 +57,7 @@ type Config struct {
 	WorkspaceRegex string
 	Kind           string
 	Channel        string
+	Url            string
 }
 
 func NewMultiWebhookSender(configs []Config, client SlackClient) (*MultiWebhookSender, error) {
@@ -72,18 +76,24 @@ func NewMultiWebhookSender(configs []Config, client SlackClient) (*MultiWebhookS
 		switch c.Kind {
 		case SlackKind:
 			if !client.TokenIsSet() {
-				return nil, errors.New("must specify top-level \"slack-token\" if using a webhook of \"kind: slack\"")
+				return nil, fmt.Errorf("must specify top-level \"slack-token\" if using a webhook of \"kind: %s\"", SlackKind)
 			}
 			if c.Channel == "" {
-				return nil, errors.New("must specify \"channel\" if using a webhook of \"kind: slack\"")
+				return nil, fmt.Errorf("must specify \"channel\" if using a webhook of \"kind: %s\"", SlackKind)
 			}
 			slack, err := NewSlack(r, c.Channel, client)
 			if err != nil {
 				return nil, err
 			}
 			webhooks = append(webhooks, slack)
+		case PostKind:
+			if c.Url == "" {
+				return nil, fmt.Errorf("must specify \"url\" if using a webhook of \"kind: %s\"", PostKind)
+			}
+			post := NewPost(c.Url)
+			webhooks = append(webhooks, post)
 		default:
-			return nil, fmt.Errorf("\"kind: %s\" not supported. Only \"kind: %s\" is supported right now", c.Kind, SlackKind)
+			return nil, fmt.Errorf("\"kind: %s\" not supported. Only \"%s\" and \"%s\" are supported right now", c.Kind, SlackKind, PostKind)
 		}
 	}
 
@@ -96,7 +106,7 @@ func NewMultiWebhookSender(configs []Config, client SlackClient) (*MultiWebhookS
 func (w *MultiWebhookSender) Send(log *logging.SimpleLogger, result ApplyResult) error {
 	for _, w := range w.Webhooks {
 		if err := w.Send(log, result); err != nil {
-			log.Warn("error sending slack webhook: %s", err)
+			log.Warn("error sending webhook: %s", err)
 		}
 	}
 	return nil

--- a/server/events/webhooks/webhooks_test.go
+++ b/server/events/webhooks/webhooks_test.go
@@ -25,21 +25,29 @@ import (
 )
 
 const (
-	validEvent   = webhooks.ApplyEvent
-	validRegex   = ".*"
-	validKind    = webhooks.SlackKind
-	validChannel = "validchannel"
+	validEvent     = webhooks.ApplyEvent
+	validRegex     = ".*"
+	validKindSlack = webhooks.SlackKind
+	validKindPost  = webhooks.PostKind
+	validChannel   = "validchannel"
+	validUrl       = "https://localhost"
 )
 
-var validConfig = webhooks.Config{
+var validConfigSlack = webhooks.Config{
 	Event:          validEvent,
 	WorkspaceRegex: validRegex,
-	Kind:           validKind,
+	Kind:           validKindSlack,
 	Channel:        validChannel,
 }
 
+var validConfigPost = webhooks.Config{
+	Event: validEvent,
+	Kind:  validKindPost,
+	Url:   validUrl,
+}
+
 func validConfigs() []webhooks.Config {
-	return []webhooks.Config{validConfig}
+	return []webhooks.Config{validConfigSlack, validConfigPost}
 }
 
 func TestNewWebhooksManager_InvalidRegex(t *testing.T) {
@@ -92,6 +100,15 @@ func TestNewWebhooksManager_NoKind(t *testing.T) {
 	Equals(t, "must specify \"kind\" and \"event\" keys for webhooks", err.Error())
 }
 
+func TestNewWebhooksManager_NoUrl(t *testing.T) {
+	t.Log("When the url key is not specified in a config, an error is returned")
+	confs := validConfigs()[1:]
+	confs[0].Url = ""
+	_, err := webhooks.NewMultiWebhookSender(confs, nil)
+	Assert(t, err != nil, "expected error")
+	Equals(t, "must specify \"url\" if using a webhook of \"kind: post\"", err.Error())
+}
+
 func TestNewWebhooksManager_UnsupportedKind(t *testing.T) {
 	t.Log("When given an unsupported kind in a config, an error is returned")
 	RegisterMockTestingT(t)
@@ -103,7 +120,7 @@ func TestNewWebhooksManager_UnsupportedKind(t *testing.T) {
 	configs[0].Kind = unsupportedKind
 	_, err := webhooks.NewMultiWebhookSender(configs, client)
 	Assert(t, err != nil, "expected error")
-	Equals(t, "\"kind: badkind\" not supported. Only \"kind: slack\" is supported right now", err.Error())
+	Equals(t, "\"kind: badkind\" not supported. Only \"slack\" and \"post\" are supported right now", err.Error())
 }
 
 func TestNewWebhooksManager_NoConfigSuccess(t *testing.T) {
@@ -122,15 +139,26 @@ func TestNewWebhooksManager_NoConfigSuccess(t *testing.T) {
 	Assert(t, m != nil, "manager shouldn't be nil")
 	Equals(t, 0, len(m.Webhooks)) // nolint: staticcheck
 }
-func TestNewWebhooksManager_SingleConfigSuccess(t *testing.T) {
+
+func TestNewWebhooksManager_SingleConfigSuccessSlack(t *testing.T) {
 	t.Log("When there is one valid config, function should succeed")
 	RegisterMockTestingT(t)
 	client := mocks.NewMockSlackClient()
 	When(client.TokenIsSet()).ThenReturn(true)
 	When(client.ChannelExists(validChannel)).ThenReturn(true, nil)
 
-	configs := validConfigs()
+	configs := validConfigs()[:1]
 	m, err := webhooks.NewMultiWebhookSender(configs, client)
+	Ok(t, err)
+	Assert(t, m != nil, "manager shouldn't be nil")
+	Equals(t, 1, len(m.Webhooks)) // nolint: staticcheck
+}
+
+func TestNewWebhooksManager_SingleConfigSuccessPost(t *testing.T) {
+	t.Log("When there is one valid config, function should succeed")
+
+	configs := validConfigs()[1:]
+	m, err := webhooks.NewMultiWebhookSender(configs, nil)
 	Ok(t, err)
 	Assert(t, m != nil, "manager shouldn't be nil")
 	Equals(t, 1, len(m.Webhooks)) // nolint: staticcheck
@@ -146,12 +174,15 @@ func TestNewWebhooksManager_MultipleConfigSuccess(t *testing.T) {
 	var configs []webhooks.Config
 	nConfigs := 5
 	for i := 0; i < nConfigs; i++ {
-		configs = append(configs, validConfig)
+		configs = append(configs, validConfigSlack)
+	}
+	for i := 0; i < nConfigs; i++ {
+		configs = append(configs, validConfigPost)
 	}
 	m, err := webhooks.NewMultiWebhookSender(configs, client)
 	Ok(t, err)
 	Assert(t, m != nil, "manager shouldn't be nil")
-	Equals(t, nConfigs, len(m.Webhooks)) // nolint: staticcheck
+	Equals(t, nConfigs+nConfigs, len(m.Webhooks)) // nolint: staticcheck
 }
 
 func TestSend_SingleSuccess(t *testing.T) {

--- a/server/server.go
+++ b/server/server.go
@@ -108,6 +108,9 @@ type WebhookConfig struct {
 	// Channel is the channel to send this webhook to. It only applies to
 	// slack webhooks. Should be without '#'.
 	Channel string `mapstructure:"channel"`
+	// Url is the webhook url to send a POST request to. It only applies to
+	// post webhooks.
+	Url string `mapstructure:"url"`
 }
 
 // NewServer returns a new server. If there are issues starting the server or
@@ -224,6 +227,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 			Event:          c.Event,
 			Kind:           c.Kind,
 			WorkspaceRegex: c.WorkspaceRegex,
+			Url:            c.Url,
 		}
 		webhooksConfig = append(webhooksConfig, config)
 	}


### PR DESCRIPTION
This is similar to Slack webhook, but instead it sends the whole `ApplyResult` struct to the specified URL as json.

Config look like the following:

```
    webhooks:
      - event: apply
        kind: post
        url: https://example.com/
```