### PR TITLE
Fix bug with Stale/Old Plan Files

### DIFF
--- a/server/events/mocks/mock_working_dir_locker.go
+++ b/server/events/mocks/mock_working_dir_locker.go
@@ -62,6 +62,25 @@ func (mock *MockWorkingDirLocker) TryLockPull(repoFullName string, pullNum int) 
 	return ret0, ret1
 }
 
+func (mock *MockWorkingDirLocker) IsPullLocked(repoFullName string, pullNum int) (bool, error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockWorkingDirLocker().")
+	}
+	params := []pegomock.Param{repoFullName, pullNum}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("IsPullLocked", params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 bool
+	var ret1 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(bool)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(error)
+		}
+	}
+	return ret0, ret1
+}
+
 func (mock *MockWorkingDirLocker) VerifyWasCalledOnce() *VerifierMockWorkingDirLocker {
 	return &VerifierMockWorkingDirLocker{
 		mock:                   mock,
@@ -69,14 +88,14 @@ func (mock *MockWorkingDirLocker) VerifyWasCalledOnce() *VerifierMockWorkingDirL
 	}
 }
 
-func (mock *MockWorkingDirLocker) VerifyWasCalled(invocationCountMatcher pegomock.Matcher) *VerifierMockWorkingDirLocker {
+func (mock *MockWorkingDirLocker) VerifyWasCalled(invocationCountMatcher pegomock.InvocationCountMatcher) *VerifierMockWorkingDirLocker {
 	return &VerifierMockWorkingDirLocker{
 		mock:                   mock,
 		invocationCountMatcher: invocationCountMatcher,
 	}
 }
 
-func (mock *MockWorkingDirLocker) VerifyWasCalledInOrder(invocationCountMatcher pegomock.Matcher, inOrderContext *pegomock.InOrderContext) *VerifierMockWorkingDirLocker {
+func (mock *MockWorkingDirLocker) VerifyWasCalledInOrder(invocationCountMatcher pegomock.InvocationCountMatcher, inOrderContext *pegomock.InOrderContext) *VerifierMockWorkingDirLocker {
 	return &VerifierMockWorkingDirLocker{
 		mock:                   mock,
 		invocationCountMatcher: invocationCountMatcher,
@@ -84,7 +103,7 @@ func (mock *MockWorkingDirLocker) VerifyWasCalledInOrder(invocationCountMatcher 
 	}
 }
 
-func (mock *MockWorkingDirLocker) VerifyWasCalledEventually(invocationCountMatcher pegomock.Matcher, timeout time.Duration) *VerifierMockWorkingDirLocker {
+func (mock *MockWorkingDirLocker) VerifyWasCalledEventually(invocationCountMatcher pegomock.InvocationCountMatcher, timeout time.Duration) *VerifierMockWorkingDirLocker {
 	return &VerifierMockWorkingDirLocker{
 		mock:                   mock,
 		invocationCountMatcher: invocationCountMatcher,
@@ -94,7 +113,7 @@ func (mock *MockWorkingDirLocker) VerifyWasCalledEventually(invocationCountMatch
 
 type VerifierMockWorkingDirLocker struct {
 	mock                   *MockWorkingDirLocker
-	invocationCountMatcher pegomock.Matcher
+	invocationCountMatcher pegomock.InvocationCountMatcher
 	inOrderContext         *pegomock.InOrderContext
 	timeout                time.Duration
 }
@@ -151,6 +170,37 @@ func (c *MockWorkingDirLocker_TryLockPull_OngoingVerification) GetCapturedArgume
 }
 
 func (c *MockWorkingDirLocker_TryLockPull_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []int) {
+	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(params) > 0 {
+		_param0 = make([]string, len(c.methodInvocations))
+		for u, param := range params[0] {
+			_param0[u] = param.(string)
+		}
+		_param1 = make([]int, len(c.methodInvocations))
+		for u, param := range params[1] {
+			_param1[u] = param.(int)
+		}
+	}
+	return
+}
+
+func (verifier *VerifierMockWorkingDirLocker) IsPullLocked(repoFullName string, pullNum int) *MockWorkingDirLocker_IsPullLocked_OngoingVerification {
+	params := []pegomock.Param{repoFullName, pullNum}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "IsPullLocked", params, verifier.timeout)
+	return &MockWorkingDirLocker_IsPullLocked_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockWorkingDirLocker_IsPullLocked_OngoingVerification struct {
+	mock              *MockWorkingDirLocker
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockWorkingDirLocker_IsPullLocked_OngoingVerification) GetCapturedArguments() (string, int) {
+	repoFullName, pullNum := c.GetAllCapturedArguments()
+	return repoFullName[len(repoFullName)-1], pullNum[len(pullNum)-1]
+}
+
+func (c *MockWorkingDirLocker_IsPullLocked_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []int) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]string, len(c.methodInvocations))

--- a/server/events/working_dir_locker.go
+++ b/server/events/working_dir_locker.go
@@ -38,6 +38,7 @@ type WorkingDirLocker interface {
 	// an error if the workspace is already locked. The error is expected to
 	// be printed to the pull request.
 	TryLockPull(repoFullName string, pullNum int) (func(), error)
+	IsPullLocked(repoFullName string, pullNum int) (bool, error)
 }
 
 // DefaultWorkingDirLocker implements WorkingDirLocker.
@@ -127,4 +128,14 @@ func (d *DefaultWorkingDirLocker) workspaceKey(repo string, pull int, workspace 
 
 func (d *DefaultWorkingDirLocker) pullKey(repo string, pull int) string {
 	return fmt.Sprintf("%s/%d", repo, pull)
+}
+
+func (d *DefaultWorkingDirLocker) IsPullLocked(repoFullName string, pullNum int) (bool, error) {
+	pullKey := d.pullKey(repoFullName, pullNum)
+	for _, l := range d.locks {
+		if l == pullKey || strings.HasPrefix(l, pullKey+"/") {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/server/events/working_dir_locker_test.go
+++ b/server/events/working_dir_locker_test.go
@@ -196,3 +196,24 @@ func TestLockPull_WorkspaceFirst(t *testing.T) {
 	_, err = locker.TryLockPull("owner/repo", 1)
 	Ok(t, err)
 }
+
+func TestIsPullLocked(t *testing.T) {
+	locker := events.NewDefaultWorkingDirLocker()
+
+	isLocked, err := locker.IsPullLocked("owner/repo", 1)
+	Ok(t, err)
+	Assert(t, isLocked == false, "exp unlocked")
+
+	unlock, err := locker.TryLockPull("owner/repo", 1)
+	Ok(t, err)
+
+	isLocked, err = locker.IsPullLocked("owner/repo", 1)
+	Ok(t, err)
+	Assert(t, isLocked == true, "exp locked")
+
+	// After unlocking, should be able to get a pull lock.
+	unlock()
+	isLocked, err = locker.IsPullLocked("owner/repo", 1)
+	Ok(t, err)
+	Assert(t, isLocked == false, "exp unlocked")
+}


### PR DESCRIPTION
Hello Atlantis Community, this is my first PR so please show some mercy. 🙏🏽 

**Bug Description:**
There is an edge case in which if the plan files for modules (1),(2) have
been already created for a commit (a) in a PR and then the user understands
that he made a mistake and he didn't want to change module (2) and drops
the terraform code of it in commit (b), then when the user will try to
run the apply command Atlantis will apply the (2) module plan file as well
as the `PendingPlanFinder.Find` finds all the differences between the upstream
branch and what Atlantis contains and filters out the `.tfplan` files.
There is an issue connected to this bug #1122

**How this PR fixes the problem:**

In order to mitigate the above bug after some careful consideration, it seems
that the best solution is to drop all the plan files in case the PR has been
locked anytime in the past, which translates that it most likely have created
`.tfplan` files.

**Risks introduced:**
This commit is not expected to create any side-effects or introduce any
new problems.

P.S.
I would like to create a test for this edge case but it seems to be a bit difficult on how and where should I place it. Any suggestions are more than welcome 😄 
