### PR TITLE
Update terragrunt workflow documentation

### DIFF
--- a/runatlantis.io/docs/custom-workflows.md
+++ b/runatlantis.io/docs/custom-workflows.md
@@ -176,14 +176,14 @@ workflows:
       - env:
           name: TERRAGRUNT_TFPATH
           command: 'echo "terraform${ATLANTIS_TERRAFORM_VERSION}"'
-      - run: terragrunt plan -out=$PLANFILE
+      - run: terragrunt plan -input=false -out=$PLANFILE
       - run: terragrunt show -json $PLANFILE > $SHOWFILE
     apply:
       steps:
       - env:
           name: TERRAGRUNT_TFPATH
           command: 'echo "terraform${ATLANTIS_TERRAFORM_VERSION}"'
-      - run: terragrunt apply $PLANFILE
+      - run: terragrunt apply -input=false $PLANFILE
 ```
 
 If using the repo's `atlantis.yaml` file you would use the following config:


### PR DESCRIPTION
With #2261, we now open a stdin pipe like the built-in terraform client
does. Doing so apparently caused some user's `plan`s to hang when they
had variables requiring inputs, since `terraform` saw that stdin was
open and prompted for a value.

https://github.com/runatlantis/atlantis/pull/2261#issuecomment-1170513957
https://github.com/runatlantis/atlantis/pull/2261#issuecomment-1170513957
https://github.com/runatlantis/atlantis/pull/2261#issuecomment-1170552929