### PR TITLE
Add Missing allow-draft-pr Server Flag Docs

### DIFF
--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -47,6 +47,12 @@ Values are chosen in this order:
 
 
 ## Flags
+* ### `--allow-draft-prs`
+  ```bash
+  atlantis server --allow-draft-prs
+  ```
+  Respond to pull requests from draft prs. Defaults to `false`.
+  
 * ### `--allow-fork-prs`
   ```bash
   atlantis server --allow-fork-prs


### PR DESCRIPTION
This was added in #1053 but is not documented.