### PR TITLE
fix: allow requests to /healthz without authentication

### DIFF
--- a/server/middleware.go
+++ b/server/middleware.go
@@ -43,7 +43,10 @@ type RequestLogger struct {
 func (l *RequestLogger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	l.logger.Debug("%s %s – from %s", r.Method, r.URL.RequestURI(), r.RemoteAddr)
 	allowed := false
-	if !l.WebAuthentication || r.URL.Path == "/events" || r.URL.Path == "/healthz" {
+	if !l.WebAuthentication ||
+		r.URL.Path == "/events" ||
+		r.URL.Path == "/healthz" ||
+		r.URL.Path == "/status" {
 		allowed = true
 	} else {
 		user, pass, ok := r.BasicAuth()

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -43,7 +43,7 @@ type RequestLogger struct {
 func (l *RequestLogger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	l.logger.Debug("%s %s – from %s", r.Method, r.URL.RequestURI(), r.RemoteAddr)
 	allowed := false
-	if r.URL.Path == "/events" || !l.WebAuthentication {
+	if !l.WebAuthentication || r.URL.Path == "/events" || r.URL.Path == "/healthz" {
 		allowed = true
 	} else {
 		user, pass, ok := r.BasicAuth()


### PR DESCRIPTION
#### Problem
Basic Auth support was added in https://github.com/runatlantis/atlantis/pull/1777, however this disabled the ability to use AWS ELB health checks against the `/healthz` endpoint. This purpose of this change is to allow the `/healthz` endpoint to work for systems that check automatically and do not support authentication or it is desired to configure without authentication, including AWS ELB health checks and Kubernetes probes.

#### Solution
This PR changes the behavior of the middleware when it checks if Basic Auth is enabled to allow unauthenticated requests to `/healthz` in the same way that requests to `/events` were excepted from the check.


