### PR TITLE
Allow applying 0 projects when disable-apply-all is used

### DIFF
--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -214,7 +214,7 @@ func (c *DefaultCommandRunner) RunCommentCommand(baseRepo models.Repo, maybeHead
 		return
 	}
 
-	if c.DisableApplyAll && cmd.Name == models.ApplyCommand && !cmd.IsForSpecificProject() {
+	if c.DisableApplyAll && !cmd.Empty && cmd.Name == models.ApplyCommand && !cmd.IsForSpecificProject() {
 		log.Info("ignoring apply command without flags since apply all is disabled")
 		if err := c.VCSClient.CreateComment(baseRepo, pullNum, applyAllDisabledComment, models.ApplyCommand.String()); err != nil {
 			log.Err("unable to comment on pull request: %s", err)
@@ -620,7 +620,8 @@ var automergeComment = `Automatically merging because all plans have been succes
 // applyAllDisabledComment is posted when apply all commands (i.e. "atlantis apply")
 // are disabled and an apply all command is issued.
 var applyAllDisabledComment = "**Error:** Running `atlantis apply` without flags is disabled." +
-	" You must specify which project to apply via the `-d <dir>`, `-w <workspace>` or `-p <project name>` flags."
+	" You must specify which project to apply via the `-d <dir>`, `-w <workspace>` or `-p <project name>` flags." +
+	" Or apply zero projects with the `-e` flag."
 
 // applyDisabledComment is posted when apply commands are disabled globally and an apply command is issued.
 var applyDisabledComment = "**Error:** Running `atlantis apply` is disabled."

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -196,7 +196,7 @@ func TestRunCommentCommand_DisableApplyAllDisabled(t *testing.T) {
 	ch.DisableApplyAll = true
 	modelPull := models.PullRequest{BaseRepo: fixtures.GithubRepo, State: models.OpenPullState}
 	ch.RunCommentCommand(fixtures.GithubRepo, nil, nil, fixtures.User, modelPull.Num, &events.CommentCommand{Name: models.ApplyCommand})
-	vcsClient.VerifyWasCalledOnce().CreateComment(fixtures.GithubRepo, modelPull.Num, "**Error:** Running `atlantis apply` without flags is disabled. You must specify which project to apply via the `-d <dir>`, `-w <workspace>` or `-p <project name>` flags.", "apply")
+	vcsClient.VerifyWasCalledOnce().CreateComment(fixtures.GithubRepo, modelPull.Num, "**Error:** Running `atlantis apply` without flags is disabled. You must specify which project to apply via the `-d <dir>`, `-w <workspace>` or `-p <project name>` flags. Or apply zero projects with the `-e` flag.", "apply")
 }
 
 func TestRunCommentCommand_ApplyDisabled(t *testing.T) {

--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -258,7 +258,7 @@ func (e *CommentParser) Parse(comment string, vcsHost models.VCSHostType) Commen
 	}
 
 	return CommentParseResult{
-		Command: NewCommentCommand(dir, extraArgs, name, verbose, workspace, project),
+		Command: NewCommentCommand(dir, extraArgs, name, empty, verbose, workspace, project),
 	}
 }
 

--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -560,6 +560,62 @@ func TestParse_Parsing(t *testing.T) {
 	}
 }
 
+func TestBuildApplyEmpytComment(t *testing.T) {
+	cases := []struct {
+		flags        string
+		expWorkspace string
+		expDir       string
+		expEmpty     bool
+		expVerbose   bool
+		expExtraArgs string
+		expProject   string
+	}{
+		{
+			"",
+			"",
+			"",
+			false,
+			false,
+			"",
+			"",
+		},
+		{
+			"-e",
+			"",
+			"",
+			true,
+			false,
+			"",
+			"",
+		},
+		{
+			"--empty",
+			"",
+			"",
+			true,
+			false,
+			"",
+			"",
+		},
+	}
+
+	for _, test := range cases {
+		comment := fmt.Sprintf("atlantis %s %s", "apply", test.flags)
+		t.Run(comment, func(t *testing.T) {
+			r := commentParser.Parse(comment, models.Github)
+			Assert(t, r.CommentResponse == "", "CommentResponse should have been empty but was %q for comment %q", r.CommentResponse, comment)
+			Assert(t, test.expDir == r.Command.RepoRelDir, "exp dir to equal %q but was %q for comment %q", test.expDir, r.Command.RepoRelDir, comment)
+			Assert(t, test.expWorkspace == r.Command.Workspace, "exp workspace to equal %q but was %q for comment %q", test.expWorkspace, r.Command.Workspace, comment)
+			Assert(t, test.expEmpty == r.Command.Empty, "exp empty to equal %v but was %v for comment %q", test.expEmpty, r.Command.Empty, comment)
+			Assert(t, test.expVerbose == r.Command.Verbose, "exp verbose to equal %v but was %v for comment %q", test.expVerbose, r.Command.Verbose, comment)
+			actExtraArgs := strings.Join(r.Command.Flags, " ")
+			Assert(t, test.expExtraArgs == actExtraArgs, "exp extra args to equal %v but got %v for comment %q", test.expExtraArgs, actExtraArgs, comment)
+			Assert(t, r.Command.Name == models.ApplyCommand, "did not parse comment %q as apply command", comment)
+		})
+	}
+
+}
+
 func TestBuildPlanApplyComment(t *testing.T) {
 	cases := []struct {
 		repoRelDir    string

--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -221,8 +221,8 @@ func TestParse_InvalidFlags(t *testing.T) {
 			"Error: unknown flag: --abc",
 		},
 		{
-			"atlantis apply -e",
-			"Error: unknown shorthand flag: 'e' in -e",
+			"atlantis apply -x",
+			"Error: unknown shorthand flag: 'x' in -x",
 		},
 		{
 			"atlantis apply --abc",
@@ -786,6 +786,7 @@ var PlanUsage = `Usage of plan:
 var ApplyUsage = `Usage of apply:
   -d, --dir string         Apply the plan for this directory, relative to root of
                            repo, ex. 'child/dir'.
+  -e, --empty              Apply when there is no projects planned.
   -p, --project string     Apply the plan for this project. Refers to the name of
                            the project configured in atlantis.yaml. Cannot be used
                            at same time as workspace or dir flags.

--- a/server/events/event_parser.go
+++ b/server/events/event_parser.go
@@ -72,6 +72,8 @@ type CommentCommand struct {
 	Flags []string
 	// Name is the name of the command the comment specified.
 	Name models.CommandName
+	// Empty is true if the command should only allow apply when no projects where planned.
+	Empty bool
 	// Verbose is true if the command should output verbosely.
 	Verbose bool
 	// Workspace is the name of the Terraform workspace to run the command in.
@@ -111,7 +113,7 @@ func (c CommentCommand) String() string {
 }
 
 // NewCommentCommand constructs a CommentCommand, setting all missing fields to defaults.
-func NewCommentCommand(repoRelDir string, flags []string, name models.CommandName, verbose bool, workspace string, project string) *CommentCommand {
+func NewCommentCommand(repoRelDir string, flags []string, name models.CommandName, empty, verbose bool, workspace string, project string) *CommentCommand {
 	// If repoRelDir was empty we want to keep it that way to indicate that it
 	// wasn't specified in the comment.
 	if repoRelDir != "" {
@@ -124,6 +126,7 @@ func NewCommentCommand(repoRelDir string, flags []string, name models.CommandNam
 		RepoRelDir:  repoRelDir,
 		Flags:       flags,
 		Name:        name,
+		Empty:       empty,
 		Verbose:     verbose,
 		Workspace:   workspace,
 		ProjectName: project,

--- a/server/events/event_parser_test.go
+++ b/server/events/event_parser_test.go
@@ -650,18 +650,19 @@ func TestNewCommand_CleansDir(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.RepoRelDir, func(t *testing.T) {
-			cmd := events.NewCommentCommand(c.RepoRelDir, nil, models.PlanCommand, false, "workspace", "")
+			cmd := events.NewCommentCommand(c.RepoRelDir, nil, models.PlanCommand, false, false, "workspace", "")
 			Equals(t, c.ExpDir, cmd.RepoRelDir)
 		})
 	}
 }
 
 func TestNewCommand_EmptyDirWorkspaceProject(t *testing.T) {
-	cmd := events.NewCommentCommand("", nil, models.PlanCommand, false, "", "")
+	cmd := events.NewCommentCommand("", nil, models.PlanCommand, false, false, "", "")
 	Equals(t, events.CommentCommand{
 		RepoRelDir:  "",
 		Flags:       nil,
 		Name:        models.PlanCommand,
+		Empty:       false,
 		Verbose:     false,
 		Workspace:   "",
 		ProjectName: "",
@@ -669,10 +670,11 @@ func TestNewCommand_EmptyDirWorkspaceProject(t *testing.T) {
 }
 
 func TestNewCommand_AllFieldsSet(t *testing.T) {
-	cmd := events.NewCommentCommand("dir", []string{"a", "b"}, models.PlanCommand, true, "workspace", "project")
+	cmd := events.NewCommentCommand("dir", []string{"a", "b"}, models.PlanCommand, true, true, "workspace", "project")
 	Equals(t, events.CommentCommand{
 		Workspace:   "workspace",
 		RepoRelDir:  "dir",
+		Empty:       true,
 		Verbose:     true,
 		Flags:       []string{"a", "b"},
 		Name:        models.PlanCommand,


### PR DESCRIPTION
This PR introduces a new flag `--empty/-e` to the `apply` command. This makes it possible to "apply" all changes when the `--disable-apply-all` flag is set. Without this this you can't get such PR merged if Github has `atlantis/apply` as a required status check.

## TODO

- [ ] Docs

## Alternative solution

Instead of adding the `-e` flag to the apply command the check in [command_runner.go#L217](https://github.com/runatlantis/atlantis/blob/master/server/events/command_runner.go#L217) can be postponed and allow `atlantis apply` without flags _if and only if_ there is zero projects to apply even if the `--disable-apply-all` flag was used.
 
Fixes: #1359