### PR TITLE
Ignore gpg signing for tests

### DIFF
--- a/server/core/runtime/common/common_test.go
+++ b/server/core/runtime/common/common_test.go
@@ -105,6 +105,7 @@ func initRepo(t *testing.T) (string, func()) {
 	runCmd(t, repoDir, "git", "add", ".gitkeep")
 	runCmd(t, repoDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
 	runCmd(t, repoDir, "git", "config", "--local", "user.name", "atlantisbot")
+	runCmd(t, repoDir, "git", "config", "--local", "commit.gpgsign", "false")
 	runCmd(t, repoDir, "git", "commit", "-m", "initial commit")
 	runCmd(t, repoDir, "git", "branch", "branch")
 	return repoDir, cleanup

--- a/server/core/runtime/init_step_runner_test.go
+++ b/server/core/runtime/init_step_runner_test.go
@@ -325,6 +325,7 @@ func initRepo(t *testing.T) (string, func()) {
 	runCmd(t, repoDir, "git", "add", ".gitkeep")
 	runCmd(t, repoDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
 	runCmd(t, repoDir, "git", "config", "--local", "user.name", "atlantisbot")
+	runCmd(t, repoDir, "git", "config", "--local", "commit.gpgsign", "false")
 	runCmd(t, repoDir, "git", "commit", "-m", "initial commit")
 	runCmd(t, repoDir, "git", "branch", "branch")
 	return repoDir, cleanup

--- a/server/events/pending_plan_finder_test.go
+++ b/server/events/pending_plan_finder_test.go
@@ -226,7 +226,8 @@ func TestPendingPlanFinder_FindPlanCheckedIn(t *testing.T) {
 	runCmd(t, repoDir, "git", "add", ".")
 	runCmd(t, repoDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
 	runCmd(t, repoDir, "git", "config", "--local", "user.name", "atlantisbot")
-	runCmd(t, repoDir, "git", "commit", "--no-gpg-sign", "-m", "initial commit")
+	runCmd(t, repoDir, "git", "config", "--local", "commit.gpgsign", "false")
+	runCmd(t, repoDir, "git", "commit", "-m", "initial commit")
 
 	pf := &events.DefaultPendingPlanFinder{}
 	actPlans, err := pf.Find(tmpDir)

--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -66,6 +66,8 @@ type FileWorkspace struct {
 	// from the "origin" remote. If this is false, we fetch "+refs/heads/$HEAD_BRANCH"
 	// from the "head" remote.
 	GithubAppEnabled bool
+	// use the global setting without overriding
+	GpgNoSigningEnabled bool
 }
 
 // Clone git clones headRepo, checks out the branch and then returns the absolute
@@ -240,16 +242,21 @@ func (w *FileWorkspace) forceClone(log logging.SimpleLogging,
 			{
 				"git", "fetch", fetchRemote, fetchRef,
 			},
-			// We use --no-ff because we always want there to be a merge commit.
-			// This way, our branch will look the same regardless if the merge
-			// could be fast forwarded. This is useful later when we run
-			// git rev-parse HEAD^2 to get the head commit because it will
-			// always succeed whereas without --no-ff, if the merge was fast
-			// forwarded then git rev-parse HEAD^2 would fail.
-			{
-				"git", "merge", "-q", "--no-ff", "-m", "atlantis-merge", "FETCH_HEAD",
-			},
 		}
+		if w.GpgNoSigningEnabled {
+			cmds = append(cmds, []string{
+				"git", "config", "--local", "commit.gpgsign", "false",
+			})
+		}
+		// We use --no-ff because we always want there to be a merge commit.
+		// This way, our branch will look the same regardless if the merge
+		// could be fast forwarded. This is useful later when we run
+		// git rev-parse HEAD^2 to get the head commit because it will
+		// always succeed whereas without --no-ff, if the merge was fast
+		// forwarded then git rev-parse HEAD^2 would fail.
+		cmds = append(cmds, []string{
+			"git", "merge", "-q", "--no-ff", "-m", "atlantis-merge", "FETCH_HEAD",
+		})
 	} else {
 		cmds = [][]string{
 			{

--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -39,6 +39,7 @@ func TestClone_NoneExisting(t *testing.T) {
 		DataDir:                     dataDir,
 		CheckoutMerge:               false,
 		TestingOverrideHeadCloneURL: fmt.Sprintf("file://%s", repoDir),
+		GpgNoSigningEnabled:         true,
 	}
 
 	cloneDir, _, err := wd.Clone(logging.NewNoopLogger(t), models.Repo{}, models.PullRequest{
@@ -89,6 +90,7 @@ func TestClone_CheckoutMergeNoneExisting(t *testing.T) {
 		CheckoutMerge:               true,
 		TestingOverrideHeadCloneURL: overrideURL,
 		TestingOverrideBaseCloneURL: overrideURL,
+		GpgNoSigningEnabled:         true,
 	}
 
 	cloneDir, hasDiverged, err := wd.Clone(logging.NewNoopLogger(t), models.Repo{}, models.PullRequest{
@@ -138,6 +140,7 @@ func TestClone_CheckoutMergeNoReclone(t *testing.T) {
 		CheckoutMerge:               true,
 		TestingOverrideHeadCloneURL: overrideURL,
 		TestingOverrideBaseCloneURL: overrideURL,
+		GpgNoSigningEnabled:         true,
 	}
 
 	_, hasDiverged, err := wd.Clone(logging.NewNoopLogger(t), models.Repo{}, models.PullRequest{
@@ -188,6 +191,7 @@ func TestClone_CheckoutMergeNoRecloneFastForward(t *testing.T) {
 		CheckoutMerge:               true,
 		TestingOverrideHeadCloneURL: overrideURL,
 		TestingOverrideBaseCloneURL: overrideURL,
+		GpgNoSigningEnabled:         true,
 	}
 
 	_, hasDiverged, err := wd.Clone(logging.NewNoopLogger(t), models.Repo{}, models.PullRequest{
@@ -243,6 +247,7 @@ func TestClone_CheckoutMergeConflict(t *testing.T) {
 		CheckoutMerge:               true,
 		TestingOverrideHeadCloneURL: overrideURL,
 		TestingOverrideBaseCloneURL: overrideURL,
+		GpgNoSigningEnabled:         true,
 	}
 
 	_, _, err := wd.Clone(logging.NewNoopLogger(t), models.Repo{}, models.PullRequest{
@@ -275,6 +280,7 @@ func TestClone_NoReclone(t *testing.T) {
 		DataDir:                     dataDir,
 		CheckoutMerge:               false,
 		TestingOverrideHeadCloneURL: fmt.Sprintf("file://%s", repoDir),
+		GpgNoSigningEnabled:         true,
 	}
 	cloneDir, hasDiverged, err := wd.Clone(logging.NewNoopLogger(t), models.Repo{}, models.PullRequest{
 		BaseRepo:   models.Repo{},
@@ -311,6 +317,7 @@ func TestClone_RecloneWrongCommit(t *testing.T) {
 		DataDir:                     dataDir,
 		CheckoutMerge:               false,
 		TestingOverrideHeadCloneURL: fmt.Sprintf("file://%s", repoDir),
+		GpgNoSigningEnabled:         true,
 	}
 	cloneDir, hasDiverged, err := wd.Clone(logging.NewNoopLogger(t), models.Repo{}, models.PullRequest{
 		BaseRepo:   models.Repo{},
@@ -346,6 +353,7 @@ func TestClone_MasterHasDiverged(t *testing.T) {
 	runCmd(t, firstPRDir, "git", "fetch", "head", "+refs/heads/first-pr")
 	runCmd(t, firstPRDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
 	runCmd(t, firstPRDir, "git", "config", "--local", "user.name", "atlantisbot")
+	runCmd(t, firstPRDir, "git", "config", "--local", "commit.gpgsign", "false")
 	runCmd(t, firstPRDir, "git", "merge", "-q", "--no-ff", "-m", "atlantis-merge", "FETCH_HEAD")
 
 	// Simulate second PR.
@@ -363,6 +371,7 @@ func TestClone_MasterHasDiverged(t *testing.T) {
 	runCmd(t, secondPRDir, "git", "fetch", "head", "+refs/heads/second-pr")
 	runCmd(t, secondPRDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
 	runCmd(t, secondPRDir, "git", "config", "--local", "user.name", "atlantisbot")
+	runCmd(t, secondPRDir, "git", "config", "--local", "commit.gpgsign", "false")
 	runCmd(t, secondPRDir, "git", "merge", "-q", "--no-ff", "-m", "atlantis-merge", "FETCH_HEAD")
 
 	// Merge first PR
@@ -375,8 +384,9 @@ func TestClone_MasterHasDiverged(t *testing.T) {
 
 	// Run the clone.
 	wd := &events.FileWorkspace{
-		DataDir:       repoDir,
-		CheckoutMerge: true,
+		DataDir:             repoDir,
+		CheckoutMerge:       true,
+		GpgNoSigningEnabled: true,
 	}
 	_, hasDiverged, err := wd.Clone(logging.NewNoopLogger(t), models.Repo{CloneURL: repoDir}, models.PullRequest{
 		BaseRepo:   models.Repo{CloneURL: repoDir},
@@ -417,6 +427,7 @@ func TestHasDiverged_MasterHasDiverged(t *testing.T) {
 	runCmd(t, firstPRDir, "git", "fetch", "head", "+refs/heads/first-pr")
 	runCmd(t, firstPRDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
 	runCmd(t, firstPRDir, "git", "config", "--local", "user.name", "atlantisbot")
+	runCmd(t, firstPRDir, "git", "config", "--local", "commit.gpgsign", "false")
 	runCmd(t, firstPRDir, "git", "merge", "-q", "--no-ff", "-m", "atlantis-merge", "FETCH_HEAD")
 
 	// Simulate second PR.
@@ -434,6 +445,7 @@ func TestHasDiverged_MasterHasDiverged(t *testing.T) {
 	runCmd(t, secondPRDir, "git", "fetch", "head", "+refs/heads/second-pr")
 	runCmd(t, secondPRDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
 	runCmd(t, secondPRDir, "git", "config", "--local", "user.name", "atlantisbot")
+	runCmd(t, secondPRDir, "git", "config", "--local", "commit.gpgsign", "false")
 	runCmd(t, secondPRDir, "git", "merge", "-q", "--no-ff", "-m", "atlantis-merge", "FETCH_HEAD")
 
 	// Merge first PR
@@ -449,8 +461,9 @@ func TestHasDiverged_MasterHasDiverged(t *testing.T) {
 
 	// Run the clone.
 	wd := &events.FileWorkspace{
-		DataDir:       repoDir,
-		CheckoutMerge: true,
+		DataDir:             repoDir,
+		CheckoutMerge:       true,
+		GpgNoSigningEnabled: true,
 	}
 	hasDiverged := wd.HasDiverged(logging.NewNoopLogger(t), repoDir+"/repos/0/default")
 	Equals(t, hasDiverged, true)
@@ -469,6 +482,7 @@ func initRepo(t *testing.T) (string, func()) {
 	runCmd(t, repoDir, "git", "add", ".gitkeep")
 	runCmd(t, repoDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
 	runCmd(t, repoDir, "git", "config", "--local", "user.name", "atlantisbot")
+	runCmd(t, repoDir, "git", "config", "--local", "commit.gpgsign", "false")
 	runCmd(t, repoDir, "git", "commit", "-m", "initial commit")
 	runCmd(t, repoDir, "git", "branch", "branch")
 	return repoDir, cleanup


### PR DESCRIPTION
## what

* Ignore gpg signing for tests

## why

* `make test` fails for me because I gpg sign all my commits by default
* It seems like this has been seen before because `TestPendingPlanFinder_FindPlanCheckedIn` contains `--no-gpg-sign` and others don't.
