### PR TITLE
fix: branch CI pipeline due to unchecked err in test

### DIFF
--- a/server/events/vcs/gitlab_client_test.go
+++ b/server/events/vcs/gitlab_client_test.go
@@ -298,7 +298,7 @@ func TestGitlabClient_PullIsMergeable(t *testing.T) {
 					case "/api/v4/projects/4580910/repository/commits/67cb91d3f6198189f433c045154a885784ba6977/statuses":
 						w.WriteHeader(http.StatusOK)
 						response := fmt.Sprintf(`[{"id":133702594,"sha":"67cb91d3f6198189f433c045154a885784ba6977","ref":"patch-1","status":"%s","name":"%s","target_url":null,"description":"ApplySuccess","created_at":"2018-12-12T18:31:57.957Z","started_at":null,"finished_at":"2018-12-12T18:31:58.480Z","allow_failure":false,"coverage":null,"author":{"id":1755902,"username":"lkysow","name":"LukeKysow","state":"active","avatar_url":"https://secure.gravatar.com/avatar/25fd57e71590fe28736624ff24d41c5f?s=80&d=identicon","web_url":"https://gitlab.com/lkysow"}}]`, c.status, c.statusName)
-						w.Write([]byte(response))
+						w.Write([]byte(response)) // nolint: errcheck
 					default:
 						t.Errorf("got unexpected request at %q", r.RequestURI)
 						http.Error(w, "not found", http.StatusNotFound)


### PR DESCRIPTION
Currently this is failing on PRs. Looks like this was added in the last day in #2137

```
server/events/vcs/gitlab_client_test.go:301:14: Error return value of `w.Write` is not checked (errcheck)
                                                w.Write([]byte(response))
```