### PR TITLE
Add flag to permit disabling the "Disable Apply Commands" button

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -56,6 +56,7 @@ const (
 	DefaultTFVersionFlag       = "default-tf-version"
 	DisableApplyAllFlag        = "disable-apply-all"
 	DisableApplyFlag           = "disable-apply"
+	AllowApplyDisable          = "allow-apply-disable"
 	DisableAutoplanFlag        = "disable-autoplan"
 	DisableMarkdownFoldingFlag = "disable-markdown-folding"
 	DisableRepoLockingFlag     = "disable-repo-locking"
@@ -300,6 +301,10 @@ var boolFlags = map[string]boolFlag{
 	DisableApplyFlag: {
 		description:  "Disable all \"atlantis apply\" command regardless of which flags are passed with it.",
 		defaultValue: false,
+	},
+	AllowApplyDisable: {
+		description:  "Disable the \"Disable Apply Commands\" button from the Web UI",
+		defaultValue: true,
 	},
 	DisableAutoplanFlag: {
 		description:  "Disable atlantis auto planning feature",

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -47,6 +47,12 @@ Values are chosen in this order:
 
 
 ## Flags
+* ### `--allow-apply-disable`
+  ```bash
+  atlantis server --allow-apply-disable=true
+  ```
+  Disable the "Disable Apply Commands" button on the web UI
+
 * ### `--allow-draft-prs`
   ```bash
   atlantis server --allow-draft-prs

--- a/server/controllers/templates/web_templates.go
+++ b/server/controllers/templates/web_templates.go
@@ -55,7 +55,8 @@ type IndexData struct {
 	// CleanedBasePath is the path Atlantis is accessible at externally. If
 	// not using a path-based proxy, this will be an empty string. Never ends
 	// in a '/' (hence "cleaned").
-	CleanedBasePath string
+	CleanedBasePath   string
+	AllowApplyDisable bool
 }
 
 var IndexTemplate = template.Must(template.New("index.html.tmpl").Parse(`
@@ -96,7 +97,8 @@ var IndexTemplate = template.Must(template.New("index.html.tmpl").Parse(`
       <h6><code>Active Since</code>: <strong>{{ .ApplyLock.TimeFormatted }}</strong></h6>
       <a class="button button-primary" id="applyUnlockPrompt">Enable Apply Commands</a>
     </div>
-    {{ else }}
+    {{ end }}
+    {{ if .AllowApplyDisable }}
     <div class="twelve columns">
       <h6><strong>Apply commands are enabled</strong></h6>
       <a class="button button-primary" id="applyLockPrompt">Disable Apply Commands</a>

--- a/server/server.go
+++ b/server/server.go
@@ -97,6 +97,7 @@ type Server struct {
 	SSLCertFile                   string
 	SSLKeyFile                    string
 	Drainer                       *events.Drainer
+	UserConfig                    UserConfig
 }
 
 // Config holds config for server that isn't passed in by the user.
@@ -654,6 +655,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		SSLKeyFile:                    userConfig.SSLKeyFile,
 		SSLCertFile:                   userConfig.SSLCertFile,
 		Drainer:                       drainer,
+		UserConfig:                    userConfig,
 	}, nil
 }
 
@@ -775,10 +777,11 @@ func (s *Server) Index(w http.ResponseWriter, _ *http.Request) {
 	sort.SliceStable(lockResults, func(i, j int) bool { return lockResults[i].Time.After(lockResults[j].Time) })
 
 	err = s.IndexTemplate.Execute(w, templates.IndexData{
-		Locks:           lockResults,
-		ApplyLock:       applyLockData,
-		AtlantisVersion: s.AtlantisVersion,
-		CleanedBasePath: s.AtlantisURL.Path,
+		Locks:             lockResults,
+		ApplyLock:         applyLockData,
+		AtlantisVersion:   s.AtlantisVersion,
+		CleanedBasePath:   s.AtlantisURL.Path,
+		AllowApplyDisable: s.UserConfig.AllowApplyDisable,
 	})
 	if err != nil {
 		s.Logger.Err(err.Error())

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -8,6 +8,7 @@ import (
 // The mapstructure tags correspond to flags in cmd/server.go and are used when
 // the config is parsed from a YAML file.
 type UserConfig struct {
+	AllowApplyDisable          bool   `mapstructure:"allow-apply-disable"`
 	AllowForkPRs               bool   `mapstructure:"allow-fork-prs"`
 	AllowRepoConfig            bool   `mapstructure:"allow-repo-config"`
 	AtlantisURL                string `mapstructure:"atlantis-url"`


### PR DESCRIPTION
After updating our instance of Atlantis recently, we noticed that there was a new button in the web UI that allows anyone with access to the page to disable applies. This page is not behind any authentication and we do not wish for non-administrators to have this capability. This PR adds a simple flag/config option to switch this button off in the index template.