### PR TITLE
docs: fix incorrect wildcard and more precise instruction to --gh-team-allowlist option.

### DIFF
--- a/runatlantis.io/docs/repo-level-atlantis-yaml.md
+++ b/runatlantis.io/docs/repo-level-atlantis-yaml.md
@@ -54,7 +54,7 @@ projects:
   terraform_version: v0.11.0
   delete_source_branch_on_merge: true
   autoplan:
-    when_modified: ["*.tf", "../modules/**.tf"]
+    when_modified: ["*.tf", "../modules/**/*.tf"]
     enabled: true
   apply_requirements: [mergeable, approved]
   workflow: myworkflow

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -364,7 +364,7 @@ Values are chosen in this order:
   ```bash
   atlantis server --gh-team-allowlist="myteam:plan, secteam:apply"
   ```
-  Comma-separated list of GitHub team and permission pairs.  By default, any team can plan and apply.
+  Comma-separated list of GitHub team name (not a slug) and permission pairs. By default, any team can plan and apply.
 
 * ### `--gitlab-hostname`
   ```bash


### PR DESCRIPTION
I've faced two problems during my Atlantis setup, and I'd like to suggest some changes to make the documentation more user-friendly.