### PR TITLE
docs: Add unlock command

### DIFF
--- a/runatlantis.io/docs/locking.md
+++ b/runatlantis.io/docs/locking.md
@@ -43,8 +43,8 @@ You can click on a lock to view its details:
 ## Unlocking
 The project and workspace will be automatically unlocked when the PR is merged or closed.
 
-To unlock the project and workspace without completing an `apply` and merging, click the link
-at the bottom of the plan comment to discard the plan and delete the lock where
+To unlock the project and workspace without completing an `apply` and merging, comment `atlantis unlock` on the PR,
+or click the link at the bottom of the plan comment to discard the plan and delete the lock where
 it says **"To discard this plan click here"**:
 
 ![Locks View](./images/lock-delete-comment.png)


### PR DESCRIPTION
Currently, the only way to unlock according to the docs is to click through to the UI, which may not be available due to security issues etc. Update the docs to include `atlantis unlock` as a method to remove the lock from a PR.