### PR TITLE
feat: add git-ssh-clone flag

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -63,6 +63,7 @@ const (
 	EnablePolicyChecksFlag     = "enable-policy-checks"
 	EnableRegExpCmdFlag        = "enable-regexp-cmd"
 	EnableDiffMarkdownFormat   = "enable-diff-markdown-format"
+	GitSSHCloneFlag            = "git-ssh-clone"
 	GHHostnameFlag             = "gh-hostname"
 	GHTokenFlag                = "gh-token"
 	GHUserFlag                 = "gh-user"
@@ -393,6 +394,11 @@ var boolFlags = map[string]boolFlag{
 	WriteGitCredsFlag: {
 		description: "Write out a .git-credentials file with the provider user and token to allow cloning private modules over HTTPS or SSH." +
 			" This writes secrets to disk and should only be enabled in a secure environment.",
+		defaultValue: false,
+	},
+	GitSSHCloneFlag: {
+		description: "Configure git to use SSH instead of HTTPS during clone." +
+			" Also adds githost ssh keys to ~/.ssh/known_hosts. Omitted when write-git-creds set to true",
 		defaultValue: false,
 	},
 	SkipCloneNoChanges: {

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -45,6 +45,7 @@ type UserConfig struct {
 	GitlabToken                string `mapstructure:"gitlab-token"`
 	GitlabUser                 string `mapstructure:"gitlab-user"`
 	GitlabWebhookSecret        string `mapstructure:"gitlab-webhook-secret"`
+	GitSSHClone                bool   `mapstructure:"git-ssh-clone"`
 	HidePrevPlanComments       bool   `mapstructure:"hide-prev-plan-comments"`
 	LogLevel                   string `mapstructure:"log-level"`
 	ParallelPoolSize           int    `mapstructure:"parallel-pool-size"`


### PR DESCRIPTION
Hi! 

During my atlantis first try I was struggling to clone git repos when only SSH is allowed - enforced by security. Seems that I was not the only person that is missing this feature #176 so I would like to propose additional `git-ssh-clone` flag.

It would be omitted when `write-git-creds` is set to `true` - because they mutually exclusive. 

It assumes that `id_rsa` and `id_rsa.pub` will be provided in `~/.ssh`

Had no time to write some tests - just done some manual verification - please let me know if it has any future

Also I thing that i could implement it in a different way - to not forward `https` onto `ssh` but to force actual cloning using ssh
