### PR TITLE
fix: TFE remote ops detection for >= tf 1.0.0

### DIFF
--- a/server/core/runtime/plan_step_runner.go
+++ b/server/core/runtime/plan_step_runner.go
@@ -63,7 +63,7 @@ func (p *PlanStepRunner) isRemoteOpsErr(output string, err error) bool {
 	if err == nil {
 		return false
 	}
-	return strings.Contains(output, remoteOpsErr01114) || strings.Contains(output, remoteOpsErr012)
+	return strings.Contains(output, remoteOpsErr01114) || strings.Contains(output, remoteOpsErr012) || strings.Contains(output, remoteOpsErr100)
 }
 
 // remotePlan runs a terraform plan command compatible with TFE remote
@@ -330,6 +330,14 @@ var remoteOpsErr012 = `Error: Saving a generated plan is currently not supported
 The "remote" backend does not support saving the generated execution plan
 locally at this time.
 
+`
+
+// remoteOpsErr100 is the error terraform plan will retrun if this project is
+// using TFE remote operations in TF 1.0.{0,1}.
+var remoteOpsErr100 = `Error: Saving a generated plan is currently not supported
+
+The "remote" backend does not support saving the generated execution plan
+locally at this time.
 `
 
 // remoteOpsHeader is the header we add to the planfile if this plan was


### PR DESCRIPTION
Atlantis fails during the plan step when using TFE remote ops and Terraform version 1.0.0. (Same issue with 1.0.1). This is due to a slight change in the error message that gets printed when trying to run plan with the -out param on a TFE workspace set up for remote operations. This change fixes that by adding the Terraform 1.0.{0,1} specific error message to the remote ops detection logic.