### PR TITLE
Set TF_WORKSPACE env var

### DIFF
--- a/server/events/terraform/terraform_client.go
+++ b/server/events/terraform/terraform_client.go
@@ -265,6 +265,7 @@ func (c *DefaultClient) prepCmd(log *logging.SimpleLogger, v *version.Version, w
 		"TF_IN_AUTOMATION=true",
 		// Cache plugins so terraform init runs faster.
 		fmt.Sprintf("WORKSPACE=%s", workspace),
+		fmt.Sprintf("TF_WORKSPACE=%s", workspace),
 		fmt.Sprintf("ATLANTIS_TERRAFORM_VERSION=%s", v.String()),
 		fmt.Sprintf("DIR=%s", path),
 	}


### PR DESCRIPTION
For remote runs to target the correct workspace, custom workflows are needed. This PR sets the `TF_WORKSPACE` environment variable, to make it work without custom workflows.

fixes #661