### PR TITLE
Add the ability to disable Atlantis locking a repo

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -56,6 +56,7 @@ const (
 	DisableApplyFlag           = "disable-apply"
 	DisableAutoplanFlag        = "disable-autoplan"
 	DisableMarkdownFoldingFlag = "disable-markdown-folding"
+	DisableRepoLockingFlag     = "disable-repo-locking"
 	GHHostnameFlag             = "gh-hostname"
 	GHTokenFlag                = "gh-token"
 	GHUserFlag                 = "gh-user"
@@ -289,6 +290,10 @@ var boolFlags = map[string]boolFlag{
 	},
 	DisableAutoplanFlag: {
 		description:  "Disable atlantis auto planning feature",
+		defaultValue: false,
+	},
+	DisableRepoLockingFlag: {
+		description:  "Disable atlantis locking repos",
 		defaultValue: false,
 	},
 	AllowDraftPRs: {

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -67,6 +67,7 @@ var testFlags = map[string]interface{}{
 	DisableApplyAllFlag:        true,
 	DisableApplyFlag:           true,
 	DisableMarkdownFoldingFlag: true,
+	DisableRepoLockingFlag:     true,
 	GHHostnameFlag:             "ghhostname",
 	GHTokenFlag:                "token",
 	GHUserFlag:                 "user",

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -220,6 +220,12 @@ Values are chosen in this order:
   ```
   Disable atlantis auto planning
 
+* ### `--disable-repo-locking`
+  ```bash
+  atlantis server --disable-repo-locking
+  ```
+  Stops atlantis locking projects and or workspaces when running terraform
+
 * ### `--gh-hostname`
   ```bash
   atlantis server --gh-hostname="my.github.enterprise.com"

--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -16,16 +16,17 @@ package events
 import (
 	"bytes"
 	"fmt"
-	"github.com/flynn-archive/go-shlex"
-	"github.com/runatlantis/atlantis/server/events/models"
-	"github.com/runatlantis/atlantis/server/events/yaml"
-	"github.com/spf13/pflag"
 	"io/ioutil"
 	"net/url"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"text/template"
+
+	"github.com/flynn-archive/go-shlex"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/events/yaml"
+	"github.com/spf13/pflag"
 )
 
 const (

--- a/server/events/locking/locking.go
+++ b/server/events/locking/locking.go
@@ -146,3 +146,47 @@ func (c *Client) lockKeyToProjectWorkspace(key string) (models.Project, string, 
 
 	return models.Project{RepoFullName: matches[1], Path: matches[2]}, matches[3], nil
 }
+
+type NoOpLocker struct{}
+
+// NewNoOpLocker returns a new lno operation lockingclient.
+func NewNoOpLocker() *NoOpLocker {
+	return &NoOpLocker{}
+}
+
+// TryLock attempts to acquire a lock to a project and workspace.
+func (c *NoOpLocker) TryLock(p models.Project, workspace string, pull models.PullRequest, user models.User) (TryLockResponse, error) {
+	return TryLockResponse{true, models.ProjectLock{}, c.key(p, workspace)}, nil
+}
+
+// Unlock attempts to unlock a project and workspace. If successful,
+// a pointer to the now deleted lock will be returned. Else, that
+// pointer will be nil. An error will only be returned if there was
+// an error deleting the lock (i.e. not if there was no lock).
+func (c *NoOpLocker) Unlock(key string) (*models.ProjectLock, error) {
+	return &models.ProjectLock{}, nil
+}
+
+// List returns a map of all locks with their lock key as the map key.
+// The lock key can be used in GetLock() and Unlock().
+func (c *NoOpLocker) List() (map[string]models.ProjectLock, error) {
+	m := make(map[string]models.ProjectLock)
+	return m, nil
+}
+
+// UnlockByPull deletes all locks associated with that pull request.
+func (c *NoOpLocker) UnlockByPull(repoFullName string, pullNum int) ([]models.ProjectLock, error) {
+	return []models.ProjectLock{}, nil
+}
+
+// GetLock attempts to get the lock stored at key. If successful,
+// a pointer to the lock will be returned. Else, the pointer will be nil.
+// An error will only be returned if there was an error getting the lock
+// (i.e. not if there was no lock).
+func (c *NoOpLocker) GetLock(key string) (*models.ProjectLock, error) {
+	return nil, nil
+}
+
+func (c *NoOpLocker) key(p models.Project, workspace string) string {
+	return fmt.Sprintf("%s/%s/%s", p.RepoFullName, p.Path, workspace)
+}

--- a/server/events/locking/locking_test.go
+++ b/server/events/locking/locking_test.go
@@ -144,3 +144,40 @@ func TestGetLock(t *testing.T) {
 	Ok(t, err)
 	Equals(t, &pl, lock)
 }
+
+func TestTryLock_NoOpLocker(t *testing.T) {
+	RegisterMockTestingT(t)
+	currLock := models.ProjectLock{}
+	l := locking.NewNoOpLocker()
+	r, err := l.TryLock(project, workspace, pull, user)
+	Ok(t, err)
+	Equals(t, locking.TryLockResponse{LockAcquired: true, CurrLock: currLock, LockKey: "owner/repo/path/workspace"}, r)
+}
+
+func TestUnlock_NoOpLocker(t *testing.T) {
+	l := locking.NewNoOpLocker()
+	lock, err := l.Unlock("owner/repo/path/workspace")
+	Ok(t, err)
+	Equals(t, &models.ProjectLock{}, lock)
+}
+
+func TestList_NoOpLocker(t *testing.T) {
+	l := locking.NewNoOpLocker()
+	list, err := l.List()
+	Ok(t, err)
+	Equals(t, map[string]models.ProjectLock{}, list)
+}
+
+func TestUnlockByPull_NoOpLocker(t *testing.T) {
+	l := locking.NewNoOpLocker()
+	_, err := l.UnlockByPull("owner/repo", 1)
+	Ok(t, err)
+}
+
+func TestGetLock_NoOpLocker(t *testing.T) {
+	l := locking.NewNoOpLocker()
+	lock, err := l.GetLock("owner/repo/path/workspace")
+	Ok(t, err)
+	var expected *models.ProjectLock = nil
+	Equals(t, expected, lock)
+}

--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -1416,3 +1416,477 @@ This plan was not saved because one or more projects failed and automerge requir
 		})
 	}
 }
+
+// test that id repo locking is disabled the link to unlock the project is not rendered
+func TestRenderProjectResultsWithRepoLockingDisabled(t *testing.T) {
+	cases := []struct {
+		Description    string
+		Command        models.CommandName
+		ProjectResults []models.ProjectResult
+		VCSHost        models.VCSHostType
+		Expected       string
+	}{
+		{
+			"no projects",
+			models.PlanCommand,
+			[]models.ProjectResult{},
+			models.Github,
+			"Ran Plan for 0 projects:\n\n\n\n",
+		},
+		{
+			"single successful plan",
+			models.PlanCommand,
+			[]models.ProjectResult{
+				{
+					PlanSuccess: &models.PlanSuccess{
+						TerraformOutput: "terraform-output",
+						LockURL:         "lock-url",
+						RePlanCmd:       "atlantis plan -d path -w workspace",
+						ApplyCmd:        "atlantis apply -d path -w workspace",
+					},
+					Workspace:  "workspace",
+					RepoRelDir: "path",
+				},
+			},
+			models.Github,
+			`Ran Plan for dir: $path$ workspace: $workspace$
+
+$$$diff
+terraform-output
+$$$
+
+* :arrow_forward: To **apply** this plan, comment:
+    * $atlantis apply -d path -w workspace$
+* :repeat: To **plan** this project again, comment:
+    * $atlantis plan -d path -w workspace$
+
+---
+* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
+    * $atlantis apply$
+* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+    * $atlantis unlock$
+`,
+		},
+		{
+			"single successful plan with master ahead",
+			models.PlanCommand,
+			[]models.ProjectResult{
+				{
+					PlanSuccess: &models.PlanSuccess{
+						TerraformOutput: "terraform-output",
+						LockURL:         "lock-url",
+						RePlanCmd:       "atlantis plan -d path -w workspace",
+						ApplyCmd:        "atlantis apply -d path -w workspace",
+						HasDiverged:     true,
+					},
+					Workspace:  "workspace",
+					RepoRelDir: "path",
+				},
+			},
+			models.Github,
+			`Ran Plan for dir: $path$ workspace: $workspace$
+
+$$$diff
+terraform-output
+$$$
+
+* :arrow_forward: To **apply** this plan, comment:
+    * $atlantis apply -d path -w workspace$
+* :repeat: To **plan** this project again, comment:
+    * $atlantis plan -d path -w workspace$
+
+:warning: The branch we're merging into is ahead, it is recommended to pull new commits first.
+
+---
+* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
+    * $atlantis apply$
+* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+    * $atlantis unlock$
+`,
+		},
+		{
+			"single successful plan with project name",
+			models.PlanCommand,
+			[]models.ProjectResult{
+				{
+					PlanSuccess: &models.PlanSuccess{
+						TerraformOutput: "terraform-output",
+						LockURL:         "lock-url",
+						RePlanCmd:       "atlantis plan -d path -w workspace",
+						ApplyCmd:        "atlantis apply -d path -w workspace",
+					},
+					Workspace:   "workspace",
+					RepoRelDir:  "path",
+					ProjectName: "projectname",
+				},
+			},
+			models.Github,
+			`Ran Plan for project: $projectname$ dir: $path$ workspace: $workspace$
+
+$$$diff
+terraform-output
+$$$
+
+* :arrow_forward: To **apply** this plan, comment:
+    * $atlantis apply -d path -w workspace$
+* :repeat: To **plan** this project again, comment:
+    * $atlantis plan -d path -w workspace$
+
+---
+* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
+    * $atlantis apply$
+* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+    * $atlantis unlock$
+`,
+		},
+		{
+			"single successful apply",
+			models.ApplyCommand,
+			[]models.ProjectResult{
+				{
+					ApplySuccess: "success",
+					Workspace:    "workspace",
+					RepoRelDir:   "path",
+				},
+			},
+			models.Github,
+			`Ran Apply for dir: $path$ workspace: $workspace$
+
+$$$diff
+success
+$$$
+
+`,
+		},
+		{
+			"single successful apply with project name",
+			models.ApplyCommand,
+			[]models.ProjectResult{
+				{
+					ApplySuccess: "success",
+					Workspace:    "workspace",
+					RepoRelDir:   "path",
+					ProjectName:  "projectname",
+				},
+			},
+			models.Github,
+			`Ran Apply for project: $projectname$ dir: $path$ workspace: $workspace$
+
+$$$diff
+success
+$$$
+
+`,
+		},
+		{
+			"multiple successful plans",
+			models.PlanCommand,
+			[]models.ProjectResult{
+				{
+					Workspace:  "workspace",
+					RepoRelDir: "path",
+					PlanSuccess: &models.PlanSuccess{
+						TerraformOutput: "terraform-output",
+						LockURL:         "lock-url",
+						ApplyCmd:        "atlantis apply -d path -w workspace",
+						RePlanCmd:       "atlantis plan -d path -w workspace",
+					},
+				},
+				{
+					Workspace:   "workspace",
+					RepoRelDir:  "path2",
+					ProjectName: "projectname",
+					PlanSuccess: &models.PlanSuccess{
+						TerraformOutput: "terraform-output2",
+						LockURL:         "lock-url2",
+						ApplyCmd:        "atlantis apply -d path2 -w workspace",
+						RePlanCmd:       "atlantis plan -d path2 -w workspace",
+					},
+				},
+			},
+			models.Github,
+			`Ran Plan for 2 projects:
+
+1. dir: $path$ workspace: $workspace$
+1. project: $projectname$ dir: $path2$ workspace: $workspace$
+
+### 1. dir: $path$ workspace: $workspace$
+$$$diff
+terraform-output
+$$$
+
+* :arrow_forward: To **apply** this plan, comment:
+    * $atlantis apply -d path -w workspace$
+* :repeat: To **plan** this project again, comment:
+    * $atlantis plan -d path -w workspace$
+
+---
+### 2. project: $projectname$ dir: $path2$ workspace: $workspace$
+$$$diff
+terraform-output2
+$$$
+
+* :arrow_forward: To **apply** this plan, comment:
+    * $atlantis apply -d path2 -w workspace$
+* :repeat: To **plan** this project again, comment:
+    * $atlantis plan -d path2 -w workspace$
+
+---
+* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
+    * $atlantis apply$
+* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+    * $atlantis unlock$
+`,
+		},
+		{
+			"multiple successful applies",
+			models.ApplyCommand,
+			[]models.ProjectResult{
+				{
+					RepoRelDir:   "path",
+					Workspace:    "workspace",
+					ProjectName:  "projectname",
+					ApplySuccess: "success",
+				},
+				{
+					RepoRelDir:   "path2",
+					Workspace:    "workspace",
+					ApplySuccess: "success2",
+				},
+			},
+			models.Github,
+			`Ran Apply for 2 projects:
+
+1. project: $projectname$ dir: $path$ workspace: $workspace$
+1. dir: $path2$ workspace: $workspace$
+
+### 1. project: $projectname$ dir: $path$ workspace: $workspace$
+$$$diff
+success
+$$$
+
+---
+### 2. dir: $path2$ workspace: $workspace$
+$$$diff
+success2
+$$$
+
+---
+
+`,
+		},
+		{
+			"single errored plan",
+			models.PlanCommand,
+			[]models.ProjectResult{
+				{
+					Error:      errors.New("error"),
+					RepoRelDir: "path",
+					Workspace:  "workspace",
+				},
+			},
+			models.Github,
+			`Ran Plan for dir: $path$ workspace: $workspace$
+
+**Plan Error**
+$$$
+error
+$$$
+
+`,
+		},
+		{
+			"single failed plan",
+			models.PlanCommand,
+			[]models.ProjectResult{
+				{
+					RepoRelDir: "path",
+					Workspace:  "workspace",
+					Failure:    "failure",
+				},
+			},
+			models.Github,
+			`Ran Plan for dir: $path$ workspace: $workspace$
+
+**Plan Failed**: failure
+
+`,
+		},
+		{
+			"successful, failed, and errored plan",
+			models.PlanCommand,
+			[]models.ProjectResult{
+				{
+					Workspace:  "workspace",
+					RepoRelDir: "path",
+					PlanSuccess: &models.PlanSuccess{
+						TerraformOutput: "terraform-output",
+						LockURL:         "lock-url",
+						ApplyCmd:        "atlantis apply -d path -w workspace",
+						RePlanCmd:       "atlantis plan -d path -w workspace",
+					},
+				},
+				{
+					Workspace:  "workspace",
+					RepoRelDir: "path2",
+					Failure:    "failure",
+				},
+				{
+					Workspace:   "workspace",
+					RepoRelDir:  "path3",
+					ProjectName: "projectname",
+					Error:       errors.New("error"),
+				},
+			},
+			models.Github,
+			`Ran Plan for 3 projects:
+
+1. dir: $path$ workspace: $workspace$
+1. dir: $path2$ workspace: $workspace$
+1. project: $projectname$ dir: $path3$ workspace: $workspace$
+
+### 1. dir: $path$ workspace: $workspace$
+$$$diff
+terraform-output
+$$$
+
+* :arrow_forward: To **apply** this plan, comment:
+    * $atlantis apply -d path -w workspace$
+* :repeat: To **plan** this project again, comment:
+    * $atlantis plan -d path -w workspace$
+
+---
+### 2. dir: $path2$ workspace: $workspace$
+**Plan Failed**: failure
+
+---
+### 3. project: $projectname$ dir: $path3$ workspace: $workspace$
+**Plan Error**
+$$$
+error
+$$$
+
+---
+* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
+    * $atlantis apply$
+* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+    * $atlantis unlock$
+`,
+		},
+		{
+			"successful, failed, and errored apply",
+			models.ApplyCommand,
+			[]models.ProjectResult{
+				{
+					Workspace:    "workspace",
+					RepoRelDir:   "path",
+					ApplySuccess: "success",
+				},
+				{
+					Workspace:  "workspace",
+					RepoRelDir: "path2",
+					Failure:    "failure",
+				},
+				{
+					Workspace:  "workspace",
+					RepoRelDir: "path3",
+					Error:      errors.New("error"),
+				},
+			},
+			models.Github,
+			`Ran Apply for 3 projects:
+
+1. dir: $path$ workspace: $workspace$
+1. dir: $path2$ workspace: $workspace$
+1. dir: $path3$ workspace: $workspace$
+
+### 1. dir: $path$ workspace: $workspace$
+$$$diff
+success
+$$$
+
+---
+### 2. dir: $path2$ workspace: $workspace$
+**Apply Failed**: failure
+
+---
+### 3. dir: $path3$ workspace: $workspace$
+**Apply Error**
+$$$
+error
+$$$
+
+---
+
+`,
+		},
+		{
+			"successful, failed, and errored apply",
+			models.ApplyCommand,
+			[]models.ProjectResult{
+				{
+					Workspace:    "workspace",
+					RepoRelDir:   "path",
+					ApplySuccess: "success",
+				},
+				{
+					Workspace:  "workspace",
+					RepoRelDir: "path2",
+					Failure:    "failure",
+				},
+				{
+					Workspace:  "workspace",
+					RepoRelDir: "path3",
+					Error:      errors.New("error"),
+				},
+			},
+			models.Github,
+			`Ran Apply for 3 projects:
+
+1. dir: $path$ workspace: $workspace$
+1. dir: $path2$ workspace: $workspace$
+1. dir: $path3$ workspace: $workspace$
+
+### 1. dir: $path$ workspace: $workspace$
+$$$diff
+success
+$$$
+
+---
+### 2. dir: $path2$ workspace: $workspace$
+**Apply Failed**: failure
+
+---
+### 3. dir: $path3$ workspace: $workspace$
+**Apply Error**
+$$$
+error
+$$$
+
+---
+
+`,
+		},
+	}
+
+	r := events.MarkdownRenderer{}
+	r.DisableRepoLocking = true
+	for _, c := range cases {
+		t.Run(c.Description, func(t *testing.T) {
+			res := events.CommandResult{
+				ProjectResults: c.ProjectResults,
+			}
+			for _, verbose := range []bool{true, false} {
+				t.Run(c.Description, func(t *testing.T) {
+					s := r.Render(res, c.Command, "log", verbose, c.VCSHost)
+					expWithBackticks := strings.Replace(c.Expected, "$", "`", -1)
+					if !verbose {
+						Equals(t, expWithBackticks, s)
+					} else {
+						Equals(t, expWithBackticks+"<details><summary>Log</summary>\n  <p>\n\n```\nlog```\n</p></details>\n", s)
+					}
+				})
+			}
+		})
+	}
+}

--- a/server/events/mock_workingdir_test.go
+++ b/server/events/mock_workingdir_test.go
@@ -4,11 +4,12 @@
 package events
 
 import (
+	"reflect"
+	"time"
+
 	pegomock "github.com/petergtz/pegomock"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	logging "github.com/runatlantis/atlantis/server/logging"
-	"reflect"
-	"time"
 )
 
 type MockWorkingDir struct {

--- a/server/server.go
+++ b/server/server.go
@@ -255,13 +255,19 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		DisableApplyAll:          userConfig.DisableApplyAll,
 		DisableMarkdownFolding:   userConfig.DisableMarkdownFolding,
 		DisableApply:             userConfig.DisableApply,
+		DisableRepoLocking:       userConfig.DisableRepoLocking,
 	}
 
 	boltdb, err := db.New(userConfig.DataDir)
 	if err != nil {
 		return nil, err
 	}
-	lockingClient := locking.NewClient(boltdb)
+	var lockingClient locking.Locker
+	if userConfig.DisableRepoLocking {
+		lockingClient = locking.NewClient(boltdb)
+	} else {
+		lockingClient = locking.NewNoOpLocker()
+	}
 	workingDirLocker := events.NewDefaultWorkingDirLocker()
 
 	var workingDir events.WorkingDir = &events.FileWorkspace{

--- a/server/server.go
+++ b/server/server.go
@@ -264,9 +264,9 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	}
 	var lockingClient locking.Locker
 	if userConfig.DisableRepoLocking {
-		lockingClient = locking.NewClient(boltdb)
-	} else {
 		lockingClient = locking.NewNoOpLocker()
+	} else {
+		lockingClient = locking.NewClient(boltdb)
 	}
 	workingDirLocker := events.NewDefaultWorkingDirLocker()
 

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -26,6 +26,7 @@ type UserConfig struct {
 	DisableApply               bool   `mapstructure:"disable-apply"`
 	DisableAutoplan            bool   `mapstructure:"disable-autoplan"`
 	DisableMarkdownFolding     bool   `mapstructure:"disable-markdown-folding"`
+	DisableRepoLocking         bool   `mapstructure:"disable-repo-locking"`
 	GithubHostname             string `mapstructure:"gh-hostname"`
 	GithubToken                string `mapstructure:"gh-token"`
 	GithubUser                 string `mapstructure:"gh-user"`


### PR DESCRIPTION
This change introduces a no-op Locker implementation that when enabled effectively disables the locking of projects and workspace

This is another possible solution to #1212, my initial change just automatically unlock after a plan had run (#1258)  