### PR TITLE
fix(docker): Multi-arch Docker images, attempt two

### DIFF
--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -17,21 +17,35 @@ RUN addgroup atlantis && \
     chmod g=u /home/atlantis/ && \
     chmod g=u /etc/passwd
 
-# Install dumb-init, gosu and git-lfs.
-ENV DUMB_INIT_VERSION=1.2.5
+# Install gosu and git-lfs.
 ENV GOSU_VERSION=1.14
 ENV GIT_LFS_VERSION=3.1.2
-RUN apk add --no-cache ca-certificates gnupg curl git unzip bash openssh libcap openssl && \
-    curl -L -s --output /bin/dumb-init "https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_x86_64" && \
-    chmod +x /bin/dumb-init && \
+
+# Automatically populated with the architecture the image is being built for.
+ARG TARGETPLATFORM
+
+# Install packages needed for running Atlantis.
+RUN apk add --no-cache ca-certificates curl git unzip bash openssh libcap dumb-init && \
+    # Install packages needed for building dependencies.
+    apk add --no-cache --virtual .build-deps gnupg openssl && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
-    curl -L -s --output git-lfs.tar.gz "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-amd64-v${GIT_LFS_VERSION}.tar.gz" && \
+
+    # git-lfs
+    curl -L -s --output git-lfs.tar.gz "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-${TARGETPLATFORM##*/}-v${GIT_LFS_VERSION}.tar.gz" && \
     tar -xf git-lfs.tar.gz && \
     chmod +x git-lfs && \
     mv git-lfs /usr/bin/git-lfs && \
-    curl -L -s --output gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64" && \
-    curl -L -s --output gosu.asc "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc" && \
+    git-lfs --version && \
+
+    # gosu
+    case ${TARGETPLATFORM} in \
+        "linux/amd64") GOSU_ARCH=amd64 ;; \
+        "linux/arm64") GOSU_ARCH=arm64 ;; \
+        "linux/arm/v7") GOSU_ARCH=armhf ;; \
+    esac && \
+    curl -L -s --output gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${GOSU_ARCH}" && \
+    curl -L -s --output gosu.asc "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${GOSU_ARCH}.asc" && \
     for server in $(shuf -e ipv4.pool.sks-keyservers.net \
                             hkp://p80.pool.sks-keyservers.net:80 \
                             keyserver.ubuntu.com \
@@ -42,13 +56,15 @@ RUN apk add --no-cache ca-certificates gnupg curl git unzip bash openssh libcap 
     gpg --batch --verify gosu.asc gosu && \
     chmod +x gosu && \
     cp gosu /bin && \
-        cd /tmp && \
-        rm -rf /tmp/build && \
-        gpgconf --kill dirmngr && \
-        gpgconf --kill gpg-agent && \
-        apk del gnupg openssl && \
-        rm -rf /root/.gnupg && \
-        rm -rf /var/cache/apk/*
+    gosu --version && \
+
+    # Cleanup
+    cd /tmp && \
+    rm -rf /tmp/build && \
+    gpgconf --kill dirmngr && \
+    gpgconf --kill gpg-agent && \
+    apk del .build-deps && \
+    rm -rf /root/.gnupg
 
 # Set up nsswitch.conf for Go's "netgo" implementation
 # - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275

--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -32,7 +32,12 @@ RUN apk add --no-cache ca-certificates curl git unzip bash openssh libcap dumb-i
     cd /tmp/build && \
 
     # git-lfs
-    curl -L -s --output git-lfs.tar.gz "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-${TARGETPLATFORM##*/}-v${GIT_LFS_VERSION}.tar.gz" && \
+    case ${TARGETPLATFORM} in \
+        "linux/amd64") GIT_LFS_ARCH=amd64 ;; \
+        "linux/arm64") GIT_LFS_ARCH=arm64 ;; \
+        "linux/arm/v7") GIT_LFS_ARCH=arm ;; \
+    esac && \
+    curl -L -s --output git-lfs.tar.gz "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-${GIT_LFS_ARCH}-v${GIT_LFS_VERSION}.tar.gz" && \
     tar -xf git-lfs.tar.gz && \
     chmod +x git-lfs && \
     mv git-lfs /usr/bin/git-lfs && \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/dumb-init /bin/sh
+#!/usr/bin/dumb-init /bin/sh
 set -e
 
 # Modified: https://github.com/hashicorp/docker-consul/blob/2c2873f9d619220d1eef0bc46ec78443f55a10b5/0.X/docker-entrypoint.sh


### PR DESCRIPTION
This reintroduces the changes that were reverted in #2106 and adds one extra change in 697ea1723ebca89be49d4049a94861fcc056f77c which fixes the problem reported in #2104.

The gist is the path to `dumb-init` changes from `/bin/dumb-init` to `/usr/bin/dumb-init` when we install it via `apk` rather than downloading the binary directly. Since it's the first binary Docker tries to execute and it can't find it, it gives the somewhat cryptic error message:
> standard_init_linux.go:228: exec user process caused: no such file or directory

I believe the steps for getting this merged and built correctly are:

1. Merge this PR
1. Wait for the `atlantis-base` image to be built
1. Change the tag for the `atlantis-base` image in `Dockerfile` to point at the newly built base image
1. Wait for the `atlantis:dev` image to be built and do some quick testing to make sure it works as expected

Then it should be ready for a release after that.