### PR TITLE
Add support for deleting a branch on merge in BitBucket Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 * How to get started: [www.runatlantis.io/guide](https://www.runatlantis.io/guide)
 * Full documentation: [www.runatlantis.io/docs](https://www.runatlantis.io/docs)
 * Download the latest release: [github.com/runatlantis/atlantis/releases/latest](https://github.com/runatlantis/atlantis/releases/latest)
-* Get help in our [Slack channel](https://thawing-headland-22460.herokuapp.com) or our [Gitter channel](https://gitter.im/runatlantis/Lobby)
+* Get help in our [Slack channel](https://thawing-headland-22460.herokuapp.com)
 * Start Contributing: [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## What is Atlantis?

--- a/server/events/vcs/bitbucketserver/client.go
+++ b/server/events/vcs/bitbucketserver/client.go
@@ -281,6 +281,9 @@ func (b *Client) MergePull(pull models.PullRequest, pullOptions models.PullReque
 
 		path = fmt.Sprintf("%s/rest/branch-utils/1.0/projects/%s/repos/%s/branches", b.BaseURL, projectKey, pull.BaseRepo.Name)
 		_, err = b.makeRequest("DELETE", path, bytes.NewBuffer(bodyBytes))
+		if err != nil {
+			return err
+		}
 	}
 	return err
 }

--- a/server/events/vcs/bitbucketserver/client_test.go
+++ b/server/events/vcs/bitbucketserver/client_test.go
@@ -1,6 +1,7 @@
 package bitbucketserver_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -179,6 +180,64 @@ func TestClient_MergePull(t *testing.T) {
 		},
 	}, models.PullRequestOptions{
 		DeleteSourceBranchOnMerge: false,
+	})
+	Ok(t, err)
+}
+
+// Test that we delete the source branch in our call to merge the pull
+// request.
+func TestClient_MergePullDeleteSourceBranch(t *testing.T) {
+	pullRequest, err := ioutil.ReadFile(filepath.Join("testdata", "pull-request.json"))
+	Ok(t, err)
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.RequestURI {
+		// The first request should hit this URL.
+		case "/rest/api/1.0/projects/ow/repos/repo/pull-requests/1":
+			w.Write(pullRequest) // nolint: errcheck
+			return
+		case "/rest/api/1.0/projects/ow/repos/repo/pull-requests/1/merge?version=3":
+			Equals(t, "POST", r.Method)
+			w.Write(pullRequest) // nolint: errcheck
+		case "/rest/branch-utils/1.0/projects/ow/repos/repo/branches":
+			Equals(t, "DELETE", r.Method)
+			defer r.Body.Close()
+			b, err := ioutil.ReadAll(r.Body)
+			Ok(t, err)
+			var payload bitbucketserver.DeleteSourceBranch
+			json.Unmarshal(b, &payload)
+			Equals(t, "refs/heads/foo", payload.Name)
+			w.WriteHeader(http.StatusNoContent) // nolint: errcheck
+		default:
+			t.Errorf("got unexpected request at %q", r.RequestURI)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+	}))
+	defer testServer.Close()
+
+	client, err := bitbucketserver.NewClient(http.DefaultClient, "user", "pass", testServer.URL, "runatlantis.io")
+	Ok(t, err)
+
+	err = client.MergePull(models.PullRequest{
+		Num:        1,
+		HeadCommit: "",
+		URL:        "",
+		HeadBranch: "foo",
+		BaseBranch: "",
+		Author:     "",
+		State:      0,
+		BaseRepo: models.Repo{
+			FullName:          "owner/repo",
+			Owner:             "owner",
+			Name:              "repo",
+			SanitizedCloneURL: fmt.Sprintf("%s/scm/ow/repo.git", testServer.URL),
+			VCSHost: models.VCSHost{
+				Type:     models.BitbucketServer,
+				Hostname: "bitbucket.org",
+			},
+		},
+	}, models.PullRequestOptions{
+		DeleteSourceBranchOnMerge: true,
 	})
 	Ok(t, err)
 }

--- a/server/events/vcs/bitbucketserver/client_test.go
+++ b/server/events/vcs/bitbucketserver/client_test.go
@@ -204,7 +204,8 @@ func TestClient_MergePullDeleteSourceBranch(t *testing.T) {
 			b, err := ioutil.ReadAll(r.Body)
 			Ok(t, err)
 			var payload bitbucketserver.DeleteSourceBranch
-			json.Unmarshal(b, &payload)
+			err = json.Unmarshal(b, &payload)
+			Ok(t, err)
 			Equals(t, "refs/heads/foo", payload.Name)
 			w.WriteHeader(http.StatusNoContent) // nolint: errcheck
 		default:


### PR DESCRIPTION
This PR adds the support for the delete_source_branch_on_merge attribute of a atlantis.yaml file for the BitBucket Server.