### PR TITLE
deps: bump alpine to v3.14

### DIFF
--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile builds our base image with gosu, dumb-init and the atlantis
 # user. We split this from the main Dockerfile because this base doesn't change
 # and also because it kept breaking the build due to flakiness.
-FROM alpine:3.13
+FROM alpine:3.14
 LABEL authors="Anubhav Mishra, Luke Kysow"
 
 # We use gosu to step down from root and run as the atlantis user so we need


### PR DESCRIPTION
Fixes apk-tools vulnerability CVE-2021-36159 and fix curl vulnerabilities CVE-2021-22924, CVE-2021-22923 and CVE-2021-22925