### PR TITLE
Remove plan when first apply fail

### DIFF
--- a/server/core/runtime/apply_step_runner_test.go
+++ b/server/core/runtime/apply_step_runner_test.go
@@ -109,7 +109,7 @@ func TestRun_FailureWithoutStateRemovesPlans(t *testing.T) {
 		RepoRelDir:         ".",
 		EscapedCommentArgs: []string{"comment", "args"},
 	}, []string{"extra", "args"}, tmpDir, map[string]string(nil))
-	ErrEquals(t, "Apply Error", err)
+	ErrEquals(t, "apply has errors below, please re run Atlantis plan to try again \n\n: Apply Error", err)
 
 	terraform.VerifyWasCalledOnce().RunCommandWithVersion(logger, tmpDir, []string{"apply", "-input=false", "-no-color", "extra", "args", "comment", "args", fmt.Sprintf("%q", planPath)}, map[string]string(nil), nil, "workspace")
 	_, err = os.Stat(planPath)


### PR DESCRIPTION
Resolves issue [here](https://github.com/runatlantis/atlantis/issues/1933) . 
Due to a bug in Terraform, initial plans on terraform states with no lineage would not turn stale even after apply, allowing Terraform to reapply the plan over and over again, resulting to invalid states. 

Since Atlantis operates based on created plans, upon apply failure on a clean Terraform project, previously saved plans should be deleted and user would need to replan their Terraform projects again to refresh the state and ensure that the plan now has the correct state lineage. 

This PR would delete those plans and include a prompt in the error message to instruct users to run Atlantis plan again.