### PR TITLE
Add gcompat library to Docker base image for convenience

### DIFF
--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -25,7 +25,7 @@ ENV GIT_LFS_VERSION=3.1.2
 ARG TARGETPLATFORM
 
 # Install packages needed for running Atlantis.
-RUN apk add --no-cache ca-certificates curl git unzip bash openssh libcap dumb-init && \
+RUN apk add --no-cache ca-certificates curl git unzip bash openssh libcap dumb-init gcompat && \
     # Install packages needed for building dependencies.
     apk add --no-cache --virtual .build-deps gnupg openssl && \
     mkdir -p /tmp/build && \


### PR DESCRIPTION
"Fixes" https://github.com/runatlantis/atlantis/issues/2174 and might also be related to https://github.com/runatlantis/atlantis/issues/1047. This is not a hard issue but more of a convenience addon that might save some folks a lot of headaches.