### PR TITLE
Include no GitHub allowlist rules by default

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -117,7 +117,7 @@ const (
 	DefaultBitbucketBaseURL = bitbucketcloud.BaseURL
 	DefaultDataDir          = "~/.atlantis"
 	DefaultGHHostname       = "github.com"
-	DefaultGHTeamAllowlist  = "*:plan,*:apply"
+	DefaultGHTeamAllowlist  = ""
 	DefaultGitlabHostname   = "gitlab.com"
 	DefaultLogLevel         = "info"
 	DefaultParallelPoolSize = 15


### PR DESCRIPTION
There shouldn't be any GitHub team allowlist rules by default, since the feature and team API integration doesn't make sense for everybody.  [With no rules to enforce, no API call is made](https://github.com/runatlantis/atlantis/blob/bc368465a00353e79aa3947eed11965a95e1fba8/server/events/command_runner.go#L177-L181), so this should resolve https://github.com/runatlantis/atlantis/issues/1967

More generally, the way of defaulting flags when the value is "" seems dubious, and should instead depend on the presence of the flag itself.  However, that behavior isn't specific to this flag and is made moot with this change.