### PR TITLE
Move argument deduplication logic to a utility package

### DIFF
--- a/server/events/runtime/common/common.go
+++ b/server/events/runtime/common/common.go
@@ -1,0 +1,63 @@
+package common
+
+import "strings"
+
+// Looks for any argument in commandArgs that has been overridden by an entry in extra args and replaces them
+// any extraArgs that are not used as overrides are added yo the end of the final string slice
+func DeDuplicateExtraArgs(commandArgs []string, extraArgs []string) []string {
+	// work if any of the core args have been overridden
+	finalArgs := []string{}
+	usedExtraArgs := []string{}
+	for _, arg := range commandArgs {
+		override := ""
+		prefix := arg
+		argSplit := strings.Split(arg, "=")
+		if len(argSplit) == 2 {
+			prefix = argSplit[0]
+		}
+		for _, extraArgOrig := range extraArgs {
+			extraArg := extraArgOrig
+			if strings.HasPrefix(extraArg, prefix) {
+				override = extraArgOrig
+				break
+			}
+			if strings.HasPrefix(extraArg, "--") {
+				extraArg = extraArgOrig[1:]
+				if strings.HasPrefix(extraArg, prefix) {
+					override = extraArgOrig
+					break
+				}
+			}
+			if strings.HasPrefix(prefix, "--") {
+				prefixWithoutDash := prefix[1:]
+				if strings.HasPrefix(extraArg, prefixWithoutDash) {
+					override = extraArgOrig
+					break
+				}
+			}
+
+		}
+		if override != "" {
+			finalArgs = append(finalArgs, override)
+			usedExtraArgs = append(usedExtraArgs, override)
+		} else {
+			finalArgs = append(finalArgs, arg)
+		}
+	}
+	// add any extra args that are not overrides
+	for _, extraArg := range extraArgs {
+		if !stringInSlice(usedExtraArgs, extraArg) {
+			finalArgs = append(finalArgs, extraArg)
+		}
+	}
+	return finalArgs
+}
+
+func stringInSlice(stringSlice []string, target string) bool {
+	for _, value := range stringSlice {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/server/events/runtime/common/common_test.go
+++ b/server/events/runtime/common/common_test.go
@@ -1,0 +1,86 @@
+package common
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_DeDuplicateExtraArgs(t *testing.T) {
+	cases := []struct {
+		description  string
+		inputArgs    []string
+		extraArgs    []string
+		expectedArgs []string
+	}{
+		{
+			"No extra args",
+			[]string{"init", "-input=false", "-no-color", "-upgrade"},
+			[]string{},
+			[]string{"init", "-input=false", "-no-color", "-upgrade"},
+		},
+		{
+			"Override -upgrade",
+			[]string{"init", "-input=false", "-no-color", "-upgrade"},
+			[]string{"-upgrade=false"},
+			[]string{"init", "-input=false", "-no-color", "-upgrade=false"},
+		},
+		{
+			"Override -input",
+			[]string{"init", "-input=false", "-no-color", "-upgrade"},
+			[]string{"-input=true"},
+			[]string{"init", "-input=true", "-no-color", "-upgrade"},
+		},
+		{
+			"Override -input and -upgrade",
+			[]string{"init", "-input=false", "-no-color", "-upgrade"},
+			[]string{"-input=true", "-upgrade=false"},
+			[]string{"init", "-input=true", "-no-color", "-upgrade=false"},
+		},
+		{
+			"Non duplicate extra args",
+			[]string{"init", "-input=false", "-no-color", "-upgrade"},
+			[]string{"extra", "args"},
+			[]string{"init", "-input=false", "-no-color", "-upgrade", "extra", "args"},
+		},
+		{
+			"Override upgrade with extra args",
+			[]string{"init", "-input=false", "-no-color", "-upgrade"},
+			[]string{"extra", "args", "-upgrade=false"},
+			[]string{"init", "-input=false", "-no-color", "-upgrade=false", "extra", "args"},
+		},
+		{
+			"Override -input (using --input)",
+			[]string{"init", "-input=false", "-no-color", "-upgrade"},
+			[]string{"--input=true"},
+			[]string{"init", "--input=true", "-no-color", "-upgrade"},
+		},
+		{
+			"Override -input (using --input) and -upgrade (using --upgrade)",
+			[]string{"init", "-input=false", "-no-color", "-upgrade"},
+			[]string{"--input=true", "--upgrade=false"},
+			[]string{"init", "--input=true", "-no-color", "--upgrade=false"},
+		},
+		{
+			"Override long form flag ",
+			[]string{"init", "--input=false", "-no-color", "-upgrade"},
+			[]string{"--input=true"},
+			[]string{"init", "--input=true", "-no-color", "-upgrade"},
+		},
+		{
+			"Override --input using (-input) ",
+			[]string{"init", "--input=false", "-no-color", "-upgrade"},
+			[]string{"-input=true"},
+			[]string{"init", "-input=true", "-no-color", "-upgrade"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			finalArgs := DeDuplicateExtraArgs(c.inputArgs, c.extraArgs)
+
+			if !reflect.DeepEqual(c.expectedArgs, finalArgs) {
+				t.Fatalf("finalArgs (%v) does not match expectedArgs (%v)", finalArgs, c.expectedArgs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR moves the argument de-duplication logic out into to a utility package so  it can be re-used as requested 

I have also tried to cater for matching  "--argname" vs "-argname" in both argument lists 