### PR TITLE
fix: Update multienv_step_runner Env Var Parsing Logic (#2351)

### DIFF
--- a/server/core/runtime/multienv_step_runner.go
+++ b/server/core/runtime/multienv_step_runner.go
@@ -22,7 +22,7 @@ func (r *MultiEnvStepRunner) Run(ctx command.ProjectContext, command string, pat
 			var sb strings.Builder
 			sb.WriteString("Dynamic environment variables added:\n")
 			for _, item := range envVars {
-				nameValue := strings.Split(item, "=")
+				nameValue := strings.SplitN(item, "=", 2)
 				if len(nameValue) == 2 {
 					envs[nameValue[0]] = nameValue[1]
 					sb.WriteString(nameValue[0])

--- a/server/core/runtime/multienv_step_runner_test.go
+++ b/server/core/runtime/multienv_step_runner_test.go
@@ -27,6 +27,16 @@ func TestMultiEnvStepRunner_Run(t *testing.T) {
 			ExpOut:  "Dynamic environment variables added:\nTF_VAR_REPODEFINEDVARIABLE_ONE\n",
 			Version: "v1.2.3",
 		},
+		{
+			Command: `echo 'TF_VAR_REPODEFINEDVARIABLE_TWO=value=1='`,
+			ExpOut:  "Dynamic environment variables added:\nTF_VAR_REPODEFINEDVARIABLE_TWO\n",
+			Version: "v1.2.3",
+		},
+		{
+			Command: `echo 'TF_VAR_REPODEFINEDVARIABLE_NO_VALUE'`,
+			ExpErr: "Invalid environment variable definition: TF_VAR_REPODEFINEDVARIABLE_NO_VALUE",
+			Version: "v1.2.3",
+		},
 	}
 	RegisterMockTestingT(t)
 	tfClient := mocks.NewMockClient()

--- a/server/core/runtime/multienv_step_runner_test.go
+++ b/server/core/runtime/multienv_step_runner_test.go
@@ -34,7 +34,7 @@ func TestMultiEnvStepRunner_Run(t *testing.T) {
 		},
 		{
 			Command: `echo 'TF_VAR_REPODEFINEDVARIABLE_NO_VALUE'`,
-			ExpErr: "Invalid environment variable definition: TF_VAR_REPODEFINEDVARIABLE_NO_VALUE",
+			ExpErr:  "Invalid environment variable definition: TF_VAR_REPODEFINEDVARIABLE_NO_VALUE",
 			Version: "v1.2.3",
 		},
 	}


### PR DESCRIPTION
Fixes #2351.

* Update multienv_step_runner.go to split only on the first = character
* Add affirmative and failing test cases