### PR TITLE
add a valid variable definition file extension to list of exceptions

### DIFF
--- a/server/events/project_finder.go
+++ b/server/events/project_finder.go
@@ -148,7 +148,7 @@ func (p *DefaultProjectFinder) DetermineProjectsViaConfig(log *logging.SimpleLog
 // filterToTerraform filters non-terraform files from files.
 func (p *DefaultProjectFinder) filterToTerraform(files []string) []string {
 	var filtered []string
-	fileNameRe, _ := regexp.Compile(`^.*(\.tf|\.tfvars)$`)
+	fileNameRe, _ := regexp.Compile(`^.*(\.tf|\.tfvars|\.tfvars.json)$`)
 
 	for _, fileName := range files {
 		if !p.shouldIgnore(fileName) && (fileNameRe.MatchString(fileName) || filepath.Base(fileName) == "terragrunt.hcl") {

--- a/server/events/project_finder_test.go
+++ b/server/events/project_finder_test.go
@@ -256,7 +256,7 @@ func TestDefaultProjectFinder_DetermineProjectsViaConfig(t *testing.T) {
 	tmpDir, cleanup := DirStructure(t, map[string]interface{}{
 		"main.tf": nil,
 		"project1": map[string]interface{}{
-			"main.tf": nil,
+			"main.tf":               nil,
 			"terraform.tfvars.json": nil,
 		},
 		"project2": map[string]interface{}{

--- a/server/events/project_finder_test.go
+++ b/server/events/project_finder_test.go
@@ -93,6 +93,7 @@ func setupTmpRepos(t *testing.T) {
 	// env/
 	//   staging.tfvars
 	//   production.tfvars
+	//   global-env-config.auto.tfvars.json
 	envDir, err = ioutil.TempDir("", "")
 	Ok(t, err)
 	err = os.MkdirAll(filepath.Join(envDir, "env"), 0700)
@@ -245,6 +246,7 @@ func TestDefaultProjectFinder_DetermineProjectsViaConfig(t *testing.T) {
 	// main.tf
 	// project1/
 	//   main.tf
+	//   terraform.tfvars.json
 	// project2/
 	//   main.tf
 	//   terraform.tfvars
@@ -255,6 +257,7 @@ func TestDefaultProjectFinder_DetermineProjectsViaConfig(t *testing.T) {
 		"main.tf": nil,
 		"project1": map[string]interface{}{
 			"main.tf": nil,
+			"terraform.tfvars.json": nil,
 		},
 		"project2": map[string]interface{}{
 			"main.tf":          nil,


### PR DESCRIPTION
Fix for https://github.com/runatlantis/atlantis/issues/1330

https://www.terraform.io/docs/configuration/variables.html#variable-definitions-tfvars-files

```
Terraform also automatically loads a number of variable definitions files if they are present:

Files named exactly terraform.tfvars or terraform.tfvars.json.
Any files with names ending in .auto.tfvars or .auto.tfvars.json.
```