### PR TITLE
Fix autoplan when .terraform.lock.hcl is modifed

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -112,7 +112,7 @@ const (
 	DefaultADBasicUser      = ""
 	DefaultADBasicPassword  = ""
 	DefaultADHostname       = "dev.azure.com"
-	DefaultAutoplanFileList = "**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl"
+	DefaultAutoplanFileList = "**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl"
 	DefaultCheckoutStrategy = "branch"
 	DefaultBitbucketBaseURL = bitbucketcloud.BaseURL
 	DefaultDataDir          = "~/.atlantis"

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -121,8 +121,8 @@ Values are chosen in this order:
   * Accepts a comma separated list, ex. `pattern1,pattern2`.
   * Patterns use the [`.dockerignore` syntax](https://docs.docker.com/engine/reference/builder/#dockerignore-file)
   * List of file patterns will be used by both automatic and manually run plans.
-  * When not set, defaults to all `.tf`, `.tfvars`, `.tfvars.json` and `terragrunt.hcl` files
-    (`--autoplan-file-list='**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl'`).
+  * When not set, defaults to all `.tf`, `.tfvars`, `.tfvars.json`,  `terragrunt.hcl` and `.terraform.lock.hcl` files
+    (`--autoplan-file-list='**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl'`).
   * Setting `--autoplan-file-list` will override the defaults. You **must** add `**/*.tf` and other defaults if you want to include them.
   * A custom [Workflow](repo-level-atlantis-yaml.html#configuring-planning) that uses autoplan `when_modified` will ignore this value.
 

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -512,6 +512,20 @@ func TestSimlpleWorkflow_terraformLockFile(t *testing.T) {
 			},
 			LockFileTracked: false,
 		},
+		{
+			Description:   "Modified .terraform.lock.hcl triggers autoplan ",
+			RepoDir:       "simple-with-lockfile",
+			ModifiedFiles: []string{".terraform.lock.hcl"},
+			ExpAutoplan:   true,
+			Comments: []string{
+				"atlantis plan",
+			},
+			ExpReplies: [][]string{
+				{"exp-output-autoplan.txt"},
+				{"exp-output-plan.txt"},
+			},
+			LockFileTracked: true,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.Description, func(t *testing.T) {
@@ -894,7 +908,7 @@ func setupE2E(t *testing.T, repoDir string) (events_controllers.VCSEventsControl
 		commentParser,
 		false,
 		false,
-		"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
+		"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl",
 	)
 
 	showStepRunner, err := runtime.NewShowStepRunner(terraformClient, defaultTFVersion)

--- a/server/events/project_command_builder_internal_test.go
+++ b/server/events/project_command_builder_internal_test.go
@@ -614,7 +614,7 @@ projects:
 				&CommentParser{},
 				false,
 				false,
-				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
+				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl",
 			)
 
 			// We run a test for each type of command.
@@ -805,7 +805,7 @@ projects:
 				&CommentParser{},
 				false,
 				true,
-				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
+				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl",
 			)
 
 			// We run a test for each type of command, again specific projects
@@ -1024,7 +1024,7 @@ workflows:
 				&CommentParser{},
 				false,
 				false,
-				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
+				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl",
 			)
 
 			cmd := models.PolicyCheckCommand

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -155,7 +155,7 @@ projects:
 				&events.CommentParser{},
 				false,
 				false,
-				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
+				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl",
 			)
 
 			ctxs, err := builder.BuildAutoplanCommands(&events.CommandContext{
@@ -419,7 +419,7 @@ projects:
 					&events.CommentParser{},
 					false,
 					true,
-					"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
+					"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl",
 				)
 
 				var actCtxs []models.ProjectCommandContext
@@ -570,7 +570,7 @@ projects:
 				&events.CommentParser{},
 				false,
 				false,
-				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
+				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl",
 			)
 
 			ctxs, err := builder.BuildPlanCommands(
@@ -657,7 +657,7 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply(t *testing.T) {
 		&events.CommentParser{},
 		false,
 		false,
-		"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
+		"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl",
 	)
 
 	ctxs, err := builder.BuildApplyCommands(
@@ -737,7 +737,7 @@ projects:
 		&events.CommentParser{},
 		false,
 		false,
-		"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
+		"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl",
 	)
 
 	ctx := &events.CommandContext{
@@ -812,7 +812,7 @@ func TestDefaultProjectCommandBuilder_EscapeArgs(t *testing.T) {
 				&events.CommentParser{},
 				false,
 				false,
-				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
+				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl",
 			)
 
 			var actCtxs []models.ProjectCommandContext
@@ -991,7 +991,7 @@ projects:
 				&events.CommentParser{},
 				false,
 				false,
-				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
+				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl",
 			)
 
 			actCtxs, err := builder.BuildPlanCommands(
@@ -1054,7 +1054,7 @@ projects:
 		&events.CommentParser{},
 		true,
 		false,
-		"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
+		"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl",
 	)
 
 	var actCtxs []models.ProjectCommandContext
@@ -1108,7 +1108,7 @@ func TestDefaultProjectCommandBuilder_WithPolicyCheckEnabled_BuildAutoplanComman
 		&events.CommentParser{},
 		false,
 		false,
-		"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
+		"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl",
 	)
 
 	ctxs, err := builder.BuildAutoplanCommands(&events.CommandContext{
@@ -1186,7 +1186,7 @@ func TestDefaultProjectCommandBuilder_BuildVersionCommand(t *testing.T) {
 		&events.CommentParser{},
 		false,
 		false,
-		"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
+		"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl",
 	)
 
 	ctxs, err := builder.BuildVersionCommands(

--- a/server/events/project_finder_test.go
+++ b/server/events/project_finder_test.go
@@ -106,7 +106,7 @@ func TestDetermineProjects(t *testing.T) {
 	noopLogger := logging.NewNoopLogger(t)
 	setupTmpRepos(t)
 
-	defaultAutoplanFileList := "**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl"
+	defaultAutoplanFileList := "**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl"
 
 	cases := []struct {
 		description      string
@@ -247,6 +247,13 @@ func TestDetermineProjects(t *testing.T) {
 			[]string{"project1"},
 			topLevelModules,
 			"**/*.yml,!project2/*.yml",
+		},
+		{
+			"Should not ignore .terraform.lock.hcl files",
+			[]string{"project1/.terraform.lock.hcl"},
+			[]string{"project1"},
+			nestedModules1,
+			defaultAutoplanFileList,
 		},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
This pull request should fix #1970 by adding `.terraform.lock.hcl` to  DefaultAutoplanFileList

I have modified  existing unit and e2e tests to cover this case