### PR TITLE
workflows: build image in parallel

### DIFF
--- a/.github/workflows/atlantis-base.yml
+++ b/.github/workflows/atlantis-base.yml
@@ -18,8 +18,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  docker:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - linux/arm64/v8
+          - linux/amd64
+          - linux/arm/v7
     steps:
     - uses: actions/checkout@v3
 
@@ -44,7 +50,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: docker-base
-        platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
+        platforms: ${{ matrix.platform }}
         push: true
         tags: |
           ghcr.io/${{ github.repository_owner }}/atlantis-base:${{env.TODAY}}

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -16,6 +16,13 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - linux/arm64/v8
+          - linux/amd64
+          - linux/arm/v7
+        
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
@@ -44,7 +51,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: .
-        platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
+        platforms: ${{ matrix.platform }}
         push: true
         tags: |
           ghcr.io/${{ github.repository_owner }}/atlantis:dev
@@ -59,7 +66,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: .
-        platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
+        platforms: ${{ matrix.platform }}
         push: true
         tags: |
           ghcr.io/${{ github.repository_owner }}/atlantis:${{ env.RELEASE_VERSION }}
@@ -70,7 +77,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: .
-        platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
+        platforms: ${{ matrix.platform }}
         push: true
         tags: |
           ghcr.io/${{ github.repository_owner }}/atlantis:${{ env.RELEASE_VERSION }}

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -22,7 +22,6 @@ jobs:
           - linux/arm64/v8
           - linux/amd64
           - linux/arm/v7
-        
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3

--- a/.github/workflows/testing-env-image.yml
+++ b/.github/workflows/testing-env-image.yml
@@ -16,6 +16,12 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - linux/arm64/v8
+          - linux/amd64
+          - linux/arm/v7
     steps:
     - uses: actions/checkout@v3
 
@@ -40,7 +46,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: testing
-        platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
+        platforms: ${{ matrix.platform }}
         push: true
         tags: |
            ghcr.io/runatlantis/testing-env:${{env.TODAY}}


### PR DESCRIPTION
Change the build job for the docker image to use the matrix jobs feature, speeding up the image creation.

https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs

