### PR TITLE
Add undiverged apply requirement

### DIFF
--- a/runatlantis.io/docs/apply-requirements.md
+++ b/runatlantis.io/docs/apply-requirements.md
@@ -135,6 +135,40 @@ In Azure DevOps, all pull requests are mergeable unless there is a conflict. You
 At this time, the Azure DevOps client only supports merging using the default 'no fast-forward' strategy. Make sure your branch policies permit this type of merge.
 :::
 
+### UnDiverged
+Prevent applies if there are any changes on the base branch since the most recent plan. 
+Applies to `merge` checkout strategy only.
+
+#### Usage
+You can set the `undiverged` requirement by:
+1. Creating a `repos.yaml` file with the `apply_requirements` key:
+   ```yaml
+   repos:
+   - id: /.*/
+     apply_requirements: [undiverged]
+   ```
+1. Or by allowing an `atlantis.yaml` file to specify the `apply_requirements` key in your `repos.yaml` config:
+   #### repos.yaml
+    ```yaml
+    repos:
+    - id: /.*/
+      allowed_overrides: [apply_requirements]
+    ```
+
+   #### atlantis.yaml
+    ```yaml
+    version: 3
+    projects:
+    - dir: .
+      apply_requirements: [undiverged]
+     ```
+### Meaning
+The `merge` checkout strategy creates a temporary merge commit and runs the `plan` on the Atlantis local version of the PR 
+source and destination branch. The local destination branch can become out of date since changes to the destination branch are not fetched 
+if there are no changes to the source branch. `undiverged` enforces that Atlantis local version of master is up to date 
+with remote so that the state of the source during the `apply` is identical to that if you were to merge the PR at that 
+time. 
+
 ## Setting Apply Requirements
 As mentioned above, you can set apply requirements via flags, in `repos.yaml`, or in `atlantis.yaml` if `repos.yaml`
 allows the override.

--- a/server/events/mock_workingdir_test.go
+++ b/server/events/mock_workingdir_test.go
@@ -49,6 +49,9 @@ func (mock *MockWorkingDir) Clone(log logging.SimpleLogging, headRepo models.Rep
 	}
 	return ret0, ret1, ret2
 }
+func (mock *MockWorkingDir) HasDiverged(log logging.SimpleLogging, cloneDir string) bool {
+	return false
+}
 
 func (mock *MockWorkingDir) GetWorkingDir(r models.Repo, p models.PullRequest, workspace string) (string, error) {
 	if mock == nil {

--- a/server/events/mocks/mock_working_dir.go
+++ b/server/events/mocks/mock_working_dir.go
@@ -48,6 +48,9 @@ func (mock *MockWorkingDir) Clone(log logging.SimpleLogging, headRepo models.Rep
 	}
 	return ret0, ret1, ret2
 }
+func (mock *MockWorkingDir) HasDiverged(log logging.SimpleLogging, cloneDir string) bool {
+	return true
+}
 
 func (mock *MockWorkingDir) GetWorkingDir(r models.Repo, p models.PullRequest, workspace string) (string, error) {
 	if mock == nil {

--- a/server/events/project_command_builder_internal_test.go
+++ b/server/events/project_command_builder_internal_test.go
@@ -573,7 +573,13 @@ projects:
 			globalCfgPath := filepath.Join(tmp, "global.yaml")
 			Ok(t, ioutil.WriteFile(globalCfgPath, []byte(c.globalCfg), 0600))
 			parser := &yaml.ParserValidator{}
-			globalCfg, err := parser.ParseGlobalCfg(globalCfgPath, valid.NewGlobalCfg(false, false, false))
+			globalCfgArgs := valid.GlobalCfgArgs{
+				AllowRepoCfg:  false,
+				MergeableReq:  false,
+				ApprovedReq:   false,
+				UnDivergedReq: false,
+			}
+			globalCfg, err := parser.ParseGlobalCfg(globalCfgPath, valid.NewGlobalCfgFromArgs(globalCfgArgs))
 			Ok(t, err)
 
 			if c.repoCfg != "" {
@@ -966,7 +972,14 @@ workflows:
 			globalCfgPath := filepath.Join(tmp, "global.yaml")
 			Ok(t, ioutil.WriteFile(globalCfgPath, []byte(c.globalCfg), 0600))
 			parser := &yaml.ParserValidator{}
-			globalCfg, err := parser.ParseGlobalCfg(globalCfgPath, valid.NewGlobalCfg(false, false, false))
+			globalCfgArgs := valid.GlobalCfgArgs{
+				AllowRepoCfg:  false,
+				MergeableReq:  false,
+				ApprovedReq:   false,
+				UnDivergedReq: false,
+			}
+
+			globalCfg, err := parser.ParseGlobalCfg(globalCfgPath, valid.NewGlobalCfgFromArgs(globalCfgArgs))
 			Ok(t, err)
 
 			if c.repoCfg != "" {

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -136,6 +136,13 @@ projects:
 				Ok(t, err)
 			}
 
+			globalCfgArgs := valid.GlobalCfgArgs{
+				AllowRepoCfg:  false,
+				MergeableReq:  false,
+				ApprovedReq:   false,
+				UnDivergedReq: false,
+			}
+
 			builder := events.NewProjectCommandBuilder(
 				false,
 				&yaml.ParserValidator{},
@@ -143,7 +150,7 @@ projects:
 				vcsClient,
 				workingDir,
 				events.NewDefaultWorkingDirLocker(),
-				valid.NewGlobalCfg(false, false, false),
+				valid.NewGlobalCfgFromArgs(globalCfgArgs),
 				&events.DefaultPendingPlanFinder{},
 				&events.CommentParser{},
 				false,
@@ -391,6 +398,13 @@ projects:
 					Ok(t, err)
 				}
 
+				globalCfgArgs := valid.GlobalCfgArgs{
+					AllowRepoCfg:  true,
+					MergeableReq:  false,
+					ApprovedReq:   false,
+					UnDivergedReq: false,
+				}
+
 				builder := events.NewProjectCommandBuilder(
 					false,
 					&yaml.ParserValidator{},
@@ -398,7 +412,7 @@ projects:
 					vcsClient,
 					workingDir,
 					events.NewDefaultWorkingDirLocker(),
-					valid.NewGlobalCfg(true, false, false),
+					valid.NewGlobalCfgFromArgs(globalCfgArgs),
 					&events.DefaultPendingPlanFinder{},
 					&events.CommentParser{},
 					false,
@@ -535,6 +549,13 @@ projects:
 				Ok(t, err)
 			}
 
+			globalCfgArgs := valid.GlobalCfgArgs{
+				AllowRepoCfg:  true,
+				MergeableReq:  false,
+				ApprovedReq:   false,
+				UnDivergedReq: false,
+			}
+
 			builder := events.NewProjectCommandBuilder(
 				false,
 				&yaml.ParserValidator{},
@@ -542,7 +563,7 @@ projects:
 				vcsClient,
 				workingDir,
 				events.NewDefaultWorkingDirLocker(),
-				valid.NewGlobalCfg(true, false, false),
+				valid.NewGlobalCfgFromArgs(globalCfgArgs),
 				&events.DefaultPendingPlanFinder{},
 				&events.CommentParser{},
 				false,
@@ -615,6 +636,13 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply(t *testing.T) {
 
 	logger := logging.NewNoopLogger(t)
 
+	globalCfgArgs := valid.GlobalCfgArgs{
+		AllowRepoCfg:  false,
+		MergeableReq:  false,
+		ApprovedReq:   false,
+		UnDivergedReq: false,
+	}
+
 	builder := events.NewProjectCommandBuilder(
 		false,
 		&yaml.ParserValidator{},
@@ -622,7 +650,7 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply(t *testing.T) {
 		nil,
 		workingDir,
 		events.NewDefaultWorkingDirLocker(),
-		valid.NewGlobalCfg(false, false, false),
+		valid.NewGlobalCfgFromArgs(globalCfgArgs),
 		&events.DefaultPendingPlanFinder{},
 		&events.CommentParser{},
 		false,
@@ -688,6 +716,19 @@ projects:
 		matchers.AnyModelsPullRequest(),
 		AnyString())).ThenReturn(repoDir, nil)
 
+<<<<<<< HEAD
+=======
+	scope := stats.NewStore(stats.NewNullSink(), false)
+	logger := logging.NewNoopLogger(t)
+
+	globalCfgArgs := valid.GlobalCfgArgs{
+		AllowRepoCfg:  true,
+		MergeableReq:  false,
+		ApprovedReq:   false,
+		UnDivergedReq: false,
+	}
+
+>>>>>>> 4ec5e5fa... ORCA-731 Force PR authors to rebase if master has diverged (#70)
 	builder := events.NewProjectCommandBuilder(
 		false,
 		&yaml.ParserValidator{},
@@ -695,7 +736,7 @@ projects:
 		nil,
 		workingDir,
 		events.NewDefaultWorkingDirLocker(),
-		valid.NewGlobalCfg(true, false, false),
+		valid.NewGlobalCfgFromArgs(globalCfgArgs),
 		&events.DefaultPendingPlanFinder{},
 		&events.CommentParser{},
 		false,
@@ -756,6 +797,13 @@ func TestDefaultProjectCommandBuilder_EscapeArgs(t *testing.T) {
 			vcsClient := vcsmocks.NewMockClient()
 			When(vcsClient.GetModifiedFiles(matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest())).ThenReturn([]string{"main.tf"}, nil)
 
+			globalCfgArgs := valid.GlobalCfgArgs{
+				AllowRepoCfg:  true,
+				MergeableReq:  false,
+				ApprovedReq:   false,
+				UnDivergedReq: false,
+			}
+
 			builder := events.NewProjectCommandBuilder(
 				false,
 				&yaml.ParserValidator{},
@@ -763,7 +811,7 @@ func TestDefaultProjectCommandBuilder_EscapeArgs(t *testing.T) {
 				vcsClient,
 				workingDir,
 				events.NewDefaultWorkingDirLocker(),
-				valid.NewGlobalCfg(true, false, false),
+				valid.NewGlobalCfgFromArgs(globalCfgArgs),
 				&events.DefaultPendingPlanFinder{},
 				&events.CommentParser{},
 				false,
@@ -928,6 +976,13 @@ projects:
 				matchers.AnyModelsPullRequest(),
 				AnyString())).ThenReturn(tmpDir, nil)
 
+			globalCfgArgs := valid.GlobalCfgArgs{
+				AllowRepoCfg:  true,
+				MergeableReq:  false,
+				ApprovedReq:   false,
+				UnDivergedReq: false,
+			}
+
 			builder := events.NewProjectCommandBuilder(
 				false,
 				&yaml.ParserValidator{},
@@ -935,7 +990,7 @@ projects:
 				vcsClient,
 				workingDir,
 				events.NewDefaultWorkingDirLocker(),
-				valid.NewGlobalCfg(true, false, false),
+				valid.NewGlobalCfgFromArgs(globalCfgArgs),
 				&events.DefaultPendingPlanFinder{},
 				&events.CommentParser{},
 				false,
@@ -984,6 +1039,13 @@ projects:
 
 	logger := logging.NewNoopLogger(t)
 
+	globalCfgArgs := valid.GlobalCfgArgs{
+		AllowRepoCfg:  true,
+		MergeableReq:  false,
+		ApprovedReq:   false,
+		UnDivergedReq: false,
+	}
+
 	builder := events.NewProjectCommandBuilder(
 		false,
 		&yaml.ParserValidator{},
@@ -991,7 +1053,7 @@ projects:
 		vcsClient,
 		workingDir,
 		events.NewDefaultWorkingDirLocker(),
-		valid.NewGlobalCfg(true, false, false),
+		valid.NewGlobalCfgFromArgs(globalCfgArgs),
 		&events.DefaultPendingPlanFinder{},
 		&events.CommentParser{},
 		true,
@@ -1026,7 +1088,15 @@ func TestDefaultProjectCommandBuilder_WithPolicyCheckEnabled_BuildAutoplanComman
 	When(workingDir.Clone(matchers.AnyPtrToLoggingSimpleLogger(), matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest(), AnyString())).ThenReturn(tmpDir, false, nil)
 	vcsClient := vcsmocks.NewMockClient()
 	When(vcsClient.GetModifiedFiles(matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest())).ThenReturn([]string{"main.tf"}, nil)
-	globalCfg := valid.NewGlobalCfg(false, false, false)
+
+	globalCfgArgs := valid.GlobalCfgArgs{
+		AllowRepoCfg:  false,
+		MergeableReq:  false,
+		ApprovedReq:   false,
+		UnDivergedReq: false,
+	}
+
+	globalCfg := valid.NewGlobalCfgFromArgs(globalCfgArgs)
 
 	builder := events.NewProjectCommandBuilder(
 		true,

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -716,11 +716,6 @@ projects:
 		matchers.AnyModelsPullRequest(),
 		AnyString())).ThenReturn(repoDir, nil)
 
-<<<<<<< HEAD
-=======
-	scope := stats.NewStore(stats.NewNullSink(), false)
-	logger := logging.NewNoopLogger(t)
-
 	globalCfgArgs := valid.GlobalCfgArgs{
 		AllowRepoCfg:  true,
 		MergeableReq:  false,
@@ -728,7 +723,6 @@ projects:
 		UnDivergedReq: false,
 	}
 
->>>>>>> 4ec5e5fa... ORCA-731 Force PR authors to rebase if master has diverged (#70)
 	builder := events.NewProjectCommandBuilder(
 		false,
 		&yaml.ParserValidator{},

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -342,6 +342,10 @@ func (p *DefaultProjectCommandRunner) doApply(ctx models.ProjectCommandContext) 
 			if !ctx.PullMergeable {
 				return "", "Pull request must be mergeable before running apply.", nil
 			}
+		case raw.UnDivergedApplyRequirement:
+			if p.WorkingDir.HasDiverged(ctx.Log, repoDir) {
+				return "", "Default branch must be rebased onto pull request before running apply.", nil
+			}
 		}
 	}
 	// Acquire internal lock for the directory we're going to operate in.

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -184,6 +184,25 @@ func TestDefaultProjectCommandRunner_ApplyNotMergeable(t *testing.T) {
 	Equals(t, "Pull request must be mergeable before running apply.", res.Failure)
 }
 
+// Test that if undiverged is required and the PR is diverged we give an error.
+func TestDefaultProjectCommandRunner_ApplyDiverged(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	runner := &events.DefaultProjectCommandRunner{
+		WorkingDir:       mockWorkingDir,
+		WorkingDirLocker: events.NewDefaultWorkingDirLocker(),
+	}
+	ctx := models.ProjectCommandContext{
+		ApplyRequirements: []string{"undiverged"},
+	}
+	tmp, cleanup := TempDir(t)
+	defer cleanup()
+	When(mockWorkingDir.GetWorkingDir(ctx.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(tmp, nil)
+
+	res := runner.Apply(ctx)
+	Equals(t, "Default branch must be rebased onto pull request before running apply.", res.Failure)
+}
+
 // Test that it runs the expected apply steps.
 func TestDefaultProjectCommandRunner_Apply(t *testing.T) {
 	cases := []struct {

--- a/server/events/yaml/parser_validator_test.go
+++ b/server/events/yaml/parser_validator_test.go
@@ -15,7 +15,14 @@ import (
 	. "github.com/runatlantis/atlantis/testing"
 )
 
-var globalCfg = valid.NewGlobalCfg(true, false, false)
+var globalCfgArgs = valid.GlobalCfgArgs{
+	AllowRepoCfg:  true,
+	MergeableReq:  false,
+	ApprovedReq:   false,
+	UnDivergedReq: false,
+}
+
+var globalCfg = valid.NewGlobalCfgFromArgs(globalCfgArgs)
 
 func TestHasRepoCfg_DirDoesNotExist(t *testing.T) {
 	r := yaml.ParserValidator{}
@@ -101,7 +108,13 @@ func TestParseCfgs_InvalidYAML(t *testing.T) {
 			r := yaml.ParserValidator{}
 			_, err = r.ParseRepoCfg(tmpDir, globalCfg, "")
 			ErrContains(t, c.expErr, err)
-			_, err = r.ParseGlobalCfg(confPath, valid.NewGlobalCfg(false, false, false))
+			globalCfgArgs := valid.GlobalCfgArgs{
+				AllowRepoCfg:  false,
+				MergeableReq:  false,
+				ApprovedReq:   false,
+				UnDivergedReq: false,
+			}
+			_, err = r.ParseGlobalCfg(confPath, valid.NewGlobalCfgFromArgs(globalCfgArgs))
 			ErrContains(t, c.expErr, err)
 		})
 	}
@@ -458,6 +471,45 @@ workflows:
 			},
 		},
 		{
+			description: "project field with undiverged apply requirement",
+			input: `
+version: 3
+projects:
+- dir: .
+  workspace: myworkspace
+  terraform_version: v0.11.0
+  apply_requirements: [undiverged]
+  workflow: myworkflow
+  autoplan:
+    enabled: false
+workflows:
+  myworkflow: ~`,
+			exp: valid.RepoCfg{
+				Version: 3,
+				Projects: []valid.Project{
+					{
+						Dir:              ".",
+						Workspace:        "myworkspace",
+						WorkflowName:     String("myworkflow"),
+						TerraformVersion: tfVersion,
+						Autoplan: valid.Autoplan{
+							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							Enabled:      false,
+						},
+						ApplyRequirements: []string{"undiverged"},
+					},
+				},
+				Workflows: map[string]valid.Workflow{
+					"myworkflow": {
+						Name:        "myworkflow",
+						Apply:       valid.DefaultApplyStage,
+						Plan:        valid.DefaultPlanStage,
+						PolicyCheck: valid.DefaultPolicyCheckStage,
+					},
+				},
+			},
+		},
+		{
 			description: "project field with mergeable and approved apply requirements",
 			input: `
 version: 3
@@ -484,6 +536,123 @@ workflows:
 							Enabled:      false,
 						},
 						ApplyRequirements: []string{"mergeable", "approved"},
+					},
+				},
+				Workflows: map[string]valid.Workflow{
+					"myworkflow": {
+						Name:        "myworkflow",
+						Apply:       valid.DefaultApplyStage,
+						Plan:        valid.DefaultPlanStage,
+						PolicyCheck: valid.DefaultPolicyCheckStage,
+					},
+				},
+			},
+		},
+		{
+			description: "project field with undiverged and approved apply requirements",
+			input: `
+version: 3
+projects:
+- dir: .
+  workspace: myworkspace
+  terraform_version: v0.11.0
+  apply_requirements: [undiverged, approved]
+  workflow: myworkflow
+  autoplan:
+    enabled: false
+workflows:
+  myworkflow: ~`,
+			exp: valid.RepoCfg{
+				Version: 3,
+				Projects: []valid.Project{
+					{
+						Dir:              ".",
+						Workspace:        "myworkspace",
+						WorkflowName:     String("myworkflow"),
+						TerraformVersion: tfVersion,
+						Autoplan: valid.Autoplan{
+							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							Enabled:      false,
+						},
+						ApplyRequirements: []string{"undiverged", "approved"},
+					},
+				},
+				Workflows: map[string]valid.Workflow{
+					"myworkflow": {
+						Name:        "myworkflow",
+						Apply:       valid.DefaultApplyStage,
+						Plan:        valid.DefaultPlanStage,
+						PolicyCheck: valid.DefaultPolicyCheckStage,
+					},
+				},
+			},
+		},
+		{
+			description: "project field with undiverged and mergeable apply requirements",
+			input: `
+version: 3
+projects:
+- dir: .
+  workspace: myworkspace
+  terraform_version: v0.11.0
+  apply_requirements: [undiverged, mergeable]
+  workflow: myworkflow
+  autoplan:
+    enabled: false
+workflows:
+  myworkflow: ~`,
+			exp: valid.RepoCfg{
+				Version: 3,
+				Projects: []valid.Project{
+					{
+						Dir:              ".",
+						Workspace:        "myworkspace",
+						WorkflowName:     String("myworkflow"),
+						TerraformVersion: tfVersion,
+						Autoplan: valid.Autoplan{
+							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							Enabled:      false,
+						},
+						ApplyRequirements: []string{"undiverged", "mergeable"},
+					},
+				},
+				Workflows: map[string]valid.Workflow{
+					"myworkflow": {
+						Name:        "myworkflow",
+						Apply:       valid.DefaultApplyStage,
+						Plan:        valid.DefaultPlanStage,
+						PolicyCheck: valid.DefaultPolicyCheckStage,
+					},
+				},
+			},
+		},
+		{
+			description: "project field with undiverged, mergeable and approved apply requirements",
+			input: `
+version: 3
+projects:
+- dir: .
+  workspace: myworkspace
+  terraform_version: v0.11.0
+  apply_requirements: [undiverged, mergeable, approved]
+  workflow: myworkflow
+  autoplan:
+    enabled: false
+workflows:
+  myworkflow: ~`,
+			exp: valid.RepoCfg{
+				Version: 3,
+				Projects: []valid.Project{
+					{
+						Dir:              ".",
+						Workspace:        "myworkspace",
+						WorkflowName:     String("myworkflow"),
+						TerraformVersion: tfVersion,
+						Autoplan: valid.Autoplan{
+							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							Enabled:      false,
+						},
+						ApplyRequirements: []string{"undiverged", "mergeable", "approved"},
 					},
 				},
 				Workflows: map[string]valid.Workflow{
@@ -931,18 +1100,38 @@ workflows:
 	Ok(t, err)
 
 	r := yaml.ParserValidator{}
-	_, err = r.ParseRepoCfg(tmpDir, valid.NewGlobalCfg(false, false, false), "repo_id")
+	globalCfgArgs := valid.GlobalCfgArgs{
+		AllowRepoCfg:  false,
+		MergeableReq:  false,
+		ApprovedReq:   false,
+		UnDivergedReq: false,
+	}
+
+	_, err = r.ParseRepoCfg(tmpDir, valid.NewGlobalCfgFromArgs(globalCfgArgs), "repo_id")
 	ErrEquals(t, "repo config not allowed to set 'workflow' key: server-side config needs 'allowed_overrides: [workflow]'", err)
 }
 
 func TestParseGlobalCfg_NotExist(t *testing.T) {
 	r := yaml.ParserValidator{}
-	_, err := r.ParseGlobalCfg("/not/exist", valid.NewGlobalCfg(false, false, false))
+	globalCfgArgs := valid.GlobalCfgArgs{
+		AllowRepoCfg:  false,
+		MergeableReq:  false,
+		ApprovedReq:   false,
+		UnDivergedReq: false,
+	}
+	_, err := r.ParseGlobalCfg("/not/exist", valid.NewGlobalCfgFromArgs(globalCfgArgs))
 	ErrEquals(t, "unable to read /not/exist file: open /not/exist: no such file or directory", err)
 }
 
 func TestParseGlobalCfg(t *testing.T) {
-	defaultCfg := valid.NewGlobalCfg(false, false, false)
+	globalCfgArgs := valid.GlobalCfgArgs{
+		AllowRepoCfg:  false,
+		MergeableReq:  false,
+		ApprovedReq:   false,
+		UnDivergedReq: false,
+	}
+
+	defaultCfg := valid.NewGlobalCfgFromArgs(globalCfgArgs)
 	preWorkflowHook := &valid.PreWorkflowHook{
 		StepName:   "run",
 		RunCommand: "custom workflow command",
@@ -1041,7 +1230,7 @@ func TestParseGlobalCfg(t *testing.T) {
 			input: `repos:
 - id: /.*/
   apply_requirements: [invalid]`,
-			expErr: "repos: (0: (apply_requirements: \"invalid\" is not a valid apply_requirement, only \"approved\" and \"mergeable\" are supported.).).",
+			expErr: "repos: (0: (apply_requirements: \"invalid\" is not a valid apply_requirement, only \"approved\", \"mergeable\" and \"undiverged\" are supported.).).",
 		},
 		"no workflows key": {
 			input: `repos: []`,
@@ -1287,7 +1476,14 @@ workflows:
 			path := filepath.Join(tmp, "conf.yaml")
 			Ok(t, ioutil.WriteFile(path, []byte(c.input), 0600))
 
-			act, err := r.ParseGlobalCfg(path, valid.NewGlobalCfg(false, false, false))
+			globalCfgArgs := valid.GlobalCfgArgs{
+				AllowRepoCfg:  false,
+				MergeableReq:  false,
+				ApprovedReq:   false,
+				UnDivergedReq: false,
+			}
+
+			act, err := r.ParseGlobalCfg(path, valid.NewGlobalCfgFromArgs(globalCfgArgs))
 
 			if c.expErr != "" {
 				expErr := strings.Replace(c.expErr, "<tmp>", path, -1)
@@ -1370,7 +1566,12 @@ func TestParserValidator_ParseGlobalCfgJSON(t *testing.T) {
 		},
 		"empty object": {
 			json: "{}",
-			exp:  valid.NewGlobalCfg(false, false, false),
+			exp: valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
+				AllowRepoCfg:  false,
+				MergeableReq:  false,
+				ApprovedReq:   false,
+				UnDivergedReq: false,
+			}),
 		},
 		"setting all keys": {
 			json: `
@@ -1424,7 +1625,12 @@ func TestParserValidator_ParseGlobalCfgJSON(t *testing.T) {
 `,
 			exp: valid.GlobalCfg{
 				Repos: []valid.Repo{
-					valid.NewGlobalCfg(false, false, false).Repos[0],
+					valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
+						AllowRepoCfg:  false,
+						MergeableReq:  false,
+						ApprovedReq:   false,
+						UnDivergedReq: false,
+					}).Repos[0],
 					{
 						IDRegex:              regexp.MustCompile(".*"),
 						ApplyRequirements:    []string{"mergeable", "approved"},
@@ -1442,8 +1648,13 @@ func TestParserValidator_ParseGlobalCfgJSON(t *testing.T) {
 					},
 				},
 				Workflows: map[string]valid.Workflow{
-					"default": valid.NewGlobalCfg(false, false, false).Workflows["default"],
-					"custom":  customWorkflow,
+					"default": valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
+						AllowRepoCfg:  false,
+						MergeableReq:  false,
+						ApprovedReq:   false,
+						UnDivergedReq: false,
+					}).Workflows["default"],
+					"custom": customWorkflow,
 				},
 				PolicySets: valid.PolicySets{
 					Version: conftestVersion,
@@ -1461,7 +1672,13 @@ func TestParserValidator_ParseGlobalCfgJSON(t *testing.T) {
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
 			pv := &yaml.ParserValidator{}
-			cfg, err := pv.ParseGlobalCfgJSON(c.json, valid.NewGlobalCfg(false, false, false))
+			globalCfgArgs := valid.GlobalCfgArgs{
+				AllowRepoCfg:  false,
+				MergeableReq:  false,
+				ApprovedReq:   false,
+				UnDivergedReq: false,
+			}
+			cfg, err := pv.ParseGlobalCfgJSON(c.json, valid.NewGlobalCfgFromArgs(globalCfgArgs))
 			if c.expErr != "" {
 				ErrEquals(t, c.expErr, err)
 				return
@@ -1522,7 +1739,13 @@ func TestParseRepoCfg_V2ShellParsing(t *testing.T) {
 			Ok(t, ioutil.WriteFile(v3Path, []byte("version: 3\n"+cfg), 0600))
 
 			p := &yaml.ParserValidator{}
-			v2Cfg, err := p.ParseRepoCfg(v2Dir, valid.NewGlobalCfg(true, false, false), "")
+			globalCfgArgs := valid.GlobalCfgArgs{
+				AllowRepoCfg:  true,
+				MergeableReq:  false,
+				ApprovedReq:   false,
+				UnDivergedReq: false,
+			}
+			v2Cfg, err := p.ParseRepoCfg(v2Dir, valid.NewGlobalCfgFromArgs(globalCfgArgs), "")
 			if c.expV2Err != "" {
 				ErrEquals(t, c.expV2Err, err)
 			} else {
@@ -1530,8 +1753,13 @@ func TestParseRepoCfg_V2ShellParsing(t *testing.T) {
 				Equals(t, c.expV2, v2Cfg.Workflows["custom"].Plan.Steps[0].RunCommand)
 				Equals(t, c.expV2, v2Cfg.Workflows["custom"].Apply.Steps[0].RunCommand)
 			}
-
-			v3Cfg, err := p.ParseRepoCfg(v3Dir, valid.NewGlobalCfg(true, false, false), "")
+			globalCfgArgs = valid.GlobalCfgArgs{
+				AllowRepoCfg:  true,
+				MergeableReq:  false,
+				ApprovedReq:   false,
+				UnDivergedReq: false,
+			}
+			v3Cfg, err := p.ParseRepoCfg(v3Dir, valid.NewGlobalCfgFromArgs(globalCfgArgs), "")
 			Ok(t, err)
 			Equals(t, c.in, v3Cfg.Workflows["custom"].Plan.Steps[0].RunCommand)
 			Equals(t, c.in, v3Cfg.Workflows["custom"].Apply.Steps[0].RunCommand)

--- a/server/events/yaml/raw/project.go
+++ b/server/events/yaml/raw/project.go
@@ -13,9 +13,10 @@ import (
 )
 
 const (
-	DefaultWorkspace          = "default"
-	ApprovedApplyRequirement  = "approved"
-	MergeableApplyRequirement = "mergeable"
+	DefaultWorkspace           = "default"
+	ApprovedApplyRequirement   = "approved"
+	MergeableApplyRequirement  = "mergeable"
+	UnDivergedApplyRequirement = "undiverged"
 )
 
 type Project struct {
@@ -106,8 +107,8 @@ func validProjectName(name string) bool {
 func validApplyReq(value interface{}) error {
 	reqs := value.([]string)
 	for _, r := range reqs {
-		if r != ApprovedApplyRequirement && r != MergeableApplyRequirement {
-			return fmt.Errorf("%q is not a valid apply_requirement, only %q and %q are supported", r, ApprovedApplyRequirement, MergeableApplyRequirement)
+		if r != ApprovedApplyRequirement && r != MergeableApplyRequirement && r != UnDivergedApplyRequirement {
+			return fmt.Errorf("%q is not a valid apply_requirement, only %q, %q and %q are supported", r, ApprovedApplyRequirement, MergeableApplyRequirement, UnDivergedApplyRequirement)
 		}
 	}
 	return nil

--- a/server/events/yaml/raw/project_test.go
+++ b/server/events/yaml/raw/project_test.go
@@ -101,7 +101,7 @@ func TestProject_Validate(t *testing.T) {
 				Dir:               String("."),
 				ApplyRequirements: []string{"unsupported"},
 			},
-			expErr: "apply_requirements: \"unsupported\" is not a valid apply_requirement, only \"approved\" and \"mergeable\" are supported.",
+			expErr: "apply_requirements: \"unsupported\" is not a valid apply_requirement, only \"approved\", \"mergeable\" and \"undiverged\" are supported.",
 		},
 		{
 			description: "apply reqs with approved requirement",
@@ -120,10 +120,42 @@ func TestProject_Validate(t *testing.T) {
 			expErr: "",
 		},
 		{
+			description: "apply reqs with undiverged requirement",
+			input: raw.Project{
+				Dir:               String("."),
+				ApplyRequirements: []string{"undiverged"},
+			},
+			expErr: "",
+		},
+		{
 			description: "apply reqs with mergeable and approved requirements",
 			input: raw.Project{
 				Dir:               String("."),
 				ApplyRequirements: []string{"mergeable", "approved"},
+			},
+			expErr: "",
+		},
+		{
+			description: "apply reqs with undiverged and approved requirements",
+			input: raw.Project{
+				Dir:               String("."),
+				ApplyRequirements: []string{"undiverged", "approved"},
+			},
+			expErr: "",
+		},
+		{
+			description: "apply reqs with undiverged and mergeable requirements",
+			input: raw.Project{
+				Dir:               String("."),
+				ApplyRequirements: []string{"undiverged", "mergeable"},
+			},
+			expErr: "",
+		},
+		{
+			description: "apply reqs with undiverged, mergeable and approved requirements",
+			input: raw.Project{
+				Dir:               String("."),
+				ApplyRequirements: []string{"undiverged", "mergeable", "approved"},
 			},
 			expErr: "",
 		},

--- a/server/events/yaml/valid/global_cfg.go
+++ b/server/events/yaml/valid/global_cfg.go
@@ -11,6 +11,7 @@ import (
 
 const MergeableApplyReq = "mergeable"
 const ApprovedApplyReq = "approved"
+const UnDivergedApplyReq = "undiverged"
 const PoliciesPassedApplyReq = "policies_passed"
 const ApplyRequirementsKey = "apply_requirements"
 const PreWorkflowHooksKey = "pre_workflow_hooks"
@@ -107,11 +108,12 @@ var DefaultPlanStage = Stage{
 }
 
 // Deprecated: use NewGlobalCfgFromArgs
-func NewGlobalCfgWithHooks(allowRepoCfg bool, mergeableReq bool, approvedReq bool, preWorkflowHooks []*PreWorkflowHook) GlobalCfg {
+func NewGlobalCfgWithHooks(allowRepoCfg bool, mergeableReq bool, approvedReq bool, unDivergedReq bool, preWorkflowHooks []*PreWorkflowHook) GlobalCfg {
 	return NewGlobalCfgFromArgs(GlobalCfgArgs{
 		AllowRepoCfg:     allowRepoCfg,
 		MergeableReq:     mergeableReq,
 		ApprovedReq:      approvedReq,
+		UnDivergedReq:    unDivergedReq,
 		PreWorkflowHooks: preWorkflowHooks,
 	})
 }
@@ -135,6 +137,7 @@ type GlobalCfgArgs struct {
 	AllowRepoCfg       bool
 	MergeableReq       bool
 	ApprovedReq        bool
+	UnDivergedReq      bool
 	PolicyCheckEnabled bool
 	PreWorkflowHooks   []*PreWorkflowHook
 }
@@ -156,6 +159,9 @@ func NewGlobalCfgFromArgs(args GlobalCfgArgs) GlobalCfg {
 	}
 	if args.ApprovedReq {
 		applyReqs = append(applyReqs, ApprovedApplyReq)
+	}
+	if args.UnDivergedReq {
+		applyReqs = append(applyReqs, UnDivergedApplyReq)
 	}
 
 	if args.PolicyCheckEnabled {

--- a/server/events/yaml/valid/global_cfg_test.go
+++ b/server/events/yaml/valid/global_cfg_test.go
@@ -65,47 +65,96 @@ func TestNewGlobalCfg(t *testing.T) {
 	}
 
 	cases := []struct {
-		allowRepoCfg bool
-		approvedReq  bool
-		mergeableReq bool
+		allowRepoCfg  bool
+		approvedReq   bool
+		mergeableReq  bool
+		unDivergedReq bool
 	}{
 		{
-			allowRepoCfg: false,
-			approvedReq:  false,
-			mergeableReq: false,
+			allowRepoCfg:  false,
+			approvedReq:   false,
+			mergeableReq:  false,
+			unDivergedReq: false,
 		},
 		{
-			allowRepoCfg: true,
-			approvedReq:  false,
-			mergeableReq: false,
+			allowRepoCfg:  true,
+			approvedReq:   false,
+			mergeableReq:  false,
+			unDivergedReq: false,
 		},
 		{
-			allowRepoCfg: false,
-			approvedReq:  true,
-			mergeableReq: false,
+			allowRepoCfg:  false,
+			approvedReq:   true,
+			mergeableReq:  false,
+			unDivergedReq: false,
 		},
 		{
-			allowRepoCfg: false,
-			approvedReq:  false,
-			mergeableReq: true,
+			allowRepoCfg:  false,
+			approvedReq:   false,
+			mergeableReq:  true,
+			unDivergedReq: false,
 		},
 		{
-			allowRepoCfg: false,
-			approvedReq:  true,
-			mergeableReq: true,
+			allowRepoCfg:  false,
+			approvedReq:   true,
+			mergeableReq:  true,
+			unDivergedReq: false,
 		},
 		{
-			allowRepoCfg: true,
-			approvedReq:  true,
-			mergeableReq: true,
+			allowRepoCfg:  true,
+			approvedReq:   true,
+			mergeableReq:  true,
+			unDivergedReq: false,
+		},
+		{
+			allowRepoCfg:  false,
+			approvedReq:   false,
+			mergeableReq:  false,
+			unDivergedReq: true,
+		},
+		{
+			allowRepoCfg:  true,
+			approvedReq:   false,
+			mergeableReq:  false,
+			unDivergedReq: true,
+		},
+		{
+			allowRepoCfg:  false,
+			approvedReq:   true,
+			mergeableReq:  false,
+			unDivergedReq: true,
+		},
+		{
+			allowRepoCfg:  false,
+			approvedReq:   false,
+			mergeableReq:  true,
+			unDivergedReq: true,
+		},
+		{
+			allowRepoCfg:  false,
+			approvedReq:   true,
+			mergeableReq:  true,
+			unDivergedReq: true,
+		},
+		{
+			allowRepoCfg:  true,
+			approvedReq:   true,
+			mergeableReq:  true,
+			unDivergedReq: true,
 		},
 	}
 
 	for _, c := range cases {
-		caseName := fmt.Sprintf("allow_repo: %t, approved: %t, mergeable: %t",
-			c.allowRepoCfg, c.approvedReq, c.mergeableReq)
+		caseName := fmt.Sprintf("allow_repo: %t, approved: %t, mergeable: %t, undiverged: %t",
+			c.allowRepoCfg, c.approvedReq, c.mergeableReq, c.unDivergedReq)
 		t.Run(caseName, func(t *testing.T) {
-			act := valid.NewGlobalCfg(c.allowRepoCfg, c.mergeableReq, c.approvedReq)
+			globalCfgArgs := valid.GlobalCfgArgs{
+				AllowRepoCfg:  c.allowRepoCfg,
+				MergeableReq:  c.mergeableReq,
+				ApprovedReq:   c.approvedReq,
+				UnDivergedReq: c.unDivergedReq,
+			}
+			act := valid.NewGlobalCfgFromArgs(globalCfgArgs)
 
 			// For each test, we change our expected cfg based on the parameters.
 			exp := deepcopy.Copy(baseCfg).(valid.GlobalCfg)
@@ -121,6 +170,9 @@ func TestNewGlobalCfg(t *testing.T) {
 			}
 			if c.approvedReq {
 				exp.Repos[0].ApplyRequirements = append(exp.Repos[0].ApplyRequirements, "approved")
+			}
+			if c.unDivergedReq {
+				exp.Repos[0].ApplyRequirements = append(exp.Repos[0].ApplyRequirements, "undiverged")
 			}
 
 			Equals(t, exp, act)
@@ -151,7 +203,12 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 		"repo uses workflow that is defined server side but not allowed (with custom workflows)": {
 			gCfg: valid.GlobalCfg{
 				Repos: []valid.Repo{
-					valid.NewGlobalCfg(true, false, false).Repos[0],
+					valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
+						AllowRepoCfg:  true,
+						MergeableReq:  false,
+						ApprovedReq:   false,
+						UnDivergedReq: false,
+					}).Repos[0],
 					{
 						ID:                   "github.com/owner/repo",
 						AllowCustomWorkflows: Bool(true),
@@ -179,7 +236,12 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 		"repo uses workflow that is defined server side but not allowed (without custom workflows)": {
 			gCfg: valid.GlobalCfg{
 				Repos: []valid.Repo{
-					valid.NewGlobalCfg(true, false, false).Repos[0],
+					valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
+						AllowRepoCfg:  true,
+						MergeableReq:  false,
+						ApprovedReq:   false,
+						UnDivergedReq: false,
+					}).Repos[0],
 					{
 						ID:                   "github.com/owner/repo",
 						AllowCustomWorkflows: Bool(false),
@@ -207,7 +269,12 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 		"repo uses workflow that is defined in both places with same name (without custom workflows)": {
 			gCfg: valid.GlobalCfg{
 				Repos: []valid.Repo{
-					valid.NewGlobalCfg(true, false, false).Repos[0],
+					valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
+						AllowRepoCfg:  true,
+						MergeableReq:  false,
+						ApprovedReq:   false,
+						UnDivergedReq: false,
+					}).Repos[0],
 					{
 						ID:                   "github.com/owner/repo",
 						AllowCustomWorkflows: Bool(false),
@@ -237,7 +304,12 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 		"repo uses workflow that is defined repo side, but not allowed (with custom workflows)": {
 			gCfg: valid.GlobalCfg{
 				Repos: []valid.Repo{
-					valid.NewGlobalCfg(true, false, false).Repos[0],
+					valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
+						AllowRepoCfg:  true,
+						MergeableReq:  false,
+						ApprovedReq:   false,
+						UnDivergedReq: false,
+					}).Repos[0],
 					{
 						ID:                   "github.com/owner/repo",
 						AllowCustomWorkflows: Bool(true),
@@ -267,7 +339,12 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 		"repo uses workflow that is defined server side and allowed (without custom workflows)": {
 			gCfg: valid.GlobalCfg{
 				Repos: []valid.Repo{
-					valid.NewGlobalCfg(true, false, false).Repos[0],
+					valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
+						AllowRepoCfg:  true,
+						MergeableReq:  false,
+						ApprovedReq:   false,
+						UnDivergedReq: false,
+					}).Repos[0],
 					{
 						ID:                   "github.com/owner/repo",
 						AllowCustomWorkflows: Bool(false),
@@ -295,7 +372,12 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 		"repo uses workflow that is defined server side and allowed (with custom workflows)": {
 			gCfg: valid.GlobalCfg{
 				Repos: []valid.Repo{
-					valid.NewGlobalCfg(true, false, false).Repos[0],
+					valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
+						AllowRepoCfg:  true,
+						MergeableReq:  false,
+						ApprovedReq:   false,
+						UnDivergedReq: false,
+					}).Repos[0],
 					{
 						ID:                   "github.com/owner/repo",
 						AllowCustomWorkflows: Bool(true),
@@ -321,7 +403,12 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 			expErr: "",
 		},
 		"workflow not allowed": {
-			gCfg: valid.NewGlobalCfg(false, false, false),
+			gCfg: valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
+				AllowRepoCfg:  false,
+				MergeableReq:  false,
+				ApprovedReq:   false,
+				UnDivergedReq: false,
+			}),
 			rCfg: valid.RepoCfg{
 				Projects: []valid.Project{
 					{
@@ -333,7 +420,12 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 			expErr: "repo config not allowed to set 'workflow' key: server-side config needs 'allowed_overrides: [workflow]'",
 		},
 		"custom workflows not allowed": {
-			gCfg: valid.NewGlobalCfg(false, false, false),
+			gCfg: valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
+				AllowRepoCfg:  false,
+				MergeableReq:  false,
+				ApprovedReq:   false,
+				UnDivergedReq: false,
+			}),
 			rCfg: valid.RepoCfg{
 				Workflows: map[string]valid.Workflow{
 					"custom": {},
@@ -343,7 +435,12 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 			expErr: "repo config not allowed to define custom workflows: server-side config needs 'allow_custom_workflows: true'",
 		},
 		"custom workflows allowed": {
-			gCfg: valid.NewGlobalCfg(true, false, false),
+			gCfg: valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
+				AllowRepoCfg:  true,
+				MergeableReq:  false,
+				ApprovedReq:   false,
+				UnDivergedReq: false,
+			}),
 			rCfg: valid.RepoCfg{
 				Workflows: map[string]valid.Workflow{
 					"custom": {},
@@ -353,7 +450,12 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 			expErr: "",
 		},
 		"repo uses custom workflow defined on repo": {
-			gCfg: valid.NewGlobalCfg(true, false, false),
+			gCfg: valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
+				AllowRepoCfg:  true,
+				MergeableReq:  false,
+				ApprovedReq:   false,
+				UnDivergedReq: false,
+			}),
 			rCfg: valid.RepoCfg{
 				Projects: []valid.Project{
 					{
@@ -372,7 +474,12 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 		"custom workflows allowed for this repo only": {
 			gCfg: valid.GlobalCfg{
 				Repos: []valid.Repo{
-					valid.NewGlobalCfg(false, false, false).Repos[0],
+					valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
+						AllowRepoCfg:  false,
+						MergeableReq:  false,
+						ApprovedReq:   false,
+						UnDivergedReq: false,
+					}).Repos[0],
 					{
 						ID:                   "github.com/owner/repo",
 						AllowCustomWorkflows: Bool(true),
@@ -388,7 +495,12 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 			expErr: "",
 		},
 		"repo uses global workflow": {
-			gCfg: valid.NewGlobalCfg(true, false, false),
+			gCfg: valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
+				AllowRepoCfg:  true,
+				MergeableReq:  false,
+				ApprovedReq:   false,
+				UnDivergedReq: false,
+			}),
 			rCfg: valid.RepoCfg{
 				Projects: []valid.Project{
 					{
@@ -402,7 +514,12 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 			expErr: "",
 		},
 		"apply_reqs not allowed": {
-			gCfg: valid.NewGlobalCfg(false, false, false),
+			gCfg: valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
+				AllowRepoCfg:  false,
+				MergeableReq:  false,
+				ApprovedReq:   false,
+				UnDivergedReq: false,
+			}),
 			rCfg: valid.RepoCfg{
 				Projects: []valid.Project{
 					{
@@ -416,7 +533,12 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 			expErr: "repo config not allowed to set 'apply_requirements' key: server-side config needs 'allowed_overrides: [apply_requirements]'",
 		},
 		"repo workflow doesn't exist": {
-			gCfg: valid.NewGlobalCfg(true, false, false),
+			gCfg: valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
+				AllowRepoCfg:  true,
+				MergeableReq:  false,
+				ApprovedReq:   false,
+				UnDivergedReq: false,
+			}),
 			rCfg: valid.RepoCfg{
 				Projects: []valid.Project{
 					{
@@ -541,10 +663,22 @@ policies:
 				path := filepath.Join(tmp, "config.yaml")
 				Ok(t, ioutil.WriteFile(path, []byte(c.gCfg), 0600))
 				var err error
-				global, err = (&yaml.ParserValidator{}).ParseGlobalCfg(path, valid.NewGlobalCfg(false, false, false))
+				globalCfgArgs := valid.GlobalCfgArgs{
+					AllowRepoCfg:  false,
+					MergeableReq:  false,
+					ApprovedReq:   false,
+					UnDivergedReq: false,
+				}
+				global, err = (&yaml.ParserValidator{}).ParseGlobalCfg(path, valid.NewGlobalCfgFromArgs(globalCfgArgs))
 				Ok(t, err)
 			} else {
-				global = valid.NewGlobalCfg(false, false, false)
+				globalCfgArgs := valid.GlobalCfgArgs{
+					AllowRepoCfg:  false,
+					MergeableReq:  false,
+					ApprovedReq:   false,
+					UnDivergedReq: false,
+				}
+				global = valid.NewGlobalCfgFromArgs(globalCfgArgs)
 			}
 
 			Equals(t,
@@ -700,10 +834,23 @@ repos:
 				path := filepath.Join(tmp, "config.yaml")
 				Ok(t, ioutil.WriteFile(path, []byte(c.gCfg), 0600))
 				var err error
-				global, err = (&yaml.ParserValidator{}).ParseGlobalCfg(path, valid.NewGlobalCfg(false, false, false))
+				globalCfgArgs := valid.GlobalCfgArgs{
+					AllowRepoCfg:  false,
+					MergeableReq:  false,
+					ApprovedReq:   false,
+					UnDivergedReq: false,
+				}
+
+				global, err = (&yaml.ParserValidator{}).ParseGlobalCfg(path, valid.NewGlobalCfgFromArgs(globalCfgArgs))
 				Ok(t, err)
 			} else {
-				global = valid.NewGlobalCfg(false, false, false)
+				globalCfgArgs := valid.GlobalCfgArgs{
+					AllowRepoCfg:  false,
+					MergeableReq:  false,
+					ApprovedReq:   false,
+					UnDivergedReq: false,
+				}
+				global = valid.NewGlobalCfgFromArgs(globalCfgArgs)
 			}
 
 			global.PolicySets = emptyPolicySets

--- a/server/server.go
+++ b/server/server.go
@@ -349,6 +349,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 			AllowRepoCfg:       userConfig.AllowRepoConfig,
 			MergeableReq:       userConfig.RequireMergeable,
 			ApprovedReq:        userConfig.RequireApproval,
+			UnDivergedReq:      userConfig.RequireUnDiverged,
 			PolicyCheckEnabled: userConfig.EnablePolicyChecksFlag,
 		})
 	if userConfig.RepoConfig != "" {

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -60,7 +60,10 @@ type UserConfig struct {
 	// allowing terraform apply's to run.
 	RequireMergeable bool `mapstructure:"require-mergeable"`
 	// SilenceNoProjects is whether Atlantis should respond to a PR if no projects are found.
-	SilenceNoProjects   bool `mapstructure:"silence-no-projects"`
+	SilenceNoProjects bool `mapstructure:"silence-no-projects"`
+	// RequireUnDiverged is whether to require pull requests to rebase default branch before
+	// allowing terraform apply's to run.
+	RequireUnDiverged   bool `mapstructure:"require-undiverged"`
 	SilenceForkPRErrors bool `mapstructure:"silence-fork-pr-errors"`
 	// SilenceVCSStatusNoPlans is whether autoplan should set commit status if no plans
 	// are found.


### PR DESCRIPTION
This PR adds an `undiverged` Apply requirement which prevents applies if there are any changes on the base branch since the most recent plan. The apply requirement only effects repos/projects with the 'merge' checkout strategy and prevents the situation where an 'apply' is run on Atlantis but not all changes from remote/master had been pulled locally to Atlantis. This is the same situation where we already warn users on the 'plan' but additionally prevents the apply.


Example workflow: 

<img width="985" alt="Screen Shot 2021-05-20 at 2 27 55 PM" src="https://user-images.githubusercontent.com/1891649/119051269-d58d8300-b977-11eb-9531-299e900897c5.png">
