### PR TITLE
Add run step environment variable SHOWFILE

### DIFF
--- a/runatlantis.io/docs/custom-workflows.md
+++ b/runatlantis.io/docs/custom-workflows.md
@@ -165,6 +165,7 @@ If using the server `repos.yaml` file, you would use the following config:
 ```yaml
 # repos.yaml
 # Specify TERRAGRUNT_TFPATH environment variable to accomodate setting --default-tf-version
+# Generate json plan via terragrunt for policy checks
 repos:
 - id: "/.*/"
   workflow: terragrunt
@@ -176,6 +177,7 @@ workflows:
           name: TERRAGRUNT_TFPATH
           command: 'echo "terraform${ATLANTIS_TERRAFORM_VERSION}"'
       - run: terragrunt plan -no-color -out=$PLANFILE
+      - run: terragrunt show -no-color -json $PLANFILE > $SHOWFILE
     apply:
       steps:
       - env:
@@ -356,6 +358,9 @@ Or a custom command
   * `PLANFILE` - Absolute path to the location where Atlantis expects the plan to
   either be generated (by plan) or already exist (if running apply). Can be used to
   override the built-in `plan`/`apply` commands, ex. `run: terraform plan -out $PLANFILE`.
+  * `SHOWFILE` - Absolute path to the location where Atlantis expects the plan in json format to
+  either be generated (by show) or already exist (if running policy checks). Can be used to
+  override the built-in `plan`/`apply` commands, ex. `run: terraform show -json $PLANFILE > $SHOWFILE`.
   * `BASE_REPO_NAME` - Name of the repository that the pull request will be merged into, ex. `atlantis`.
   * `BASE_REPO_OWNER` - Owner of the repository that the pull request will be merged into, ex. `runatlantis`.
   * `HEAD_REPO_NAME` - Name of the repository that is getting merged into the base repository, ex. `atlantis`.

--- a/server/events/runtime/run_step_runner.go
+++ b/server/events/runtime/run_step_runner.go
@@ -49,6 +49,7 @@ func (r *RunStepRunner) Run(ctx models.ProjectCommandContext, command string, pa
 		"HEAD_REPO_OWNER":            ctx.HeadRepo.Owner,
 		"PATH":                       fmt.Sprintf("%s:%s", os.Getenv("PATH"), r.TerraformBinDir),
 		"PLANFILE":                   filepath.Join(path, GetPlanFilename(ctx.Workspace, ctx.ProjectName)),
+		"SHOWFILE":                   filepath.Join(path, ctx.GetShowResultFileName()),
 		"PROJECT_NAME":               ctx.ProjectName,
 		"PULL_AUTHOR":                ctx.Pull.Author,
 		"PULL_NUM":                   fmt.Sprintf("%d", ctx.Pull.Num),

--- a/server/events/runtime/run_step_runner_test.go
+++ b/server/events/runtime/run_step_runner_test.go
@@ -56,13 +56,13 @@ func TestRunStepRunner_Run(t *testing.T) {
 			ExpErr:  "exit status 127: running \"lkjlkj\" in",
 		},
 		{
-			Command: "echo workspace=$WORKSPACE version=$ATLANTIS_TERRAFORM_VERSION dir=$DIR planfile=$PLANFILE project=$PROJECT_NAME",
-			ExpOut:  "workspace=myworkspace version=0.11.0 dir=$DIR planfile=$DIR/myworkspace.tfplan project=\n",
+			Command: "echo workspace=$WORKSPACE version=$ATLANTIS_TERRAFORM_VERSION dir=$DIR planfile=$PLANFILE showfile=$SHOWFILE project=$PROJECT_NAME",
+			ExpOut:  "workspace=myworkspace version=0.11.0 dir=$DIR planfile=$DIR/myworkspace.tfplan showfile=$DIR/myworkspace.json project=\n",
 		},
 		{
-			Command:     "echo workspace=$WORKSPACE version=$ATLANTIS_TERRAFORM_VERSION dir=$DIR planfile=$PLANFILE project=$PROJECT_NAME",
+			Command:     "echo workspace=$WORKSPACE version=$ATLANTIS_TERRAFORM_VERSION dir=$DIR planfile=$PLANFILE showfile=$SHOWFILE project=$PROJECT_NAME",
 			ProjectName: "my/project/name",
-			ExpOut:      "workspace=myworkspace version=0.11.0 dir=$DIR planfile=$DIR/my::project::name-myworkspace.tfplan project=my/project/name\n",
+			ExpOut:      "workspace=myworkspace version=0.11.0 dir=$DIR planfile=$DIR/my::project::name-myworkspace.tfplan showfile=$DIR/my::project::name-myworkspace.json project=my/project/name\n",
 		},
 		{
 			Command: "echo base_repo_name=$BASE_REPO_NAME base_repo_owner=$BASE_REPO_OWNER head_repo_name=$HEAD_REPO_NAME head_repo_owner=$HEAD_REPO_OWNER head_branch_name=$HEAD_BRANCH_NAME head_commit=$HEAD_COMMIT base_branch_name=$BASE_BRANCH_NAME pull_num=$PULL_NUM pull_author=$PULL_AUTHOR repo_rel_dir=$REPO_REL_DIR",


### PR DESCRIPTION
Policy checks require the PLANFILE in json format. The default show workflow step defaults to `terraform show`. This breaks custom workflows, e.g. a terragrunt workflow.

This PR adds a SHOWFILE environment variable which is set to the expected absolute path of the json formatted PLANFILE. This allows for the following custom show command:
```yaml
 - run: terragrunt show -no-color -json $PLANFILE > $SHOWFILE
 ```

fixes #1562 