### PR TITLE
docs: add colon to policy checking yaml

### DIFF
--- a/runatlantis.io/docs/policy-checking.md
+++ b/runatlantis.io/docs/policy-checking.md
@@ -60,7 +60,7 @@ Example Server Side Repo configuration using `--all-namespaces` and a local src 
 ```
 repos:
   - id: github.com/myorg/example-repo
-policies
+policies:
   owners:
     users:
       - example-dev


### PR DESCRIPTION
Invalid YAML, add missing colon.