### PR TITLE
Stream output for custom workflows

### DIFF
--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -973,8 +973,9 @@ func setupE2E(t *testing.T, repoDir string) (events_controllers.VCSEventsControl
 			TerraformExecutor: terraformClient,
 		},
 		RunStepRunner: &runtime.RunStepRunner{
-			TerraformExecutor: terraformClient,
-			DefaultTFVersion:  defaultTFVersion,
+			TerraformExecutor:       terraformClient,
+			DefaultTFVersion:        defaultTFVersion,
+			ProjectCmdOutputHandler: projectCmdOutputHandler,
 		},
 		WorkingDir:       workingDir,
 		Webhooks:         &mockWebhookSender{},

--- a/server/core/runtime/env_step_runner_test.go
+++ b/server/core/runtime/env_step_runner_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/terraform/mocks"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
+	jobmocks "github.com/runatlantis/atlantis/server/jobs/mocks"
 	"github.com/runatlantis/atlantis/server/logging"
 
 	. "github.com/petergtz/pegomock"
@@ -40,9 +41,11 @@ func TestEnvStepRunner_Run(t *testing.T) {
 	tfClient := mocks.NewMockClient()
 	tfVersion, err := version.NewVersion("0.12.0")
 	Ok(t, err)
+	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 	runStepRunner := runtime.RunStepRunner{
-		TerraformExecutor: tfClient,
-		DefaultTFVersion:  tfVersion,
+		TerraformExecutor:       tfClient,
+		DefaultTFVersion:        tfVersion,
+		ProjectCmdOutputHandler: projectCmdOutputHandler,
 	}
 	envRunner := runtime.EnvStepRunner{
 		RunStepRunner: &runStepRunner,

--- a/server/core/runtime/multienv_step_runner_test.go
+++ b/server/core/runtime/multienv_step_runner_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/terraform/mocks"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
+	jobmocks "github.com/runatlantis/atlantis/server/jobs/mocks"
 	"github.com/runatlantis/atlantis/server/logging"
 	. "github.com/runatlantis/atlantis/testing"
 )
@@ -31,9 +32,11 @@ func TestMultiEnvStepRunner_Run(t *testing.T) {
 	tfClient := mocks.NewMockClient()
 	tfVersion, err := version.NewVersion("0.12.0")
 	Ok(t, err)
+	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 	runStepRunner := runtime.RunStepRunner{
-		TerraformExecutor: tfClient,
-		DefaultTFVersion:  tfVersion,
+		TerraformExecutor:       tfClient,
+		DefaultTFVersion:        tfVersion,
+		ProjectCmdOutputHandler: projectCmdOutputHandler,
 	}
 	multiEnvStepRunner := runtime.MultiEnvStepRunner{
 		RunStepRunner: &runStepRunner,

--- a/server/core/runtime/run_step_runner.go
+++ b/server/core/runtime/run_step_runner.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/events/terraform/ansi"
 	"github.com/runatlantis/atlantis/server/jobs"
 )
 
@@ -100,7 +101,7 @@ func (r *RunStepRunner) Run(ctx command.ProjectContext, command string, path str
 		return "", err
 	}
 	ctx.Log.Info("successfully ran %q in %q", command, path)
-	return string(output.String()), nil
+	return ansi.Strip(output.String()), nil
 }
 
 func (r RunStepRunner) streamOutput(ctx command.ProjectContext, reader io.Reader, buffer *bytes.Buffer, mutex *sync.Mutex) {

--- a/server/core/runtime/run_step_runner_test.go
+++ b/server/core/runtime/run_step_runner_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/mocks/matchers"
 	"github.com/runatlantis/atlantis/server/events/models"
+	jobmocks "github.com/runatlantis/atlantis/server/jobs/mocks"
 	"github.com/runatlantis/atlantis/server/logging"
 	. "github.com/runatlantis/atlantis/testing"
 )
@@ -38,11 +39,11 @@ func TestRunStepRunner_Run(t *testing.T) {
 		},
 		{
 			Command: `printf \'your main.tf file does not provide default region.\\ncheck\'`,
-			ExpOut:  `'your`,
+			ExpOut:  "'your\n",
 		},
 		{
 			Command: `printf 'your main.tf file does not provide default region.\ncheck'`,
-			ExpOut:  "your main.tf file does not provide default region.\ncheck",
+			ExpOut:  "your main.tf file does not provide default region.\ncheck\n",
 		},
 		{
 			Command: "echo 'a",
@@ -104,11 +105,13 @@ func TestRunStepRunner_Run(t *testing.T) {
 			ThenReturn(nil)
 
 		logger := logging.NewNoopLogger(t)
+		projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 
 		r := runtime.RunStepRunner{
-			TerraformExecutor: terraform,
-			DefaultTFVersion:  defaultVersion,
-			TerraformBinDir:   "/bin/dir",
+			TerraformExecutor:       terraform,
+			DefaultTFVersion:        defaultVersion,
+			TerraformBinDir:         "/bin/dir",
+			ProjectCmdOutputHandler: projectCmdOutputHandler,
 		}
 		t.Run(c.Command, func(t *testing.T) {
 			tmpDir, cleanup := TempDir(t)

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -30,6 +30,7 @@ import (
 	eventmocks "github.com/runatlantis/atlantis/server/events/mocks"
 	"github.com/runatlantis/atlantis/server/events/mocks/matchers"
 	"github.com/runatlantis/atlantis/server/events/models"
+	jobmocks "github.com/runatlantis/atlantis/server/jobs/mocks"
 	"github.com/runatlantis/atlantis/server/logging"
 	. "github.com/runatlantis/atlantis/testing"
 )
@@ -537,9 +538,11 @@ func TestDefaultProjectCommandRunner_RunEnvSteps(t *testing.T) {
 	tfClient := tmocks.NewMockClient()
 	tfVersion, err := version.NewVersion("0.12.0")
 	Ok(t, err)
+	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 	run := runtime.RunStepRunner{
-		TerraformExecutor: tfClient,
-		DefaultTFVersion:  tfVersion,
+		TerraformExecutor:       tfClient,
+		DefaultTFVersion:        tfVersion,
+		ProjectCmdOutputHandler: projectCmdOutputHandler,
 	}
 	env := runtime.EnvStepRunner{
 		RunStepRunner: &run,

--- a/server/server.go
+++ b/server/server.go
@@ -466,9 +466,10 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	defaultTfVersion := terraformClient.DefaultVersion()
 	pendingPlanFinder := &events.DefaultPendingPlanFinder{}
 	runStepRunner := &runtime.RunStepRunner{
-		TerraformExecutor: terraformClient,
-		DefaultTFVersion:  defaultTfVersion,
-		TerraformBinDir:   terraformClient.TerraformBinDir(),
+		TerraformExecutor:       terraformClient,
+		DefaultTFVersion:        defaultTfVersion,
+		TerraformBinDir:         terraformClient.TerraformBinDir(),
+		ProjectCmdOutputHandler: projectCmdOutputHandler,
 	}
 	drainer := &events.Drainer{}
 	statusController := &controllers.StatusController{


### PR DESCRIPTION
Fixes #2054 

Opening up to get feedback on this approach before I get too far. Will add some tests but wanted to check that I was on the right track since today is my first time looking at the Atlantis source code.

I noticed that in #1937 which originally added this feature (e.g. https://github.com/runatlantis/atlantis/pull/1937/files#diff-edf527ba8643ff7bfca5f560491ea7055af472f5d6f3bbda127f1776b63d4b06L179) that the documentation around setting up `terragrunt` for custom workflows removed the `-no-color` option.

I'm not sure if this was by mistake, but to allow colorization in the in-browser terminal I've added `ansi.Strip()` around the generic RunStepRunner. If this is out of scope I can back those changes out (but we should probably update the docs to re-add the `-no-color` flags to `terragrunt` workflows, otherwise the output is mangled in e.g. GitHub comments).

Tested by updating my atlantis instance to a build of this branch and removing the `-no-color` flags from my workflow.

I'm using the following server configuration:

```yaml
repos:
  - id: "/.*/"
    workflow: terragrunt
    pre_workflow_hooks:
      - run: >
          terragrunt-atlantis-config generate
          --output atlantis.yaml
          --autoplan --automerge
workflows:
  terragrunt:
    plan:
      steps:
      - env:
          name: TERRAGRUNT_TFPATH
          command: 'echo "terraform${ATLANTIS_TERRAFORM_VERSION}"'
      - run: terragrunt plan -out=$PLANFILE
      - run: terragrunt show -json $PLANFILE > $SHOWFILE
    apply:
      steps:
      - env:
          name: TERRAGRUNT_TFPATH
          command: 'echo "terraform${ATLANTIS_TERRAFORM_VERSION}"'
      - run: terragrunt apply $PLANFILE

```

![image](https://user-images.githubusercontent.com/97087/168747995-f71c5212-5443-476c-9e47-eee3079ff7aa.png)

I ended up appending trailing newlines to every line so I could keep using `bufio.NewScanner` which makes parsing the lines a lot easier. If it's important to preserve the (lack of) trailing newline in the output I can revisit this.