### PR TITLE
build(deps): bump alpine base image from 3.15 to 3.15.2

### DIFF
--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile builds our base image with gosu, dumb-init and the atlantis
 # user. We split this from the main Dockerfile because this base doesn't change
 # and also because it kept breaking the build due to flakiness.
-FROM alpine:3.15
+FROM alpine:3.15.2
 LABEL authors="Anubhav Mishra, Luke Kysow"
 
 # We use gosu to step down from root and run as the atlantis user so we need


### PR DESCRIPTION
Bump [hub.docker.com/_/alpine/](https://hub.docker.com/_/alpine/) from 3.15 to 3.15.2 that addresses `libretls` vulnerability.
More details here: https://alpinelinux.org/posts/Alpine-3.15.2-released.html
