### PR TITLE
Add version to /status endpoint

### DIFF
--- a/server/controllers/status_controller.go
+++ b/server/controllers/status_controller.go
@@ -26,8 +26,8 @@ type StatusResponse struct {
 func (d *StatusController) Get(w http.ResponseWriter, r *http.Request) {
 	status := d.Drainer.GetStatus()
 	data, err := json.MarshalIndent(&StatusResponse{
-		ShuttingDown:  status.ShuttingDown,
-		InProgressOps: status.InProgressOps,
+		ShuttingDown:    status.ShuttingDown,
+		InProgressOps:   status.InProgressOps,
 		AtlantisVersion: d.AtlantisVersion,
 	}, "", "  ")
 	if err != nil {

--- a/server/controllers/status_controller.go
+++ b/server/controllers/status_controller.go
@@ -11,13 +11,15 @@ import (
 
 // StatusController handles the status of Atlantis.
 type StatusController struct {
-	Logger  logging.SimpleLogging
-	Drainer *events.Drainer
+	Logger          logging.SimpleLogging
+	Drainer         *events.Drainer
+	AtlantisVersion string
 }
 
 type StatusResponse struct {
-	ShuttingDown  bool `json:"shutting_down"`
-	InProgressOps int  `json:"in_progress_operations"`
+	ShuttingDown    bool   `json:"shutting_down"`
+	InProgressOps   int    `json:"in_progress_operations"`
+	AtlantisVersion string `json:"version"`
 }
 
 // Get is the GET /status route.
@@ -26,6 +28,7 @@ func (d *StatusController) Get(w http.ResponseWriter, r *http.Request) {
 	data, err := json.MarshalIndent(&StatusResponse{
 		ShuttingDown:  status.ShuttingDown,
 		InProgressOps: status.InProgressOps,
+		AtlantisVersion: d.AtlantisVersion,
 	}, "", "  ")
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/server/controllers/status_controller_test.go
+++ b/server/controllers/status_controller_test.go
@@ -20,8 +20,8 @@ func TestStatusController_Startup(t *testing.T) {
 	w := httptest.NewRecorder()
 	dr := &events.Drainer{}
 	d := &controllers.StatusController{
-		Logger:  logger,
-		Drainer: dr,
+		Logger:          logger,
+		Drainer:         dr,
 		AtlantisVersion: "1.0.0",
 	}
 	d.Get(w, r)
@@ -44,8 +44,8 @@ func TestStatusController_InProgress(t *testing.T) {
 	dr.StartOp()
 
 	d := &controllers.StatusController{
-		Logger:  logger,
-		Drainer: dr,
+		Logger:          logger,
+		Drainer:         dr,
 		AtlantisVersion: "1.0.0",
 	}
 	d.Get(w, r)
@@ -68,8 +68,8 @@ func TestStatusController_Shutdown(t *testing.T) {
 	dr.ShutdownBlocking()
 
 	d := &controllers.StatusController{
-		Logger:  logger,
-		Drainer: dr,
+		Logger:          logger,
+		Drainer:         dr,
 		AtlantisVersion: "1.0.0",
 	}
 	d.Get(w, r)

--- a/server/controllers/status_controller_test.go
+++ b/server/controllers/status_controller_test.go
@@ -22,6 +22,7 @@ func TestStatusController_Startup(t *testing.T) {
 	d := &controllers.StatusController{
 		Logger:  logger,
 		Drainer: dr,
+		AtlantisVersion: "1.0.0",
 	}
 	d.Get(w, r)
 
@@ -45,6 +46,7 @@ func TestStatusController_InProgress(t *testing.T) {
 	d := &controllers.StatusController{
 		Logger:  logger,
 		Drainer: dr,
+		AtlantisVersion: "1.0.0",
 	}
 	d.Get(w, r)
 
@@ -68,6 +70,7 @@ func TestStatusController_Shutdown(t *testing.T) {
 	d := &controllers.StatusController{
 		Logger:  logger,
 		Drainer: dr,
+		AtlantisVersion: "1.0.0",
 	}
 	d.Get(w, r)
 

--- a/server/server.go
+++ b/server/server.go
@@ -472,8 +472,8 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	}
 	drainer := &events.Drainer{}
 	statusController := &controllers.StatusController{
-		Logger:  logger,
-		Drainer: drainer,
+		Logger:          logger,
+		Drainer:         drainer,
 		AtlantisVersion: config.AtlantisVersion,
 	}
 	preWorkflowHooksCommandRunner := &events.DefaultPreWorkflowHooksCommandRunner{

--- a/server/server.go
+++ b/server/server.go
@@ -474,6 +474,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	statusController := &controllers.StatusController{
 		Logger:  logger,
 		Drainer: drainer,
+		AtlantisVersion: config.AtlantisVersion,
 	}
 	preWorkflowHooksCommandRunner := &events.DefaultPreWorkflowHooksCommandRunner{
 		VCSClient:             vcsClient,


### PR DESCRIPTION
## what

* Add version to /status endpoint

## why

* Much easier to identify what version is actively running

## references

* Finally closes https://github.com/runatlantis/atlantis/issues/1119
* Previous PR https://github.com/runatlantis/atlantis/pull/1120
* and helpful comments from @lkysow !

## commands

```
CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -v -o atlantis .
./atlantis server --gh-user=nitrocode --repo-allowlist=atlantis
```

```
✗ curl localhost:4141/status
{
  "shutting_down": false,
  "in_progress_operations": 0,
  "version": "0.19.3"
}
```