### PR TITLE
feat(init): Don't upgrade provider on init since Terraform 0.14.0 has lock file

### DIFF
--- a/server/events/runtime/init_step_runner.go
+++ b/server/events/runtime/init_step_runner.go
@@ -16,12 +16,12 @@ func (i *InitStepRunner) Run(ctx models.ProjectCommandContext, extraArgs []strin
 	if ctx.TerraformVersion != nil {
 		tfVersion = ctx.TerraformVersion
 	}
-	terraformInitCmd := append([]string{"init", "-input=false", "-no-color", "-upgrade"}, extraArgs...)
+	terraformInitCmd := append([]string{"init", "-input=false", "-no-color"}, extraArgs...)
 
 	// If we're running < 0.9 we have to use `terraform get` instead of `init`.
 	if MustConstraint("< 0.9.0").Check(tfVersion) {
 		ctx.Log.Info("running terraform version %s so will use `get` instead of `init`", tfVersion)
-		terraformInitCmd = append([]string{"get", "-no-color", "-upgrade"}, extraArgs...)
+		terraformInitCmd = append([]string{"get", "-no-color"}, extraArgs...)
 	}
 
 	out, err := i.TerraformExecutor.RunCommandWithVersion(ctx.Log, path, terraformInitCmd, envs, tfVersion, ctx.Workspace)

--- a/server/events/runtime/init_step_runner_test.go
+++ b/server/events/runtime/init_step_runner_test.go
@@ -59,9 +59,9 @@ func TestRun_UsesGetOrInitForRightVersion(t *testing.T) {
 			Equals(t, "", output)
 
 			// If using init then we specify -input=false but not for get.
-			expArgs := []string{c.expCmd, "-input=false", "-no-color", "-upgrade", "extra", "args"}
+			expArgs := []string{c.expCmd, "-input=false", "-no-color", "extra", "args"}
 			if c.expCmd == "get" {
-				expArgs = []string{c.expCmd, "-no-color", "-upgrade", "extra", "args"}
+				expArgs = []string{c.expCmd, "-no-color", "extra", "args"}
 			}
 			terraform.VerifyWasCalledOnce().RunCommandWithVersion(nil, "/path", expArgs, map[string]string(nil), tfVersion, "workspace")
 		})


### PR DESCRIPTION
Before 0.14.0 that make sens to always upgrade provider. But since Terraform 0.14.0, the command `terraform init` ensure the version of provider from the `.terraform.lock.hcl`.

It's a change in behavior, but the continuous integration system must respect the `.terraform.lock.hcl` file, else that may cause an unexpected result. This is the same behaviour from `npm ci` or `bundle install`.

The old behavior can be done with a workflow modification like:

```
workflows:
  production:
    plan:
      steps:
      - init:
          extra_args: ["-upgrade"]
      - plan:

    apply:
      steps:
      - init:
          extra_args: ["-upgrade"]
      - apply
```