### PR TITLE
docs: typo in heading level

### DIFF
--- a/runatlantis.io/guide/testing-locally.md
+++ b/runatlantis.io/guide/testing-locally.md
@@ -262,7 +262,7 @@ atlantis server \
 --repo-allowlist="$REPO_ALLOWLIST"
 ```
 
-##### Azure DevOps
+### Azure DevOps
 
 A certificate and private key are required if using Basic authentication for webhooks.
 


### PR DESCRIPTION
The DevOps section doesn't show up in the Table of Content. This PR sets the number of `#`s to be the same as the previous section.
