### PR TITLE
Fixed instructions for adding Webhook under Gitlab

### DIFF
--- a/runatlantis.io/guide/testing-locally.md
+++ b/runatlantis.io/guide/testing-locally.md
@@ -86,7 +86,7 @@ Take the URL that ngrok output and create a webhook in your GitHub, GitLab or Bi
     <summary>Expand</summary>
     <ul>
         <li>Go to your repo's home page</li>
-        <li>Click <strong>Settings &gt; Integrations</strong> in the sidebar</li>
+        <li>Click <strong>Settings &gt; Webhooks</strong> in the sidebar</li>
         <li>set <strong>URL</strong> to your ngrok url with <code>/events</code> at the end. Ex. <code>https://c5004d84.ngrok.io/events</code></li>
         <li>double-check you added <code>/events</code> to the end of your URL.</li>
         <li>set <strong>Secret Token</strong> to your random string</li>


### PR DESCRIPTION
The instructions incorrectly asked to visit "Settings->Integrations" , whereas the correct instruction is to visit "Settings->Webhooks".

This PR fixes the error.