### PR TITLE
fix: Add CleanedBasePath to GithubSetupData (#2141)

### DIFF
--- a/server/controllers/github_app_controller.go
+++ b/server/controllers/github_app_controller.go
@@ -70,12 +70,13 @@ func (g *GithubAppController) ExchangeCode(w http.ResponseWriter, r *http.Reques
 	g.Logger.Debug("Found credentials for GitHub app %q with id %d", app.Name, app.ID)
 
 	err = templates.GithubAppSetupTemplate.Execute(w, templates.GithubSetupData{
-		Target:        "",
-		Manifest:      "",
-		ID:            app.ID,
-		Key:           app.Key,
-		WebhookSecret: app.WebhookSecret,
-		URL:           app.URL,
+		Target:          "",
+		Manifest:        "",
+		ID:              app.ID,
+		Key:             app.Key,
+		WebhookSecret:   app.WebhookSecret,
+		URL:             app.URL,
+		CleanedBasePath: g.AtlantisURL.Path,
 	})
 	if err != nil {
 		g.Logger.Err(err.Error())

--- a/server/controllers/templates/web_templates.go
+++ b/server/controllers/templates/web_templates.go
@@ -501,12 +501,13 @@ var ProjectJobsErrorTemplate = template.Must(template.New("blank.html.tmpl").Par
 
 // GithubSetupData holds the data for rendering the github app setup page
 type GithubSetupData struct {
-	Target        string
-	Manifest      string
-	ID            int64
-	Key           string
-	WebhookSecret string
-	URL           string
+	Target          string
+	Manifest        string
+	ID              int64
+	Key             string
+	WebhookSecret   string
+	URL             string
+	CleanedBasePath string
 }
 
 var GithubAppSetupTemplate = template.Must(template.New("github-app.html.tmpl").Parse(`


### PR DESCRIPTION
Fixes: https://github.com/runatlantis/atlantis/issues/2141

### Background
Template for `GithubAppSetupTemplate` refers to the property `CleanedBasePath` of `GithubSetupData` struct that was undefined.

### Changes:
- Property `CleanedBasePath` was added into `GithubSetupData` struct
- Property `CleanedBasePath` is assigned in `server/controllers/github_app_controller.go` with `g.AtlantisURL.path`
Where `g` is `GithubAppController` struct

### Test
- Tested locally with modified for local dev `docker-compose run atlantis server`. 
Was able to see `http://localhost:4141/github-app/setup` page