### PR TITLE
Update alpine base from 3.15.2 to latest patch version 3.15.4

### DIFF
--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile builds our base image with gosu, dumb-init and the atlantis
 # user. We split this from the main Dockerfile because this base doesn't change
 # and also because it kept breaking the build due to flakiness.
-FROM alpine:3.15.2
+FROM alpine:3.15.4
 LABEL authors="Anubhav Mishra, Luke Kysow"
 
 # We use gosu to step down from root and run as the atlantis user so we need


### PR DESCRIPTION
# Updating the alpine base image to get the latest package updates.

## Why do we want this PR?

Updating the base image upgrades packages to address vulnerabilities

If I run `apk update && apk upgrade` on the original alpine base image `3.15.2`, the following upgrades are made:
```
➜ docker run --rm -ti localhost/atlantis-base:3.15.2 bash                  
bash-5.1# apk update -vvv
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/community/x86_64/APKINDEX.tar.gz
v3.15.4-28-gf3bb9d0183 [https://dl-cdn.alpinelinux.org/alpine/v3.15/main]
v3.15.4-38-gf7d0da3611 [https://dl-cdn.alpinelinux.org/alpine/v3.15/community]
OK: 15858 distinct packages available
bash-5.1# apk upgrade -vvvv
The following packages will be upgraded:
  busybox ssl_client zlib
After this operation, 0 B of additional disk space will be used.
(1/3) Upgrading busybox (1.34.1-r4 -> 1.34.1-r5)
bin/ (dir)
bin/busybox
bin/sh
etc/ (dir)
etc/logrotate.d/ (dir)
etc/logrotate.d/acpid
etc/network/ (dir)
etc/network/if-down.d/ (dir)
etc/network/if-post-down.d/ (dir)
etc/network/if-post-up.d/ (dir)
etc/network/if-pre-down.d/ (dir)
etc/network/if-pre-up.d/ (dir)
etc/network/if-up.d/ (dir)
etc/network/if-up.d/dad
etc/securetty
etc/udhcpd.conf
sbin/ (dir)
tmp/ (dir)
usr/ (dir)
usr/sbin/ (dir)
usr/share/ (dir)
usr/share/udhcpc/ (dir)
usr/share/udhcpc/default.script
var/ (dir)
var/cache/ (dir)
var/cache/misc/ (dir)
var/lib/ (dir)
var/lib/udhcpd/ (dir)
Executing busybox-1.34.1-r5.post-upgrade
(2/3) Upgrading ssl_client (1.34.1-r4 -> 1.34.1-r5)
usr/ (dir)
usr/bin/ (dir)
usr/bin/ssl_client
(3/3) Upgrading zlib (1.2.11-r3 -> 1.2.12-r0)
lib/ (dir)
lib/libz.so.1
lib/libz.so.1.2.12
lib/libz.so.1.2.11
Executing busybox-1.34.1-r5.trigger
OK: 37 packages, 126 dirs, 577 files, 28 MiB
```

Using the base alpine image of `3.15.4` and then performing the same update check yields the following output:
```
➜ docker run --rm -ti localhost/atlantis-base:3.15.4 bash
bash-5.1# apk update -vvvv
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/community/x86_64/APKINDEX.tar.gz
v3.15.4-39-g17994082e8 [https://dl-cdn.alpinelinux.org/alpine/v3.15/main]
v3.15.4-38-gf7d0da3611 [https://dl-cdn.alpinelinux.org/alpine/v3.15/community]
OK: 15855 distinct packages available
bash-5.1# apk upgrade -vvvv
After this operation, 0 B of additional disk space will be used.
OK: 37 packages, 126 dirs, 577 files, 28 MiB
```

In other words, using `3.15.4` shows we are up to date with no package upgrades required.