### PR TITLE
docs: add missing the `branch` key in the reference for server side repo config

### DIFF
--- a/runatlantis.io/docs/apply-requirements.md
+++ b/runatlantis.io/docs/apply-requirements.md
@@ -87,6 +87,13 @@ You can set the `mergeable` requirement by:
      
 #### Meaning
 Each VCS provider has a different concept of "mergeability":
+
+::: warning
+Some VCS providers have a feature for branch protection to control "mergeability". If you want to use it,
+you probably need to limit the base branch not to bypass the branch protection.
+See also the `branch` keyword in [Server Side Repo Config](server-side-repo-config.html#reference) for more details.
+:::
+
 #### GitHub
 In GitHub, if you're not using [Protected Branches](https://help.github.com/articles/about-protected-branches/) then
 all pull requests are mergeable unless there is a conflict.

--- a/runatlantis.io/docs/server-side-repo-config.md
+++ b/runatlantis.io/docs/server-side-repo-config.md
@@ -348,6 +348,7 @@ custom workflows.
 ```yaml
 repos:
 - id: /.*/
+  branch: /.*/
   apply_requirements: []
   workflow: default
   allowed_overrides: []
@@ -373,6 +374,7 @@ If you set a workflow with the key `default`, it will override this.
 | Key                           | Type     | Default | Required | Description                                                                                                                                                                                                                                                                                              |
 |-------------------------------|----------|---------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | id                            | string   | none    | yes      | Value can be a regular expression when specified as /&lt;regex&gt;/ or an exact string match. Repo IDs are of the form `{vcs hostname}/{org}/{name}`, ex. `github.com/owner/repo`. Hostname is specified without scheme or port. For Bitbucket Server, {org} is the **name** of the project, not the key. |
+| branch                        | string   | none    | no       | An regex matching pull requests by base branch (the branch the pull request is getting merged into). By default, all branches are matched                                                                                                                                                                 |
 | workflow                      | string   | none    | no       | A custom workflow.                                                                                                                                                                                                                                                                                       |
 | apply_requirements            | []string | none    | no       | Requirements that must be satisfied before `atlantis apply` can be run. Currently the only supported requirements are `approved` and `mergeable`. See [Apply Requirements](apply-requirements.html) for more details.                                                                                    |
 | allowed_overrides             | []string | none    | no       | A list of restricted keys that `atlantis.yaml` files can override. The only supported keys are `apply_requirements`, `workflow` and `delete_source_branch_on_merge`                                                                                                                                      |


### PR DESCRIPTION
Fixes #1695

The branch matcher feature has been implemented in #1383 and #1768. There is only an example for it, but not in the reference.

https://github.com/runatlantis/atlantis/pull/1383/files#diff-5dd8dd3b7c37191b78109efaaa1bb73184ff7a1690632d687fed7cd748847f5eR31-R34

Add missing the `branch` key in the reference for server side repo config.

I also add a warning for `mergeable` requirement to check the `branch` setting because I think a typical branch protection rule only restricts a default branch. We should let users know that someone can potentially bypass it without the `branch` restriction in atlantis.