### PR TITLE
fix: add retries to GitHub client for GetModifiedFiles on 404

### DIFF
--- a/server/events/vcs/github_client_test.go
+++ b/server/events/vcs/github_client_test.go
@@ -52,15 +52,15 @@ func TestGithubClient_GetModifiedFiles(t *testing.T) {
 					t.Logf("forcing retry %q", r.RequestURI)
 					http.Error(w, "not found", http.StatusNotFound)
 					return
-				} else {
-					// decrement numCalls to force one retry on page 2 as well
-					numCalls--
-					// We write a header that means there's an additional page.
-					w.Header().Add("Link", `<https://api.github.com/resource?page=2>; rel="next",
-      <https://api.github.com/resource?page=2>; rel="last"`)
-					w.Write([]byte(firstResp)) // nolint: errcheck
-					return
 				}
+				// decrement numCalls to force one retry on page 2 as well
+				numCalls--
+				// We write a header that means there's an additional page.
+				w.Header().Add("Link", `<https://api.github.com/resource?page=2>; rel="next",
+      <https://api.github.com/resource?page=2>; rel="last"`)
+				w.Write([]byte(firstResp)) // nolint: errcheck
+				return
+
 				// The second should hit this URL.
 			case "/api/v3/repos/owner/repo/pulls/1/files?page=2&per_page=300":
 				if numCalls < maxCalls {
@@ -68,9 +68,9 @@ func TestGithubClient_GetModifiedFiles(t *testing.T) {
 					t.Logf("forcing retry %q", r.RequestURI)
 					http.Error(w, "not found", http.StatusNotFound)
 					return
-				} else {
-					w.Write([]byte(secondResp)) // nolint: errcheck
 				}
+				w.Write([]byte(secondResp)) // nolint: errcheck
+
 			default:
 				t.Errorf("got unexpected request at %q", r.RequestURI)
 				http.Error(w, "not found", http.StatusNotFound)


### PR DESCRIPTION
This is a follow on to resolve similar issues to #1019.

In #1131 retries were added to GetPullRequest. And in #1810 a backoff was included.

However, those only resolve one potential request at the very beginning of a PR creation. The other request that happens early on during auto-plan is one to ListFiles to detect the modified files. This too can sometimes result in a 404 due to async updates on the GitHub side.

---

My team recently upgraded a few Atlantis instances that were pretty old. They didn't yet include the fixes described above.

We upgraded to v0.18.1. After upgrading we were hopeful our dev teams would be happy to know these race condition errors were a thing of the past. But in only a couple of days, we got another report!

I was able to find an error log with the following message (org/repo/pr-number redacted):
```
GET https://api.github.com/repos/{owner}/{repo}/pulls/{number}/files?per_page=300: 404 Not Found []
```

And the following stacktrace:
```
github.com/runatlantis/atlantis/server/events.(*PullUpdater).updatePull
	github.com/runatlantis/atlantis/server/events/pull_updater.go:14
github.com/runatlantis/atlantis/server/events.(*PlanCommandRunner).runAutoplan
	github.com/runatlantis/atlantis/server/events/plan_command_runner.go:77
github.com/runatlantis/atlantis/server/events.(*PlanCommandRunner).Run
	github.com/runatlantis/atlantis/server/events/plan_command_runner.go:221
github.com/runatlantis/atlantis/server/events.(*DefaultCommandRunner).RunAutoplanCommand
	github.com/runatlantis/atlantis/server/events/command_runner.go:163
```

The fixes for #1019 added retries for the `/repos/{owner}/{repo}/pulls` API but _not_ for the `/repos/{owner}/{repo}/pulls/{number}/files` API.

---

Extra updates:

* Update a variable name in `NewGithubClient`: It was named `transport` but it was _not_ a Transport type. It's really an `*http.Client` configured with the required GitHub credentials.
* Simplified the `ListOptions` and `nextPage` logic. All `ListFiles` calls now include the page number.
  * This enabled updating the debug logs to include a page number. It also means that when an error like this crops up again we'll know which page the error happened on.