### PR TITLE
Upgrade project to golang-1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     - run: make check-lint
   e2e:
     docker:
-    - image: circleci/golang:1.17 # If you update this, update it in the Makefile too
+    - image: circleci/golang:1.18 # If you update this, update it in the Makefile too
       environment:
         # This version of TF will be downloaded before Atlantis is started.
         # We do this instead of setting --default-tf-version because setting

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.17
+        go-version: 1.18
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.17
+        go-version: 1.18
 
     - name: Run GoReleaser for stable release
       uses: goreleaser/goreleaser-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: build artifact
-FROM golang:1.17-alpine AS builder
+FROM golang:1.18-alpine AS builder
 
 WORKDIR /app
 COPY . /app

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ dist: ## Package up everything in static/ using go-bindata-assetfs so it can be 
 	rm -f server/static/bindata_assetfs.go && go-bindata-assetfs -o bindata_assetfs.go -pkg static -prefix server server/static/... && mv bindata_assetfs.go server/static
 
 release: ## Create packages for a release
-	docker run -v $$(pwd):/go/src/github.com/runatlantis/atlantis circleci/golang:1.17 sh -c 'cd /go/src/github.com/runatlantis/atlantis && scripts/binary-release.sh'
+	docker run -v $$(pwd):/go/src/github.com/runatlantis/atlantis circleci/golang:1.18 sh -c 'cd /go/src/github.com/runatlantis/atlantis && scripts/binary-release.sh'
 
 fmt: ## Run goimports (which also formats)
 	goimports -w $$(find . -type f -name '*.go' ! -path "./vendor/*" ! -path "./server/static/bindata_assetfs.go" ! -path "**/mocks/*")

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/runatlantis/atlantis/e2e
 
-go 1.17
+go 1.18
 
 require (
 	github.com/google/go-github/v28 v28.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/runatlantis/atlantis
 
-go 1.17
+go 1.18
 
 replace google.golang.org/grpc => google.golang.org/grpc v1.29.1
 

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.18
 
 RUN apt-get update && apt-get install unzip
 


### PR DESCRIPTION
## what
* Upgrade project to golang-1.18

## why
* Why not ?

## references
* https://go.dev/blog/go1.18
* Edit: looks like an earlier pr https://github.com/runatlantis/atlantis/pull/2145/files

## commands

```
CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -v -o atlantis .
```