### PR TITLE
fix: working dir tests initial branch assumes "master"

### DIFF
--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -464,7 +464,7 @@ func TestHasDiverged_MasterHasDiverged(t *testing.T) {
 
 func initRepo(t *testing.T) (string, func()) {
 	repoDir, cleanup := TempDir(t)
-	runCmd(t, repoDir, "git", "init")
+	runCmd(t, repoDir, "git", "init", "--initial-branch=master")
 	runCmd(t, repoDir, "touch", ".gitkeep")
 	runCmd(t, repoDir, "git", "add", ".gitkeep")
 	runCmd(t, repoDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")


### PR DESCRIPTION
This fixes the tests to not rely in the implicit value of the
"defaultBranch" git configuration value, since they later assume that
it's "master".

For example, if you run:

```sh
git config --global init.defaultBranch main
```

And then run these tests, you get:

```sh
--- FAIL: TestClone_CheckoutMergeNoneExisting (0.69s)
    working_dir_test.go:71: err running "git checkout master": error: pathspec 'master' did not match any file(s) known to git
        
--- FAIL: TestClone_CheckoutMergeNoReclone (0.71s)
    working_dir_test.go:127: err running "git checkout master": error: pathspec 'master' did not match any file(s) known to git
        
--- FAIL: TestClone_CheckoutMergeNoRecloneFastForward (0.71s)
    logger.go:130: 2022-05-17T10:15:03.244-0700 INFO    creating dir "/tmp/3840955393/repos/0/default"
    working_dir_test.go:198: unexpected error: running git clone --branch master --single-branch file:///tmp/857183047 /tmp/3840955393/repos/0/default: Cloning into '/tmp/3840955393/repos/0/default'...
        warning: Could not find remote branch master to clone.
        fatal: Remote branch master not found in upstream origin
        : exit status 128
--- FAIL: TestClone_CheckoutMergeConflict (0.69s)
    working_dir_test.go:232: err running "git checkout master": error: pathspec 'master' did not match any file(s) known to git
        
--- FAIL: TestClone_MasterHasDiverged (0.68s)
    working_dir_test.go:344: err running "git clone --branch master --single-branch /tmp/3624040418 .": Cloning into '.'...
        warning: Could not find remote branch master to clone.
        fatal: Remote branch master not found in upstream origin
        
--- FAIL: TestHasDiverged_MasterHasDiverged (0.68s)
    working_dir_test.go:415: err running "git clone --branch master --single-branch /tmp/3534950134 .": Cloning into '.'...
        warning: Could not find remote branch master to clone.
        fatal: Remote branch master not found in upstream origin
        
FAIL
FAIL    github.com/runatlantis/atlantis/server/events   8.831s
```