### PR TITLE
docs: update streaming-logs

### DIFF
--- a/runatlantis.io/docs/streaming-logs.md
+++ b/runatlantis.io/docs/streaming-logs.md
@@ -2,9 +2,8 @@
 
 Atlantis supports streaming terraform logs in real time by default. Currently, only two commands are supported
 
-* terraform init
-* terraform plan
-* terraform apply
+* atlantis plan
+* atlantis apply
 
 ::: warning
 As of now, custom workflow outputs and other terraform commands are not supported


### PR DESCRIPTION
Hello, I was reading through these docs and this section seemed incorrect. I assume the 2 commands it supports are atlantis plan/apply and not the underlying 3 terraform commands. Let me know if I'm misinterpreting this. Thanks!