### PR TITLE
fix: fallback to default TF version in apply step

### DIFF
--- a/server/core/runtime/apply_step_runner.go
+++ b/server/core/runtime/apply_step_runner.go
@@ -16,11 +16,17 @@ import (
 // ApplyStepRunner runs `terraform apply`.
 type ApplyStepRunner struct {
 	TerraformExecutor   TerraformExec
+	DefaultTFVersion    *version.Version
 	CommitStatusUpdater StatusUpdater
 	AsyncTFExec         AsyncTFExec
 }
 
 func (a *ApplyStepRunner) Run(ctx models.ProjectCommandContext, extraArgs []string, path string, envs map[string]string) (string, error) {
+	tfVersion := a.DefaultTFVersion
+	if ctx.TerraformVersion != nil {
+		tfVersion = ctx.TerraformVersion
+	}
+
 	if a.hasTargetFlag(ctx, extraArgs) {
 		return "", errors.New("cannot run apply with -target because we are applying an already generated plan. Instead, run -target with atlantis plan")
 	}
@@ -40,7 +46,7 @@ func (a *ApplyStepRunner) Run(ctx models.ProjectCommandContext, extraArgs []stri
 	// TODO: Leverage PlanTypeStepRunnerDelegate here
 	if IsRemotePlan(contents) {
 		args := append(append([]string{"apply", "-input=false", "-no-color"}, extraArgs...), ctx.EscapedCommentArgs...)
-		out, err = a.runRemoteApply(ctx, args, path, planPath, ctx.TerraformVersion, envs)
+		out, err = a.runRemoteApply(ctx, args, path, planPath, tfVersion, envs)
 		if err == nil {
 			out = a.cleanRemoteApplyOutput(out)
 		}
@@ -48,7 +54,7 @@ func (a *ApplyStepRunner) Run(ctx models.ProjectCommandContext, extraArgs []stri
 		// NOTE: we need to quote the plan path because Bitbucket Server can
 		// have spaces in its repo owner names which is part of the path.
 		args := append(append(append([]string{"apply", "-input=false", "-no-color"}, extraArgs...), ctx.EscapedCommentArgs...), fmt.Sprintf("%q", planPath))
-		out, err = a.TerraformExecutor.RunCommandWithVersion(ctx.Log, path, args, envs, ctx.TerraformVersion, ctx.Workspace)
+		out, err = a.TerraformExecutor.RunCommandWithVersion(ctx.Log, path, args, envs, tfVersion, ctx.Workspace)
 	}
 
 	// If the apply was successful, delete the plan.

--- a/server/server.go
+++ b/server/server.go
@@ -487,6 +487,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		PolicyCheckStepRunner: policyCheckRunner,
 		ApplyStepRunner: &runtime.ApplyStepRunner{
 			TerraformExecutor:   terraformClient,
+			DefaultTFVersion:    defaultTfVersion,
 			CommitStatusUpdater: commitStatusUpdater,
 			AsyncTFExec:         terraformClient,
 		},


### PR DESCRIPTION
The plan step has a mechanism to use the default tf version from the Terraform client if the context does not define one, however the apply step does not have this. This results in remote executions of apply failing with a nil pointer dereference when it checks tfVersion in StripRefreshingFromPlanOutput. This fix involves copying what the PlanStepRunner does and falls back to the default version if the context's version is nil.

Fixes #1804 and #1852