### PR TITLE
Add Azure CLI version 2.37.0 to Atlantis Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,14 @@ RUN AVAILABLE_CONFTEST_VERSIONS="${DEFAULT_CONFTEST_VERSION}" && \
 
 RUN ln -s /usr/local/bin/cft/versions/${DEFAULT_CONFTEST_VERSION}/conftest /usr/local/bin/conftest
 
+# install Azure CLI
+ENV DEFAULT_AZURE_CLI_VERSION=2.37.0
+
+RUN apk add --no-cache py3-pip && \
+    apk add --no-cache --virtual .azure-cli-deps gcc musl-dev python3-dev libffi-dev openssl-dev cargo make && \
+    pip install --no-cache-dir azure-cli==${DEFAULT_AZURE_CLI_VERSION} && \
+    apk del .azure-cli-deps
+
 # copy binary
 COPY --from=builder /app/atlantis /usr/local/bin/atlantis
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,10 +60,15 @@ RUN ln -s /usr/local/bin/cft/versions/${DEFAULT_CONFTEST_VERSION}/conftest /usr/
 # install Azure CLI
 ENV DEFAULT_AZURE_CLI_VERSION=2.37.0
 
-RUN apk add --no-cache py3-pip && \
-    apk add --no-cache --virtual .azure-cli-deps gcc musl-dev python3-dev libffi-dev openssl-dev cargo make && \
-    pip install --no-cache-dir azure-cli==${DEFAULT_AZURE_CLI_VERSION} && \
-    apk del .azure-cli-deps
+# Only supported for linux/amd64
+RUN if [ "${TARGETPLATFORM}" == "linux/amd64" ]; \
+    then \
+      apk add --no-cache py3-pip && \
+      pip install --upgrade --no-cache pip && \
+      apk add --no-cache --virtual .azure-cli-deps gcc musl-dev python3-dev libffi-dev openssl-dev cargo make && \
+      pip install --no-cache-dir azure-cli==${DEFAULT_AZURE_CLI_VERSION} && \
+      apk del .azure-cli-deps; \
+    fi
 
 # copy binary
 COPY --from=builder /app/atlantis /usr/local/bin/atlantis


### PR DESCRIPTION
Fixes #1082
Add the Azure CLI to the Atlantis Docker image to allow creation of Azure resources.
