### PR TITLE
Update Terraform 0.11.14 version to latest 0.11.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL authors="Anubhav Mishra, Luke Kysow"
 ENV DEFAULT_TERRAFORM_VERSION=0.15.1
 
 # In the official Atlantis image we only have the latest of each Terraform version.
-RUN AVAILABLE_TERRAFORM_VERSIONS="0.8.8 0.9.11 0.10.8 0.11.14 0.12.31 0.13.7 0.14.11 ${DEFAULT_TERRAFORM_VERSION}" && \
+RUN AVAILABLE_TERRAFORM_VERSIONS="0.8.8 0.9.11 0.10.8 0.11.15 0.12.31 0.13.7 0.14.11 ${DEFAULT_TERRAFORM_VERSION}" && \
     for VERSION in ${AVAILABLE_TERRAFORM_VERSIONS}; do \
         curl -LOs https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_linux_amd64.zip && \
         curl -LOs https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_SHA256SUMS && \

--- a/server/events/runtime/minimum_version_step_runner_delegate_test.go
+++ b/server/events/runtime/minimum_version_step_runner_delegate_test.go
@@ -16,7 +16,7 @@ func TestRunMinimumVersionDelegate(t *testing.T) {
 	mockDelegate := mocks.NewMockRunner()
 
 	tfVersion12, _ := version.NewVersion("0.12.0")
-	tfVersion11, _ := version.NewVersion("0.11.14")
+	tfVersion11, _ := version.NewVersion("0.11.15")
 
 	// these stay the same for all tests
 	extraArgs := []string{"extra", "args"}
@@ -89,7 +89,7 @@ func TestRunMinimumVersionDelegate(t *testing.T) {
 
 		mockDelegate.VerifyWasCalled(Never())
 
-		Equals(t, "Version: 0.11.14 is unsupported for this step. Minimum version is: 0.12.0", output)
+		Equals(t, "Version: 0.11.15 is unsupported for this step. Minimum version is: 0.12.0", output)
 		Ok(t, err)
 	})
 
@@ -113,7 +113,7 @@ func TestRunMinimumVersionDelegate(t *testing.T) {
 
 		mockDelegate.VerifyWasCalled(Never())
 
-		Equals(t, "Version: 0.11.14 is unsupported for this step. Minimum version is: 0.12.0", output)
+		Equals(t, "Version: 0.11.15 is unsupported for this step. Minimum version is: 0.12.0", output)
 		Ok(t, err)
 	})
 

--- a/server/events/runtime/plan_step_runner.go
+++ b/server/events/runtime/plan_step_runner.go
@@ -314,7 +314,7 @@ func StripRefreshingFromPlanOutput(output string, tfVersion *version.Version) st
 }
 
 // remoteOpsErr01114 is the error terraform plan will return if this project is
-// using TFE remote operations in TF 0.11.14.
+// using TFE remote operations in TF 0.11.15.
 var remoteOpsErr01114 = `Error: Saving a generated plan is currently not supported!
 
 The "remote" backend does not support saving the generated execution

--- a/server/events/runtime/plan_step_runner_test.go
+++ b/server/events/runtime/plan_step_runner_test.go
@@ -690,7 +690,7 @@ func TestRun_NoOptionalVarsIn012(t *testing.T) {
 // Test plans if using remote ops.
 func TestRun_RemoteOps(t *testing.T) {
 	cases := map[string]string{
-		"0.11.14 error": `Error: Saving a generated plan is currently not supported!
+		"0.11.15 error": `Error: Saving a generated plan is currently not supported!
 
 The "remote" backend does not support saving the generated execution
 plan locally at this time.


### PR DESCRIPTION
Terraform 0.11.14 is now incompatible with the providers, due to the PGP key issue. This PR is a quick find/replace of 0.11.14 to the latest 0.11.15, which resolves the issue.