### PR TITLE
Add BasicAuth Support to Atlantis ServeHTTP

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -101,6 +101,9 @@ const (
 	TFEHostnameFlag            = "tfe-hostname"
 	TFETokenFlag               = "tfe-token"
 	WriteGitCredsFlag          = "write-git-creds"
+	WebBasicAuthFlag           = "web-basic-auth"
+	WebUsernameFlag            = "web-username"
+	WebPasswordFlag            = "web-password"
 
 	// NOTE: Must manually set these as defaults in the setDefaults function.
 	DefaultADBasicUser      = ""
@@ -117,6 +120,9 @@ const (
 	DefaultTFDownloadURL    = "https://releases.hashicorp.com"
 	DefaultTFEHostname      = "app.terraform.io"
 	DefaultVCSStatusName    = "atlantis"
+	DefaultWebBasicAuth     = false
+	DefaultWebUsername      = "atlantis"
+	DefaultWebPassword      = "atlantis"
 )
 
 var stringFlags = map[string]stringFlag{
@@ -280,6 +286,14 @@ var stringFlags = map[string]stringFlag{
 		description:  "Name used to identify Atlantis for pull request statuses.",
 		defaultValue: DefaultVCSStatusName,
 	},
+	WebUsernameFlag: {
+		description:  "Username used for Web Basic Authentication on Atlantis HTTP Middleware",
+		defaultValue: DefaultWebUsername,
+	},
+	WebPasswordFlag: {
+		description:  "Password used for Web Basic Authentication on Atlantis HTTP Middleware",
+		defaultValue: DefaultWebPassword,
+	},
 }
 
 var boolFlags = map[string]boolFlag{
@@ -373,6 +387,10 @@ var boolFlags = map[string]boolFlag{
 	SkipCloneNoChanges: {
 		description:  "Skips cloning the PR repo if there are no projects were changed in the PR.",
 		defaultValue: false,
+	},
+	WebBasicAuthFlag: {
+		description:  "Switches on or off the Basic Authentication on the HTTP Middleware interface",
+		defaultValue: DefaultWebBasicAuth,
 	},
 }
 var intFlags = map[string]intFlag{
@@ -619,6 +637,12 @@ func (s *ServerCmd) setDefaults(c *server.UserConfig) {
 	}
 	if c.TFEHostname == "" {
 		c.TFEHostname = DefaultTFEHostname
+	}
+	if c.WebUsername == "" {
+		c.WebUsername = DefaultWebUsername
+	}
+	if c.WebPassword == "" {
+		c.WebPassword = DefaultWebPassword
 	}
 }
 

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -21,18 +21,49 @@ import (
 )
 
 // NewRequestLogger creates a RequestLogger.
-func NewRequestLogger(logger logging.SimpleLogging) *RequestLogger {
-	return &RequestLogger{logger}
+func NewRequestLogger(s *Server) *RequestLogger {
+	return &RequestLogger{
+		s.Logger,
+		s.WebAuthentication,
+		s.WebUsername,
+		s.WebPassword,
+	}
 }
 
-// RequestLogger logs requests and their response codes.
+// RequestLogger logs requests and their response codes
+// as well as handle the basicauth on the requests
 type RequestLogger struct {
-	logger logging.SimpleLogging
+	logger            logging.SimpleLogging
+	WebAuthentication bool
+	WebUsername       string
+	WebPassword       string
 }
 
 // ServeHTTP implements the middleware function. It logs all requests at DEBUG level.
 func (l *RequestLogger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	l.logger.Debug("%s %s – from %s", r.Method, r.URL.RequestURI(), r.RemoteAddr)
-	next(rw, r)
+	allowed := false
+	if r.URL.Path == "/events" || !l.WebAuthentication {
+		allowed = true
+	} else {
+		user, pass, ok := r.BasicAuth()
+		if ok {
+			r.SetBasicAuth(user, pass)
+			l.logger.Debug("user: %s / pass: %s >> url: %s", user, pass, r.URL.RequestURI())
+			if user == l.WebUsername && pass == l.WebPassword {
+				l.logger.Debug("[VALID] user: %s / pass: %s >> url: %s", user, pass, r.URL.RequestURI())
+				allowed = true
+			} else {
+				allowed = false
+				l.logger.Info("[INVALID] user: %s / pass: %s >> url: %s", user, pass, r.URL.RequestURI())
+			}
+		}
+	}
+	if !allowed {
+		rw.Header().Set("WWW-Authenticate", `Basic realm="restricted", charset="UTF-8"`)
+		http.Error(rw, "Unauthorized", http.StatusUnauthorized)
+	} else {
+		next(rw, r)
+	}
 	l.logger.Debug("%s %s – respond HTTP %d", r.Method, r.URL.RequestURI(), rw.(negroni.ResponseWriter).Status())
 }

--- a/server/server.go
+++ b/server/server.go
@@ -98,6 +98,9 @@ type Server struct {
 	SSLCertFile                   string
 	SSLKeyFile                    string
 	Drainer                       *events.Drainer
+	WebAuthentication             bool
+	WebUsername                   string
+	WebPassword                   string
 }
 
 // Config holds config for server that isn't passed in by the user.
@@ -652,7 +655,6 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		GithubHostname:      userConfig.GithubHostname,
 		GithubOrg:           userConfig.GithubOrg,
 	}
-
 	return &Server{
 		AtlantisVersion:               config.AtlantisVersion,
 		AtlantisURL:                   parsedURL,
@@ -672,6 +674,9 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		SSLKeyFile:                    userConfig.SSLKeyFile,
 		SSLCertFile:                   userConfig.SSLCertFile,
 		Drainer:                       drainer,
+		WebAuthentication:             userConfig.WebBasicAuth,
+		WebUsername:                   userConfig.WebUsername,
+		WebPassword:                   userConfig.WebPassword,
 	}, nil
 }
 
@@ -696,7 +701,7 @@ func (s *Server) Start() error {
 		PrintStack: false,
 		StackAll:   false,
 		StackSize:  1024 * 8,
-	}, NewRequestLogger(s.Logger))
+	}, NewRequestLogger(s))
 	n.UseHandler(s.Router)
 
 	defer s.Logger.Flush()

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -85,6 +85,9 @@ type UserConfig struct {
 	VCSStatusName          string          `mapstructure:"vcs-status-name"`
 	DefaultTFVersion       string          `mapstructure:"default-tf-version"`
 	Webhooks               []WebhookConfig `mapstructure:"webhooks"`
+	WebBasicAuth           bool            `mapstructure:"web-basic-auth"`
+	WebUsername            string          `mapstructure:"web-username"`
+	WebPassword            string          `mapstructure:"web-password"`
 	WriteGitCreds          bool            `mapstructure:"write-git-creds"`
 }
 


### PR DESCRIPTION
This PR:

1) Introduces the following flags:
`--web-basic-auth=bool` (false by default) to enable/disable basic-auth on the web server
`--web-username=string` (atlantis by default) to set the web server username
`--web-password=string` (atlantis by default) to set the web server password

2) BasicAuth feature over middleware HTTP server of Atlantis
- The URLPath `/events` is filtered out of the basic-auth requirement, as this element is can be protected already by webhook secrets.
- The rest of the routes (lock, unlock, etc), if enabled, will request a basic-auth header in order to access the web server.

Probably `RequestLogger` should be relabeled to something else that now identifies both the authentication, serving, and logging scenario for HTTP requests.