### PR TITLE
feat: more colorful diff format

### DIFF
--- a/server/controllers/events/testfixtures/test-repos/automerge/exp-output-autoplan.txt
+++ b/server/controllers/events/testfixtures/test-repos/automerge/exp-output-autoplan.txt
@@ -10,13 +10,13 @@ Ran Plan for 2 projects:
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.automerge[0] will be created
-+ resource "null_resource" "automerge" {
-      + id = (known after apply)
++   resource "null_resource" "automerge" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -39,13 +39,13 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.automerge[0] will be created
-+ resource "null_resource" "automerge" {
-      + id = (known after apply)
++   resource "null_resource" "automerge" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.

--- a/server/controllers/events/testfixtures/test-repos/automerge/exp-output-autoplan.txt.act
+++ b/server/controllers/events/testfixtures/test-repos/automerge/exp-output-autoplan.txt.act
@@ -10,13 +10,13 @@ Ran Plan for 2 projects:
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.automerge[0] will be created
-+ resource "null_resource" "automerge" {
-      + id = (known after apply)
++   resource "null_resource" "automerge" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -39,13 +39,13 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.automerge[0] will be created
-+ resource "null_resource" "automerge" {
-      + id = (known after apply)
++   resource "null_resource" "automerge" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.

--- a/server/controllers/events/testfixtures/test-repos/modules-yaml/exp-output-autoplan.txt
+++ b/server/controllers/events/testfixtures/test-repos/modules-yaml/exp-output-autoplan.txt
@@ -10,19 +10,19 @@ Ran Plan for 2 projects:
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # module.null.null_resource.this will be created
-+ resource "null_resource" "this" {
-      + id = (known after apply)
++   resource "null_resource" "this" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var = "staging"
++   var = "staging"
 
 ```
 
@@ -42,19 +42,19 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # module.null.null_resource.this will be created
-+ resource "null_resource" "this" {
-      + id = (known after apply)
++   resource "null_resource" "this" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var = "production"
++   var = "production"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/modules-yaml/exp-output-autoplan.txt.act
+++ b/server/controllers/events/testfixtures/test-repos/modules-yaml/exp-output-autoplan.txt.act
@@ -10,19 +10,19 @@ Ran Plan for 2 projects:
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # module.null.null_resource.this will be created
-+ resource "null_resource" "this" {
-      + id = (known after apply)
++   resource "null_resource" "this" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var = "staging"
++   var = "staging"
 
 ```
 
@@ -42,19 +42,19 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # module.null.null_resource.this will be created
-+ resource "null_resource" "this" {
-      + id = (known after apply)
++   resource "null_resource" "this" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var = "production"
++   var = "production"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/modules/exp-output-autoplan-only-staging.txt
+++ b/server/controllers/events/testfixtures/test-repos/modules/exp-output-autoplan-only-staging.txt
@@ -6,19 +6,19 @@ Ran Plan for dir: `staging` workspace: `default`
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # module.null.null_resource.this will be created
-+ resource "null_resource" "this" {
-      + id = (known after apply)
++   resource "null_resource" "this" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var = "staging"
++   var = "staging"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/modules/exp-output-autoplan-only-staging.txt.act
+++ b/server/controllers/events/testfixtures/test-repos/modules/exp-output-autoplan-only-staging.txt.act
@@ -6,19 +6,19 @@ Ran Plan for dir: `staging` workspace: `default`
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # module.null.null_resource.this will be created
-+ resource "null_resource" "this" {
-      + id = (known after apply)
++   resource "null_resource" "this" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var = "staging"
++   var = "staging"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/modules/exp-output-plan-production.txt
+++ b/server/controllers/events/testfixtures/test-repos/modules/exp-output-plan-production.txt
@@ -6,19 +6,19 @@ Ran Plan for dir: `production` workspace: `default`
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # module.null.null_resource.this will be created
-+ resource "null_resource" "this" {
-      + id = (known after apply)
++   resource "null_resource" "this" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var = "production"
++   var = "production"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/modules/exp-output-plan-production.txt.act
+++ b/server/controllers/events/testfixtures/test-repos/modules/exp-output-plan-production.txt.act
@@ -6,19 +6,19 @@ Ran Plan for dir: `production` workspace: `default`
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # module.null.null_resource.this will be created
-+ resource "null_resource" "this" {
-      + id = (known after apply)
++   resource "null_resource" "this" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var = "production"
++   var = "production"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/modules/exp-output-plan-staging.txt
+++ b/server/controllers/events/testfixtures/test-repos/modules/exp-output-plan-staging.txt
@@ -6,19 +6,19 @@ Ran Plan for dir: `staging` workspace: `default`
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # module.null.null_resource.this will be created
-+ resource "null_resource" "this" {
-      + id = (known after apply)
++   resource "null_resource" "this" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var = "staging"
++   var = "staging"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/modules/exp-output-plan-staging.txt.act
+++ b/server/controllers/events/testfixtures/test-repos/modules/exp-output-plan-staging.txt.act
@@ -6,19 +6,19 @@ Ran Plan for dir: `staging` workspace: `default`
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # module.null.null_resource.this will be created
-+ resource "null_resource" "this" {
-      + id = (known after apply)
++   resource "null_resource" "this" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var = "staging"
++   var = "staging"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-apply-reqs/exp-output-autoplan.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-apply-reqs/exp-output-autoplan.txt
@@ -6,19 +6,19 @@ Ran Plan for dir: `.` workspace: `default`
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ workspace = "default"
++   workspace = "default"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-diff-owner/exp-output-autoplan.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-diff-owner/exp-output-autoplan.txt
@@ -6,19 +6,19 @@ Ran Plan for dir: `.` workspace: `default`
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ workspace = "default"
++   workspace = "default"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-extra-args/exp-output-autoplan.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-extra-args/exp-output-autoplan.txt
@@ -6,19 +6,19 @@ Ran Plan for dir: `.` workspace: `default`
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ workspace = "default"
++   workspace = "default"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/exp-output-autoplan.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/exp-output-autoplan.txt
@@ -10,19 +10,19 @@ Ran Plan for 2 projects:
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ workspace = "default"
++   workspace = "default"
 
 ```
 
@@ -42,19 +42,19 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.forbidden[0] will be created
-+ resource "null_resource" "forbidden" {
-      + id = (known after apply)
++   resource "null_resource" "forbidden" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ workspace = "default"
++   workspace = "default"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/policy-checks/exp-output-autoplan.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks/exp-output-autoplan.txt
@@ -6,19 +6,19 @@ Ran Plan for dir: `.` workspace: `default`
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ workspace = "default"
++   workspace = "default"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/server-side-cfg/exp-output-autoplan.txt
+++ b/server/controllers/events/testfixtures/test-repos/server-side-cfg/exp-output-autoplan.txt
@@ -12,19 +12,19 @@ preinit custom
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ workspace = "default"
++   workspace = "default"
 
 postplan custom
 
@@ -48,19 +48,19 @@ preinit staging
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ workspace = "staging"
++   workspace = "staging"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/server-side-cfg/exp-output-autoplan.txt.act
+++ b/server/controllers/events/testfixtures/test-repos/server-side-cfg/exp-output-autoplan.txt.act
@@ -12,19 +12,19 @@ preinit custom
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ workspace = "default"
++   workspace = "default"
 
 postplan custom
 
@@ -48,13 +48,13 @@ preinit staging
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.

--- a/server/controllers/events/testfixtures/test-repos/simple-with-lockfile/exp-output-autoplan.txt
+++ b/server/controllers/events/testfixtures/test-repos/simple-with-lockfile/exp-output-autoplan.txt
@@ -6,30 +6,30 @@ Ran Plan for dir: `.` workspace: `default`
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
   # null_resource.simple2 will be created
-+ resource "null_resource" "simple2" {
-      + id = (known after apply)
++   resource "null_resource" "simple2" {
++       id = (known after apply)
     }
 
   # null_resource.simple3 will be created
-+ resource "null_resource" "simple3" {
-      + id = (known after apply)
++   resource "null_resource" "simple3" {
++       id = (known after apply)
     }
 
 Plan: 3 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var       = "default"
-+ workspace = "default"
++   var       = "default"
++   workspace = "default"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/simple-with-lockfile/exp-output-plan.txt
+++ b/server/controllers/events/testfixtures/test-repos/simple-with-lockfile/exp-output-plan.txt
@@ -6,30 +6,30 @@ Ran Plan for dir: `.` workspace: `default`
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
   # null_resource.simple2 will be created
-+ resource "null_resource" "simple2" {
-      + id = (known after apply)
++   resource "null_resource" "simple2" {
++       id = (known after apply)
     }
 
   # null_resource.simple3 will be created
-+ resource "null_resource" "simple3" {
-      + id = (known after apply)
++   resource "null_resource" "simple3" {
++       id = (known after apply)
     }
 
 Plan: 3 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var       = "default"
-+ workspace = "default"
++   var       = "default"
++   workspace = "default"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/simple-yaml/exp-output-autoplan.txt
+++ b/server/controllers/events/testfixtures/test-repos/simple-yaml/exp-output-autoplan.txt
@@ -12,20 +12,20 @@ preinit
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var       = "fromconfig"
-+ workspace = "default"
++   var       = "fromconfig"
++   workspace = "default"
 
 postplan
 
@@ -47,20 +47,20 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var       = "fromfile"
-+ workspace = "staging"
++   var       = "fromfile"
++   workspace = "staging"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/simple-yaml/exp-output-autoplan.txt.act
+++ b/server/controllers/events/testfixtures/test-repos/simple-yaml/exp-output-autoplan.txt.act
@@ -12,20 +12,20 @@ preinit
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var       = "fromconfig"
-+ workspace = "default"
++   var       = "fromconfig"
++   workspace = "default"
 
 postplan
 
@@ -47,20 +47,20 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var       = "fromfile"
-+ workspace = "staging"
++   var       = "fromfile"
++   workspace = "staging"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/simple/exp-output-atlantis-plan-new-workspace.txt
+++ b/server/controllers/events/testfixtures/test-repos/simple/exp-output-atlantis-plan-new-workspace.txt
@@ -6,30 +6,30 @@ Ran Plan for dir: `.` workspace: `new_workspace`
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
   # null_resource.simple2 will be created
-+ resource "null_resource" "simple2" {
-      + id = (known after apply)
++   resource "null_resource" "simple2" {
++       id = (known after apply)
     }
 
   # null_resource.simple3 will be created
-+ resource "null_resource" "simple3" {
-      + id = (known after apply)
++   resource "null_resource" "simple3" {
++       id = (known after apply)
     }
 
 Plan: 3 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var       = "new_workspace"
-+ workspace = "new_workspace"
++   var       = "new_workspace"
++   workspace = "new_workspace"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/simple/exp-output-atlantis-plan-new-workspace.txt.act
+++ b/server/controllers/events/testfixtures/test-repos/simple/exp-output-atlantis-plan-new-workspace.txt.act
@@ -6,30 +6,30 @@ Ran Plan for dir: `.` workspace: `new_workspace`
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
   # null_resource.simple2 will be created
-+ resource "null_resource" "simple2" {
-      + id = (known after apply)
++   resource "null_resource" "simple2" {
++       id = (known after apply)
     }
 
   # null_resource.simple3 will be created
-+ resource "null_resource" "simple3" {
-      + id = (known after apply)
++   resource "null_resource" "simple3" {
++       id = (known after apply)
     }
 
 Plan: 3 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var       = "new_workspace"
-+ workspace = "new_workspace"
++   var       = "new_workspace"
++   workspace = "new_workspace"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/simple/exp-output-atlantis-plan-var-overridden.txt
+++ b/server/controllers/events/testfixtures/test-repos/simple/exp-output-atlantis-plan-var-overridden.txt
@@ -6,30 +6,30 @@ Ran Plan for dir: `.` workspace: `default`
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
   # null_resource.simple2 will be created
-+ resource "null_resource" "simple2" {
-      + id = (known after apply)
++   resource "null_resource" "simple2" {
++       id = (known after apply)
     }
 
   # null_resource.simple3 will be created
-+ resource "null_resource" "simple3" {
-      + id = (known after apply)
++   resource "null_resource" "simple3" {
++       id = (known after apply)
     }
 
 Plan: 3 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var       = "overridden"
-+ workspace = "default"
++   var       = "overridden"
++   workspace = "default"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/simple/exp-output-atlantis-plan-var-overridden.txt.act
+++ b/server/controllers/events/testfixtures/test-repos/simple/exp-output-atlantis-plan-var-overridden.txt.act
@@ -6,30 +6,30 @@ Ran Plan for dir: `.` workspace: `default`
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
   # null_resource.simple2 will be created
-+ resource "null_resource" "simple2" {
-      + id = (known after apply)
++   resource "null_resource" "simple2" {
++       id = (known after apply)
     }
 
   # null_resource.simple3 will be created
-+ resource "null_resource" "simple3" {
-      + id = (known after apply)
++   resource "null_resource" "simple3" {
++       id = (known after apply)
     }
 
 Plan: 3 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var       = "overridden"
-+ workspace = "default"
++   var       = "overridden"
++   workspace = "default"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/simple/exp-output-atlantis-plan.txt
+++ b/server/controllers/events/testfixtures/test-repos/simple/exp-output-atlantis-plan.txt
@@ -6,30 +6,30 @@ Ran Plan for dir: `.` workspace: `default`
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
   # null_resource.simple2 will be created
-+ resource "null_resource" "simple2" {
-      + id = (known after apply)
++   resource "null_resource" "simple2" {
++       id = (known after apply)
     }
 
   # null_resource.simple3 will be created
-+ resource "null_resource" "simple3" {
-      + id = (known after apply)
++   resource "null_resource" "simple3" {
++       id = (known after apply)
     }
 
 Plan: 3 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var       = "default_workspace"
-+ workspace = "default"
++   var       = "default_workspace"
++   workspace = "default"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/simple/exp-output-atlantis-plan.txt.act
+++ b/server/controllers/events/testfixtures/test-repos/simple/exp-output-atlantis-plan.txt.act
@@ -6,30 +6,30 @@ Ran Plan for dir: `.` workspace: `default`
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
   # null_resource.simple2 will be created
-+ resource "null_resource" "simple2" {
-      + id = (known after apply)
++   resource "null_resource" "simple2" {
++       id = (known after apply)
     }
 
   # null_resource.simple3 will be created
-+ resource "null_resource" "simple3" {
-      + id = (known after apply)
++   resource "null_resource" "simple3" {
++       id = (known after apply)
     }
 
 Plan: 3 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var       = "default_workspace"
-+ workspace = "default"
++   var       = "default_workspace"
++   workspace = "default"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/simple/exp-output-autoplan.txt
+++ b/server/controllers/events/testfixtures/test-repos/simple/exp-output-autoplan.txt
@@ -6,30 +6,30 @@ Ran Plan for dir: `.` workspace: `default`
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
   # null_resource.simple2 will be created
-+ resource "null_resource" "simple2" {
-      + id = (known after apply)
++   resource "null_resource" "simple2" {
++       id = (known after apply)
     }
 
   # null_resource.simple3 will be created
-+ resource "null_resource" "simple3" {
-      + id = (known after apply)
++   resource "null_resource" "simple3" {
++       id = (known after apply)
     }
 
 Plan: 3 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var       = "default"
-+ workspace = "default"
++   var       = "default"
++   workspace = "default"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/simple/exp-output-autoplan.txt.act
+++ b/server/controllers/events/testfixtures/test-repos/simple/exp-output-autoplan.txt.act
@@ -6,30 +6,30 @@ Ran Plan for dir: `.` workspace: `default`
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
   # null_resource.simple2 will be created
-+ resource "null_resource" "simple2" {
-      + id = (known after apply)
++   resource "null_resource" "simple2" {
++       id = (known after apply)
     }
 
   # null_resource.simple3 will be created
-+ resource "null_resource" "simple3" {
-      + id = (known after apply)
++   resource "null_resource" "simple3" {
++       id = (known after apply)
     }
 
 Plan: 3 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var       = "default"
-+ workspace = "default"
++   var       = "default"
++   workspace = "default"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-default.txt
+++ b/server/controllers/events/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-default.txt
@@ -6,20 +6,20 @@ Ran Plan for project: `default` dir: `.` workspace: `default`
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var       = "default"
-+ workspace = "default"
++   var       = "default"
++   workspace = "default"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-default.txt.act
+++ b/server/controllers/events/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-default.txt.act
@@ -6,20 +6,20 @@ Ran Plan for project: `default` dir: `.` workspace: `default`
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var       = "default"
-+ workspace = "default"
++   var       = "default"
++   workspace = "default"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-staging.txt
+++ b/server/controllers/events/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-staging.txt
@@ -6,20 +6,20 @@ Ran Plan for project: `staging` dir: `.` workspace: `default`
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var       = "staging"
-+ workspace = "default"
++   var       = "staging"
++   workspace = "default"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-staging.txt.act
+++ b/server/controllers/events/testfixtures/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-staging.txt.act
@@ -6,20 +6,20 @@ Ran Plan for project: `staging` dir: `.` workspace: `default`
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var       = "staging"
-+ workspace = "default"
++   var       = "staging"
++   workspace = "default"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/tfvars-yaml/exp-output-autoplan.txt
+++ b/server/controllers/events/testfixtures/test-repos/tfvars-yaml/exp-output-autoplan.txt
@@ -10,20 +10,20 @@ Ran Plan for 2 projects:
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var       = "default"
-+ workspace = "default"
++   var       = "default"
++   workspace = "default"
 
 workspace=default
 
@@ -45,20 +45,20 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var       = "staging"
-+ workspace = "default"
++   var       = "staging"
++   workspace = "default"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/tfvars-yaml/exp-output-autoplan.txt.act
+++ b/server/controllers/events/testfixtures/test-repos/tfvars-yaml/exp-output-autoplan.txt.act
@@ -10,20 +10,20 @@ Ran Plan for 2 projects:
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var       = "default"
-+ workspace = "default"
++   var       = "default"
++   workspace = "default"
 
 workspace=default
 
@@ -45,20 +45,20 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
-      + id = (known after apply)
++   resource "null_resource" "simple" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ var       = "staging"
-+ workspace = "default"
++   var       = "staging"
++   workspace = "default"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/workspace-parallel-yaml/exp-output-autoplan-production.txt
+++ b/server/controllers/events/testfixtures/test-repos/workspace-parallel-yaml/exp-output-autoplan-production.txt
@@ -10,19 +10,19 @@ Ran Plan for 2 projects:
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.this will be created
-+ resource "null_resource" "this" {
-      + id = (known after apply)
++   resource "null_resource" "this" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ workspace = "production"
++   workspace = "production"
 
 ```
 
@@ -42,19 +42,19 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.this will be created
-+ resource "null_resource" "this" {
-      + id = (known after apply)
++   resource "null_resource" "this" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ workspace = "staging"
++   workspace = "staging"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/workspace-parallel-yaml/exp-output-autoplan-production.txt.act
+++ b/server/controllers/events/testfixtures/test-repos/workspace-parallel-yaml/exp-output-autoplan-production.txt.act
@@ -10,19 +10,19 @@ Ran Plan for 2 projects:
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.this will be created
-+ resource "null_resource" "this" {
-      + id = (known after apply)
++   resource "null_resource" "this" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ workspace = "production"
++   workspace = "production"
 
 ```
 
@@ -42,19 +42,19 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.this will be created
-+ resource "null_resource" "this" {
-      + id = (known after apply)
++   resource "null_resource" "this" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ workspace = "staging"
++   workspace = "staging"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/workspace-parallel-yaml/exp-output-autoplan-staging.txt
+++ b/server/controllers/events/testfixtures/test-repos/workspace-parallel-yaml/exp-output-autoplan-staging.txt
@@ -10,19 +10,19 @@ Ran Plan for 2 projects:
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.this will be created
-+ resource "null_resource" "this" {
-      + id = (known after apply)
++   resource "null_resource" "this" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ workspace = "production"
++   workspace = "production"
 
 ```
 
@@ -42,19 +42,19 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.this will be created
-+ resource "null_resource" "this" {
-      + id = (known after apply)
++   resource "null_resource" "this" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ workspace = "staging"
++   workspace = "staging"
 
 ```
 

--- a/server/controllers/events/testfixtures/test-repos/workspace-parallel-yaml/exp-output-autoplan-staging.txt.act
+++ b/server/controllers/events/testfixtures/test-repos/workspace-parallel-yaml/exp-output-autoplan-staging.txt.act
@@ -10,19 +10,19 @@ Ran Plan for 2 projects:
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.this will be created
-+ resource "null_resource" "this" {
-      + id = (known after apply)
++   resource "null_resource" "this" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ workspace = "production"
++   workspace = "production"
 
 ```
 
@@ -42,19 +42,19 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-+ create
++   create
 
 Terraform will perform the following actions:
 
   # null_resource.this will be created
-+ resource "null_resource" "this" {
-      + id = (known after apply)
++   resource "null_resource" "this" {
++       id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ workspace = "staging"
++   workspace = "staging"
 
 ```
 

--- a/server/core/runtime/plan_step_runner.go
+++ b/server/core/runtime/plan_step_runner.go
@@ -19,9 +19,8 @@ const (
 )
 
 var (
-	plusDiffRegex  = regexp.MustCompile(`(?m)^ {2}\+`)
-	tildeDiffRegex = regexp.MustCompile(`(?m)^ {2}~`)
-	minusDiffRegex = regexp.MustCompile(`(?m)^ {2}-`)
+	plusMinusDiffRegex = regexp.MustCompile(`(?m)^(  *)([+-])`)
+	tildeDiffRegex     = regexp.MustCompile(`(?m)^(  *)~`)
 )
 
 type PlanStepRunner struct {
@@ -224,9 +223,8 @@ func (p *PlanStepRunner) flatten(slices [][]string) []string {
 // It also removes the "Refreshing..." preamble.
 func (p *PlanStepRunner) fmtPlanOutput(output string, tfVersion *version.Version) string {
 	output = StripRefreshingFromPlanOutput(output, tfVersion)
-	output = plusDiffRegex.ReplaceAllString(output, "+")
-	output = tildeDiffRegex.ReplaceAllString(output, "~")
-	return minusDiffRegex.ReplaceAllString(output, "-")
+	output = plusMinusDiffRegex.ReplaceAllString(output, "$2$1")
+	return tildeDiffRegex.ReplaceAllString(output, "!$1")
 }
 
 // runRemotePlan runs a terraform command that utilizes the remote operations

--- a/server/core/runtime/plan_step_runner_test.go
+++ b/server/core/runtime/plan_step_runner_test.go
@@ -520,13 +520,13 @@ Terraform will perform the following actions:
 + null_resource.test[0]
       id: <computed>
 
-  + null_resource.test[1]
++   null_resource.test[1]
       id: <computed>
 
-  ~ aws_security_group_rule.allow_all
+!   aws_security_group_rule.allow_all
       description: "" => "test3"
 
-  - aws_security_group_rule.allow_all
+-   aws_security_group_rule.allow_all
 `
 	RegisterMockTestingT(t)
 	terraform := mocks.NewMockClient()
@@ -559,22 +559,22 @@ Terraform will perform the following actions:
 	Equals(t, `
 An execution plan has been generated and is shown below.
 Resource actions are indicated with the following symbols:
-+ create
-~ update in-place
-- destroy
++   create
+!   update in-place
+-   destroy
 
 Terraform will perform the following actions:
 
 + null_resource.test[0]
       id: <computed>
 
-+ null_resource.test[1]
++   null_resource.test[1]
       id: <computed>
 
-~ aws_security_group_rule.allow_all
+!   aws_security_group_rule.allow_all
       description: "" => "test3"
 
-- aws_security_group_rule.allow_all
+-   aws_security_group_rule.allow_all
 `, actOutput)
 }
 
@@ -781,11 +781,11 @@ locally at this time.
 			Equals(t, `
 An execution plan has been generated and is shown below.
 Resource actions are indicated with the following symbols:
-- destroy
+-   destroy
 
 Terraform will perform the following actions:
 
-- null_resource.hi[1]
+-   null_resource.hi[1]
 
 
 Plan: 0 to add, 0 to change, 1 to destroy.`, output)
@@ -800,11 +800,11 @@ Plan: 0 to add, 0 to change, 1 to destroy.`, output)
 
 An execution plan has been generated and is shown below.
 Resource actions are indicated with the following symbols:
-  - destroy
+-   destroy
 
 Terraform will perform the following actions:
 
-  - null_resource.hi[1]
+-   null_resource.hi[1]
 
 
 Plan: 0 to add, 0 to change, 1 to destroy.`, string(bytes))
@@ -854,11 +854,11 @@ null_resource.hi[1]: Refreshing state... (ID: 6064510335076839362)
 
 An execution plan has been generated and is shown below.
 Resource actions are indicated with the following symbols:
-  - destroy
+-   destroy
 
 Terraform will perform the following actions:
 
-  - null_resource.hi[1]
+-   null_resource.hi[1]
 
 
 Plan: 0 to add, 0 to change, 1 to destroy.`,
@@ -871,11 +871,11 @@ Plan: 0 to add, 0 to change, 1 to destroy.`,
 		Equals(t, `
 An execution plan has been generated and is shown below.
 Resource actions are indicated with the following symbols:
-  - destroy
+-   destroy
 
 Terraform will perform the following actions:
 
-  - null_resource.hi[1]
+-   null_resource.hi[1]
 
 
 Plan: 0 to add, 0 to change, 1 to destroy.`, output)
@@ -941,11 +941,11 @@ null_resource.hi[1]: Refreshing state... (ID: 6064510335076839362)
 
 An execution plan has been generated and is shown below.
 Resource actions are indicated with the following symbols:
-  - destroy
+-   destroy
 
 Terraform will perform the following actions:
 
-  - null_resource.hi[1]
+-   null_resource.hi[1]
 
 
 Plan: 0 to add, 0 to change, 1 to destroy.`


### PR DESCRIPTION
This PR :
- format all lines with [-+~] so all lines are colored. This give move visibility when changing a field in a resource
- replace the `~` char that is not colored by `diff` with `!` which is colored
- keep the exact same spaces output from terraform ouput and just move the color char to the beginning of the line, so resource brackets keeps the same indentation

This is inspired from a bash/sed gist or stackoverflow that I cannot find back and that our company was using before switch to Atlantis (thanks for this project BTW)