### PR TITLE
workflows(atlantis-image): fix building and publishing of Docker images

### DIFF
--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -49,7 +49,7 @@ jobs:
     - name: populate release version
       if: ${{ github.event_name == 'release'}}
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-    - name: Build and push atlantis:$RELEASE_VERSION image
+    - name: Build and push atlantis:${{ env.RELEASE_VERSION }} image
       if: ${{ github.event_name == 'release'}}
       uses: docker/build-push-action@v2
       with:
@@ -57,5 +57,5 @@ jobs:
         platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
         push: true
         tags: |
-          ghcr.io/runatlantis/atlantis:$RELEASE_VERSION
+          ghcr.io/runatlantis/atlantis:${{ env.RELEASE_VERSION }}
           ghcr.io/runatlantis/atlantis:latest


### PR DESCRIPTION
https://github.com/runatlantis/atlantis/pull/1943 changed the way Docker images
were built in GitHub Actions so multi-architecture Docker images now are built,
but it unfortunately included a bug which means it hasn't worked yet on any
released version of Atlantis.

The problem is the change expected environment variables to be replaced in the
regular YAML code instead of just the commands which are run.

This attempts to fix that by instead using the template language available to
access the same environment variable.
This is based on the example provided in the documentation here:
https://docs.github.com/en/actions/learn-github-actions/environment-variables.