### PR TITLE
fix(docker): fix installation of git-lfs in armv7 image

### DIFF
--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -32,7 +32,12 @@ RUN apk add --no-cache ca-certificates curl git unzip bash openssh libcap dumb-i
     cd /tmp/build && \
 
     # git-lfs
-    curl -L -s --output git-lfs.tar.gz "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-${TARGETPLATFORM##*/}-v${GIT_LFS_VERSION}.tar.gz" && \
+    case ${TARGETPLATFORM} in \
+        "linux/amd64") GIT_LFS_ARCH=amd64 ;; \
+        "linux/arm64") GIT_LFS_ARCH=arm64 ;; \
+        "linux/arm/v7") GIT_LFS_ARCH=arm ;; \
+    esac && \
+    curl -L -s --output git-lfs.tar.gz "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-${GIT_LFS_ARCH}-v${GIT_LFS_VERSION}.tar.gz" && \
     tar -xf git-lfs.tar.gz && \
     chmod +x git-lfs && \
     mv git-lfs /usr/bin/git-lfs && \


### PR DESCRIPTION
This uses a similar pattern than what is used for `GOSU_ARCH` to map the
`TARGETPLATFORM` argument into the name of the architecture git-lfs use for
their release binaries, as "linux/arm/v7" otherwise would be mapped into "v7"
which is wrong.