### PR TITLE
Revert removal of --all-namespaces from policy checks

### DIFF
--- a/server/events/runtime/policy/conftest_client.go
+++ b/server/events/runtime/policy/conftest_client.go
@@ -59,7 +59,7 @@ func (c ConftestTestCommandArgs) build() ([]string, error) {
 		commandArgs = append(commandArgs, a.build()...)
 	}
 
-	commandArgs = append(commandArgs, c.InputFile, "--no-color")
+	commandArgs = append(commandArgs, c.InputFile, "--no-color", "--all-namespaces")
 
 	return commandArgs, nil
 }

--- a/server/events/runtime/policy/conftest_client_test.go
+++ b/server/events/runtime/policy/conftest_client_test.go
@@ -175,7 +175,7 @@ func TestRun(t *testing.T) {
 
 		expectedOutput := "Success"
 		expectedResult := "Checking plan against the following policies: \n  policy1\n  policy2\nSuccess"
-		expectedArgs := []string{executablePath, "test", "-p", localPolicySetPath1, "-p", localPolicySetPath2, "/some_workdir/testproj-default.json", "--no-color"}
+		expectedArgs := []string{executablePath, "test", "-p", localPolicySetPath1, "-p", localPolicySetPath2, "/some_workdir/testproj-default.json", "--no-color", "--all-namespaces"}
 
 		When(mockResolver.Resolve(policySet1)).ThenReturn(localPolicySetPath1, nil)
 		When(mockResolver.Resolve(policySet2)).ThenReturn(localPolicySetPath2, nil)
@@ -196,7 +196,7 @@ func TestRun(t *testing.T) {
 
 		expectedOutput := "Success"
 		expectedResult := "Checking plan against the following policies: \n  policy1\nSuccess"
-		expectedArgs := []string{executablePath, "test", "-p", localPolicySetPath1, "/some_workdir/testproj-default.json", "--no-color"}
+		expectedArgs := []string{executablePath, "test", "-p", localPolicySetPath1, "/some_workdir/testproj-default.json", "--no-color", "--all-namespaces"}
 
 		When(mockResolver.Resolve(policySet1)).ThenReturn(localPolicySetPath1, nil)
 		When(mockResolver.Resolve(policySet2)).ThenReturn("", errors.New("err"))
@@ -214,7 +214,7 @@ func TestRun(t *testing.T) {
 	t.Run("error resolving both policy sources", func(t *testing.T) {
 
 		expectedResult := "Success"
-		expectedArgs := []string{executablePath, "test", "-p", localPolicySetPath1, "/some_workdir/testproj-default.json", "--no-color"}
+		expectedArgs := []string{executablePath, "test", "-p", localPolicySetPath1, "/some_workdir/testproj-default.json", "--no-color", "--all-namespaces"}
 
 		When(mockResolver.Resolve(policySet1)).ThenReturn("", errors.New("err"))
 		When(mockResolver.Resolve(policySet2)).ThenReturn("", errors.New("err"))
@@ -232,7 +232,7 @@ func TestRun(t *testing.T) {
 	t.Run("error running cmd", func(t *testing.T) {
 		expectedOutput := "FAIL - /some_workdir/testproj-default.json - failure"
 		expectedResult := "Checking plan against the following policies: \n  policy1\n  policy2\nFAIL - <redacted plan file> - failure"
-		expectedArgs := []string{executablePath, "test", "-p", localPolicySetPath1, "-p", localPolicySetPath2, "/some_workdir/testproj-default.json", "--no-color"}
+		expectedArgs := []string{executablePath, "test", "-p", localPolicySetPath1, "-p", localPolicySetPath2, "/some_workdir/testproj-default.json", "--no-color", "--all-namespaces"}
 
 		When(mockResolver.Resolve(policySet1)).ThenReturn(localPolicySetPath1, nil)
 		When(mockResolver.Resolve(policySet2)).ThenReturn(localPolicySetPath2, nil)


### PR DESCRIPTION
#1516 included an undocumented change, removing the `--all-namespaces` argument from conftest runs.

This is a particularly painful change for myself and others, as it breaks the ability to use namespacing to manage and organize policy collections. Its a significant behavior regression from the beta as well - with no explanation as to why this was desired, or should have been a part of a version bump for conftest.

This PR reverts the parts of #1516 that removed --all-namespaces, and restores the original behavior.