### PR TITLE
server/locks_controller: add GET + DELETE lock APIs at /api/locks

### DIFF
--- a/server/locks_controller.go
+++ b/server/locks_controller.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -15,6 +17,22 @@ import (
 	"github.com/runatlantis/atlantis/server/logging"
 )
 
+// UnlockRequest is the format of requests made against /api/locks with the DELETE method to release atlantis locks
+type UnlockRequest struct {
+	LockIDs []string
+}
+
+// UnlockResponse is the format of responses made against /api/locks with the DELETE method
+type UnlockResponse struct {
+	Result []UnlockData
+}
+
+// UnlockData indicates whether the given Lock ID was able to be released
+type UnlockData struct {
+	LockID  string
+	Success bool
+}
+
 // LocksController handles all requests relating to Atlantis locks.
 type LocksController struct {
 	AtlantisVersion    string
@@ -27,6 +45,41 @@ type LocksController struct {
 	WorkingDirLocker   events.WorkingDirLocker
 	DB                 *db.BoltDB
 	DeleteLockCommand  events.DeleteLockCommand
+}
+
+// GetLocksResponse is returned to requests against GetLocks at /api/locks with the GET method. It contains a lock data object for each lock held by atlantis
+type GetLocksResponse struct {
+	Result []LockData
+}
+
+// LockData contains information about the lock, including the lock ID and which PR is holding the lock
+type LockData struct {
+	PullRequestURL string
+	LockID         string
+}
+
+// GetLocks response to requests against /api/locks with a marshaled GetLocksResponse object that contains information about all open locks
+func (l *LocksController) GetLocks(w http.ResponseWriter, _ *http.Request) {
+	var result []LockData
+	locks, err := l.Locker.List()
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "Error listing locks: %s", err)
+		return
+	}
+	for key, lock := range locks {
+		result = append(result, LockData{PullRequestURL: lock.Pull.URL, LockID: key})
+	}
+	data, err := json.Marshal(GetLocksResponse{Result: result})
+	if err != nil {
+		l.respond(w, logging.Error, http.StatusInternalServerError, "Error creating list response: %s", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, err = w.Write(data)
+	if err != nil {
+		l.respond(w, logging.Error, http.StatusInternalServerError, "Error writing list response: %s", err)
+	}
 }
 
 // GetLock is the GET /locks/{id} route. It renders the lock detail view.
@@ -96,10 +149,73 @@ func (l *LocksController) DeleteLock(w http.ResponseWriter, r *http.Request) {
 		l.respond(w, logging.Info, http.StatusNotFound, "No lock found at id %q", idUnencoded)
 		return
 	}
+	err = l.clearLock(lock)
+	if err != nil {
+		l.respond(w, logging.Error, http.StatusInternalServerError, "Failed unlocking the pull request: %s", err)
+	}
+	if lock.Pull.BaseRepo != (models.Repo{}) {
+		// Once the lock has been deleted, comment back on the pull request.
+		comment := fmt.Sprintf("**Warning**: The plan for dir: `%s` workspace: `%s` was **discarded** via the Atlantis UI.\n\n"+
+			"To `apply` this plan you must run `plan` again.", lock.Project.Path, lock.Workspace)
+		if err = l.VCSClient.CreateComment(lock.Pull.BaseRepo, lock.Pull.Num, comment, ""); err != nil {
+			l.Logger.Warn("failed commenting on pull request: %s", err)
+		}
+	}
+	l.respond(w, logging.Info, http.StatusOK, "Deleted lock id %q", id)
+}
 
-	// NOTE: Because BaseRepo was added to the PullRequest model later, previous
-	// installations of Atlantis will have locks in their DB that do not have
-	// this field on PullRequest. We skip commenting in this case.
+// Unlock accepts json list of lock IDs
+func (l *LocksController) Unlock(w http.ResponseWriter, r *http.Request) {
+	// Parse the JSON payload
+	bytes, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		l.respond(w, logging.Error, http.StatusBadRequest, "Invalid unlock request. Failed to read request: %s", err)
+		return
+	}
+	var request UnlockRequest
+	if err = json.Unmarshal(bytes, &request); err != nil {
+		l.respond(w, logging.Error, http.StatusBadRequest, "Invalid unlock request. Failed with error: %s", err)
+		return
+	}
+	if len(request.LockIDs) == 0 {
+		l.respond(w, logging.Error, http.StatusBadRequest, "Invalid unlock request. No IDs specified in request")
+		return
+	}
+	var result []UnlockData
+	for _, id := range request.LockIDs {
+		lock, err := l.Locker.Unlock(id)
+		if err != nil {
+			result = append(result, UnlockData{LockID: id, Success: false})
+			continue
+		}
+		if lock == nil {
+			// if there is no lock, we will consider that a success to make this idempotent
+			result = append(result, UnlockData{LockID: id, Success: true})
+			continue
+		}
+		err = l.clearLock(lock)
+		if err != nil {
+			result = append(result, UnlockData{LockID: id, Success: false})
+		} else {
+			result = append(result, UnlockData{LockID: id, Success: true})
+		}
+	}
+	data, err := json.Marshal(UnlockResponse{Result: result})
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "Error creating unlock response: %s", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, err = w.Write(data)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "Error writing unlock response: %s", err)
+		return
+	}
+}
+
+func (l *LocksController) clearLock(lock *models.ProjectLock) error {
 	if lock.Pull.BaseRepo != (models.Repo{}) {
 		unlock, err := l.WorkingDirLocker.TryLock(lock.Pull.BaseRepo.FullName, lock.Pull.Num, lock.Workspace)
 		if err != nil {
@@ -109,22 +225,17 @@ func (l *LocksController) DeleteLock(w http.ResponseWriter, r *http.Request) {
 			// nolint: vetshadow
 			if err := l.WorkingDir.DeleteForWorkspace(lock.Pull.BaseRepo, lock.Pull, lock.Workspace); err != nil {
 				l.Logger.Err("unable to delete workspace: %s", err)
+				return err
 			}
 		}
 		if err := l.DB.UpdateProjectStatus(lock.Pull, lock.Workspace, lock.Project.Path, models.DiscardedPlanStatus); err != nil {
 			l.Logger.Err("unable to update project status: %s", err)
-		}
-
-		// Once the lock has been deleted, comment back on the pull request.
-		comment := fmt.Sprintf("**Warning**: The plan for dir: `%s` workspace: `%s` was **discarded** via the Atlantis UI.\n\n"+
-			"To `apply` this plan you must run `plan` again.", lock.Project.Path, lock.Workspace)
-		if err = l.VCSClient.CreateComment(lock.Pull.BaseRepo, lock.Pull.Num, comment, ""); err != nil {
-			l.Logger.Warn("failed commenting on pull request: %s", err)
+			return err
 		}
 	} else {
-		l.Logger.Debug("skipping commenting on pull request and deleting workspace because BaseRepo field is empty")
+		l.Logger.Debug("skipping deleting workspace because BaseRepo field is empty")
 	}
-	l.respond(w, logging.Info, http.StatusOK, "Deleted lock id %q", id)
+	return nil
 }
 
 // respond is a helper function to respond and log the response. lvl is the log

--- a/server/server.go
+++ b/server/server.go
@@ -513,6 +513,8 @@ func (s *Server) Start() error {
 	s.Router.HandleFunc("/events", s.EventsController.Post).Methods("POST")
 	s.Router.HandleFunc("/github-app/exchange-code", s.GithubAppController.ExchangeCode).Methods("GET")
 	s.Router.HandleFunc("/github-app/setup", s.GithubAppController.New).Methods("GET")
+	s.Router.HandleFunc("/api/locks", s.LocksController.Unlock).Methods("DELETE")
+	s.Router.HandleFunc("/api/locks", s.LocksController.GetLocks).Methods("GET")
 	s.Router.HandleFunc("/locks", s.LocksController.DeleteLock).Methods("DELETE").Queries("id", "{id:.*}")
 	s.Router.HandleFunc("/lock", s.LocksController.GetLock).Methods("GET").
 		Queries(LockViewRouteIDQueryParam, fmt.Sprintf("{%s}", LockViewRouteIDQueryParam)).Name(LockViewRouteName)


### PR DESCRIPTION
Tracking ticket at #1064, related to #733. This PR consolidates the changes from #1044 and #1029 for clarity

This adds a single endpoint at /api/locks that supports GET and DELETE methods and the tracking ticket has additional details.

Example GET response - `{"Result":[{"PullRequestURL":"https://github.com/cket/example/pull/7","LockIDs":["cket/example/terraform/us-east-1/dev/test/default"]}]}`

Example DELETE input - `'{"LockIDs": ["cket/example/terraform/us-east-1/dev/test/default"]}'`

Example DELETE response - `{"Result":[{"LockID":"cket/example/terraform/us-east-1/dev/test/default","Success":true}]}`