### PR TITLE
feat: add new bitbucket server webhook event type pr:from_ref_updated(#198)

### DIFF
--- a/server/controllers/events/events_controller.go
+++ b/server/controllers/events/events_controller.go
@@ -205,7 +205,7 @@ func (e *VCSEventsController) handleBitbucketServerPost(w http.ResponseWriter, r
 		}
 	}
 	switch eventType {
-	case bitbucketserver.PullCreatedHeader, bitbucketserver.PullMergedHeader, bitbucketserver.PullDeclinedHeader, bitbucketserver.PullDeletedHeader:
+	case bitbucketserver.PullCreatedHeader, bitbucketserver.PullFromRefUpdatedHeader, bitbucketserver.PullMergedHeader, bitbucketserver.PullDeclinedHeader, bitbucketserver.PullDeletedHeader:
 		e.Logger.Debug("handling as pull request state changed event")
 		e.handleBitbucketServerPullRequestEvent(w, eventType, body, reqID)
 		return

--- a/server/events/event_parser.go
+++ b/server/events/event_parser.go
@@ -636,7 +636,9 @@ func (e *EventParser) ParseGitlabMergeRequest(mr *gitlab.MergeRequest, baseRepo 
 // event given the Bitbucket Server header.
 func (e *EventParser) GetBitbucketServerPullEventType(eventTypeHeader string) models.PullRequestEventType {
 	switch eventTypeHeader {
-	case bitbucketserver.PullCreatedHeader:
+	// PullFromRefUpdatedHeader event occurs on OPEN state pull request
+	// so no additional checks are needed.
+	case bitbucketserver.PullCreatedHeader, bitbucketserver.PullFromRefUpdatedHeader:
 		return models.OpenedPullEvent
 	case bitbucketserver.PullMergedHeader, bitbucketserver.PullDeclinedHeader, bitbucketserver.PullDeletedHeader:
 		return models.ClosedPullEvent

--- a/server/events/vcs/bitbucketserver/models.go
+++ b/server/events/vcs/bitbucketserver/models.go
@@ -3,6 +3,7 @@ package bitbucketserver
 const (
 	DiagnosticsPingHeader    = "diagnostics:ping"
 	PullCreatedHeader        = "pr:opened"
+	PullFromRefUpdatedHeader = "pr:from_ref_updated"
 	PullMergedHeader         = "pr:merged"
 	PullDeclinedHeader       = "pr:declined"
 	PullDeletedHeader        = "pr:deleted"


### PR DESCRIPTION
https://github.com/runatlantis/atlantis/issues/198
There is a new event types introduced in bitbucket server 7 "pr:from_ref_updated", which send events when a new commit is pushed to the pull request. 

```
Pull request
Source branch updated
A pull request's source branch has been updated.
```

Based on my tests, this event will not occur on DECLINED MR so no check is needed to verify the STATE of MR for this event.
<img width="450" alt="Screenshot 2021-10-23 at 22 01 34" src="https://user-images.githubusercontent.com/32264674/138673149-a43c9821-e888-4f3f-a0b5-2511dee98eb8.png">

Some notes: 
docs should be also updated(text and screenshot), will try take care of it later: 
```
Under Repository select Push ( event not in use, delete this line) 
Under Pull Request, select: Opened, Modified(should be changed to Source branch updated), Merged, Declined, Deleted and Comment added
```
![Screenshot 2021-10-25 at 12 48 23](https://user-images.githubusercontent.com/32264674/138674060-8c452e22-b5e9-498e-be3c-31007044ce33.png)
