### PR TITLE
trim whitespace from comments before parsing

### DIFF
--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -113,7 +113,9 @@ type CommentParseResult struct {
 // - atlantis version
 // - atlantis approve_policies
 //
-func (e *CommentParser) Parse(comment string, vcsHost models.VCSHostType) CommentParseResult {
+func (e *CommentParser) Parse(rawComment string, vcsHost models.VCSHostType) CommentParseResult {
+	comment := strings.TrimSpace(rawComment)
+
 	if multiLineRegex.MatchString(comment) {
 		return CommentParseResult{Ignore: true}
 	}
@@ -427,7 +429,7 @@ var DidYouMeanAtlantisComment = "Did you mean to use `atlantis` instead of `terr
 // `atlantis unlock` with flags.
 
 var UnlockUsage = "`Usage of unlock:`\n\n ```cmake\n" +
-	`atlantis unlock	
+	`atlantis unlock
 
   Unlocks the entire PR and discards all plans in this PR.
   Arguments or flags are not supported at the moment.

--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -280,6 +280,10 @@ func TestParse_Multiline(t *testing.T) {
 		"atlantis plan\n\n",
 		"atlantis plan\r\n",
 		"atlantis plan\r\n\r\n",
+		"\natlantis plan",
+		"\r\natlantis plan",
+		"\natlantis plan\n",
+		"\r\natlantis plan\r\n",
 	}
 	for _, comment := range comments {
 		t.Run(comment, func(t *testing.T) {
@@ -845,7 +849,7 @@ var ApprovePolicyUsage = `Usage of approve_policies:
       --verbose   Append Atlantis log to comment.
 `
 var UnlockUsage = "`Usage of unlock:`\n\n ```cmake\n" +
-	`atlantis unlock	
+	`atlantis unlock
 
   Unlocks the entire PR and discards all plans in this PR.
   Arguments or flags are not supported at the moment.


### PR DESCRIPTION
I ran into a minor UX issue when copy-pasting a command for Atlantis. It looks like Github added an extra line before and after my comment, causing my comment to be silently ignored, after which I thought the apply was just hanging.

Based on the code comments around this, it looks like the intent was to at least allow trailing whitespace for this reason, so I reasoned it might be ok to allow leading whitespace as well. This change just trims whitespace from the left and right of the comment before parsing it, in an attempt to make things a little more flexible. I've added test cases for both leading whitespace and whitespace on both sides, in addition to the trailing whitespace test cases from before.

It's possible that blindling trimming whitespace could be problematic, so I'm open-minded to tightening this up if desired. This is my first contribution, so just learning the ropes here.