### PR TITLE
Add plan summary to unfolded part of comment

### DIFF
--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -76,6 +76,7 @@ type resultData struct {
 
 type planSuccessData struct {
 	models.PlanSuccess
+	PlanSummary        string
 	PlanWasDeleted     bool
 	DisableApply       bool
 	DisableRepoLocking bool
@@ -147,7 +148,7 @@ func (m *MarkdownRenderer) renderProjectResults(results []models.ProjectResult, 
 			})
 		} else if result.PlanSuccess != nil {
 			if m.shouldUseWrappedTmpl(vcsHost, result.PlanSuccess.TerraformOutput) {
-				resultData.Rendered = m.renderTemplate(planSuccessWrappedTmpl, planSuccessData{PlanSuccess: *result.PlanSuccess, PlanWasDeleted: common.PlansDeleted, DisableApply: common.DisableApply, DisableRepoLocking: common.DisableRepoLocking})
+				resultData.Rendered = m.renderTemplate(planSuccessWrappedTmpl, planSuccessData{PlanSuccess: *result.PlanSuccess, PlanSummary: result.PlanSuccess.Summary(), PlanWasDeleted: common.PlansDeleted, DisableApply: common.DisableApply, DisableRepoLocking: common.DisableRepoLocking})
 			} else {
 				resultData.Rendered = m.renderTemplate(planSuccessUnwrappedTmpl, planSuccessData{PlanSuccess: *result.PlanSuccess, PlanWasDeleted: common.PlansDeleted, DisableApply: common.DisableApply, DisableRepoLocking: common.DisableRepoLocking})
 			}
@@ -281,6 +282,7 @@ var planSuccessWrappedTmpl = template.Must(template.New("").Parse(
 		"```\n\n" +
 		planNextSteps + "\n" +
 		"</details>" +
+		"{{.PlanSummary}}" + "\n\n" +
 		"{{ if .HasDiverged }}\n\n:warning: The branch we're merging into is ahead, it is recommended to pull new commits first.{{end}}"))
 
 var policyCheckSuccessUnwrappedTmpl = template.Must(template.New("").Parse(

--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -281,8 +281,8 @@ var planSuccessWrappedTmpl = template.Must(template.New("").Parse(
 		"{{.TerraformOutput}}\n" +
 		"```\n\n" +
 		planNextSteps + "\n" +
-		"</details>" +
-		"{{.PlanSummary}}" + "\n\n" +
+		"</details>" + "\n" +
+		"{{.PlanSummary}}" +
 		"{{ if .HasDiverged }}\n\n:warning: The branch we're merging into is ahead, it is recommended to pull new commits first.{{end}}"))
 
 var policyCheckSuccessUnwrappedTmpl = template.Must(template.New("").Parse(

--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -1210,7 +1210,7 @@ func TestRenderProjectResults_WrapSingleProject(t *testing.T) {
 		},
 		{
 			VCSHost:    models.Github,
-			Output:     strings.Repeat("line\n", 13),
+			Output:     strings.Repeat("line\n", 13) + fmt.Sprintf("No changes. Infrastructure is up-to-date."),
 			ShouldWrap: true,
 		},
 		{
@@ -1234,7 +1234,7 @@ func TestRenderProjectResults_WrapSingleProject(t *testing.T) {
 		{
 			VCSHost:                 models.Gitlab,
 			GitlabCommonMarkSupport: true,
-			Output:                  strings.Repeat("line\n", 13),
+			Output:                  strings.Repeat("line\n", 13) + fmt.Sprintf("No changes. Infrastructure is up-to-date."),
 			ShouldWrap:              true,
 		},
 		{
@@ -1309,6 +1309,7 @@ $$$
 * :repeat: To **plan** this project again, comment:
     * $replancmd$
 </details>
+No changes. Infrastructure is up-to-date.
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
@@ -1414,7 +1415,7 @@ $$$
 
 func TestRenderProjectResults_MultiProjectPlanWrapped(t *testing.T) {
 	mr := events.MarkdownRenderer{}
-	tfOut := strings.Repeat("line\n", 13)
+	tfOut := strings.Repeat("line\n", 13) + fmt.Sprintf("Plan: 1 to add, 0 to change, 0 to destroy.")
 	rendered := mr.Render(events.CommandResult{
 		ProjectResults: []models.ProjectResult{
 			{
@@ -1457,6 +1458,7 @@ $$$
 * :repeat: To **plan** this project again, comment:
     * $staging-replan-cmd$
 </details>
+Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
 ### 2. dir: $.$ workspace: $production$
@@ -1472,6 +1474,7 @@ $$$
 * :repeat: To **plan** this project again, comment:
     * $production-replan-cmd$
 </details>
+Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/url"
 	paths "path"
+	"regexp"
 	"strings"
 	"time"
 
@@ -489,6 +490,16 @@ type PlanSuccess struct {
 	// branch we're merging into has been updated since we cloned and merged
 	// it.
 	HasDiverged bool
+}
+
+// Summary extracts one line summary of plan changes from TerraformOutput.
+func (p *PlanSuccess) Summary() string {
+	r := regexp.MustCompile(`Plan: \d+ to add, \d+ to change, \d+ to destroy.`)
+	if match := r.FindString(p.TerraformOutput); match != "" {
+		return match
+	}
+	r = regexp.MustCompile(`No changes. Infrastructure is up-to-date.`)
+	return r.FindString(p.TerraformOutput)
 }
 
 // PolicyCheckSuccess is the result of a successful policy check run.

--- a/server/events/models/models_test.go
+++ b/server/events/models/models_test.go
@@ -484,6 +484,58 @@ func TestProjectResult_PlanStatus(t *testing.T) {
 	}
 }
 
+func TestPlanSuccess_Summary(t *testing.T) {
+	cases := []struct {
+		p         models.ProjectResult
+		expResult string
+	}{
+		{
+			p: models.ProjectResult{
+				PlanSuccess: &models.PlanSuccess{
+					TerraformOutput: `
+					An execution plan has been generated and is shown below.
+					Resource actions are indicated with the following symbols:
+					  - destroy
+
+					Terraform will perform the following actions:
+
+					  - null_resource.hi[1]
+
+
+					Plan: 0 to add, 0 to change, 1 to destroy.`,
+				},
+			},
+			expResult: "Plan: 0 to add, 0 to change, 1 to destroy.",
+		},
+		{
+			p: models.ProjectResult{
+				PlanSuccess: &models.PlanSuccess{
+					TerraformOutput: `
+					An execution plan has been generated and is shown below.
+					Resource actions are indicated with the following symbols:
+
+					No changes. Infrastructure is up-to-date.`,
+				},
+			},
+			expResult: "No changes. Infrastructure is up-to-date.",
+		},
+		{
+			p: models.ProjectResult{
+				PlanSuccess: &models.PlanSuccess{
+					TerraformOutput: `No match, expect empty`,
+				},
+			},
+			expResult: "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.expResult, func(t *testing.T) {
+			Equals(t, c.expResult, c.p.PlanSuccess.Summary())
+		})
+	}
+}
+
 func TestPullStatus_StatusCount(t *testing.T) {
 	ps := models.PullStatus{
 		Projects: []models.ProjectStatus{

--- a/server/testfixtures/test-repos/automerge/exp-output-autoplan.txt
+++ b/server/testfixtures/test-repos/automerge/exp-output-autoplan.txt
@@ -29,6 +29,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d dir1`
 </details>
+Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
 ### 2. dir: `dir2` workspace: `default`
@@ -57,6 +58,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d dir2`
 </details>
+Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/modules-yaml/exp-output-autoplan.txt
+++ b/server/testfixtures/test-repos/modules-yaml/exp-output-autoplan.txt
@@ -32,6 +32,7 @@ Changes to Outputs:
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d staging`
 </details>
+Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
 ### 2. dir: `production` workspace: `default`
@@ -63,6 +64,7 @@ Changes to Outputs:
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d production`
 </details>
+Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/modules/exp-output-autoplan-only-staging.txt
+++ b/server/testfixtures/test-repos/modules/exp-output-autoplan-only-staging.txt
@@ -28,6 +28,7 @@ Changes to Outputs:
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d staging`
 </details>
+Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/modules/exp-output-plan-production.txt
+++ b/server/testfixtures/test-repos/modules/exp-output-plan-production.txt
@@ -28,6 +28,7 @@ Changes to Outputs:
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d production`
 </details>
+Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/modules/exp-output-plan-staging.txt
+++ b/server/testfixtures/test-repos/modules/exp-output-plan-staging.txt
@@ -28,6 +28,7 @@ Changes to Outputs:
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d staging`
 </details>
+Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/policy-checks-apply-reqs/exp-output-autoplan.txt
+++ b/server/testfixtures/test-repos/policy-checks-apply-reqs/exp-output-autoplan.txt
@@ -28,6 +28,7 @@ Changes to Outputs:
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d .`
 </details>
+Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/policy-checks-diff-owner/exp-output-autoplan.txt
+++ b/server/testfixtures/test-repos/policy-checks-diff-owner/exp-output-autoplan.txt
@@ -28,6 +28,7 @@ Changes to Outputs:
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d .`
 </details>
+Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/policy-checks-multi-projects/exp-output-autoplan.txt
+++ b/server/testfixtures/test-repos/policy-checks-multi-projects/exp-output-autoplan.txt
@@ -32,6 +32,7 @@ Changes to Outputs:
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d dir1`
 </details>
+Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
 ### 2. dir: `dir2` workspace: `default`
@@ -63,6 +64,7 @@ Changes to Outputs:
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d dir2`
 </details>
+Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/policy-checks/exp-output-autoplan.txt
+++ b/server/testfixtures/test-repos/policy-checks/exp-output-autoplan.txt
@@ -28,6 +28,7 @@ Changes to Outputs:
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d .`
 </details>
+Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/server-side-cfg/exp-output-autoplan.txt
+++ b/server/testfixtures/test-repos/server-side-cfg/exp-output-autoplan.txt
@@ -36,6 +36,7 @@ postplan custom
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d .`
 </details>
+Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
 ### 2. dir: `.` workspace: `staging`
@@ -69,6 +70,7 @@ Changes to Outputs:
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -w staging`
 </details>
+Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/simple-yaml/exp-output-autoplan.txt
+++ b/server/testfixtures/test-repos/simple-yaml/exp-output-autoplan.txt
@@ -37,6 +37,7 @@ postplan
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d .`
 </details>
+Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
 ### 2. dir: `.` workspace: `staging`
@@ -69,6 +70,7 @@ Changes to Outputs:
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -w staging`
 </details>
+Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/simple/exp-output-atlantis-plan-new-workspace.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-atlantis-plan-new-workspace.txt
@@ -39,6 +39,7 @@ Changes to Outputs:
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -w new_workspace -- -var var=new_workspace`
 </details>
+Plan: 3 to add, 0 to change, 0 to destroy.
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/simple/exp-output-atlantis-plan-var-overridden.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-atlantis-plan-var-overridden.txt
@@ -39,6 +39,7 @@ Changes to Outputs:
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d . -- -var var=overridden`
 </details>
+Plan: 3 to add, 0 to change, 0 to destroy.
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/simple/exp-output-atlantis-plan.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-atlantis-plan.txt
@@ -39,6 +39,7 @@ Changes to Outputs:
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d . -- -var var=default_workspace`
 </details>
+Plan: 3 to add, 0 to change, 0 to destroy.
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/simple/exp-output-autoplan.txt
+++ b/server/testfixtures/test-repos/simple/exp-output-autoplan.txt
@@ -39,6 +39,7 @@ Changes to Outputs:
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -d .`
 </details>
+Plan: 3 to add, 0 to change, 0 to destroy.
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-default.txt
+++ b/server/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-default.txt
@@ -29,6 +29,7 @@ Changes to Outputs:
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -p default`
 </details>
+Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-staging.txt
+++ b/server/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-staging.txt
@@ -29,6 +29,7 @@ Changes to Outputs:
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -p staging`
 </details>
+Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/testfixtures/test-repos/tfvars-yaml/exp-output-autoplan.txt
+++ b/server/testfixtures/test-repos/tfvars-yaml/exp-output-autoplan.txt
@@ -35,6 +35,7 @@ workspace=default
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -p default`
 </details>
+Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
 ### 2. project: `staging` dir: `.` workspace: `default`
@@ -67,6 +68,7 @@ Changes to Outputs:
 * :repeat: To **plan** this project again, comment:
     * `atlantis plan -p staging`
 </details>
+Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:


### PR DESCRIPTION
If there are multiple projects planned and markdown folding is enabled user must click on each "Show details" button separately and scroll through the plan to check if there are any changes to the infrastructure. This may be pretty time consuming when multiple projects are planned. Some of them may not have any changes in them, due to the dependency resolution. 
This PR adds the extra summary line, so user can quickly eyeball what is the impact of his change for each project without unfolding the output.
![image](https://user-images.githubusercontent.com/7510199/115333987-6d1c6d80-a14f-11eb-81d9-c45b590815ca.png) 
