### PR TITLE
docs: update github docs links

### DIFF
--- a/runatlantis.io/docs/configuring-webhooks.md
+++ b/runatlantis.io/docs/configuring-webhooks.md
@@ -11,7 +11,7 @@ See the instructions for your specific provider below.
 [[toc]]
 
 ## GitHub/GitHub Enterprise
-You can install your webhook at the [organization](https://help.github.com/articles/differences-between-user-and-organization-accounts/) level, or for each individual repository.
+You can install your webhook at the [organization](https://docs.github.com/en/get-started/learning-about-github/types-of-github-accounts) level, or for each individual repository.
 
 ::: tip NOTE
 If only some of the repos in your organization are to be managed by Atlantis, then you
@@ -119,6 +119,6 @@ Repeat the process above until you have webhook subscriptions for the following 
 
 ## Next Steps
 * To verify that Atlantis is receiving your webhooks, create a test pull request
-  to your repo. 
+  to your repo.
 * You should see the request show up in the Atlantis logs at an `INFO` level.
 * You'll now need to configure Atlantis to add your [Provider Credentials](provider-credentials.md)

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -309,7 +309,7 @@ Values are chosen in this order:
   # or (recommended)
   ATLANTIS_GH_WEBHOOK_SECRET='secret' atlantis server
   ```
-  Secret used to validate GitHub webhooks (see [https://developer.github.com/webhooks/securing/](https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/securing-your-webhooks)).
+  Secret used to validate GitHub webhooks (see [https://developer.github.com/webhooks/securing/](https://docs.github.com/en/developers/webhooks-and-events/webhooks/securing-your-webhooks)).
 
   ::: warning SECURITY WARNING
   If not specified, Atlantis won't be able to validate that the incoming webhook call came from GitHub.
@@ -326,7 +326,7 @@ Values are chosen in this order:
   ```bash
   atlantis server --gh-app-id="00000"
   ```
-  GitHub app ID. If set, GitHub authentication will be performed as [an installation](https://developer.github.com/v3/apps/installations/).
+  GitHub app ID. If set, GitHub authentication will be performed as [an installation](https://docs.github.com/en/rest/reference/apps#installations).
 
   ::: tip
   A GitHub app can be created by starting Atlantis first, then pointing your browser at
@@ -348,18 +348,18 @@ Values are chosen in this order:
   ```bash
   atlantis server --gh-app-key-file="path/to/app-key.pem"
   ```
-  Path to a GitHub App PEM encoded private key file. If set, GitHub authentication will be performed as [an installation](https://developer.github.com/v3/apps/installations/).
+  Path to a GitHub App PEM encoded private key file. If set, GitHub authentication will be performed as [an installation](https://docs.github.com/en/rest/reference/apps#installations).
 
 - ### `--gh-app-key`
   ```bash
-  atlantis server --gh-app-key="-----BEGIN RSA PRIVATE KEY-----(...)" 
+  atlantis server --gh-app-key="-----BEGIN RSA PRIVATE KEY-----(...)"
   ```
   The PEM encoded private key for the GitHub App.
 
   ::: warning SECURITY WARNING
   The contents of the private key will be visible by anyone that can run `ps` or look at the shell history of the machine where Atlantis is running. Use `--gh-app-key-file` to mitigate that risk.
   :::
-- 
+-
 - ### `--gh-team-allowlist`
   ```bash
   atlantis server --gh-team-allowlist="myteam:plan, secteam:apply"


### PR DESCRIPTION
Fix github docs link check failures in #1961

> 2021/12/27 12:14:05 Connected to tcp://localhost:8080
> http://localhost:8080/docs/deployment.html
> 	timeout	https://github.com/runatlantis/helm-charts/tree/main/charts/atlantis
> http://localhost:8080/docs/configuring-webhooks.html
> 	timeout (following redirect https://docs.github.com/articles/differences-between-user-and-organization-accounts)	https://help.github.com/articles/differences-between-user-and-organization-accounts/
> http://localhost:8080/docs/server-configuration.html
> 	timeout	https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/securing-your-webhooks
> 	timeout (following redirect https://docs.github.com/v3/apps/installations)	https://developer.github.com/v3/apps/installations/

job ref, https://app.circleci.com/pipelines/github/runatlantis/atlantis/1770/workflows/6bc04541-2ec0-47a3-8fa4-036119d4eb8e/jobs/8920