### PR TITLE
fix: make IsOwner policy check case-insensitive

### DIFF
--- a/server/events/yaml/valid/policies.go
+++ b/server/events/yaml/valid/policies.go
@@ -1,6 +1,8 @@
 package valid
 
 import (
+	"strings"
+
 	"github.com/hashicorp/go-version"
 )
 
@@ -35,7 +37,7 @@ func (p *PolicySets) HasPolicies() bool {
 
 func (p *PolicySets) IsOwner(username string) bool {
 	for _, uname := range p.Owners.Users {
-		if uname == username {
+		if strings.EqualFold(uname, username) {
 			return true
 		}
 	}


### PR DESCRIPTION
Making policy owner check be case insensitive, since Github, Bitbucket, Gitlab and Azure Devops have case insensitive usernames:
- https://gitlab.com/edbighead -> https://gitlab.com/EdBighead
- https://bitbucket.org/edbighead/ -> https://bitbucket.org/EDbighead/
- https://github.com/edbighead -> https://github.com/edBIGHEAD
- https://dev.azure.com/edbighead/test -> https://dev.azure.com/edBIGheAD/test