### PR TITLE
Fix AzDo Throttling Timeouts

### DIFF
--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -51,6 +51,8 @@ func (s *ServerStarterMock) Start() error {
 // Adding a new flag? Add it to this slice for testing in alphabetical
 // order.
 var testFlags = map[string]interface{}{
+	ADHonorRetryAfter:          true,
+	ADTimeoutSeconds:           12,
 	ADTokenFlag:                "ad-token",
 	ADUserFlag:                 "ad-user",
 	ADWebhookPasswordFlag:      "ad-wh-pass",

--- a/server/events/vcs/azuredevops_client.go
+++ b/server/events/vcs/azuredevops_client.go
@@ -108,6 +108,9 @@ func (g *AzureDevopsClient) GetModifiedFiles(repo models.Repo, pull models.PullR
 	sourceRefName := strings.Replace(pullRequest.GetSourceRefName(), "refs/heads/", "", 1)
 
 	r, resp, err := g.Client.Git.GetDiffs(g.ctx, owner, project, repoName, targetRefName, sourceRefName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error getting diff %s to %s", sourceRefName, targetRefName)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, errors.Wrapf(err, "http response code %d getting diff %s to %s", resp.StatusCode, sourceRefName, targetRefName)
 	}

--- a/server/events/vcs/azuredevops_client_test.go
+++ b/server/events/vcs/azuredevops_client_test.go
@@ -262,6 +262,9 @@ func TestAzureDevopsClient_UpdateStatus(t *testing.T) {
 // and concat results.
 func TestAzureDevopsClient_GetModifiedFiles(t *testing.T) {
 	itemRespTemplate := `{
+		"changeCounts": {
+			"Add": 2
+		},
 		"changes": [
 	{
 		"item": {

--- a/server/server.go
+++ b/server/server.go
@@ -204,8 +204,8 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	}
 	if userConfig.AzureDevopsUser != "" {
 		azureDevopsTimeout := 10 * time.Second
-		if userConfig.AzureDevopsTimeoutSecondss != 0 {
-			azureDevopsTimeout = time.Duration(userConfig.AzureDevopsTimeoutSecondss) * time.Second
+		if userConfig.AzureDevopsTimeoutSeconds != 0 {
+			azureDevopsTimeout = time.Duration(userConfig.AzureDevopsTimeoutSeconds) * time.Second
 		}
 		supportedVCSHosts = append(supportedVCSHosts, models.AzureDevops)
 		var err error

--- a/server/server.go
+++ b/server/server.go
@@ -203,9 +203,13 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		}
 	}
 	if userConfig.AzureDevopsUser != "" {
+		azureDevopsTimeout := 10 * time.Second
+		if userConfig.AzureDevopsTimeoutSecondss != 0 {
+			azureDevopsTimeout = time.Duration(userConfig.AzureDevopsTimeoutSecondss) * time.Second
+		}
 		supportedVCSHosts = append(supportedVCSHosts, models.AzureDevops)
 		var err error
-		azuredevopsClient, err = vcs.NewAzureDevopsClient("dev.azure.com", userConfig.AzureDevopsUser, userConfig.AzureDevopsToken)
+		azuredevopsClient, err = vcs.NewAzureDevopsClient("dev.azure.com", userConfig.AzureDevopsUser, userConfig.AzureDevopsToken, azureDevopsTimeout, userConfig.AzureDevopsHonorRetryAfter)
 		if err != nil {
 			return nil, err
 		}

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -13,6 +13,8 @@ type UserConfig struct {
 	AtlantisURL                string `mapstructure:"atlantis-url"`
 	Automerge                  bool   `mapstructure:"automerge"`
 	AutoplanFileList           string `mapstructure:"autoplan-file-list"`
+	AzureDevopsHonorRetryAfter bool   `mapstructure:"azuredevops-honor-retry-after"`
+	AzureDevopsTimeoutSecondss int    `mapstructure:"azuredevops-timeout-seconds"`
 	AzureDevopsToken           string `mapstructure:"azuredevops-token"`
 	AzureDevopsUser            string `mapstructure:"azuredevops-user"`
 	AzureDevopsWebhookPassword string `mapstructure:"azuredevops-webhook-password"`

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -14,7 +14,7 @@ type UserConfig struct {
 	Automerge                  bool   `mapstructure:"automerge"`
 	AutoplanFileList           string `mapstructure:"autoplan-file-list"`
 	AzureDevopsHonorRetryAfter bool   `mapstructure:"azuredevops-honor-retry-after"`
-	AzureDevopsTimeoutSecondss int    `mapstructure:"azuredevops-timeout-seconds"`
+	AzureDevopsTimeoutSeconds  int    `mapstructure:"azuredevops-timeout-seconds"`
 	AzureDevopsToken           string `mapstructure:"azuredevops-token"`
 	AzureDevopsUser            string `mapstructure:"azuredevops-user"`
 	AzureDevopsWebhookPassword string `mapstructure:"azuredevops-webhook-password"`


### PR DESCRIPTION
Getting errors like the one below due to AzureDevops throttling of api requests:

```
Error: making pull request API call to Azure DevOps: Get "https://dev.azure.com/example/terraform/_apis/git/repositories/example-repo/pullrequests/1234?api-version=5.1-preview.1&includeWorkItemRefs=true": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```

Took two strategies to help with this:

1. Add a flag to customize the client timeout
2. Add a roundtripper to the azdo client which will honor the Retry-After header sent back from AzDo. It will then sleep that many seconds before it will do a second API request

Both of the options I added default to the present state of things (10 seconds timeout, no retry-after honoring) and will only affect end-users if they explicitly enable those features. 