### PR TITLE
Add stale github action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,15 @@
+- name: Close Stale Issues
+  on:
+    schedule:
+      - cron: '30 1 * * *'
+  jobs:
+    stale:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/stale@v3.0.15
+          with:
+            stale-pr-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+            days-before-stale: 30
+            days-before-close: 5
+            only-labels: 'waiting-on-response'
+  

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,15 +1,15 @@
-- name: Close Stale Issues
-  on:
-    schedule:
-      - cron: '30 1 * * *'
-  jobs:
-    stale:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/stale@v3.0.15
-          with:
-            stale-pr-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
-            days-before-stale: 30
-            days-before-close: 5
-            only-labels: 'waiting-on-response'
+name: Close Stale PRs
+on:
+  schedule:
+    - cron: '30 1 * * *'
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3.0.15
+        with:
+          stale-pr-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          days-before-stale: 30
+          days-before-close: 5
+          only-labels: 'waiting-on-response'
   


### PR DESCRIPTION
Right now this is only configured for PRs but can be used for issues as well.  This only cleans up PRs for which the customer is not responding to as of now.