### PR TITLE
Set Azure DevOps max comment characters to api limit

### DIFF
--- a/server/events/vcs/azuredevops_client.go
+++ b/server/events/vcs/azuredevops_client.go
@@ -104,7 +104,7 @@ func (g *AzureDevopsClient) CreateComment(repo models.Repo, pullNum int, comment
 	// maxCommentLength is the maximum number of chars allowed in a single comment
 	// This length was copied from the Github client - haven't found documentation
 	// or tested limit in Azure DevOps.
-	const maxCommentLength = 65536
+	const maxCommentLength = 150000
 
 	comments := common.SplitComment(comment, maxCommentLength, sepEnd, sepStart)
 	owner, project, repoName := SplitAzureDevopsRepoFullName(repo.FullName)


### PR DESCRIPTION
Azure DevOps comment character limit is 150.000

This limit is undocumented. However, posting a large comment via the rest api leads to a bad request with following message:
"message": "A discussion comment cannot be longer than 150000 characters.\r\nParameter name: comment.Content"