### PR TITLE
fix(bitbucketcloud): Ensure status key has at most 40 characters

### DIFF
--- a/server/events/vcs/bitbucketcloud/client.go
+++ b/server/events/vcs/bitbucketcloud/client.go
@@ -179,6 +179,11 @@ func (b *Client) UpdateStatus(repo models.Repo, pull models.PullRequest, status 
 		url = b.AtlantisURL
 	}
 
+	// Ensure key has at most 40 characters
+	if len(src) > 37 {
+		src = src[:37] + "..."
+	}
+
 	bodyBytes, err := json.Marshal(map[string]string{
 		"key":         src,
 		"url":         url,

--- a/server/events/vcs/bitbucketcloud/client.go
+++ b/server/events/vcs/bitbucketcloud/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"unicode/utf8"
 
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/events/models"
@@ -180,8 +181,8 @@ func (b *Client) UpdateStatus(repo models.Repo, pull models.PullRequest, status 
 	}
 
 	// Ensure key has at most 40 characters
-	if len(src) > 37 {
-		src = src[:37] + "..."
+	if utf8.RuneCountInString(src) > 40 {
+		src = fmt.Sprintf("%.37s...", src)
 	}
 
 	bodyBytes, err := json.Marshal(map[string]string{


### PR DESCRIPTION
I observed this error:

```json
{
  "level": "error",
  "ts": "2022-02-01T20:21:06.571Z",
  "caller": "events/project_command_runner.go:156",
  "msg": "updating project PR status%!(EXTRA *errors.errorString=making request \"POST https://api.bitbucket.org/2.0/repositories/myworkspace/myrepo/commit/abc1605a840c/statuses/build\" unexpected status code: 400, body: {\"type\": \"error\", \"error\": {\"fields\": {\"key\": [\"Ensure this value has at most 40 characters (it has 53).\"]}, \"message\": \"key: Ensure this value has at most 40 characters (it has 53).\"}})",
  "json": {
    "repo": "myworkspace/myrepo",
    "pull": "19"
  },
  "stacktrace": "github.com/runatlantis/atlantis/server/events.(*ProjectOutputWrapper).updateProjectPRStatus\n\tgithub.com/runatlantis/atlantis/server/events/project_command_runner.go:156\ngithub.com/runatlantis/atlantis/server/events.(*ProjectOutputWrapper).Apply\n\tgithub.com/runatlantis/atlantis/server/events/project_command_runner.go:133\ngithub.com/runatlantis/atlantis/server/events.runProjectCmds\n\tgithub.com/runatlantis/atlantis/server/events/project_command_pool_executor.go:47\ngithub.com/runatlantis/atlantis/server/events.(*ApplyCommandRunner).Run\n\tgithub.com/runatlantis/atlantis/server/events/apply_command_runner.go:146\ngithub.com/runatlantis/atlantis/server/events.(*DefaultCommandRunner).RunCommentCommand\n\tgithub.com/runatlantis/atlantis/server/events/command_runner.go:252"
}
```

~~It may not be the fanciest way to truncate a string and add an ellipsis (e.g. slicing `byte`s vs `rune`s issue...), but it should be enough for most cases here (if not we can always improve later imo)~~