### PR TITLE
docs: Add missing --silence-vcs-status-no-plans flag

### DIFF
--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -560,6 +560,12 @@ Values are chosen in this order:
   This is useful when running multiple Atlantis servers against a single repository so you can
   delegate work to each Atlantis server. Also useful when used with pre_workflow_hooks to dynamically generate an `atlantis.yaml` file.
 
+* ### `--silence-vcs-status-no-plans`
+  ```bash
+  atlantis server --silence-vcs-status-no-plans
+  ```
+  `--silence-vcs-status-no-plans` will tell Atlantis to ignore setting VCS status if none of the modified files are part of a project defined in the `atlantis.yaml` file.
+
 * ### `--skip-clone-no-changes`
   ```bash
   atlantis server --skip-clone-no-changes


### PR DESCRIPTION
`The Silence VCS Status` feature has been implemented in #954. However there is no reference to it in the server side repo config.

Add missing `The Silence VCS Status` `--silence-vcs-status-no-plans` in the reference for server side repo config.