### PR TITLE
docker: add support for arm64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,20 +55,21 @@ jobs:
     - image: circleci/golang:1.16 # If you update this, update it in the Makefile too
     steps:
     - checkout
-    - run: make build-service
+    - run: make build-service-multiarch
     - setup_remote_docker
     - run:
-        name: Build image
+        name: Install buildx
         command: |
-          if [ "${CIRCLE_BRANCH}" == "master" ]; then
-            docker build -t runatlantis/atlantis:latest .
-          fi
+          mkdir -p ~/.docker/cli-plugins
+          BUILDX_URL=$(curl https://api.github.com/repos/docker/buildx/releases/latest | jq -r .assets[].browser_download_url | grep amd64 | grep linux)
+          wget $BUILDX_URL -O ~/.docker/cli-plugins/docker-build
+          chmod +x ~/.docker/cli-plugins/docker-buildx
     - run:
-        name: Push image
+        name: Build and push image
         command: |
           if [ "${CIRCLE_BRANCH}" == "master" ]; then
-            docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
-            docker push runatlantis/atlantis:latest
+          docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
+            docker buildx build --platform "linux/amd64,linux/arm64" --push -t runatlantis/atlantis:latest .
           fi
   # Build and push Docker tag.
   docker_tag:
@@ -76,15 +77,21 @@ jobs:
     - image: circleci/golang:1.16 # If you update this, update it in the Makefile too
     steps:
     - checkout
-    - run: make build-service
+    - run: make build-service-multiarch
     - setup_remote_docker
+    - run:
+        name: Install buildx
+        command: |
+          mkdir -p ~/.docker/cli-plugins
+          BUILDX_URL=$(curl https://api.github.com/repos/docker/buildx/releases/latest | jq -r .assets[].browser_download_url | grep amd64 | grep linux)
+          wget $BUILDX_URL -O ~/.docker/cli-plugins/docker-build
+          chmod +x ~/.docker/cli-plugins/docker-buildx
     - run:
         name: Build and tag
         command: |
           if [ -n "${CIRCLE_TAG}" ]; then
-            docker build -t "runatlantis/atlantis:${CIRCLE_TAG}" .
             docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
-            docker push "runatlantis/atlantis:${CIRCLE_TAG}"
+            docker buildx build --platform "linux/amd64,linux/arm64" --push -t runatlantis/atlantis:${CIRCLE_TAG} .
           fi
 workflows:
   version: 2

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 *
 !docker-entrypoint.sh
-!atlantis
+!atlantis_arm64
+!atlantis_amd64

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ helm/test-values.yaml
 *.swp
 golangci-lint
 atlantis
+atlantis_amd64
+atlantis_arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,19 +2,22 @@
 FROM runatlantis/atlantis-base:v3.5
 LABEL authors="Anubhav Mishra, Luke Kysow"
 
+# This gets injected by Docker buildx
+ARG TARGETARCH
+
 # install terraform binaries
 ENV DEFAULT_TERRAFORM_VERSION=0.14.9
 
 # In the official Atlantis image we only have the latest of each Terraform version.
 RUN AVAILABLE_TERRAFORM_VERSIONS="0.8.8 0.9.11 0.10.8 0.11.14 0.12.30 0.13.6 ${DEFAULT_TERRAFORM_VERSION}" && \
     for VERSION in ${AVAILABLE_TERRAFORM_VERSIONS}; do \
-        curl -LOs https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_linux_amd64.zip && \
+        curl -LOs https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_linux_${TARGETARCH}.zip && \
         curl -LOs https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_SHA256SUMS && \
-        sed -n "/terraform_${VERSION}_linux_amd64.zip/p" terraform_${VERSION}_SHA256SUMS | sha256sum -c && \
+        sed -n "/terraform_${VERSION}_linux_${TARGETARCH}.zip/p" terraform_${VERSION}_SHA256SUMS | sha256sum -c && \
         mkdir -p /usr/local/bin/tf/versions/${VERSION} && \
-        unzip terraform_${VERSION}_linux_amd64.zip -d /usr/local/bin/tf/versions/${VERSION} && \
+        unzip terraform_${VERSION}_linux_${TARGETARCH}.zip -d /usr/local/bin/tf/versions/${VERSION} && \
         ln -s /usr/local/bin/tf/versions/${VERSION}/terraform /usr/local/bin/terraform${VERSION} && \
-        rm terraform_${VERSION}_linux_amd64.zip && \
+        rm terraform_${VERSION}_linux_${TARGETARCH}.zip && \
         rm terraform_${VERSION}_SHA256SUMS; \
     done && \
     ln -s /usr/local/bin/tf/versions/${DEFAULT_TERRAFORM_VERSION}/terraform /usr/local/bin/terraform
@@ -23,20 +26,26 @@ ENV DEFAULT_CONFTEST_VERSION=0.21.0
 
 RUN AVAILABLE_CONFTEST_VERSIONS="${DEFAULT_CONFTEST_VERSION}" && \
     for VERSION in ${AVAILABLE_CONFTEST_VERSIONS}; do \
-        curl -LOs https://github.com/open-policy-agent/conftest/releases/download/v${VERSION}/conftest_${VERSION}_Linux_x86_64.tar.gz && \
+        ARCH="x86_64" && \
+        case "$(arch)" in \
+        "aarch64") \
+            ARCH="arm64" \
+            ;; \
+        esac && \
+        curl -LOs https://github.com/open-policy-agent/conftest/releases/download/v${VERSION}/conftest_${VERSION}_Linux_${ARCH}.tar.gz && \
         curl -LOs https://github.com/open-policy-agent/conftest/releases/download/v${VERSION}/checksums.txt && \
-        sed -n "/conftest_${VERSION}_Linux_x86_64.tar.gz/p" checksums.txt | sha256sum -c && \
+        sed -n "/conftest_${VERSION}_Linux_${ARCH}.tar.gz/p" checksums.txt | sha256sum -c && \
         mkdir -p /usr/local/bin/cft/versions/${VERSION} && \
-        tar -C  /usr/local/bin/cft/versions/${VERSION} -xzf conftest_${VERSION}_Linux_x86_64.tar.gz && \
+        tar -C  /usr/local/bin/cft/versions/${VERSION} -xzf conftest_${VERSION}_Linux_${ARCH}.tar.gz && \
         ln -s /usr/local/bin/cft/versions/${VERSION}/conftest /usr/local/bin/conftest${VERSION} && \
-        rm conftest_${VERSION}_Linux_x86_64.tar.gz && \
+        rm conftest_${VERSION}_Linux_${ARCH}.tar.gz && \
         rm checksums.txt; \
     done
 
 RUN ln -s /usr/local/bin/cft/versions/${DEFAULT_CONFTEST_VERSION}/conftest /usr/local/bin/conftest
 
 # copy binary
-COPY atlantis /usr/local/bin/atlantis
+COPY ./atlantis_${TARGETARCH} /usr/local/bin/atlantis
 
 # copy docker entrypoint
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ debug: ## Output internal make variables
 build-service: ## Build the main Go service
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o atlantis .
 
+build-service-multiarch: ## Build the main Go service
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o atlantis_amd64 .
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -v -o atlantis_arm64 .
+
 go-generate: ## Run go generate in all packages
 	go generate $(PKG)
 

--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -21,12 +21,21 @@ RUN addgroup atlantis && \
 ENV DUMB_INIT_VERSION=1.2.5
 ENV GOSU_VERSION=1.12
 RUN apk add --no-cache ca-certificates gnupg curl git git-lfs unzip bash openssh libcap openssl && \
-    curl -L -s --output /bin/dumb-init "https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_x86_64" && \
+    curl -L -s --output /bin/dumb-init "https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_$(arch)" && \
     chmod +x /bin/dumb-init && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
-    curl -L -s --output gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64" && \
-    curl -L -s --output gosu.asc "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc" && \
+    ARCH="amd64" && \
+    case "$(arch)" in \
+    "aarch64") \
+        ARCH="arm64" \
+        ;; \
+    "armv7l") \
+        ARCH="arm" \
+        ;; \
+    esac && \
+    curl -L -s --output gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${ARCH}" && \
+    curl -L -s --output gosu.asc "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${ARCH}.asc" && \
     for server in $(shuf -e ipv4.pool.sks-keyservers.net \
                             hkp://p80.pool.sks-keyservers.net:80 \
                             keyserver.ubuntu.com \


### PR DESCRIPTION
Fixes https://github.com/runatlantis/atlantis/issues/857

This adds support for building ARM64 Docker images using Docker's builx. I also wanted to add ARMv7 however dependancies the images need do not have 32-bit ARM builds available.

I built an image with these changes at `ghcr.io/meyskens/atlantis:v0.17.0-beta` and am successfully running it in my Kubernetes cluster. 

Feedback welcome, especially on CircleCI as I haven't used that in a while so not 100% sure my changes will work.