### PR TITLE
feat: include comment author in atlantis logs

### DIFF
--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -54,7 +54,7 @@ var multiLineRegex = regexp.MustCompile(`.*\r?\n[^\r\n]+`)
 type CommentParsing interface {
 	// Parse attempts to parse a pull request comment to see if it's an Atlantis
 	// command.
-	Parse(comment string, vcsHost models.VCSHostType) CommentParseResult
+	Parse(comment string, user models.User, vcsHost models.VCSHostType) CommentParseResult
 }
 
 // CommentBuilder builds comment commands that can be used on pull requests.
@@ -103,7 +103,7 @@ type CommentParseResult struct {
 // - atlantis plan --verbose -- -key=value -key2 value2
 // - atlantis approve_policies
 //
-func (e *CommentParser) Parse(comment string, vcsHost models.VCSHostType) CommentParseResult {
+func (e *CommentParser) Parse(comment string, user models.User, vcsHost models.VCSHostType) CommentParseResult {
 	if multiLineRegex.MatchString(comment) {
 		return CommentParseResult{Ignore: true}
 	}
@@ -171,6 +171,7 @@ func (e *CommentParser) Parse(comment string, vcsHost models.VCSHostType) Commen
 	var verbose bool
 	var flagSet *pflag.FlagSet
 	var name models.CommandName
+	// var commentAuthor string
 
 	// Set up the flag parsing depending on the command.
 	switch command {
@@ -254,7 +255,7 @@ func (e *CommentParser) Parse(comment string, vcsHost models.VCSHostType) Commen
 	}
 
 	return CommentParseResult{
-		Command: NewCommentCommand(dir, extraArgs, name, verbose, workspace, project),
+		Command: NewCommentCommand(dir, extraArgs, name, verbose, workspace, project, user.Username),
 	}
 }
 

--- a/server/events/event_parser.go
+++ b/server/events/event_parser.go
@@ -99,7 +99,8 @@ type CommentCommand struct {
 	// ProjectName is the name of a project to run the command on. It refers to a
 	// project specified in an atlantis.yaml file.
 	// If empty then the comment specified no project.
-	ProjectName string
+	ProjectName   string
+	CommentAuthor string
 }
 
 // IsForSpecificProject returns true if the command is for a specific dir, workspace
@@ -126,11 +127,11 @@ func (c CommentCommand) IsAutoplan() bool {
 
 // String returns a string representation of the command.
 func (c CommentCommand) String() string {
-	return fmt.Sprintf("command=%q verbose=%t dir=%q workspace=%q project=%q flags=%q", c.Name.String(), c.Verbose, c.RepoRelDir, c.Workspace, c.ProjectName, strings.Join(c.Flags, ","))
+	return fmt.Sprintf("command=%q verbose=%t dir=%q workspace=%q project=%q flags=%q commentAuthor=%q", c.Name.String(), c.Verbose, c.RepoRelDir, c.Workspace, c.ProjectName, strings.Join(c.Flags, ","), c.CommentAuthor)
 }
 
 // NewCommentCommand constructs a CommentCommand, setting all missing fields to defaults.
-func NewCommentCommand(repoRelDir string, flags []string, name models.CommandName, verbose bool, workspace string, project string) *CommentCommand {
+func NewCommentCommand(repoRelDir string, flags []string, name models.CommandName, verbose bool, workspace string, project string, commentAuthor string) *CommentCommand {
 	// If repoRelDir was empty we want to keep it that way to indicate that it
 	// wasn't specified in the comment.
 	if repoRelDir != "" {
@@ -140,12 +141,13 @@ func NewCommentCommand(repoRelDir string, flags []string, name models.CommandNam
 		}
 	}
 	return &CommentCommand{
-		RepoRelDir:  repoRelDir,
-		Flags:       flags,
-		Name:        name,
-		Verbose:     verbose,
-		Workspace:   workspace,
-		ProjectName: project,
+		RepoRelDir:    repoRelDir,
+		Flags:         flags,
+		Name:          name,
+		Verbose:       verbose,
+		Workspace:     workspace,
+		ProjectName:   project,
+		CommentAuthor: commentAuthor,
 	}
 }
 
@@ -157,7 +159,7 @@ func NewCommentCommand(repoRelDir string, flags []string, name models.CommandNam
 type EventParsing interface {
 	// ParseGithubIssueCommentEvent parses GitHub pull request comment events.
 	// baseRepo is the repo that the pull request will be merged into.
-	// user is the pull request author.
+	// user is the comment author.
 	// pullNum is the number of the pull request that triggered the webhook.
 	ParseGithubIssueCommentEvent(comment *github.IssueCommentEvent) (
 		baseRepo models.Repo, user models.User, pullNum int, err error)

--- a/server/events/event_parser_test.go
+++ b/server/events/event_parser_test.go
@@ -650,33 +650,35 @@ func TestNewCommand_CleansDir(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.RepoRelDir, func(t *testing.T) {
-			cmd := events.NewCommentCommand(c.RepoRelDir, nil, models.PlanCommand, false, "workspace", "")
+			cmd := events.NewCommentCommand(c.RepoRelDir, nil, models.PlanCommand, false, "workspace", "", "author")
 			Equals(t, c.ExpDir, cmd.RepoRelDir)
 		})
 	}
 }
 
 func TestNewCommand_EmptyDirWorkspaceProject(t *testing.T) {
-	cmd := events.NewCommentCommand("", nil, models.PlanCommand, false, "", "")
+	cmd := events.NewCommentCommand("", nil, models.PlanCommand, false, "", "", "author")
 	Equals(t, events.CommentCommand{
-		RepoRelDir:  "",
-		Flags:       nil,
-		Name:        models.PlanCommand,
-		Verbose:     false,
-		Workspace:   "",
-		ProjectName: "",
+		RepoRelDir:    "",
+		Flags:         nil,
+		Name:          models.PlanCommand,
+		Verbose:       false,
+		Workspace:     "",
+		ProjectName:   "",
+		CommentAuthor: "author",
 	}, *cmd)
 }
 
 func TestNewCommand_AllFieldsSet(t *testing.T) {
-	cmd := events.NewCommentCommand("dir", []string{"a", "b"}, models.PlanCommand, true, "workspace", "project")
+	cmd := events.NewCommentCommand("dir", []string{"a", "b"}, models.PlanCommand, true, "workspace", "project", "author")
 	Equals(t, events.CommentCommand{
-		Workspace:   "workspace",
-		RepoRelDir:  "dir",
-		Verbose:     true,
-		Flags:       []string{"a", "b"},
-		Name:        models.PlanCommand,
-		ProjectName: "project",
+		Workspace:     "workspace",
+		RepoRelDir:    "dir",
+		Verbose:       true,
+		Flags:         []string{"a", "b"},
+		Name:          models.PlanCommand,
+		ProjectName:   "project",
+		CommentAuthor: "author",
 	}, *cmd)
 }
 
@@ -715,14 +717,15 @@ func TestCommentCommand_IsAutoplan(t *testing.T) {
 }
 
 func TestCommentCommand_String(t *testing.T) {
-	exp := `command="plan" verbose=true dir="mydir" workspace="myworkspace" project="myproject" flags="flag1,flag2"`
+	exp := `command="plan" verbose=true dir="mydir" workspace="myworkspace" project="myproject" flags="flag1,flag2" commentAuthor="username"`
 	Equals(t, exp, (events.CommentCommand{
-		RepoRelDir:  "mydir",
-		Flags:       []string{"flag1", "flag2"},
-		Name:        models.PlanCommand,
-		Verbose:     true,
-		Workspace:   "myworkspace",
-		ProjectName: "myproject",
+		RepoRelDir:    "mydir",
+		Flags:         []string{"flag1", "flag2"},
+		Name:          models.PlanCommand,
+		Verbose:       true,
+		Workspace:     "myworkspace",
+		ProjectName:   "myproject",
+		CommentAuthor: "username",
 	}).String())
 }
 

--- a/server/events/mocks/mock_comment_parsing.go
+++ b/server/events/mocks/mock_comment_parsing.go
@@ -79,7 +79,7 @@ type VerifierMockCommentParsing struct {
 	timeout                time.Duration
 }
 
-func (verifier *VerifierMockCommentParsing) Parse(comment string, vcsHost models.VCSHostType) *MockCommentParsing_Parse_OngoingVerification {
+func (verifier *VerifierMockCommentParsing) Parse(comment string, user models.User, vcsHost models.VCSHostType) *MockCommentParsing_Parse_OngoingVerification {
 	params := []pegomock.Param{comment, vcsHost}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "Parse", params, verifier.timeout)
 	return &MockCommentParsing_Parse_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
@@ -90,21 +90,25 @@ type MockCommentParsing_Parse_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockCommentParsing_Parse_OngoingVerification) GetCapturedArguments() (string, models.VCSHostType) {
-	comment, vcsHost := c.GetAllCapturedArguments()
-	return comment[len(comment)-1], vcsHost[len(vcsHost)-1]
+func (c *MockCommentParsing_Parse_OngoingVerification) GetCapturedArguments() (string, models.User, models.VCSHostType) {
+	comment, user, vcsHost := c.GetAllCapturedArguments()
+	return comment[len(comment)-1], user[len(user)-1], vcsHost[len(vcsHost)-1]
 }
 
-func (c *MockCommentParsing_Parse_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []models.VCSHostType) {
+func (c *MockCommentParsing_Parse_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []models.User, _param2 []models.VCSHostType) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
 		}
-		_param1 = make([]models.VCSHostType, len(c.methodInvocations))
+		_param1 = make([]models.User, len(c.methodInvocations))
 		for u, param := range params[1] {
-			_param1[u] = param.(models.VCSHostType)
+			_param1[u] = param.(models.User)
+		}
+		_param2 = make([]models.VCSHostType, len(c.methodInvocations))
+		for u, param := range params[1] {
+			_param2[u] = param.(models.VCSHostType)
 		}
 	}
 	return

--- a/server/events/mocks/mock_comment_parsing.go
+++ b/server/events/mocks/mock_comment_parsing.go
@@ -27,11 +27,11 @@ func NewMockCommentParsing(options ...pegomock.Option) *MockCommentParsing {
 func (mock *MockCommentParsing) SetFailHandler(fh pegomock.FailHandler) { mock.fail = fh }
 func (mock *MockCommentParsing) FailHandler() pegomock.FailHandler      { return mock.fail }
 
-func (mock *MockCommentParsing) Parse(comment string, vcsHost models.VCSHostType) events.CommentParseResult {
+func (mock *MockCommentParsing) Parse(comment string, user models.User, vcsHost models.VCSHostType) events.CommentParseResult {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockCommentParsing().")
 	}
-	params := []pegomock.Param{comment, vcsHost}
+	params := []pegomock.Param{comment, user, vcsHost}
 	result := pegomock.GetGenericMockFrom(mock).Invoke("Parse", params, []reflect.Type{reflect.TypeOf((*events.CommentParseResult)(nil)).Elem()})
 	var ret0 events.CommentParseResult
 	if len(result) != 0 {

--- a/server/events_controller.go
+++ b/server/events_controller.go
@@ -404,7 +404,7 @@ func (e *EventsController) HandleGitlabCommentEvent(w http.ResponseWriter, event
 }
 
 func (e *EventsController) handleCommentEvent(w http.ResponseWriter, baseRepo models.Repo, maybeHeadRepo *models.Repo, maybePull *models.PullRequest, user models.User, pullNum int, comment string, vcsHost models.VCSHostType) {
-	parseResult := e.CommentParser.Parse(comment, vcsHost)
+	parseResult := e.CommentParser.Parse(comment, user, vcsHost)
 	if parseResult.Ignore {
 		truncated := comment
 		truncateLen := 40

--- a/server/events_controller_test.go
+++ b/server/events_controller_test.go
@@ -328,6 +328,8 @@ func TestPost_GithubCommentResponse(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	e.Post(w, req)
+
+	cp.VerifyWasCalledOnce().Parse("", user, models.Github)
 	vcsClient.VerifyWasCalledOnce().CreateComment(baseRepo, 1, "a comment", "")
 	responseContains(t, w, http.StatusOK, "Commenting back on pull request")
 }


### PR DESCRIPTION
Include comment author in atlantis logs.

Ref https://github.com/runatlantis/atlantis/issues/1013

Note to reviewers: 
I'm unable to run `go generate server/events/project_command_builder.go` to [generate mock tests](https://github.com/runatlantis/atlantis/blob/master/CONTRIBUTING.md#mocks) since I can only develop off of a fork of the repo. I get the following error as a result:

```
go generate server/events/project_command_builder.go
go/build: importGo github.com/natalysheinin/atlantis/server/events: exit status 1
go: github.com/natalysheinin/atlantis/server/events: github.com/natalysheinin/atlantis@v0.16.1: parsing go.mod:
	module declares its path as: github.com/runatlantis/atlantis
	        but was required as: github.com/natalysheinin/atlantis

```