### PR TITLE
fix: allowed regexp prefixes for exact matches

### DIFF
--- a/server/events/yaml/valid/repo_cfg.go
+++ b/server/events/yaml/valid/repo_cfg.go
@@ -4,6 +4,7 @@ package valid
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"strings"
 
@@ -58,15 +59,18 @@ func (r RepoCfg) FindProjectByName(name string) *Project {
 // FindProjectsByName returns all projects that match with name.
 func (r RepoCfg) FindProjectsByName(name string) []Project {
 	var ps []Project
-	if isRegexAllowed(name, r.AllowedRegexpPrefixes) {
-		sanitizedName := "^" + name + "$"
-		for _, p := range r.Projects {
-			if p.Name != nil {
-				if match, _ := regexp.MatchString(sanitizedName, *p.Name); match {
-					ps = append(ps, p)
-				}
+	sanitizedName := "^" + name + "$"
+	for _, p := range r.Projects {
+		if p.Name != nil {
+			if match, _ := regexp.MatchString(sanitizedName, *p.Name); match {
+				ps = append(ps, p)
 			}
 		}
+	}
+	// If we found more than one project then we need to make sure that the regex is allowed.
+	if len(ps) > 1 && !isRegexAllowed(name, r.AllowedRegexpPrefixes) {
+		log.Printf("Found more than one project for regex %q. This regex is not on the allow list.", name)
+		return nil
 	}
 	return ps
 }

--- a/server/events/yaml/valid/repo_cfg_test.go
+++ b/server/events/yaml/valid/repo_cfg_test.go
@@ -164,6 +164,48 @@ func TestConfig_FindProjectsByDir(t *testing.T) {
 				},
 			},
 		},
+		{
+			description: "Always find exact matches even if the prefix is not allowed",
+			nameRegex:   ".*",
+			input: valid.RepoCfg{
+				Version: 3,
+				Projects: []valid.Project{
+					{
+						Dir:              ".",
+						Name:             String("prod_terragrunt_myproject"),
+						Workspace:        "myworkspace",
+						TerraformVersion: tfVersion,
+						Autoplan: valid.Autoplan{
+							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							Enabled:      false,
+						},
+						ApplyRequirements: []string{"approved"},
+					},
+				},
+				Workflows: map[string]valid.Workflow{
+					"myworkflow": {
+						Name:        "myworkflow",
+						Apply:       valid.DefaultApplyStage,
+						Plan:        valid.DefaultPlanStage,
+						PolicyCheck: valid.DefaultPolicyCheckStage,
+					},
+				},
+				AllowedRegexpPrefixes: []string{"dev", "staging"},
+			},
+			expProjects: []valid.Project{
+				{
+					Dir:              ".",
+					Name:             String("prod_terragrunt_myproject"),
+					Workspace:        "myworkspace",
+					TerraformVersion: tfVersion,
+					Autoplan: valid.Autoplan{
+						WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+						Enabled:      false,
+					},
+					ApplyRequirements: []string{"approved"},
+				},
+			},
+		},
 	}
 	validation.ErrorTag = "yaml"
 	for _, c := range cases {


### PR DESCRIPTION
As you can see on the test case I added on this pull request, if the user comments for example `atlantis apply -p prod/myproject` it would fail if he didn't add `prod` on the `allowed_regexp_prefixes` config (added on https://github.com/runatlantis/atlantis/pull/1884/files). 😞 

This PR fixes that to only check the `allowed_regexp_prefixes` only if there's more than one match for the regex inserted on the PR comment. If it's an exact match, it should ignore the `allowed_regexp_prefixes`.