### PR TITLE
fix(web-templates): use CleanedBasePath for static content

### DIFF
--- a/server/controllers/templates/web_templates.go
+++ b/server/controllers/templates/web_templates.go
@@ -367,11 +367,11 @@ var ProjectJobsTemplate = template.Must(template.New("blank.html.tmpl").Parse(`
     <title>atlantis</title>
     <meta name="description" content>
     <meta name="author" content>
-    <link rel="stylesheet" href="/static/css/xterm.css">
-    <link rel="stylesheet" href="/static/css/normalize.css">
-    <link rel="stylesheet" href="/static/css/skeleton.css">
-    <link rel="stylesheet" href="/static/css/custom.css">
-    <link rel="icon" type="image/png" href="/static/images/atlantis-icon.png">
+    <link rel="stylesheet" href="{{ .CleanedBasePath }}/static/css/xterm.css">
+    <link rel="stylesheet" href="{{ .CleanedBasePath }}/static/css/normalize.css">
+    <link rel="stylesheet" href="{{ .CleanedBasePath }}/static/css/skeleton.css">
+    <link rel="stylesheet" href="{{ .CleanedBasePath }}/static/css/custom.css">
+    <link rel="icon" type="image/png" href="{{ .CleanedBasePath }}/static/images/atlantis-icon.png">
     <style>
       #terminal {
         position: fixed;
@@ -391,7 +391,7 @@ var ProjectJobsTemplate = template.Must(template.New("blank.html.tmpl").Parse(`
 
   <body>
     <section class="header">
-    <a title="atlantis" href="/"><img class="hero" src="/static/images/atlantis-icon_512.png"/></a>
+    <a title="atlantis" href="/"><img class="hero" src="{{ .CleanedBasePath }}/static/images/atlantis-icon_512.png"/></a>
     <p class="title-heading">atlantis</p>
     <p class="title-heading"><strong></strong></p>
     </section>
@@ -404,10 +404,10 @@ var ProjectJobsTemplate = template.Must(template.New("blank.html.tmpl").Parse(`
   <footer>
   </footer>
 
-    <script src="/static/js/jquery-3.5.1.min.js"></script>
-    <script src="/static/js/xterm-4.9.0.js"></script>
-    <script src="/static/js/xterm-addon-attach-0.6.0.js"></script>
-    <script src="/static/js/xterm-addon-fit-0.4.0.js"></script>
+    <script src="{{ .CleanedBasePath }}/static/js/jquery-3.5.1.min.js"></script>
+    <script src="{{ .CleanedBasePath }}/static/js/xterm-4.9.0.js"></script>
+    <script src="{{ .CleanedBasePath }}/static/js/xterm-addon-attach-0.6.0.js"></script>
+    <script src="{{ .CleanedBasePath }}/static/js/xterm-addon-fit-0.4.0.js"></script>
 
     <script>
       var term = new Terminal({scrollback: 15000});
@@ -445,11 +445,11 @@ var ProjectJobsErrorTemplate = template.Must(template.New("blank.html.tmpl").Par
     <title>atlantis</title>
     <meta name="description" content>
     <meta name="author" content>
-    <link rel="stylesheet" href="/static/css/xterm.css">
-    <link rel="stylesheet" href="/static/css/normalize.css">
-    <link rel="stylesheet" href="/static/css/skeleton.css">
-    <link rel="stylesheet" href="/static/css/custom.css">
-    <link rel="icon" type="image/png" href="/static/images/atlantis-icon.png">
+    <link rel="stylesheet" href="{{ .CleanedBasePath }}/static/css/xterm.css">
+    <link rel="stylesheet" href="{{ .CleanedBasePath }}/static/css/normalize.css">
+    <link rel="stylesheet" href="{{ .CleanedBasePath }}/static/css/skeleton.css">
+    <link rel="stylesheet" href="{{ .CleanedBasePath }}/static/css/custom.css">
+    <link rel="icon" type="image/png" href="{{ .CleanedBasePath }}/static/images/atlantis-icon.png">
     <style>
       #terminal {
         width: 100%;
@@ -461,7 +461,7 @@ var ProjectJobsErrorTemplate = template.Must(template.New("blank.html.tmpl").Par
   <body>
     <div class="container">
       <section class="header">
-      <a title="atlantis" href="/"><img class="hero" src="/static/images/atlantis-icon_512.png"/></a>
+      <a title="atlantis" href="/"><img class="hero" src="{{ .CleanedBasePath }}/static/images/atlantis-icon_512.png"/></a>
       <p class="title-heading">atlantis</p>
       <p class="title-heading"><strong></strong></p>
       </section>
@@ -474,10 +474,10 @@ var ProjectJobsErrorTemplate = template.Must(template.New("blank.html.tmpl").Par
     <footer>
     </footer>
 
-    <script src="/static/js/jquery-3.5.1.min.js"></script>
-    <script src="/static/js/xterm-4.9.0.js"></script>
-    <script src="/static/js/xterm-addon-attach-0.6.0.js"></script>
-    <script src="/static/js/xterm-addon-fit-0.4.0.js"></script>
+    <script src="{{ .CleanedBasePath }}/static/js/jquery-3.5.1.min.js"></script>
+    <script src="{{ .CleanedBasePath }}/static/js/xterm-4.9.0.js"></script>
+    <script src="{{ .CleanedBasePath }}/static/js/xterm-addon-attach-0.6.0.js"></script>
+    <script src="{{ .CleanedBasePath }}/static/js/xterm-addon-fit-0.4.0.js"></script>
 
     <script>
       var term = new Terminal();
@@ -518,9 +518,9 @@ var GithubAppSetupTemplate = template.Must(template.New("github-app.html.tmpl").
   <meta name="description" content="">
   <meta name="author" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/static/css/normalize.css">
-  <link rel="stylesheet" href="/static/css/skeleton.css">
-  <link rel="stylesheet" href="/static/css/custom.css">
+  <link rel="stylesheet" href="{{ .CleanedBasePath }}/static/css/normalize.css">
+  <link rel="stylesheet" href="{{ .CleanedBasePath }}/static/css/skeleton.css">
+  <link rel="stylesheet" href="{{ .CleanedBasePath }}/static/css/custom.css">
   <style>
 
     form {
@@ -555,13 +555,13 @@ var GithubAppSetupTemplate = template.Must(template.New("github-app.html.tmpl").
       width: 80%;
     }
   </style>
-  <link rel="icon" type="image/png" href="/static/images/atlantis-icon.png">
-  <script src="/static/js/jquery-3.5.1.min.js"></script>
+  <link rel="icon" type="image/png" href="{{ .CleanedBasePath }}/static/images/atlantis-icon.png">
+  <script src="{{ .CleanedBasePath }}/static/js/jquery-3.5.1.min.js"></script>
 </head>
 <body>
 <div class="container">
   <section class="header">
-    <a title="atlantis" href="/"><img class="hero" src="/static/images/atlantis-icon_512.png"/></a>
+    <a title="atlantis" href="/"><img class="hero" src="{{ .CleanedBasePath }}/static/images/atlantis-icon_512.png"/></a>
     <p class="title-heading">atlantis</p>
 
     <p class="js-discard-success"><strong>

--- a/server/static/bindata_assetfs.go
+++ b/server/static/bindata_assetfs.go
@@ -102,7 +102,7 @@ func staticCssCustomCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "static/css/custom.css", size: 6946, mode: os.FileMode(420), modTime: time.Unix(1641777138, 0)}
+	info := bindataFileInfo{name: "static/css/custom.css", size: 6946, mode: os.FileMode(420), modTime: time.Unix(1635422826, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -122,7 +122,7 @@ func staticCssNormalizeCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "static/css/normalize.css", size: 7797, mode: os.FileMode(420), modTime: time.Unix(1641777138, 0)}
+	info := bindataFileInfo{name: "static/css/normalize.css", size: 7797, mode: os.FileMode(420), modTime: time.Unix(1635422826, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -142,7 +142,7 @@ func staticCssSkeletonCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "static/css/skeleton.css", size: 11452, mode: os.FileMode(420), modTime: time.Unix(1641777138, 0)}
+	info := bindataFileInfo{name: "static/css/skeleton.css", size: 11452, mode: os.FileMode(420), modTime: time.Unix(1635422826, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -162,7 +162,7 @@ func staticCssXtermCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "static/css/xterm.css", size: 4077, mode: os.FileMode(420), modTime: time.Unix(1588609078, 0)}
+	info := bindataFileInfo{name: "static/css/xterm.css", size: 4077, mode: os.FileMode(420), modTime: time.Unix(1643624040, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -182,7 +182,7 @@ func staticImagesAtlantisIconPng() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "static/images/atlantis-icon.png", size: 4238, mode: os.FileMode(420), modTime: time.Unix(1641777138, 0)}
+	info := bindataFileInfo{name: "static/images/atlantis-icon.png", size: 4238, mode: os.FileMode(420), modTime: time.Unix(1635422826, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -202,7 +202,7 @@ func staticImagesAtlantisIcon_512Png() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "static/images/atlantis-icon_512.png", size: 49782, mode: os.FileMode(420), modTime: time.Unix(1641777138, 0)}
+	info := bindataFileInfo{name: "static/images/atlantis-icon_512.png", size: 49782, mode: os.FileMode(420), modTime: time.Unix(1635422826, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -222,7 +222,7 @@ func staticJsJquery351MinJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "static/js/jquery-3.5.1.min.js", size: 89476, mode: os.FileMode(420), modTime: time.Unix(1641777138, 0)}
+	info := bindataFileInfo{name: "static/js/jquery-3.5.1.min.js", size: 89476, mode: os.FileMode(420), modTime: time.Unix(1635422826, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -242,7 +242,7 @@ func staticJsXterm490Js() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "static/js/xterm-4.9.0.js", size: 299239, mode: os.FileMode(420), modTime: time.Unix(1641787410, 0)}
+	info := bindataFileInfo{name: "static/js/xterm-4.9.0.js", size: 299239, mode: os.FileMode(420), modTime: time.Unix(1643624040, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -262,7 +262,7 @@ func staticJsXtermAddonAttach060Js() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "static/js/xterm-addon-attach-0.6.0.js", size: 3651, mode: os.FileMode(420), modTime: time.Unix(1641787403, 0)}
+	info := bindataFileInfo{name: "static/js/xterm-addon-attach-0.6.0.js", size: 3651, mode: os.FileMode(420), modTime: time.Unix(1643624040, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -282,7 +282,7 @@ func staticJsXtermAddonFit040Js() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "static/js/xterm-addon-fit-0.4.0.js", size: 3621, mode: os.FileMode(420), modTime: time.Unix(1641787399, 0)}
+	info := bindataFileInfo{name: "static/js/xterm-addon-fit-0.4.0.js", size: 3621, mode: os.FileMode(420), modTime: time.Unix(1643624040, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
When setting '--atlantis-url' this static content 404s.

For example, we can see this when comparig:
- /lock --> works seamless with a custom `--atlantis-url`
- /jobs --> doesn't work when using a custom `--atlantis-url`

Note that for the different templates, we are configuring `CleanedBasePath: s.AtlantisURL.Path`:

https://github.com/runatlantis/atlantis/blob/58e9b42bbc21bd6d2706b8c8b9c6cd6ad699c3c8/server/server.go#L879-L884

https://github.com/runatlantis/atlantis/blob/d914eafd2a3343fb22211018661bed1881b813e6/server/controllers/locks_controller.go#L82-L94

https://github.com/runatlantis/atlantis/blob/58e9b42bbc21bd6d2706b8c8b9c6cd6ad699c3c8/server/controllers/jobs_controller.go#L45-L54

Credit goes to @iainlane 👍 