### PR TITLE
Fix 1979: Update GenerateProjectJobURL to account for nested repo names

### DIFF
--- a/server/router.go
+++ b/server/router.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
@@ -44,7 +45,7 @@ func (r *Router) GenerateProjectJobURL(ctx models.ProjectCommandContext) (string
 	projectIdentifier := models.GetProjectIdentifier(ctx.RepoRelDir, ctx.ProjectName)
 	jobURL, err := r.Underlying.Get(r.ProjectJobsViewRouteName).URL(
 		"org", pull.BaseRepo.Owner,
-		"repo", pull.BaseRepo.Name,
+		"repo", strings.ReplaceAll(pull.BaseRepo.Name, "/", "-"), // Account for nested repo names repo/sub-repo
 		"pull", fmt.Sprintf("%d", pull.Num),
 		"project", projectIdentifier,
 		"workspace", ctx.Workspace,

--- a/server/router_test.go
+++ b/server/router_test.go
@@ -115,3 +115,23 @@ func TestGenerateProjectJobURL_ShouldGenerateURLWithDirectoryAndWorkspaceWhenPro
 
 	Equals(t, expectedURL, gotURL)
 }
+
+func TestGenerateProjectJobURL_ShouldGenerateURLWhenNestedRepo(t *testing.T) {
+	router := setupJobsRouter(t)
+	ctx := models.ProjectCommandContext{
+		Pull: models.PullRequest{
+			BaseRepo: models.Repo{
+				Owner: "test-owner",
+				Name:  "test-repo/sub-repo",
+			},
+			Num: 1,
+		},
+		RepoRelDir: "ops/terraform/test-root",
+		Workspace:  "default",
+	}
+	expectedURL := "http://localhost:4141/jobs/test-owner/test-repo-sub-repo/1/ops-terraform-test-root/default"
+	gotURL, err := router.GenerateProjectJobURL(ctx)
+	Ok(t, err)
+
+	Equals(t, expectedURL, gotURL)
+}


### PR DESCRIPTION
https://github.com/runatlantis/atlantis/issues/1979