### PR TITLE
fix: add back basic auth support

### DIFF
--- a/server/middleware.go
+++ b/server/middleware.go
@@ -31,6 +31,7 @@ func NewRequestLogger(s *Server) *RequestLogger {
 }
 
 // RequestLogger logs requests and their response codes.
+// as well as handle the basicauth on the requests
 type RequestLogger struct {
 	logger            logging.SimpleLogging
 	WebAuthentication bool

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -21,18 +21,51 @@ import (
 )
 
 // NewRequestLogger creates a RequestLogger.
-func NewRequestLogger(logger logging.SimpleLogging) *RequestLogger {
-	return &RequestLogger{logger}
+func NewRequestLogger(s *Server) *RequestLogger {
+	return &RequestLogger{
+		s.Logger,
+		s.WebAuthentication,
+		s.WebUsername,
+		s.WebPassword,
+	}
 }
 
 // RequestLogger logs requests and their response codes.
 type RequestLogger struct {
-	logger logging.SimpleLogging
+	logger            logging.SimpleLogging
+	WebAuthentication bool
+	WebUsername       string
+	WebPassword       string
 }
 
 // ServeHTTP implements the middleware function. It logs all requests at DEBUG level.
 func (l *RequestLogger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	l.logger.Debug("%s %s – from %s", r.Method, r.URL.RequestURI(), r.RemoteAddr)
-	next(rw, r)
+	allowed := false
+	if !l.WebAuthentication ||
+		r.URL.Path == "/events" ||
+		r.URL.Path == "/healthz" ||
+		r.URL.Path == "/status" {
+		allowed = true
+	} else {
+		user, pass, ok := r.BasicAuth()
+		if ok {
+			r.SetBasicAuth(user, pass)
+			l.logger.Debug("user: %s / pass: %s >> url: %s", user, pass, r.URL.RequestURI())
+			if user == l.WebUsername && pass == l.WebPassword {
+				l.logger.Debug("[VALID] user: %s / pass: %s >> url: %s", user, pass, r.URL.RequestURI())
+				allowed = true
+			} else {
+				allowed = false
+				l.logger.Info("[INVALID] user: %s / pass: %s >> url: %s", user, pass, r.URL.RequestURI())
+			}
+		}
+	}
+	if !allowed {
+		rw.Header().Set("WWW-Authenticate", `Basic realm="restricted", charset="UTF-8"`)
+		http.Error(rw, "Unauthorized", http.StatusUnauthorized)
+	} else {
+		next(rw, r)
+	}
 	l.logger.Debug("%s %s – respond HTTP %d", r.Method, r.URL.RequestURI(), rw.(negroni.ResponseWriter).Status())
 }

--- a/server/server.go
+++ b/server/server.go
@@ -103,6 +103,9 @@ type Server struct {
 	SSLCertFile                    string
 	SSLKeyFile                     string
 	Drainer                        *events.Drainer
+	WebAuthentication              bool
+	WebUsername                    string
+	WebPassword                    string
 	ProjectCmdOutputHandler        handlers.ProjectCommandOutputHandler
 }
 
@@ -744,6 +747,9 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		SSLCertFile:                    userConfig.SSLCertFile,
 		Drainer:                        drainer,
 		ProjectCmdOutputHandler:        projectCmdOutputHandler,
+		WebAuthentication:              userConfig.WebBasicAuth,
+		WebUsername:                    userConfig.WebUsername,
+		WebPassword:                    userConfig.WebPassword,
 	}, nil
 }
 
@@ -771,7 +777,7 @@ func (s *Server) Start() error {
 		PrintStack: false,
 		StackAll:   false,
 		StackSize:  1024 * 8,
-	}, NewRequestLogger(s.Logger))
+	}, NewRequestLogger(s))
 	n.UseHandler(s.Router)
 
 	defer s.Logger.Flush()


### PR DESCRIPTION
When log-streaming #1937 was upstreamed, the improved auth-support #1777 was removed. This change brings back the basic auth support. 