### PR TITLE
Fixes for pre-workflow-hook

### DIFF
--- a/server/events/pre_workflow_hooks_command_runner_test.go
+++ b/server/events/pre_workflow_hooks_command_runner_test.go
@@ -22,9 +22,7 @@ var wh events.DefaultPreWorkflowHooksCommandRunner
 var whWorkingDir *mocks.MockWorkingDir
 var whWorkingDirLocker *mocks.MockWorkingDirLocker
 var whDrainer *events.Drainer
-var whGlobalCfg valid.GlobalCfg
 var whLogger *logmocks.MockSimpleLogging
-var whPullLogger *logging.SimpleLogger
 
 func preWorkflowHooksSetup(t *testing.T) *vcsmocks.MockClient {
 	RegisterMockTestingT(t)


### PR DESCRIPTION
1. Fixes pre-workflow-hooks not logging errors #1371

2. Prevents pre-workflow-hook from locking and cloning the dir if there are no hooks registered. #1342 