### PR TITLE
fix(bitbucketcloud)!: Use AccountID as username instead of Nickname

### DIFF
--- a/server/events/event_parser.go
+++ b/server/events/event_parser.go
@@ -374,7 +374,7 @@ func (e *EventParser) parseCommonBitbucketCloudEventData(event bitbucketcloud.Co
 		BaseRepo:   baseRepo,
 	}
 	user = models.User{
-		Username: *event.Actor.Nickname,
+		Username: *event.Actor.AccountID,
 	}
 	return
 }

--- a/server/events/event_parser.go
+++ b/server/events/event_parser.go
@@ -369,7 +369,7 @@ func (e *EventParser) parseCommonBitbucketCloudEventData(event bitbucketcloud.Co
 		URL:        *event.PullRequest.Links.HTML.HREF,
 		HeadBranch: *event.PullRequest.Source.Branch.Name,
 		BaseBranch: *event.PullRequest.Destination.Branch.Name,
-		Author:     *event.Actor.Nickname,
+		Author:     *event.Actor.AccountID,
 		State:      prState,
 		BaseRepo:   baseRepo,
 	}

--- a/server/events/event_parser_test.go
+++ b/server/events/event_parser_test.go
@@ -769,7 +769,7 @@ func TestParseBitbucketCloudCommentEvent_ValidEvent(t *testing.T) {
 		URL:        "https://bitbucket.org/lkysow/atlantis-example/pull-requests/2",
 		HeadBranch: "lkysow/maintf-edited-online-with-bitbucket-1532029690581",
 		BaseBranch: "master",
-		Author:     "lkysow",
+		Author:     "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
 		State:      models.ClosedPullState,
 		BaseRepo:   expBaseRepo,
 	}, pull)
@@ -855,7 +855,7 @@ func TestParseBitbucketCloudPullEvent_ValidEvent(t *testing.T) {
 		URL:        "https://bitbucket.org/lkysow/atlantis-example/pull-requests/16",
 		HeadBranch: "Luke/maintf-edited-online-with-bitbucket-1560433073473",
 		BaseBranch: "master",
-		Author:     "Luke",
+		Author:     "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
 		State:      models.OpenPullState,
 		BaseRepo:   expBaseRepo,
 	}, pull)

--- a/server/events/event_parser_test.go
+++ b/server/events/event_parser_test.go
@@ -785,7 +785,7 @@ func TestParseBitbucketCloudCommentEvent_ValidEvent(t *testing.T) {
 		},
 	}, headRepo)
 	Equals(t, models.User{
-		Username: "lkysow",
+		Username: "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
 	}, user)
 	Equals(t, "my comment", comment)
 }
@@ -871,7 +871,7 @@ func TestParseBitbucketCloudPullEvent_ValidEvent(t *testing.T) {
 		},
 	}, headRepo)
 	Equals(t, models.User{
-		Username: "Luke",
+		Username: "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
 	}, user)
 }
 

--- a/server/events/testdata/bitbucket-cloud-comment-event.json
+++ b/server/events/testdata/bitbucket-cloud-comment-event.json
@@ -30,7 +30,6 @@
     },
     "created_on": "2018-07-19T19:51:50.607374+00:00",
     "user": {
-      "username": "lkysow",
       "display_name": "Luke",
       "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
       "links": {
@@ -159,7 +158,6 @@
     },
     "state": "MERGED",
     "author": {
-      "username": "lkysow",
       "display_name": "Luke",
       "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
       "links": {
@@ -181,7 +179,6 @@
       {
         "type": "participant",
         "user": {
-          "username": "lkysow",
           "display_name": "Luke",
           "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
           "links": {
@@ -214,7 +211,6 @@
       }
     },
     "closed_by": {
-      "username": "lkysow",
       "display_name": "Luke",
       "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
       "links": {
@@ -234,7 +230,6 @@
     "task_count": 0
   },
   "actor": {
-    "username": "lkysow",
     "nickname": "lkysow",
     "display_name": "Luke",
     "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
@@ -269,7 +264,6 @@
     },
     "full_name": "lkysow/atlantis-example",
     "owner": {
-      "username": "lkysow",
       "display_name": "Luke",
       "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
       "links": {

--- a/server/events/testdata/bitbucket-cloud-pull-event-updated.json
+++ b/server/events/testdata/bitbucket-cloud-pull-event-updated.json
@@ -107,7 +107,6 @@
     },
     "state": "OPEN",
     "author": {
-      "username": "lkysow",
       "display_name": "Luke",
       "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
       "links": {
@@ -129,7 +128,6 @@
       {
         "type": "participant",
         "user": {
-          "username": "lkysow",
           "display_name": "Luke",
           "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
           "links": {
@@ -158,7 +156,6 @@
     "task_count": 0
   },
   "actor": {
-    "username": "lkysow",
     "display_name": "Luke",
     "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
     "links": {
@@ -192,7 +189,6 @@
     },
     "full_name": "lkysow/atlantis-example",
     "owner": {
-      "username": "lkysow",
       "display_name": "Luke",
       "account_id": "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
       "links": {

--- a/server/events/vcs/bitbucketcloud/models.go
+++ b/server/events/vcs/bitbucketcloud/models.go
@@ -39,7 +39,8 @@ type DiffStatFile struct {
 }
 
 type Actor struct {
-	Nickname *string `json:"nickname,omitempty" validate:"required"`
+	AccountID *string `json:"account_id,omitempty" validate:"required"`
+	Nickname  *string `json:"nickname,omitempty" validate:"required"`
 }
 type Repository struct {
 	FullName *string `json:"full_name,omitempty" validate:"required"`

--- a/server/events/vcs/bitbucketcloud/models.go
+++ b/server/events/vcs/bitbucketcloud/models.go
@@ -40,7 +40,6 @@ type DiffStatFile struct {
 
 type Actor struct {
 	AccountID *string `json:"account_id,omitempty" validate:"required"`
-	Nickname  *string `json:"nickname,omitempty" validate:"required"`
 }
 type Repository struct {
 	FullName *string `json:"full_name,omitempty" validate:"required"`

--- a/server/events/vcs/bitbucketcloud/testdata/pull-approved-by-author.json
+++ b/server/events/vcs/bitbucketcloud/testdata/pull-approved-by-author.json
@@ -136,7 +136,6 @@
       "type": "participant",
       "approved": true,
       "user": {
-        "username": "lkysow",
         "display_name": "Luke",
         "uuid": "{bf34a99b-8a11-452c-8fbc-bdffc340e584}",
         "links": {
@@ -161,7 +160,6 @@
       "type": "participant",
       "approved": false,
       "user": {
-        "username": "atlantis-bot",
         "display_name": "Atlantisbot",
         "uuid": "{73686412-4495-426f-89a7-c69ff1c8d7b8}",
         "links": {
@@ -184,7 +182,6 @@
   "reason": "",
   "updated_on": "2019-06-03T13:55:54.081581+00:00",
   "author": {
-    "username": "lkysow",
     "display_name": "Luke",
     "uuid": "{bf34a99b-8a11-452c-8fbc-bdffc340e584}",
     "links": {

--- a/server/events/vcs/bitbucketcloud/testdata/pull-approved-multiple.json
+++ b/server/events/vcs/bitbucketcloud/testdata/pull-approved-multiple.json
@@ -136,7 +136,6 @@
       "type": "participant",
       "approved": false,
       "user": {
-        "username": "lkysow",
         "display_name": "Luke",
         "uuid": "{bf34a99b-8a11-452c-8fbc-bdffc340e584}",
         "links": {
@@ -161,7 +160,6 @@
       "type": "participant",
       "approved": true,
       "user": {
-        "username": "atlantis-bot",
         "display_name": "Atlantisbot",
         "uuid": "{73686412-4495-426f-89a7-c69ff1c8d7b8}",
         "links": {
@@ -186,7 +184,6 @@
       "type": "participant",
       "approved": true,
       "user": {
-        "username": "atlantis-bot2",
         "display_name": "Atlantisbot2",
         "uuid": "{73686412-4495-426f-89a7-c69ff1c8d7b2}",
         "links": {
@@ -209,7 +206,6 @@
   "reason": "",
   "updated_on": "2019-06-03T13:55:17.639190+00:00",
   "author": {
-    "username": "lkysow",
     "display_name": "Luke",
     "uuid": "{bf34a99b-8a11-452c-8fbc-bdffc340e584}",
     "links": {

--- a/server/events/vcs/bitbucketcloud/testdata/pull-approved.json
+++ b/server/events/vcs/bitbucketcloud/testdata/pull-approved.json
@@ -136,7 +136,6 @@
       "type": "participant",
       "approved": false,
       "user": {
-        "username": "lkysow",
         "display_name": "Luke",
         "uuid": "{bf34a99b-8a11-452c-8fbc-bdffc340e584}",
         "links": {
@@ -161,7 +160,6 @@
       "type": "participant",
       "approved": true,
       "user": {
-        "username": "atlantis-bot",
         "display_name": "Atlantisbot",
         "uuid": "{73686412-4495-426f-89a7-c69ff1c8d7b8}",
         "links": {
@@ -184,7 +182,6 @@
   "reason": "",
   "updated_on": "2019-06-03T13:55:17.639190+00:00",
   "author": {
-    "username": "lkysow",
     "display_name": "Luke",
     "uuid": "{bf34a99b-8a11-452c-8fbc-bdffc340e584}",
     "links": {

--- a/server/events/vcs/bitbucketcloud/testdata/pull-unapproved.json
+++ b/server/events/vcs/bitbucketcloud/testdata/pull-unapproved.json
@@ -136,7 +136,6 @@
       "type": "participant",
       "approved": false,
       "user": {
-        "username": "lkysow",
         "display_name": "Luke",
         "uuid": "{bf34a99b-8a11-452c-8fbc-bdffc340e584}",
         "links": {
@@ -161,7 +160,6 @@
       "type": "participant",
       "approved": false,
       "user": {
-        "username": "atlantis-bot",
         "display_name": "Atlantisbot",
         "uuid": "{73686412-4495-426f-89a7-c69ff1c8d7b8}",
         "links": {
@@ -184,7 +182,6 @@
   "reason": "",
   "updated_on": "2019-06-03T13:54:09.266101+00:00",
   "author": {
-    "username": "lkysow",
     "display_name": "Luke",
     "uuid": "{bf34a99b-8a11-452c-8fbc-bdffc340e584}",
     "links": {


### PR DESCRIPTION
I want to be able to identify the user running the workflow and do checks like https://github.com/runatlantis/atlantis/issues/308#issuecomment-479930295, and `nickname` is not appropriate:

> Note that while we are introducing a nickname field, it will not be effective for identifying user accounts, because nicknames are not guaranteed to be globally unique. If you do store user data, we strongly encourage you to use Atlassian account IDs as the identifier for your data.

https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-gdpr/

I also clean up `username` from the test data, since it has been removed on 29 April 2019.

I suppose `PullRequest.Author` is only informative, so it should be fine to keep `Nickname` there.

For reference, the change from `Username` to `Nickname` was made in #502.