### PR TITLE
fix(gitlab-client): change `pending` to `running` state

### DIFF
--- a/server/events/vcs/gitlab_client.go
+++ b/server/events/vcs/gitlab_client.go
@@ -235,7 +235,7 @@ func (g *GitlabClient) UpdateStatus(repo models.Repo, pull models.PullRequest, s
 	gitlabState := gitlab.Failed
 	switch state {
 	case models.PendingCommitStatus:
-		gitlabState = gitlab.Pending
+		gitlabState = gitlab.Running
 	case models.FailedCommitStatus:
 		gitlabState = gitlab.Failed
 	case models.SuccessCommitStatus:


### PR DESCRIPTION
The GitLab API does not permit the pipeline state to go from  `pending` to `success` without going trough `running` first. 
It does not appear that we actually need to use the `pending` state at all, instead `running` can be used which should resolve this issue.

Fixes #1356