### PR TITLE
fix: Only highlight Terraform changes on GitHub

### DIFF
--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -2173,11 +2173,40 @@ Terraform will perform the following actions:
         id      = "redacted_redacted.redacted.redacted.io_A"
         name    = "redacted.redacted.redacted.io"
       ~ records = [
+            "foo",
           - "redacted",
         ] -> (known after apply)
         ttl     = 300
         type    = "A"
         zone_id = "redacted"
+    }
+
+# helm_release.external_dns[0] will be updated in-place
+~ resource "helm_release" "external_dns" {
+      id                         = "external-dns"
+      name                       = "external-dns"
+    ~ values                     = [
+        - <<-EOT
+            image:
+              tag: "0.12.0"
+              pullSecrets:
+              - XXXXX
+
+            domainFilters: ["xxxxx","xxxxx"]
+            base64:
+              +dGhpcyBpcyBzb21lIHN0cmluZyBvciBzb21ldGhpbmcKCg==
+          EOT,
+        + <<-EOT
+            image:
+              tag: "0.12.0"
+              pullSecrets:
+              - XXXXX
+
+            domainFilters: ["xxxxx","xxxxx"]
+            base64:
+              +dGhpcyBpcyBzb21lIHN0cmluZyBvciBzb21ldGhpbmcKCg==
+          EOT,
+      ]
     }
 
 Plan: 1 to add, 1 to change, 1 to destroy.
@@ -2308,11 +2337,40 @@ Terraform will perform the following actions:
         id      = "redacted_redacted.redacted.redacted.io_A"
         name    = "redacted.redacted.redacted.io"
 !       records = [
+            "foo",
 -           "redacted",
         ] -> (known after apply)
         ttl     = 300
         type    = "A"
         zone_id = "redacted"
+    }
+
+# helm_release.external_dns[0] will be updated in-place
+! resource "helm_release" "external_dns" {
+      id                         = "external-dns"
+      name                       = "external-dns"
+!     values                     = [
+-         <<-EOT
+            image:
+              tag: "0.12.0"
+              pullSecrets:
+              - XXXXX
+
+            domainFilters: ["xxxxx","xxxxx"]
+            base64:
+              +dGhpcyBpcyBzb21lIHN0cmluZyBvciBzb21ldGhpbmcKCg==
+          EOT,
++         <<-EOT
+            image:
+              tag: "0.12.0"
+              pullSecrets:
+              - XXXXX
+
+            domainFilters: ["xxxxx","xxxxx"]
+            base64:
+              +dGhpcyBpcyBzb21lIHN0cmluZyBvciBzb21ldGhpbmcKCg==
+          EOT,
+      ]
     }
 
 Plan: 1 to add, 1 to change, 1 to destroy.

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -363,10 +363,12 @@ func (p *PlanSuccess) Summary() string {
 
 // DiffMarkdownFormattedTerraformOutput formats the Terraform output to match diff markdown format
 func (p PlanSuccess) DiffMarkdownFormattedTerraformOutput() string {
-	diffKeywordRegex := regexp.MustCompile(`(?m)^( +)([-+~])`)
+	diffKeywordRegex := regexp.MustCompile(`(?m)^( +)([-+~]\s)(.*)(\s->\s|<<|\{|\(known after apply\)|\[)(.*)`)
+	diffListRegex := regexp.MustCompile(`(?m)^( +)([-+~]\s)(".*",)`)
 	diffTildeRegex := regexp.MustCompile(`(?m)^~`)
 
-	formattedTerraformOutput := diffKeywordRegex.ReplaceAllString(p.TerraformOutput, "$2$1")
+	formattedTerraformOutput := diffKeywordRegex.ReplaceAllString(p.TerraformOutput, "$2$1$3$4$5")
+	formattedTerraformOutput = diffListRegex.ReplaceAllString(formattedTerraformOutput, "$2$1$3")
 	formattedTerraformOutput = diffTildeRegex.ReplaceAllString(formattedTerraformOutput, "!")
 
 	return formattedTerraformOutput


### PR DESCRIPTION
The lazy regex for converting Terraform diffs to GitHub diffs would also mark YAML and other plain text that happen to start with `-`, `+`, or `~`. This is a bit more selective, scanning for obvious Terraform changes that contain `->`, `<<` for heredocs, `{` for modules/resources/blocks, `known after apply`, and `[` for lists. It will also do a second pass to attempt to capture changes to lists too.

Closes #2241 