### PR TITLE
docs: document approve_policies command in comment_parser

### DIFF
--- a/server/controllers/events/testfixtures/test-repos/policy-checks-apply-reqs/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-apply-reqs/exp-output-auto-policy-check.txt
@@ -10,6 +10,8 @@ FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibit
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions
 
 ```
-* :heavy_check_mark: To **approve** failing policies either request an approval from approvers or address the failure by modifying the codebase.
+* :heavy_check_mark: To **approve** failing policies an authorized approver can comment:
+    * `atlantis approve_policies`
+* :repeat: Or, address the policy failure by modifying the codebase and re-planning.
 
 

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-diff-owner/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-diff-owner/exp-output-auto-policy-check.txt
@@ -10,6 +10,8 @@ FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibit
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions
 
 ```
-* :heavy_check_mark: To **approve** failing policies either request an approval from approvers or address the failure by modifying the codebase.
+* :heavy_check_mark: To **approve** failing policies an authorized approver can comment:
+    * `atlantis approve_policies`
+* :repeat: Or, address the policy failure by modifying the codebase and re-planning.
 
 

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-extra-args/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-extra-args/exp-output-auto-policy-check.txt
@@ -10,6 +10,8 @@ FAIL - <redacted plan file> - null_resource_policy - WARNING: Null Resource crea
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions
 
 ```
-* :heavy_check_mark: To **approve** failing policies either request an approval from approvers or address the failure by modifying the codebase.
+* :heavy_check_mark: To **approve** failing policies an authorized approver can comment:
+    * `atlantis approve_policies`
+* :repeat: Or, address the policy failure by modifying the codebase and re-planning.
 
 

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/exp-output-auto-policy-check.txt
@@ -30,7 +30,9 @@ FAIL - <redacted plan file> - main - WARNING: Forbidden Resource creation is pro
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions
 
 ```
-* :heavy_check_mark: To **approve** failing policies either request an approval from approvers or address the failure by modifying the codebase.
+* :heavy_check_mark: To **approve** failing policies an authorized approver can comment:
+    * `atlantis approve_policies`
+* :repeat: Or, address the policy failure by modifying the codebase and re-planning.
 
 
 ---

--- a/server/controllers/events/testfixtures/test-repos/policy-checks/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks/exp-output-auto-policy-check.txt
@@ -10,6 +10,8 @@ FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibit
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions
 
 ```
-* :heavy_check_mark: To **approve** failing policies either request an approval from approvers or address the failure by modifying the codebase.
+* :heavy_check_mark: To **approve** failing policies an authorized approver can comment:
+    * `atlantis approve_policies`
+* :repeat: Or, address the policy failure by modifying the codebase and re-planning.
 
 

--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -97,16 +97,19 @@ type CommentParseResult struct {
 // Valid commands contain:
 // - The initial "executable" name, 'run' or 'atlantis' or '@GithubUser'
 //   where GithubUser is the API user Atlantis is running as.
-// - Then a command, either 'plan', 'apply', 'approve_policies', or 'help'.
+// - Then a command: 'plan', 'apply', 'unlock', 'version, 'approve_policies',
+//   or 'help'.
 // - Then optional flags, then an optional separator '--' followed by optional
 //   extra flags to be appended to the terraform plan/apply command.
 //
 // Examples:
 // - atlantis help
-// - run plan
+// - run apply
 // - @GithubUser plan -w staging
 // - atlantis plan -w staging -d dir --verbose
 // - atlantis plan --verbose -- -key=value -key2 value2
+// - atlantis unlock
+// - atlantis version
 // - atlantis approve_policies
 //
 func (e *CommentParser) Parse(comment string, vcsHost models.VCSHostType) CommentParseResult {
@@ -166,7 +169,7 @@ func (e *CommentParser) Parse(comment string, vcsHost models.VCSHostType) Commen
 		return CommentParseResult{CommentResponse: e.HelpComment(e.ApplyDisabled)}
 	}
 
-	// Need to have a plan, apply, approve_policy or unlock at this point.
+	// Need plan, apply, unlock, approve_policies, or version at this point.
 	if !e.stringInSlice(command, []string{models.PlanCommand.String(), models.ApplyCommand.String(), models.UnlockCommand.String(), models.ApprovePoliciesCommand.String(), models.VersionCommand.String()}) {
 		return CommentParseResult{CommentResponse: fmt.Sprintf("```\nError: unknown command %q.\nRun 'atlantis --help' for usage.\n```", command)}
 	}
@@ -404,6 +407,8 @@ Commands:
 {{- end }}
   unlock   Removes all atlantis locks and discards all plans for this PR.
            To unlock a specific plan you can use the Atlantis UI.
+  approve_policies
+           Approves all current policy checking failures for the PR.
   version  Print the output of 'terraform version'
   help     View help.
 

--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -729,6 +729,8 @@ Commands:
            To only apply a specific plan, use the -d, -w and -p flags.
   unlock   Removes all atlantis locks and discards all plans for this PR.
            To unlock a specific plan you can use the Atlantis UI.
+  approve_policies
+           Approves all current policy checking failures for the PR.
   version  Print the output of 'terraform version'
   help     View help.
 
@@ -756,6 +758,8 @@ Commands:
            To plan a specific project, use the -d, -w and -p flags.
   unlock   Removes all atlantis locks and discards all plans for this PR.
            To unlock a specific plan you can use the Atlantis UI.
+  approve_policies
+           Approves all current policy checking failures for the PR.
   version  Print the output of 'terraform version'
   help     View help.
 

--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -371,7 +371,9 @@ var unwrappedErrTmplText = "**{{.Command}} Error**\n" +
 	"{{.Error}}\n" +
 	"```" +
 	"{{ if eq .Command \"Policy Check\" }}" +
-	"\n* :heavy_check_mark: To **approve** failing policies either request an approval from approvers or address the failure by modifying the codebase.\n" +
+	"\n* :heavy_check_mark: To **approve** failing policies an authorized approver can comment:\n" +
+	"    * `atlantis approve_policies`\n" +
+	"* :repeat: Or, address the policy failure by modifying the codebase and re-planning.\n" +
 	"{{ end }}"
 var wrappedErrTmplText = "**{{.Command}} Error**\n" +
 	"<details><summary>Show Output</summary>\n\n" +

--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -49,7 +49,9 @@ func TestRenderErr(t *testing.T) {
 			models.PolicyCheckCommand,
 			err,
 			"**Policy Check Error**\n```\nerr\n```" +
-				"\n* :heavy_check_mark: To **approve** failing policies either request an approval from approvers or address the failure by modifying the codebase.\n\n",
+				"\n* :heavy_check_mark: To **approve** failing policies an authorized approver can comment:\n" +
+				"    * `atlantis approve_policies`\n" +
+				"* :repeat: Or, address the policy failure by modifying the codebase and re-planning.\n\n",
 		},
 	}
 
@@ -639,7 +641,9 @@ $$$
 $$$
 error
 $$$
-* :heavy_check_mark: To **approve** failing policies either request an approval from approvers or address the failure by modifying the codebase.
+* :heavy_check_mark: To **approve** failing policies an authorized approver can comment:
+    * $atlantis approve_policies$
+* :repeat: Or, address the policy failure by modifying the codebase and re-planning.
 
 
 ---


### PR DESCRIPTION
The `approve_policies` command was added with policy checking but was
never included in the command parser help.

Add an explicit mention of the `approve_policies` command in the error
message on policy checking failure.

Also update the comments in the file to reflect all of the commands.