### PR TITLE
GitLab MRs should be "Mergeable" if jobs are skipped or (only) Atlantis job failed

### DIFF
--- a/server/events/vcs/gitlab_client.go
+++ b/server/events/vcs/gitlab_client.go
@@ -212,7 +212,7 @@ func (g *GitlabClient) PullIsMergeable(repo models.Repo, pull models.PullRequest
 	}
 
 	for _, status := range statuses {
-		if !strings.HasSuffix(status.Name, fmt.Sprintf("/%s", command.Apply.String())) {
+		if !strings.HasPrefix(status.Name, fmt.Sprintf("atlantis/%s", command.Apply.String())) {
 			if !status.AllowFailure && project.OnlyAllowMergeIfPipelineSucceeds && status.Status != "success" {
 				return false, nil
 			}

--- a/server/events/vcs/gitlab_client.go
+++ b/server/events/vcs/gitlab_client.go
@@ -212,10 +212,14 @@ func (g *GitlabClient) PullIsMergeable(repo models.Repo, pull models.PullRequest
 	}
 
 	for _, status := range statuses {
-		if !strings.HasPrefix(status.Name, fmt.Sprintf("atlantis/%s", command.Apply.String())) {
-			if !status.AllowFailure && project.OnlyAllowMergeIfPipelineSucceeds && status.Status != "success" {
-				return false, nil
-			}
+		// Ignore any commit statuses with 'altantis/apply' as prefix
+		if strings.HasPrefix(status.Name, fmt.Sprintf("atlantis/%s", command.Apply.String())) {
+			continue;
+		}
+
+		// If any commit-status != success, reject it
+		if !status.AllowFailure && project.OnlyAllowMergeIfPipelineSucceeds && status.Status != "success" {
+			return false, nil
 		}
 	}
 

--- a/server/events/vcs/gitlab_client.go
+++ b/server/events/vcs/gitlab_client.go
@@ -217,6 +217,11 @@ func (g *GitlabClient) PullIsMergeable(repo models.Repo, pull models.PullRequest
 			continue;
 		}
 
+		// Ignore any commit statuses with status skipped
+		if status.Status == "skipped" {
+			continue;
+		}
+
 		// If any commit-status != success, reject it
 		if !status.AllowFailure && project.OnlyAllowMergeIfPipelineSucceeds && status.Status != "success" {
 			return false, nil


### PR DESCRIPTION
Based off https://github.com/runatlantis/atlantis/pull/2137 and @skeen 's work. Also makes MR's mergable if commit statuses are skipped. This makes Atlantis much more suitable with monorepos, where you sometimes only run some tests (ie skip other jobs) based on the changes.