### PR TITLE
DeleteSourceBranchOnMerge issue fixed

### DIFF
--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -455,12 +455,10 @@ func (p *DefaultProjectCommandBuilder) buildProjectCommandCtx(ctx *CommandContex
 	var projCtxs []models.ProjectCommandContext
 	var projCfg valid.MergedProjectCfg
 	automerge := DefaultAutomergeEnabled
-	deleteBranchOnMerge := DefaultDeleteSourceBranchOnMerge
 	parallelApply := DefaultParallelApplyEnabled
 	parallelPlan := DefaultParallelPlanEnabled
 	if repoCfgPtr != nil {
 		automerge = repoCfgPtr.Automerge
-		deleteBranchOnMerge = projCfg.DeleteSourceBranchOnMerge
 		parallelApply = repoCfgPtr.ParallelApply
 		parallelPlan = repoCfgPtr.ParallelPlan
 	}
@@ -483,7 +481,7 @@ func (p *DefaultProjectCommandBuilder) buildProjectCommandCtx(ctx *CommandContex
 					commentFlags,
 					repoDir,
 					automerge,
-					deleteBranchOnMerge,
+					projCfg.DeleteSourceBranchOnMerge,
 					parallelPlan,
 					parallelApply,
 					verbose,
@@ -499,7 +497,7 @@ func (p *DefaultProjectCommandBuilder) buildProjectCommandCtx(ctx *CommandContex
 				commentFlags,
 				repoDir,
 				automerge,
-				deleteBranchOnMerge,
+				projCfg.DeleteSourceBranchOnMerge,
 				parallelPlan,
 				parallelApply,
 				verbose,


### PR DESCRIPTION
This PR is fixing the issue https://github.com/runatlantis/atlantis/issues/1555
The DeleteSourceBranchOnMerge attribute was set before calling MergeProjectCfg.