### PR TITLE
fix ignore of --parallel-pool-size flag

### DIFF
--- a/server/events/project_command_pool_executor.go
+++ b/server/events/project_command_pool_executor.go
@@ -17,7 +17,7 @@ func runProjectCmdsParallel(
 	var results []models.ProjectResult
 	mux := &sync.Mutex{}
 
-	wg := sizedwaitgroup.New(15)
+	wg := sizedwaitgroup.New(poolSize)
 	for _, pCmd := range cmds {
 		pCmd := pCmd
 		var execute func()


### PR DESCRIPTION
It seems to me that `--parallel-pool-size` flag (https://github.com/runatlantis/atlantis/blob/master/runatlantis.io/docs/server-configuration.md#--parallel-pool-size) is ignored because default value (which is 15) is hardcoded.