### PR TITLE
Revert "docs: revert to use docker hub page as 404 on github pkg registry"

### DIFF
--- a/runatlantis.io/docs/terraform-versions.md
+++ b/runatlantis.io/docs/terraform-versions.md
@@ -28,5 +28,6 @@ Atlantis will automatically download the version specified.
 :::
 
 ::: tip NOTE
-The Atlantis [latest docker image](https://hub.docker.com/layers/runatlantis/atlantis/latest/images/sha256-4f80472e20bd899b03a619e593f9e7b9a55d9e630850de443b988295f63f5c7a?context=explore) tends to have recent versions of Terraform, but there may be a delay as new versions are released. The highest version of Terraform allowed in your code is the version specified by `DEFAULT_TERRAFORM_VERSION` in the image your server is running.
+The Atlantis [latest docker image](https://github.com/runatlantis/atlantis/pkgs/container/atlantis/9854680?tag=latest) tends to have recent versions of Terraform, but there may be a delay as new versions are released. The highest version of Terraform allowed in your code is the version specified by `DEFAULT_TERRAFORM_VERSION` in the image your server is running.
 :::
+


### PR DESCRIPTION
Reverts runatlantis/atlantis#1897

---

Github has fixed the access issue, revert the code change to use the github package registry url.

```
$ curl -I https://github.com/runatlantis/atlantis/pkgs/container/atlantis/9854680?tag=latest
HTTP/2 200
server: GitHub.com
date: Wed, 17 Nov 2021 14:27:16 GMT
```