### PR TITLE
Fix for failing builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
           muffet \
             -e 'https://github\.com/runatlantis/atlantis/edit/master/.*' \
             -e 'https://github.com/helm/charts/tree/master/stable/atlantis#customization' \
+            --header 'Accept-Encoding:deflate, gzip' \
             --buffer-size 8192 \
             http://localhost:8080/
 

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ lint: ## Run linter locally
 	golangci-lint run
 
 check-lint: ## Run linter in CI/CD. If running locally use 'lint'
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b ./bin v1.39.0
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin v1.39.0
 	./bin/golangci-lint run -j 4 --timeout 5m
 
 check-fmt: ## Fail if not formatted


### PR DESCRIPTION
I noticed builds failing, for two separate issues.

The install script location for golangci-lint has been changed, you can see the new one in their docs - https://golangci-lint.run/usage/install/#other-ci

`docs.github.com` seems to have some bot protection in front of it. It can be worked around by requesting compressed content - https://github.com/github/docs/issues/17358#issuecomment-1111864031