### PR TITLE
Fix make check-lint host to correctly install `golangci-lint`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ lint: ## Run linter locally
 	golangci-lint run
 
 check-lint: ## Run linter in CI/CD. If running locally use 'lint'
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b ./bin v1.39.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin v1.39.0
 	./bin/golangci-lint run -j 4 --timeout 5m
 
 check-fmt: ## Fail if not formatted


### PR DESCRIPTION
## what

* Fix make check-lint host

The error returned from the current `make check-lint` command

```
curl: (6) Could not resolve host: install.goreleaser.com
```

## why

*  Correctly install `golangci-lint` to resolve the failed linter checks

## references

* https://app.circleci.com/pipelines/github/runatlantis/atlantis/2259/workflows/645b17ce-ee01-4212-bea0-2698554da10c/jobs/10132
* Same fix in stripe-cli https://github.com/stripe/stripe-cli/pull/880/files

## commands

```
make check-lint
```