### PR TITLE
feat: Add `--autoplan-file-list` server flag.

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -44,6 +44,7 @@ const (
 	AllowRepoConfigFlag        = "allow-repo-config"
 	AtlantisURLFlag            = "atlantis-url"
 	AutomergeFlag              = "automerge"
+	AutoplanFileListFlag       = "autoplan-file-list"
 	BitbucketBaseURLFlag       = "bitbucket-base-url"
 	BitbucketTokenFlag         = "bitbucket-token"
 	BitbucketUserFlag          = "bitbucket-user"
@@ -135,6 +136,13 @@ var stringFlags = map[string]stringFlag{
 	},
 	AtlantisURLFlag: {
 		description: "URL that Atlantis can be reached at. Defaults to http://$(hostname):$port where $port is from --" + PortFlag + ". Supports a base path ex. https://example.com/basepath.",
+	},
+	AutoplanFileListFlag: {
+		description: "Comma separated list of file patterns that Atlantis will use to check if a directory contains modified files that should trigger project planning." +
+			" Patterns use the dockerignore (https://docs.docker.com/engine/reference/builder/#dockerignore-file) syntax." +
+			" Use single quotes to avoid shell expansion of '*'. Defaults to '**/*.tf,**/*.tfvars,**/*.tfvars.json'." +
+			" A custom Workflow that uses autoplan 'when_modified' will ignore this value.",
+		defaultValue: "",
 	},
 	BitbucketUserFlag: {
 		description: "Bitbucket username of API user.",

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/runatlantis/atlantis/testing"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
 )
 
 // passedConfig is set to whatever config ended up being passed to NewServer.
@@ -58,6 +59,7 @@ var testFlags = map[string]interface{}{
 	AllowForkPRsFlag:           true,
 	AllowRepoConfigFlag:        true,
 	AutomergeFlag:              true,
+	AutoplanFileListFlag:       "**/*.tf,**/*.yml",
 	BitbucketBaseURLFlag:       "https://bitbucket-base-url.com",
 	BitbucketTokenFlag:         "bitbucket-token",
 	BitbucketUserFlag:          "bitbucket-user",
@@ -166,11 +168,10 @@ func TestExecute_Flags(t *testing.T) {
 
 func TestExecute_ConfigFile(t *testing.T) {
 	t.Log("Should use all the values from the config file.")
-	var cfgContents string
-	for flag, value := range testFlags {
-		cfgContents += fmt.Sprintf("%s: %v\n", flag, value)
-	}
-	tmpFile := tempFile(t, cfgContents)
+	// Use yaml package to quote values that need quoting
+	cfgContents, yamlErr := yaml.Marshal(&testFlags)
+	Ok(t, yamlErr)
+	tmpFile := tempFile(t, string(cfgContents))
 	defer os.Remove(tmpFile) // nolint: errcheck
 	c := setup(map[string]interface{}{
 		ConfigFlag: tmpFile,

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -768,9 +768,9 @@ func TestExecute_AutoplanFileList(t *testing.T) {
 		{
 			"invalid pattern",
 			map[string]interface{}{
-				AutoplanFileListFlag: "?[",
+				AutoplanFileListFlag: "[^]",
 			},
-			"invalid pattern in --autoplan-file-list, ?[: syntax error in pattern",
+			"invalid pattern in --autoplan-file-list, [^]: syntax error in pattern",
 		},
 	}
 	for _, testCase := range cases {

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -738,6 +738,53 @@ func TestExecute_RepoWhitelistDeprecation(t *testing.T) {
 	Equals(t, "*", passedConfig.RepoAllowlist)
 }
 
+func TestExecute_AutoplanFileList(t *testing.T) {
+	cases := []struct {
+		description string
+		flags       map[string]interface{}
+		expectErr   string
+	}{
+		{
+			"default value",
+			map[string]interface{}{
+				AutoplanFileListFlag: DefaultAutoplanFileList,
+			},
+			"",
+		},
+		{
+			"valid value",
+			map[string]interface{}{
+				AutoplanFileListFlag: "**/*.tf",
+			},
+			"",
+		},
+		{
+			"invalid exclusion pattern",
+			map[string]interface{}{
+				AutoplanFileListFlag: "**/*.yml,!",
+			},
+			"invalid pattern in --autoplan-file-list, **/*.yml,!: illegal exclusion pattern: \"!\"",
+		},
+		{
+			"invalid pattern",
+			map[string]interface{}{
+				AutoplanFileListFlag: "?[",
+			},
+			"invalid pattern in --autoplan-file-list, ?[: syntax error in pattern",
+		},
+	}
+	for _, testCase := range cases {
+		t.Log("Should validate autoplan file list when " + testCase.description)
+		c := setupWithDefaults(testCase.flags, t)
+		err := c.Execute()
+		if testCase.expectErr != "" {
+			ErrEquals(t, testCase.expectErr, err)
+		} else {
+			Ok(t, err)
+		}
+	}
+}
+
 func setup(flags map[string]interface{}, t *testing.T) *cobra.Command {
 	vipr := viper.New()
 	for k, v := range flags {

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -110,6 +110,29 @@ Values are chosen in this order:
   Automatically merge pull requests after all plans have been successfully applied.
   Defaults to `false`. See [Automerging](automerging.html) for more details.
 
+* ### `--autoplan-file-list`
+  ```bash
+  # NOTE: Use single quotes to avoid shell expansion of *.
+  atlantis server --autoplan-file-list='**/*.tf,project1/*.pkr.hcl'
+  ```
+  List of file patterns that Atlantis will use to check if a directory contains modified files that should trigger project planning.
+
+  Notes:
+  * Accepts a comma separated list, ex. `pattern1,pattern2`.
+  * Patterns use the [`.dockerignore` syntax](https://docs.docker.com/engine/reference/builder/#dockerignore-file)
+  * List of file patterns will be used by both automatic and manually run plans.
+  * When not set, defaults to all `.tf`, `.tfvars` and `.tfvars.json` files (`--autoplan-file-list='**/*.tf,**/*.tfvars,**/*.tfvars.json'`).
+  * Setting `--autoplan-file-list` will override the defaults. You **must** add `**/*.tf` and other defaults if you want to include them.
+  * A custom [Workflow](repo-level-atlantis-yaml.html#configuring-planning) that uses autoplan `when_modified` will ignore this value.
+
+  Examples:
+  * Autoplan when any `*.tf` or `*.tfvars` file is modified.
+    * `--autoplan-file-list='**/*.tf,**/*.tfvars'`
+  * Autoplan when any `*.tf` file is modified except in `project2/` directory
+    * `--autoplan-file-list='**/*.tf,!project2'`
+  * Autoplan when any `*.tf` files or `.yml` files in subfolder of `project1` is modified.
+    * `--autoplan-file-list='**/*.tf,project2/**/*.yml'`
+
 * ### `--azuredevops-webhook-password`
   ```bash
   atlantis server --azuredevops-webhook-password="password123"

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -121,7 +121,8 @@ Values are chosen in this order:
   * Accepts a comma separated list, ex. `pattern1,pattern2`.
   * Patterns use the [`.dockerignore` syntax](https://docs.docker.com/engine/reference/builder/#dockerignore-file)
   * List of file patterns will be used by both automatic and manually run plans.
-  * When not set, defaults to all `.tf`, `.tfvars` and `.tfvars.json` files (`--autoplan-file-list='**/*.tf,**/*.tfvars,**/*.tfvars.json'`).
+  * When not set, defaults to all `.tf`, `.tfvars`, `.tfvars.json` and `terragrunt.hcl` files
+    (`--autoplan-file-list='**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl'`).
   * Setting `--autoplan-file-list` will override the defaults. You **must** add `**/*.tf` and other defaults if you want to include them.
   * A custom [Workflow](repo-level-atlantis-yaml.html#configuring-planning) that uses autoplan `when_modified` will ignore this value.
 

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -244,7 +244,7 @@ func (p *DefaultProjectCommandBuilder) buildPlanAllCommands(ctx *CommandContext,
 		// If there is no config file, then we'll plan each project that
 		// our algorithm determines was modified.
 		ctx.Log.Info("found no %s file", yaml.AtlantisYAMLFilename)
-		modifiedProjects, err := p.ProjectFinder.DetermineProjects(ctx.Log, modifiedFiles, ctx.Pull.BaseRepo.FullName, repoDir, p.AutoplanFileList)
+		modifiedProjects := p.ProjectFinder.DetermineProjects(ctx.Log, modifiedFiles, ctx.Pull.BaseRepo.FullName, repoDir, p.AutoplanFileList)
 		if err != nil {
 			return nil, errors.Wrapf(err, "finding modified projects: %s", modifiedFiles)
 		}

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -39,6 +39,7 @@ func NewProjectCommandBuilder(
 	commentBuilder CommentBuilder,
 	skipCloneNoChanges bool,
 	EnableRegExpCmd bool,
+	AutoplanFileList string,
 ) *DefaultProjectCommandBuilder {
 	projectCommandBuilder := &DefaultProjectCommandBuilder{
 		ParserValidator:    parserValidator,
@@ -50,6 +51,7 @@ func NewProjectCommandBuilder(
 		PendingPlanFinder:  pendingPlanFinder,
 		SkipCloneNoChanges: skipCloneNoChanges,
 		EnableRegExpCmd:    EnableRegExpCmd,
+		AutoplanFileList:   AutoplanFileList,
 		ProjectCommandContextBuilder: NewProjectCommandContextBulder(
 			policyChecksSupported,
 			commentBuilder,
@@ -104,6 +106,7 @@ type DefaultProjectCommandBuilder struct {
 	ProjectCommandContextBuilder ProjectCommandContextBuilder
 	SkipCloneNoChanges           bool
 	EnableRegExpCmd              bool
+	AutoplanFileList             string
 }
 
 // See ProjectCommandBuilder.BuildAutoplanCommands.
@@ -241,7 +244,10 @@ func (p *DefaultProjectCommandBuilder) buildPlanAllCommands(ctx *CommandContext,
 		// If there is no config file, then we'll plan each project that
 		// our algorithm determines was modified.
 		ctx.Log.Info("found no %s file", yaml.AtlantisYAMLFilename)
-		modifiedProjects := p.ProjectFinder.DetermineProjects(ctx.Log, modifiedFiles, ctx.Pull.BaseRepo.FullName, repoDir)
+		modifiedProjects, err := p.ProjectFinder.DetermineProjects(ctx.Log, modifiedFiles, ctx.Pull.BaseRepo.FullName, repoDir, p.AutoplanFileList)
+		if err != nil {
+			return nil, errors.Wrapf(err, "finding modified projects: %s", modifiedFiles)
+		}
 		ctx.Log.Info("automatically determined that there were %d projects modified in this pull request: %s", len(modifiedProjects), modifiedProjects)
 		for _, mp := range modifiedProjects {
 			ctx.Log.Debug("determining config for project at dir: %q", mp.Path)

--- a/server/events/project_command_builder_internal_test.go
+++ b/server/events/project_command_builder_internal_test.go
@@ -592,6 +592,7 @@ projects:
 				&CommentParser{},
 				false,
 				false,
+				"",
 			)
 
 			// We run a test for each type of command.
@@ -778,6 +779,7 @@ projects:
 				&CommentParser{},
 				false,
 				true,
+				"",
 			)
 
 			// We run a test for each type of command, again specific projects
@@ -983,6 +985,7 @@ workflows:
 				&CommentParser{},
 				false,
 				false,
+				"",
 			)
 
 			cmd := models.PolicyCheckCommand

--- a/server/events/project_command_builder_internal_test.go
+++ b/server/events/project_command_builder_internal_test.go
@@ -592,7 +592,7 @@ projects:
 				&CommentParser{},
 				false,
 				false,
-				"",
+				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
 			)
 
 			// We run a test for each type of command.
@@ -779,7 +779,7 @@ projects:
 				&CommentParser{},
 				false,
 				true,
-				"",
+				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
 			)
 
 			// We run a test for each type of command, again specific projects
@@ -985,7 +985,7 @@ workflows:
 				&CommentParser{},
 				false,
 				false,
-				"",
+				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
 			)
 
 			cmd := models.PolicyCheckCommand

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -148,7 +148,7 @@ projects:
 				&events.CommentParser{},
 				false,
 				false,
-				"",
+				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
 			)
 
 			ctxs, err := builder.BuildAutoplanCommands(&events.CommandContext{
@@ -378,7 +378,7 @@ projects:
 					&events.CommentParser{},
 					false,
 					true,
-					"",
+					"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
 				)
 
 				var actCtxs []models.ProjectCommandContext
@@ -520,7 +520,7 @@ projects:
 				&events.CommentParser{},
 				false,
 				false,
-				"",
+				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
 			)
 
 			ctxs, err := builder.BuildPlanCommands(
@@ -600,7 +600,7 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply(t *testing.T) {
 		&events.CommentParser{},
 		false,
 		false,
-		"",
+		"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
 	)
 
 	ctxs, err := builder.BuildApplyCommands(
@@ -673,7 +673,7 @@ projects:
 		&events.CommentParser{},
 		false,
 		false,
-		"",
+		"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
 	)
 
 	ctx := &events.CommandContext{
@@ -741,7 +741,7 @@ func TestDefaultProjectCommandBuilder_EscapeArgs(t *testing.T) {
 				&events.CommentParser{},
 				false,
 				false,
-				"",
+				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
 			)
 
 			var actCtxs []models.ProjectCommandContext
@@ -913,7 +913,7 @@ projects:
 				&events.CommentParser{},
 				false,
 				false,
-				"",
+				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
 			)
 
 			actCtxs, err := builder.BuildPlanCommands(
@@ -969,7 +969,7 @@ projects:
 		&events.CommentParser{},
 		true,
 		false,
-		"",
+		"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
 	)
 
 	var actCtxs []models.ProjectCommandContext
@@ -1013,7 +1013,7 @@ func TestDefaultProjectCommandBuilder_WithPolicyCheckEnabled_BuildAutoplanComman
 		&events.CommentParser{},
 		false,
 		false,
-		"",
+		"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
 	)
 
 	ctxs, err := builder.BuildAutoplanCommands(&events.CommandContext{

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -148,6 +148,7 @@ projects:
 				&events.CommentParser{},
 				false,
 				false,
+				"",
 			)
 
 			ctxs, err := builder.BuildAutoplanCommands(&events.CommandContext{
@@ -377,6 +378,7 @@ projects:
 					&events.CommentParser{},
 					false,
 					true,
+					"",
 				)
 
 				var actCtxs []models.ProjectCommandContext
@@ -518,6 +520,7 @@ projects:
 				&events.CommentParser{},
 				false,
 				false,
+				"",
 			)
 
 			ctxs, err := builder.BuildPlanCommands(
@@ -597,6 +600,7 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply(t *testing.T) {
 		&events.CommentParser{},
 		false,
 		false,
+		"",
 	)
 
 	ctxs, err := builder.BuildApplyCommands(
@@ -669,6 +673,7 @@ projects:
 		&events.CommentParser{},
 		false,
 		false,
+		"",
 	)
 
 	ctx := &events.CommandContext{
@@ -736,6 +741,7 @@ func TestDefaultProjectCommandBuilder_EscapeArgs(t *testing.T) {
 				&events.CommentParser{},
 				false,
 				false,
+				"",
 			)
 
 			var actCtxs []models.ProjectCommandContext
@@ -907,6 +913,7 @@ projects:
 				&events.CommentParser{},
 				false,
 				false,
+				"",
 			)
 
 			actCtxs, err := builder.BuildPlanCommands(
@@ -962,6 +969,7 @@ projects:
 		&events.CommentParser{},
 		true,
 		false,
+		"",
 	)
 
 	var actCtxs []models.ProjectCommandContext
@@ -1005,6 +1013,7 @@ func TestDefaultProjectCommandBuilder_WithPolicyCheckEnabled_BuildAutoplanComman
 		&events.CommentParser{},
 		false,
 		false,
+		"",
 	)
 
 	ctxs, err := builder.BuildAutoplanCommands(&events.CommandContext{

--- a/server/events/project_finder.go
+++ b/server/events/project_finder.go
@@ -147,10 +147,6 @@ func (p *DefaultProjectFinder) DetermineProjectsViaConfig(log logging.SimpleLogg
 // filterToFileList filters out files not included in the file list
 func (p *DefaultProjectFinder) filterToFileList(log logging.SimpleLogging, files []string, fileList string) []string {
 	var filtered []string
-	if fileList == "" {
-		fileList = "**/*.tf,**/*.tfvars,**/*.tfvars.json"
-	}
-
 	patterns := strings.Split(fileList, ",")
 	// Ignore pattern matcher error here as it was checked for errors in server validation
 	patternMatcher, _ := fileutils.NewPatternMatcher(patterns)

--- a/server/events/project_finder_test.go
+++ b/server/events/project_finder_test.go
@@ -107,149 +107,126 @@ func TestDetermineProjects(t *testing.T) {
 	noopLogger := logging.NewNoopLogger(t)
 	setupTmpRepos(t)
 
+	defaultAutoplanFileList := "**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl"
+
 	cases := []struct {
 		description      string
 		files            []string
 		expProjectPaths  []string
 		repoDir          string
 		autoplanFileList string
-		expErr           string
 	}{
 		{
 			"If no files were modified then should return an empty list",
 			nil,
 			nil,
 			nestedModules1,
-			"",
-			"",
+			defaultAutoplanFileList,
 		},
 		{
 			"Should ignore non .tf files and return an empty list",
 			[]string{"non-tf", "non.tf.suffix"},
 			nil,
 			nestedModules1,
-			"",
-			"",
+			defaultAutoplanFileList,
 		},
 		{
 			"Should ignore .tflint.hcl files and return an empty list",
 			[]string{".tflint.hcl", "project1/.tflint.hcl"},
 			nil,
 			nestedModules1,
-			"",
-			"",
+			defaultAutoplanFileList,
 		},
 		{
 			"Should plan in the parent directory from modules if that dir has a main.tf",
 			[]string{"project1/modules/main.tf"},
 			[]string{"project1"},
 			nestedModules1,
-			"",
-			"",
+			defaultAutoplanFileList,
 		},
 		{
 			"Should plan in the parent directory from modules if that dir has a main.tf",
 			[]string{"modules/main.tf"},
 			[]string{"."},
 			nestedModules2,
-			"",
-			"",
+			defaultAutoplanFileList,
 		},
 		{
 			"Should plan in the parent directory from modules when module is in a subdir if that dir has a main.tf",
 			[]string{"modules/subdir/main.tf"},
 			[]string{"."},
 			nestedModules2,
-			"",
-			"",
+			defaultAutoplanFileList,
 		},
 		{
 			"Should not plan in the parent directory from modules if that dir does not have a main.tf",
 			[]string{"modules/main.tf"},
 			[]string{},
 			topLevelModules,
-			"",
-			"",
+			defaultAutoplanFileList,
 		},
 		{
 			"Should not plan in the parent directory from modules if that dir does not have a main.tf",
 			[]string{"modules/main.tf", "project1/main.tf"},
 			[]string{"project1"},
 			topLevelModules,
-			"",
-			"",
+			defaultAutoplanFileList,
 		},
 		{
 			"Should ignore tfstate files and return an empty list",
 			[]string{"terraform.tfstate", "terraform.tfstate.backup", "parent/terraform.tfstate", "parent/terraform.tfstate.backup"},
 			nil,
 			nestedModules1,
-			"",
-			"",
+			defaultAutoplanFileList,
 		},
 		{
 			"Should return '.' when changed file is at root",
 			[]string{"a.tf"},
 			[]string{"."},
 			nestedModules2,
-			"",
-			"",
+			defaultAutoplanFileList,
 		},
 		{
 			"Should return directory when changed file is in a dir",
 			[]string{"project1/a.tf"},
 			[]string{"project1"},
 			nestedModules1,
-			"",
-			"",
+			defaultAutoplanFileList,
 		},
 		{
 			"Should return parent dir when changed file is in an env/ dir",
 			[]string{"env/staging.tfvars"},
 			[]string{"."},
 			envDir,
-			"",
-			"",
+			defaultAutoplanFileList,
 		},
 		{
 			"Should de-duplicate when multiple files changed in the same dir",
 			[]string{"env/staging.tfvars", "main.tf", "other.tf"},
 			[]string{"."},
 			"",
-			"",
-			"",
+			defaultAutoplanFileList,
 		},
 		{
 			"Should ignore changes in a dir that was deleted",
 			[]string{"wasdeleted/main.tf"},
 			[]string{},
 			"",
-			"",
-			"",
+			defaultAutoplanFileList,
 		},
 		{
 			"Should not ignore terragrunt.hcl files",
 			[]string{"terragrunt.hcl"},
 			[]string{"."},
 			nestedModules2,
-			"",
-			"",
+			defaultAutoplanFileList,
 		},
 		{
 			"Should find terragrunt.hcl file inside a nested directory",
 			[]string{"project1/terragrunt.hcl"},
 			[]string{"project1"},
 			nestedModules1,
-			"",
-			"",
-		},
-		{
-			"Should error on invalid pattern",
-			[]string{"project1/main.tf"},
-			[]string{"project1"},
-			nestedModules1,
-			"*[]",
-			"filtering modified files by autoplanFileList: *[]: filtering modified files with patterns: [*[]]: syntax error in pattern",
+			defaultAutoplanFileList,
 		},
 		{
 			"Should find packer files and ignore default tf files",
@@ -257,7 +234,6 @@ func TestDetermineProjects(t *testing.T) {
 			[]string{"project1"},
 			topLevelModules,
 			"**/*.pkr.hcl",
-			"",
 		},
 		{
 			"Should find yaml files in addition to defaults",
@@ -265,7 +241,6 @@ func TestDetermineProjects(t *testing.T) {
 			[]string{"project1", "project2"},
 			topLevelModules,
 			"**/*.tf,**/*.yml",
-			"",
 		},
 		{
 			"Should find yaml files unless excluded",
@@ -273,17 +248,11 @@ func TestDetermineProjects(t *testing.T) {
 			[]string{"project1"},
 			topLevelModules,
 			"**/*.yml,!project2/*.yml",
-			"",
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
-			projects, err := m.DetermineProjects(noopLogger, c.files, modifiedRepo, c.repoDir, c.autoplanFileList)
-			if c.expErr != "" {
-				ErrEquals(t, c.expErr, err)
-				return
-			}
-			Ok(t, err)
+			projects := m.DetermineProjects(noopLogger, c.files, modifiedRepo, c.repoDir, c.autoplanFileList)
 
 			// Extract the paths from the projects. We use a slice here instead of a
 			// map so we can test whether there are duplicates returned.

--- a/server/events_controller_e2e_test.go
+++ b/server/events_controller_e2e_test.go
@@ -701,7 +701,7 @@ func setupE2E(t *testing.T, repoDir string) (server.EventsController, *vcsmocks.
 		commentParser,
 		false,
 		false,
-		"",
+		"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
 	)
 
 	showStepRunner, err := runtime.NewShowStepRunner(terraformClient, defaultTFVersion)

--- a/server/events_controller_e2e_test.go
+++ b/server/events_controller_e2e_test.go
@@ -701,6 +701,7 @@ func setupE2E(t *testing.T, repoDir string) (server.EventsController, *vcsmocks.
 		commentParser,
 		false,
 		false,
+		"",
 	)
 
 	showStepRunner, err := runtime.NewShowStepRunner(terraformClient, defaultTFVersion)

--- a/server/server.go
+++ b/server/server.go
@@ -421,6 +421,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		commentParser,
 		userConfig.SkipCloneNoChanges,
 		userConfig.EnableRegExpCmd,
+		userConfig.AutoplanFileList,
 	)
 
 	showStepRunner, err := runtime.NewShowStepRunner(terraformClient, defaultTfVersion)

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -12,6 +12,7 @@ type UserConfig struct {
 	AllowRepoConfig            bool   `mapstructure:"allow-repo-config"`
 	AtlantisURL                string `mapstructure:"atlantis-url"`
 	Automerge                  bool   `mapstructure:"automerge"`
+	AutoplanFileList           string `mapstructure:"autoplan-file-list"`
 	AzureDevopsToken           string `mapstructure:"azuredevops-token"`
 	AzureDevopsUser            string `mapstructure:"azuredevops-user"`
 	AzureDevopsWebhookPassword string `mapstructure:"azuredevops-webhook-password"`


### PR DESCRIPTION
This adds a new server flag that allows modifying the list of files that trigger default project planning.

We use terraform/atlantis to build AWS AMI's using packer and ansible. We wanted changes to the packer (`*.pkr.hcl`) and ansible (`*.yml`) files to trigger an autoplan when modified in a commit. It looked like we could do this with an `atlantis.yml` file (Workflow), but we have a large repo with 100's of small projects and rely on the default atlantis workflow. Defining `atlantis.yml` would require us to define every existing project, and all new projects in that workflow.

Instead, I added a server flag/ENV that would allow modifying/overriding the list of file patterns that trigger an autoplan.

`--autoplan-file-list` uses the same dockeringore syntax as Custom workflows autoplan `when_modified`. This allows for overriding the default list, adding more file types, and file exclusions.

Examples:
* Default: `--autoplan-file-list="**/*.tf,**/*.tfvars,**/*.tfvars.json"`
* Add packer and YML files: `--autoplan-file-list="**/*.tf,**/*.tfvars,**/*.tfvars.json,**/*.pkr.hcl,**/*.yml"`
* ENV var: `ATLANTIS_AUTOPLAN_FILE_LIST="**/*.tf,**/*.hcl"`
