### PR TITLE
Improve github pull request call retries

### DIFF
--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -294,7 +294,7 @@ func (g *GithubClient) GetPullRequest(repo models.Repo, num int) (*github.PullRe
 	for i := 0; i < maxAttempts; i++ {
 		// First don't sleep, then sleep 1, 3, 7, etc.
 		time.Sleep(attemptDelay)
-		attemptDelay = 2 * attemptDelay + 1 * time.Second
+		attemptDelay = 2*attemptDelay + 1*time.Second
 
 		pull, _, err = g.client.PullRequests.Get(g.ctx, repo.Owner, repo.Name, num)
 		if err == nil {


### PR DESCRIPTION
Retry with fixed 1 second backoff up to 3 retries was added by #1131 to address #1019, but the issue continued to show up (#1453).

Increase max attempts to 5 and use exponential backoff for a maximum total retry time of (2^n - n - 1) seconds, which is roughly 30 seconds for current max attempts n = 5.

Also move the sleep to the top of the loop so that we never sleep without sending the request again on the last iteration.

I decided not to change the test case added in #1131 to avoid sleeping the full time in the test suite - I can bump the retries there to 5 to keep it in sync if that would be better.

I can also add jitter so the backoff isn't deterministic / less vulnerable to thundering herds but didn't for now since there's already existing retry logic in this exact place that is deterministic and linear and making it exponential could be done with a small change without pulling in additional dependencies.

Also would it be good to expose configuration options for this and make the default behavior match current with max wait 3 seconds? (like what is proposed in https://github.com/runatlantis/atlantis/pull/1715, though the problem here is not waiting long enough to retry rather than throttling) I'm not entirely sure what the implications are for a longer wait here with concurrent PRs that need planning, etc (I think it's fine for my use case, not as confident it's fine for everyone's)