### PR TITLE
chore: improve `/healthz` endpoint performance

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -17,7 +17,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
@@ -899,16 +898,9 @@ func mkSubDir(parentDir string, subDir string) (string, error) {
 
 // Healthz returns the health check response. It always returns a 200 currently.
 func (s *Server) Healthz(w http.ResponseWriter, _ *http.Request) {
-	data, err := json.MarshalIndent(&struct {
-		Status string `json:"status"`
-	}{
-		Status: "ok",
-	}, "", "  ")
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintf(w, "Error creating status json response: %s", err)
-		return
-	}
+	data := []byte(`{
+  "status": "ok"
+}`)
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(data) // nolint: errcheck
 }

--- a/server/server.go
+++ b/server/server.go
@@ -898,12 +898,13 @@ func mkSubDir(parentDir string, subDir string) (string, error) {
 
 // Healthz returns the health check response. It always returns a 200 currently.
 func (s *Server) Healthz(w http.ResponseWriter, _ *http.Request) {
-	data := []byte(`{
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(healthzData) // nolint: errcheck
+}
+
+var healthzData = []byte(`{
   "status": "ok"
 }`)
-	w.Header().Set("Content-Type", "application/json")
-	w.Write(data) // nolint: errcheck
-}
 
 // ParseAtlantisURL parses the user-passed atlantis URL to ensure it is valid
 // and we can use it in our templates.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -147,6 +147,25 @@ func TestHealthz(t *testing.T) {
 }`, string(body))
 }
 
+type mockRW struct{}
+
+var _ http.ResponseWriter = mockRW{}
+var mh = http.Header{}
+
+func (w mockRW) WriteHeader(int)           {}
+func (w mockRW) Write([]byte) (int, error) { return 0, nil }
+func (w mockRW) Header() http.Header       { return mh }
+
+var w = mockRW{}
+var s = &server.Server{}
+
+func BenchmarkHealthz(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		s.Healthz(w, nil)
+	}
+}
+
 func TestParseAtlantisURL(t *testing.T) {
 	cases := []struct {
 		In     string


### PR DESCRIPTION
:wave: team. First and foremost: thank you for open sourcing and maintaining this project, it's been really useful. Today while working on an unrelated issue I started to investigate the `/healthz` endpoint in Atlantis and found that it could be improved in both speed and memory allocations.

The first thing I did was adding a benchmark to have a baseline for comparing my changes:

```
goos: darwin
goarch: amd64
pkg: github.com/runatlantis/atlantis/server
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkHealthz-12       100000               531.0 ns/op           112 B/op          4 allocs/op
PASS
ok      github.com/runatlantis/atlantis/server  0.370s
```

Then I implemented my improvements. I noticed that the response body is always the following:

```json
{
  "status": "ok"
}
```

However, I noticed the body was built by defining an inline struct and calling `json.MarshalIndent` on it, checking if there was a marshaling error which should never happen, so I removed all of that code and simply define a variable with the expected body. The benchmarks results already show improvements:

```
goos: darwin
goarch: amd64
pkg: github.com/runatlantis/atlantis/server
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkHealthz-12       100000                94.31 ns/op           40 B/op          2 allocs/op
PASS
ok      github.com/runatlantis/atlantis/server  1.431s
```

Lastly, I realized there was no need to always initialize this variable, so I moved it to a private package variable and ran the benchmarks again:

```
goos: darwin
goarch: amd64
pkg: github.com/runatlantis/atlantis/server
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkHealthz-12       100000                60.20 ns/op           16 B/op          1 allocs/op
PASS
ok      github.com/runatlantis/atlantis/server  0.336s
```

Most of all of the allocations were removed and the speedup is ~90%! In all steps I actually generated more benchmarks results using the following command:

```
go test -v -{run,bench}=Healthz -benchmem -benchtime=100000x -count=100 ./server/
```

With this I was able to later run `benchstat` to compare the results:

```
name        old time/op    new time/op    delta
Healthz-12     444ns ± 7%      52ns ±25%  -88.33%  (p=0.000 n=84+100)

name        old alloc/op   new alloc/op   delta
Healthz-12      112B ± 0%       16B ± 0%  -85.71%  (p=0.000 n=100+100)

name        old allocs/op  new allocs/op  delta
Healthz-12      4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.000 n=100+100)
```

Anyway, I hope you find this useful and worthy of contribution! 😸 