### PR TITLE
Add libc6-compat to docker-base

### DIFF
--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -42,6 +42,10 @@ RUN apk add --no-cache ca-certificates gnupg curl git git-lfs unzip bash openssh
         apk del gnupg openssl && \
         rm -rf /root/.gnupg && rm -rf /var/cache/apk/*
 
+# Install dependencies for atlantis
+RUN apk add --no-cache libc6-compat && \
+  rm -rf /var/cache/apk/*
+
 # Set up nsswitch.conf for Go's "netgo" implementation
 # - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
 RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf


### PR DESCRIPTION
v0.17.0 seems to require libc6-compat to work with alpine.
This should resolve https://github.com/runatlantis/atlantis/issues/1569

Requires base bump in Dockerfile after new docker-base version is released.