### PR TITLE
fix: urls on webhooks documentation

### DIFF
--- a/runatlantis.io/docs/configuring-webhooks.md
+++ b/runatlantis.io/docs/configuring-webhooks.md
@@ -2,9 +2,9 @@
 Atlantis needs to receive Webhooks from your Git host so that it can respond to pull request events.
 
 :::tip Prerequisites
-* You have created an [access credential](access-credentials.html)
-* You have created a [webhook secret](webhook-secrets.html)
-* You have [deployed](deployment.html) Atlantis and have a url for it
+* You have created an [access credential](access-credentials.md)
+* You have created a [webhook secret](webhook-secrets.md)
+* You have [deployed](deployment.md) Atlantis and have a url for it
 :::
 
 See the instructions for your specific provider below.
@@ -18,7 +18,7 @@ If only some of the repos in your organization are to be managed by Atlantis, th
 may want to only install on specific repos for now.
 :::
 
-When authenticating as a Github App, Webhooks are automatically created and need no additional setup, beyond being installed to your organization/user account after creation. Refer to the [Github App setup](access-credentials.html#github-app) section for instructions on how to do so.
+When authenticating as a Github App, Webhooks are automatically created and need no additional setup, beyond being installed to your organization/user account after creation. Refer to the [Github App setup](access-credentials.md#github-app) section for instructions on how to do so.
 
 If you're installing on the organization, navigate to your organization's page and click **Settings**.
 If installing on a single repository, navigate to the repository home page and click **Settings**.
@@ -121,4 +121,4 @@ Repeat the process above until you have webhook subscriptions for the following 
 * To verify that Atlantis is receiving your webhooks, create a test pull request
   to your repo. 
 * You should see the request show up in the Atlantis logs at an `INFO` level.
-* You'll now need to configure Atlantis to add your [Provider Credentials](provider-credentials.html)
+* You'll now need to configure Atlantis to add your [Provider Credentials](provider-credentials.md)


### PR DESCRIPTION
Some links were broken because they had `.html` instead of `.md`