### PR TITLE
Fixes to the base image

### DIFF
--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -26,14 +26,20 @@ ENV GIT_LFS_VERSION=3.1.2
 RUN apk add --no-cache ca-certificates curl git unzip bash openssh libcap && \
     # Install packages needed for building dependencies.
     apk add --no-cache --virtual .build-deps gnupg openssl && \
-    curl -L -s --output /bin/dumb-init "https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_x86_64" && \
-    chmod +x /bin/dumb-init && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
+
+    # dumb-init
+    curl -L -s --output /bin/dumb-init "https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_x86_64" && \
+    chmod +x /bin/dumb-init && \
+
+    # git-lfs
     curl -L -s --output git-lfs.tar.gz "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-amd64-v${GIT_LFS_VERSION}.tar.gz" && \
     tar -xf git-lfs.tar.gz && \
     chmod +x git-lfs && \
     mv git-lfs /usr/bin/git-lfs && \
+
+    # gosu
     curl -L -s --output gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64" && \
     curl -L -s --output gosu.asc "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc" && \
     for server in $(shuf -e ipv4.pool.sks-keyservers.net \
@@ -46,6 +52,8 @@ RUN apk add --no-cache ca-certificates curl git unzip bash openssh libcap && \
     gpg --batch --verify gosu.asc gosu && \
     chmod +x gosu && \
     cp gosu /bin && \
+
+    # Cleanup
     cd /tmp && \
     rm -rf /tmp/build && \
     gpgconf --kill dirmngr && \

--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -21,7 +21,11 @@ RUN addgroup atlantis && \
 ENV DUMB_INIT_VERSION=1.2.5
 ENV GOSU_VERSION=1.14
 ENV GIT_LFS_VERSION=3.1.2
-RUN apk add --no-cache ca-certificates gnupg curl git unzip bash openssh libcap openssl && \
+
+# Install packages needed for running Atlantis.
+RUN apk add --no-cache ca-certificates curl git unzip bash openssh libcap && \
+    # Install packages needed for building dependencies.
+    apk add --no-cache --virtual .build-deps gnupg openssl && \
     curl -L -s --output /bin/dumb-init "https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_x86_64" && \
     chmod +x /bin/dumb-init && \
     mkdir -p /tmp/build && \
@@ -46,7 +50,7 @@ RUN apk add --no-cache ca-certificates gnupg curl git unzip bash openssh libcap 
     rm -rf /tmp/build && \
     gpgconf --kill dirmngr && \
     gpgconf --kill gpg-agent && \
-    apk del gnupg openssl && \
+    apk del .build-deps && \
     rm -rf /root/.gnupg && \
     rm -rf /var/cache/apk/*
 

--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -42,13 +42,13 @@ RUN apk add --no-cache ca-certificates gnupg curl git unzip bash openssh libcap 
     gpg --batch --verify gosu.asc gosu && \
     chmod +x gosu && \
     cp gosu /bin && \
-        cd /tmp && \
-        rm -rf /tmp/build && \
-        gpgconf --kill dirmngr && \
-        gpgconf --kill gpg-agent && \
-        apk del gnupg openssl && \
-        rm -rf /root/.gnupg && \
-        rm -rf /var/cache/apk/*
+    cd /tmp && \
+    rm -rf /tmp/build && \
+    gpgconf --kill dirmngr && \
+    gpgconf --kill gpg-agent && \
+    apk del gnupg openssl && \
+    rm -rf /root/.gnupg && \
+    rm -rf /var/cache/apk/*
 
 # Set up nsswitch.conf for Go's "netgo" implementation
 # - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275

--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -17,22 +17,16 @@ RUN addgroup atlantis && \
     chmod g=u /home/atlantis/ && \
     chmod g=u /etc/passwd
 
-# Install dumb-init, gosu and git-lfs.
-ENV DUMB_INIT_VERSION=1.2.5
+# Install gosu and git-lfs.
 ENV GOSU_VERSION=1.14
 ENV GIT_LFS_VERSION=3.1.2
 
 # Install packages needed for running Atlantis.
-RUN apk add --no-cache ca-certificates curl git unzip bash openssh libcap && \
+RUN apk add --no-cache ca-certificates curl git unzip bash openssh libcap dumb-init && \
     # Install packages needed for building dependencies.
     apk add --no-cache --virtual .build-deps gnupg openssl && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
-
-    # dumb-init
-    curl -L -s --output /bin/dumb-init "https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_x86_64" && \
-    chmod +x /bin/dumb-init && \
-    dumb-init --version && \
 
     # git-lfs
     curl -L -s --output git-lfs.tar.gz "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-amd64-v${GIT_LFS_VERSION}.tar.gz" && \

--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -51,8 +51,7 @@ RUN apk add --no-cache ca-certificates curl git unzip bash openssh libcap && \
     gpgconf --kill dirmngr && \
     gpgconf --kill gpg-agent && \
     apk del .build-deps && \
-    rm -rf /root/.gnupg && \
-    rm -rf /var/cache/apk/*
+    rm -rf /root/.gnupg
 
 # Set up nsswitch.conf for Go's "netgo" implementation
 # - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275

--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -32,12 +32,14 @@ RUN apk add --no-cache ca-certificates curl git unzip bash openssh libcap && \
     # dumb-init
     curl -L -s --output /bin/dumb-init "https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_x86_64" && \
     chmod +x /bin/dumb-init && \
+    dumb-init --version && \
 
     # git-lfs
     curl -L -s --output git-lfs.tar.gz "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-amd64-v${GIT_LFS_VERSION}.tar.gz" && \
     tar -xf git-lfs.tar.gz && \
     chmod +x git-lfs && \
     mv git-lfs /usr/bin/git-lfs && \
+    git-lfs --version && \
 
     # gosu
     curl -L -s --output gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64" && \
@@ -52,6 +54,7 @@ RUN apk add --no-cache ca-certificates curl git unzip bash openssh libcap && \
     gpg --batch --verify gosu.asc gosu && \
     chmod +x gosu && \
     cp gosu /bin && \
+    gosu --version && \
 
     # Cleanup
     cd /tmp && \

--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -21,6 +21,9 @@ RUN addgroup atlantis && \
 ENV GOSU_VERSION=1.14
 ENV GIT_LFS_VERSION=3.1.2
 
+# Automatically populated with the architecture the image is being built for.
+ARG TARGETPLATFORM
+
 # Install packages needed for running Atlantis.
 RUN apk add --no-cache ca-certificates curl git unzip bash openssh libcap dumb-init && \
     # Install packages needed for building dependencies.
@@ -29,7 +32,7 @@ RUN apk add --no-cache ca-certificates curl git unzip bash openssh libcap dumb-i
     cd /tmp/build && \
 
     # git-lfs
-    curl -L -s --output git-lfs.tar.gz "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-amd64-v${GIT_LFS_VERSION}.tar.gz" && \
+    curl -L -s --output git-lfs.tar.gz "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-${TARGETPLATFORM##*/}-v${GIT_LFS_VERSION}.tar.gz" && \
     tar -xf git-lfs.tar.gz && \
     chmod +x git-lfs && \
     mv git-lfs /usr/bin/git-lfs && \

--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -39,8 +39,13 @@ RUN apk add --no-cache ca-certificates curl git unzip bash openssh libcap dumb-i
     git-lfs --version && \
 
     # gosu
-    curl -L -s --output gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64" && \
-    curl -L -s --output gosu.asc "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc" && \
+    case ${TARGETPLATFORM} in \
+        "linux/amd64") GOSU_ARCH=amd64 ;; \
+        "linux/arm64") GOSU_ARCH=arm64 ;; \
+        "linux/arm/v7") GOSU_ARCH=armhf ;; \
+    esac && \
+    curl -L -s --output gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${GOSU_ARCH}" && \
+    curl -L -s --output gosu.asc "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${GOSU_ARCH}.asc" && \
     for server in $(shuf -e ipv4.pool.sks-keyservers.net \
                             hkp://p80.pool.sks-keyservers.net:80 \
                             keyserver.ubuntu.com \


### PR DESCRIPTION
This work was inspired by getting the Atlantis Docker image to work on ARM architectures (#2001).

I noticed the base image installs binaries for the amd64 architecture and doesn't take into account what architecture the image actually is intended to be built for, so this fixes that.

I've also done a bit of tidying of the Dockerfile at the same time. Everything is split into separate commits so it should be easier to review.