### PR TITLE
Nil pointer dereference when userConfig.DisableRepoLocking is true

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -303,11 +303,10 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	var applyLockingClient locking.ApplyLocker
 	if userConfig.DisableRepoLocking {
 		lockingClient = locking.NewNoOpLocker()
-		applyLockingClient = locking.NewApplyClient(boltdb, userConfig.DisableApply)
 	} else {
 		lockingClient = locking.NewClient(boltdb)
-		applyLockingClient = locking.NewApplyClient(boltdb, userConfig.DisableApply)
 	}
+	applyLockingClient = locking.NewApplyClient(boltdb, userConfig.DisableApply)
 	workingDirLocker := events.NewDefaultWorkingDirLocker()
 
 	var workingDir events.WorkingDir = &events.FileWorkspace{

--- a/server/server.go
+++ b/server/server.go
@@ -303,6 +303,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	var applyLockingClient locking.ApplyLocker
 	if userConfig.DisableRepoLocking {
 		lockingClient = locking.NewNoOpLocker()
+		applyLockingClient = locking.NewApplyClient(boltdb, userConfig.DisableApply)
 	} else {
 		lockingClient = locking.NewClient(boltdb)
 		applyLockingClient = locking.NewApplyClient(boltdb, userConfig.DisableApply)


### PR DESCRIPTION
## Description
This PR fixes the nil pointer dereference from https://github.com/runatlantis/atlantis/issues/1551

When `DisableRepoLocking` is true, we should still initialize the new `applyLockingClient`

## Testing
You can reproduce this by hitting the server index page 
`go run . server --disable-repo-locking=true --repo-allowlist=*`