### PR TITLE
Standardised logging timestamp to ISO8601

### DIFF
--- a/server/logging/simple_logger.go
+++ b/server/logging/simple_logger.go
@@ -74,12 +74,14 @@ type StructuredLogger struct {
 func NewStructuredLoggerFromLevel(lvl LogLevel) (SimpleLogging, error) {
 	cfg := zap.NewProductionConfig()
 
+	cfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	cfg.Level = zap.NewAtomicLevelAt(lvl.zLevel)
 	return newStructuredLogger(cfg)
 }
 
 func NewStructuredLogger() (SimpleLogging, error) {
 	cfg := zap.NewProductionConfig()
+	cfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	return newStructuredLogger(cfg)
 }
 


### PR DESCRIPTION
Atlantis version - atlantis 0.17.0

Issue - 
With the current format of logs, the timestamp is printed in the format -
**{"level":"info","ts":1623266081.273087,"caller":"server/server.go:715","msg":"All in-progress operations complete, shutting down","json":{}}**
This particular format makes it really difficult or impossible to ingest atlantis logs into logging system like ELK. Also to the bare eye it is difficult to understand the format.

Solution offered -
Zap logs can be formatted to be printed in ISO8601 standards. This has been configured in the logger initialisation. With this configs logs are printed in the below format -
**{"level":"info","ts":"2021-06-10T00:44:51.559+0530","caller":"server/server.go:148","msg":"Policy Checks are enabled","json":{}}**

This format is more readable and easier to ingest into logging system like ELK. 