### PR TITLE
docs: include infracost ref in post-workflow-hooks

### DIFF
--- a/runatlantis.io/docs/post-workflow-hooks.md
+++ b/runatlantis.io/docs/post-workflow-hooks.md
@@ -21,7 +21,8 @@ You can add a post workflow hook to perform custom reporting after all workflows
 have finished.
 
 In this example we use a custom workflow to generate cost estimates for each
-workflow, then create a summary report after all workflows have completed.
+workflow using [Infracost](https://www.infracost.io/docs/integrations/atlantis/), then create a summary report after all workflows have completed.
+
 
 ```yaml
 # repos.yaml


### PR DESCRIPTION
Added link to infracost Docs. I am using Atlantis with infracost latest version . It might be good to link to the Docs.
so its clear.