### PR TITLE
fix(docker): download Terraform and conftest versions maching image architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM ghcr.io/runatlantis/atlantis-base:2022.03.02 AS base
 ENV DEFAULT_TERRAFORM_VERSION=1.1.6
 
 # In the official Atlantis image we only have the latest of each Terraform version.
-RUN AVAILABLE_TERRAFORM_VERSIONS="0.8.8 0.9.11 0.10.8 0.11.15 0.12.31 0.13.7 0.14.11 0.15.5 1.0.11 ${DEFAULT_TERRAFORM_VERSION}" && \
+RUN AVAILABLE_TERRAFORM_VERSIONS="0.11.15 0.12.31 0.13.7 0.14.11 0.15.5 1.0.11 ${DEFAULT_TERRAFORM_VERSION}" && \
     for VERSION in ${AVAILABLE_TERRAFORM_VERSIONS}; do \
         curl -LOs https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_linux_amd64.zip && \
         curl -LOs https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_SHA256SUMS && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,14 +37,20 @@ RUN AVAILABLE_TERRAFORM_VERSIONS="0.11.15 0.12.31 0.13.7 0.14.11 0.15.5 1.0.11 $
 ENV DEFAULT_CONFTEST_VERSION=0.30.0
 
 RUN AVAILABLE_CONFTEST_VERSIONS="${DEFAULT_CONFTEST_VERSION}" && \
+    case ${TARGETPLATFORM} in \
+        "linux/amd64") CONFTEST_ARCH=x86_64 ;; \
+        "linux/arm64") CONFTEST_ARCH=arm64 ;; \
+        # There is currently no compiled version of conftest for armv7
+        "linux/arm/v7") CONFTEST_ARCH=x86_64 ;; \
+    esac && \
     for VERSION in ${AVAILABLE_CONFTEST_VERSIONS}; do \
-        curl -LOs https://github.com/open-policy-agent/conftest/releases/download/v${VERSION}/conftest_${VERSION}_Linux_x86_64.tar.gz && \
+        curl -LOs https://github.com/open-policy-agent/conftest/releases/download/v${VERSION}/conftest_${VERSION}_Linux_${CONFTEST_ARCH}.tar.gz && \
         curl -LOs https://github.com/open-policy-agent/conftest/releases/download/v${VERSION}/checksums.txt && \
-        sed -n "/conftest_${VERSION}_Linux_x86_64.tar.gz/p" checksums.txt | sha256sum -c && \
+        sed -n "/conftest_${VERSION}_Linux_${CONFTEST_ARCH}.tar.gz/p" checksums.txt | sha256sum -c && \
         mkdir -p /usr/local/bin/cft/versions/${VERSION} && \
-        tar -C  /usr/local/bin/cft/versions/${VERSION} -xzf conftest_${VERSION}_Linux_x86_64.tar.gz && \
+        tar -C /usr/local/bin/cft/versions/${VERSION} -xzf conftest_${VERSION}_Linux_${CONFTEST_ARCH}.tar.gz && \
         ln -s /usr/local/bin/cft/versions/${VERSION}/conftest /usr/local/bin/conftest${VERSION} && \
-        rm conftest_${VERSION}_Linux_x86_64.tar.gz && \
+        rm conftest_${VERSION}_Linux_${CONFTEST_ARCH}.tar.gz && \
         rm checksums.txt; \
     done
 


### PR DESCRIPTION
This firstly drops Terraform versions prior to 0.11.15 because they don't have all the architectures available that Docker images are built for. I don't assume many people use those versions anymore. Should this be communicated in some special way as it technically is a breaking change?

Terraform is now downloaded for the architecture the Docker image is being built for and the same goes for conftest, although this makes it apparent there's no binary available for conftest for armv7.

I have kept it downloading the x86_64 binary for now in order to keep this change simpler, but I guess the alternatives are:
* to compile an armv7 version of conftest when building the Docker image
* keep it like it is now and say conftest is unsupported on armv7 (at least for now)
* drop support of the armv7 Docker image which hasn't been working so far anyways, as far as I can gather