### PR TITLE
Document --auto-merge-disabled option

### DIFF
--- a/runatlantis.io/docs/automerging.md
+++ b/runatlantis.io/docs/automerging.md
@@ -21,6 +21,10 @@ Automerging can be enabled either by:
     to be configured under the `projects` key.
     :::
 
+## How to Disable
+If automerge is enabled, you can disable it for a single `atlantis apply`
+command with the `--auto-merge-disabled` option.
+
 ## All Plans Must Succeed
 When automerge is enabled, **all plans** in a pull request **must succeed** before
 **any** plans can be applied.

--- a/runatlantis.io/docs/using-atlantis.md
+++ b/runatlantis.io/docs/using-atlantis.md
@@ -86,6 +86,7 @@ atlantis apply -w staging
 * `-d directory` Apply the plan for this directory, relative to root of repo. Use `.` for root.
 * `-p project` Apply the plan for this project. Refers to the name of the project configured in the repo's [`atlantis.yaml` file](repo-level-atlantis-yaml.html). Cannot be used at same time as `-d` or `-w`.
 * `-w workspace` Apply the plan for this [Terraform workspace](https://www.terraform.io/docs/state/workspaces.html). If not using Terraform workspaces you can ignore this.
+* `--auto-merge-disabled` Disable [automerge](automerging.html) for this apply command.
 * `--verbose` Append Atlantis log to comment.
 
 ### Additional Terraform flags


### PR DESCRIPTION
This flag was added in #1533 but was not documented.