### PR TITLE
fix: fix support for terraform workspaces

### DIFF
--- a/server/events/terraform/terraform_client.go
+++ b/server/events/terraform/terraform_client.go
@@ -310,7 +310,6 @@ func (c *DefaultClient) prepCmd(log logging.SimpleLogging, v *version.Version, w
 		"TF_IN_AUTOMATION=true",
 		// Cache plugins so terraform init runs faster.
 		fmt.Sprintf("WORKSPACE=%s", workspace),
-		fmt.Sprintf("TF_WORKSPACE=%s", workspace),
 		fmt.Sprintf("ATLANTIS_TERRAFORM_VERSION=%s", v.String()),
 		fmt.Sprintf("DIR=%s", path),
 	}


### PR DESCRIPTION
PR #1363 hardcoded a 3rd-party configuration variable (Terraform's TF_WORKSPACE), breaking terraform workspaces support in Atlantis.

This PR reverts the change made by #1363 to restore support for terraform workspaces. Users wishing to set TF_WORKSPACE to any value including the current workspace name, can easily do so with a custom workflow, or by externally setting the TF_WORKSPACE environment variable system-wide or session-wide.

Please see #1517 for bug report.
