### PR TITLE
fix: fixing apply permission when MR is in a draft status

### DIFF
--- a/server/events/vcs/gitlab_client.go
+++ b/server/events/vcs/gitlab_client.go
@@ -208,6 +208,7 @@ func (g *GitlabClient) PullIsMergeable(repo models.Repo, pull models.PullRequest
 	if mr.MergeStatus == "can_be_merged" &&
 		mr.ApprovalsBeforeMerge <= 0 &&
 		mr.BlockingDiscussionsResolved &&
+		!mr.WorkInProgress &&
 		(allowSkippedPipeline || !isPipelineSkipped) {
 		return true, nil
 	}


### PR DESCRIPTION
Why:
This PR solves the following issue:

MR can be applied when MR is in a draft status (Work In Progress)