### PR TITLE
fix: broken Log Streaming URL when working directory is set to "./"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
         # We do this instead of setting --default-tf-version because setting
         # that flag starts the download asynchronously so we'd have a race
         # condition.
-        TERRAFORM_VERSION: 1.1.3
+        TERRAFORM_VERSION: 1.1.4
     steps:
     - checkout
     - run: make build-service

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -v -o atlantis .
 FROM ghcr.io/runatlantis/atlantis-base:2021.12.15 AS base
 
 # install terraform binaries
-ENV DEFAULT_TERRAFORM_VERSION=1.1.3
+ENV DEFAULT_TERRAFORM_VERSION=1.1.4
 
 # In the official Atlantis image we only have the latest of each Terraform version.
 RUN AVAILABLE_TERRAFORM_VERSIONS="0.8.8 0.9.11 0.10.8 0.11.15 0.12.31 0.13.7 0.14.11 0.15.5 1.0.11 ${DEFAULT_TERRAFORM_VERSION}" && \

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -437,7 +437,10 @@ func GetProjectIdentifier(relRepoDir string, projectName string) string {
 	if projectName != "" {
 		return projectName
 	}
-	return strings.ReplaceAll(relRepoDir, "/", "-")
+	// Replace directory separator / with -
+	// Replace . with _ to ensure projects with no project name and root dir set to "." have a valid URL
+	replacer := strings.NewReplacer("/", "-", ".", "_")
+	return replacer.Replace(relRepoDir)
 }
 
 // SplitRepoFullName splits a repo full name up into its owner and repo

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -21,18 +21,52 @@ import (
 )
 
 // NewRequestLogger creates a RequestLogger.
-func NewRequestLogger(logger logging.SimpleLogging) *RequestLogger {
-	return &RequestLogger{logger}
+func NewRequestLogger(s *Server) *RequestLogger {
+	return &RequestLogger{
+		s.Logger,
+		s.WebAuthentication,
+		s.WebUsername,
+		s.WebPassword,
+	}
 }
 
 // RequestLogger logs requests and their response codes.
+// as well as handle the basicauth on the requests
 type RequestLogger struct {
-	logger logging.SimpleLogging
+	logger            logging.SimpleLogging
+	WebAuthentication bool
+	WebUsername       string
+	WebPassword       string
 }
 
 // ServeHTTP implements the middleware function. It logs all requests at DEBUG level.
 func (l *RequestLogger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	l.logger.Debug("%s %s – from %s", r.Method, r.URL.RequestURI(), r.RemoteAddr)
-	next(rw, r)
+	allowed := false
+	if !l.WebAuthentication ||
+		r.URL.Path == "/events" ||
+		r.URL.Path == "/healthz" ||
+		r.URL.Path == "/status" {
+		allowed = true
+	} else {
+		user, pass, ok := r.BasicAuth()
+		if ok {
+			r.SetBasicAuth(user, pass)
+			l.logger.Debug("user: %s / pass: %s >> url: %s", user, pass, r.URL.RequestURI())
+			if user == l.WebUsername && pass == l.WebPassword {
+				l.logger.Debug("[VALID] user: %s / pass: %s >> url: %s", user, pass, r.URL.RequestURI())
+				allowed = true
+			} else {
+				allowed = false
+				l.logger.Info("[INVALID] user: %s / pass: %s >> url: %s", user, pass, r.URL.RequestURI())
+			}
+		}
+	}
+	if !allowed {
+		rw.Header().Set("WWW-Authenticate", `Basic realm="restricted", charset="UTF-8"`)
+		http.Error(rw, "Unauthorized", http.StatusUnauthorized)
+	} else {
+		next(rw, r)
+	}
 	l.logger.Debug("%s %s – respond HTTP %d", r.Method, r.URL.RequestURI(), rw.(negroni.ResponseWriter).Status())
 }

--- a/server/router.go
+++ b/server/router.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
@@ -44,7 +45,7 @@ func (r *Router) GenerateProjectJobURL(ctx models.ProjectCommandContext) (string
 	projectIdentifier := models.GetProjectIdentifier(ctx.RepoRelDir, ctx.ProjectName)
 	jobURL, err := r.Underlying.Get(r.ProjectJobsViewRouteName).URL(
 		"org", pull.BaseRepo.Owner,
-		"repo", pull.BaseRepo.Name,
+		"repo", strings.ReplaceAll(pull.BaseRepo.Name, "/", "-"), // Account for nested repo names repo/sub-repo
 		"pull", fmt.Sprintf("%d", pull.Num),
 		"project", projectIdentifier,
 		"workspace", ctx.Workspace,

--- a/server/router_test.go
+++ b/server/router_test.go
@@ -116,6 +116,26 @@ func TestGenerateProjectJobURL_ShouldGenerateURLWithDirectoryAndWorkspaceWhenPro
 	Equals(t, expectedURL, gotURL)
 }
 
+func TestGenerateProjectJobURL_ShouldGenerateURLWhenWorkingDirSetToBase(t *testing.T) {
+	router := setupJobsRouter(t)
+	ctx := models.ProjectCommandContext{
+		Pull: models.PullRequest{
+			BaseRepo: models.Repo{
+				Owner: "test-owner",
+				Name:  "test-repo",
+			},
+			Num: 1,
+		},
+		RepoRelDir: ".",
+		Workspace:  "default",
+	}
+	expectedURL := "http://localhost:4141/jobs/test-owner/test-repo/1/_/default"
+	gotURL, err := router.GenerateProjectJobURL(ctx)
+	Ok(t, err)
+
+	Equals(t, expectedURL, gotURL)
+}
+
 func TestGenerateProjectJobURL_ShouldGenerateURLWhenNestedRepo(t *testing.T) {
 	router := setupJobsRouter(t)
 	ctx := models.ProjectCommandContext{

--- a/server/router_test.go
+++ b/server/router_test.go
@@ -115,3 +115,23 @@ func TestGenerateProjectJobURL_ShouldGenerateURLWithDirectoryAndWorkspaceWhenPro
 
 	Equals(t, expectedURL, gotURL)
 }
+
+func TestGenerateProjectJobURL_ShouldGenerateURLWhenNestedRepo(t *testing.T) {
+	router := setupJobsRouter(t)
+	ctx := models.ProjectCommandContext{
+		Pull: models.PullRequest{
+			BaseRepo: models.Repo{
+				Owner: "test-owner",
+				Name:  "test-repo/sub-repo",
+			},
+			Num: 1,
+		},
+		RepoRelDir: "ops/terraform/test-root",
+		Workspace:  "default",
+	}
+	expectedURL := "http://localhost:4141/jobs/test-owner/test-repo-sub-repo/1/ops-terraform-test-root/default"
+	gotURL, err := router.GenerateProjectJobURL(ctx)
+	Ok(t, err)
+
+	Equals(t, expectedURL, gotURL)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -17,7 +17,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
@@ -899,19 +898,13 @@ func mkSubDir(parentDir string, subDir string) (string, error) {
 
 // Healthz returns the health check response. It always returns a 200 currently.
 func (s *Server) Healthz(w http.ResponseWriter, _ *http.Request) {
-	data, err := json.MarshalIndent(&struct {
-		Status string `json:"status"`
-	}{
-		Status: "ok",
-	}, "", "  ")
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintf(w, "Error creating status json response: %s", err)
-		return
-	}
 	w.Header().Set("Content-Type", "application/json")
-	w.Write(data) // nolint: errcheck
+	w.Write(healthzData) // nolint: errcheck
 }
+
+var healthzData = []byte(`{
+  "status": "ok"
+}`)
 
 // ParseAtlantisURL parses the user-passed atlantis URL to ensure it is valid
 // and we can use it in our templates.

--- a/server/server.go
+++ b/server/server.go
@@ -103,6 +103,9 @@ type Server struct {
 	SSLCertFile                    string
 	SSLKeyFile                     string
 	Drainer                        *events.Drainer
+	WebAuthentication              bool
+	WebUsername                    string
+	WebPassword                    string
 	ProjectCmdOutputHandler        handlers.ProjectCommandOutputHandler
 }
 
@@ -744,6 +747,9 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		SSLCertFile:                    userConfig.SSLCertFile,
 		Drainer:                        drainer,
 		ProjectCmdOutputHandler:        projectCmdOutputHandler,
+		WebAuthentication:              userConfig.WebBasicAuth,
+		WebUsername:                    userConfig.WebUsername,
+		WebPassword:                    userConfig.WebPassword,
 	}, nil
 }
 
@@ -771,7 +777,7 @@ func (s *Server) Start() error {
 		PrintStack: false,
 		StackAll:   false,
 		StackSize:  1024 * 8,
-	}, NewRequestLogger(s.Logger))
+	}, NewRequestLogger(s))
 	n.UseHandler(s.Router)
 
 	defer s.Logger.Flush()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -147,6 +147,25 @@ func TestHealthz(t *testing.T) {
 }`, string(body))
 }
 
+type mockRW struct{}
+
+var _ http.ResponseWriter = mockRW{}
+var mh = http.Header{}
+
+func (w mockRW) WriteHeader(int)           {}
+func (w mockRW) Write([]byte) (int, error) { return 0, nil }
+func (w mockRW) Header() http.Header       { return mh }
+
+var w = mockRW{}
+var s = &server.Server{}
+
+func BenchmarkHealthz(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		s.Healthz(w, nil)
+	}
+}
+
 func TestParseAtlantisURL(t *testing.T) {
 	cases := []struct {
 		In     string

--- a/testdrive/utils.go
+++ b/testdrive/utils.go
@@ -34,7 +34,7 @@ import (
 )
 
 const hashicorpReleasesURL = "https://releases.hashicorp.com"
-const terraformVersion = "1.1.3"
+const terraformVersion = "1.1.4"
 const ngrokDownloadURL = "https://bin.equinox.io/c/4VmDzA7iaHb"
 const ngrokAPIURL = "localhost:41414" // We hope this isn't used.
 const atlantisPort = 4141

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.17
 RUN apt-get update && apt-get install unzip
 
 # Install Terraform
-ENV TERRAFORM_VERSION=1.1.3
+ENV TERRAFORM_VERSION=1.1.4
 RUN case $(uname -m) in x86_64|amd64) ARCH="amd64" ;; aarch64|arm64|armv7l) ARCH="arm64" ;; esac && \
     wget -nv -O terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${ARCH}.zip && \
     mkdir -p /usr/local/bin/tf/versions/${TERRAFORM_VERSION} && \


### PR DESCRIPTION
We'll eventually be moving to a UUID based log-streaming job identifier, removing any dependencies on the project name or the directory. So, replacing the "." character with a "_" as a temporary fix! 

https://github.com/runatlantis/atlantis/issues/1993 