### PR TITLE
Use circle ci contexts to scope secret access

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,11 +91,15 @@ workflows:
           branches:
             ignore: /.*-docs/
     - e2e:
+        context:
+          - atlantis-e2e-tests
         requires: [test]
         filters:
           branches:
             ignore: /.*-docs/
     - docker_master:
+        context:
+          - docker-push
         requires: [e2e]
         filters:
           branches:
@@ -104,6 +108,8 @@ workflows:
   tag:
     jobs:
     - docker_tag:
+        context:
+          - docker-push
         filters:
           branches:
             ignore: /.*/


### PR DESCRIPTION
CircleCI contexts (https://circleci.com/docs/2.0/contexts/) can be used
to scope environment variables to specific jobs rather than all jobs in
a repo.

This change adds contexts for docker publish and e2e tests which are the
only jobs that need secrets.