### PR TITLE
Add --var-file-allowlist in server configuration

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -101,6 +101,7 @@ const (
 	SSLCertFileFlag            = "ssl-cert-file"
 	SSLKeyFileFlag             = "ssl-key-file"
 	TFDownloadURLFlag          = "tf-download-url"
+	VarFileAllowlistFlag       = "var-file-allowlist"
 	VCSStatusName              = "vcs-status-name"
 	TFEHostnameFlag            = "tfe-hostname"
 	TFETokenFlag               = "tfe-token"
@@ -306,6 +307,10 @@ var stringFlags = map[string]stringFlag{
 	DefaultTFVersionFlag: {
 		description: "Terraform version to default to (ex. v0.12.0). Will download if not yet on disk." +
 			" If not set, Atlantis uses the terraform binary in its PATH.",
+	},
+	VarFileAllowlistFlag: {
+		description: "Comma-separated list of additional paths where variable definition files can be read from." +
+			" If this argument is not provided, it defaults to Atlantis' data directory, determined by the --data-dir argument.",
 	},
 	VCSStatusName: {
 		description:  "Name used to identify Atlantis for pull request statuses.",
@@ -609,6 +614,7 @@ func (s *ServerCmd) run() error {
 	if err := s.setDataDir(&userConfig); err != nil {
 		return err
 	}
+	s.setVarFileAllowlist(&userConfig)
 	if err := s.deprecationWarnings(&userConfig); err != nil {
 		return err
 	}
@@ -812,6 +818,14 @@ func (s *ServerCmd) setDataDir(userConfig *server.UserConfig) error {
 	}
 	userConfig.DataDir = finalPath
 	return nil
+}
+
+// setVarFileAllowlist checks if var-file-allowlist is unassigned and makes it default to data-dir for better backward
+// compatibility.
+func (s *ServerCmd) setVarFileAllowlist(userConfig *server.UserConfig) {
+	if userConfig.VarFileAllowlist == "" {
+		userConfig.VarFileAllowlist = userConfig.DataDir
+	}
 }
 
 // trimAtSymbolFromUsers trims @ from the front of the github and gitlab usernames

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -131,11 +131,12 @@ func TestExecute_Defaults(t *testing.T) {
 	Ok(t, err)
 
 	strExceptions := map[string]string{
-		GHUserFlag:        "user",
-		GHTokenFlag:       "token",
-		DataDirFlag:       dataDir,
-		AtlantisURLFlag:   "http://" + hostname + ":4141",
-		RepoAllowlistFlag: "*",
+		GHUserFlag:           "user",
+		GHTokenFlag:          "token",
+		DataDirFlag:          dataDir,
+		AtlantisURLFlag:      "http://" + hostname + ":4141",
+		RepoAllowlistFlag:    "*",
+		VarFileAllowlistFlag: dataDir,
 	}
 	strIgnore := map[string]bool{
 		"config": true,

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -634,6 +634,14 @@ Values are chosen in this order:
   ```
   A token for Terraform Cloud/Terraform Enterprise integration. See [Terraform Cloud](terraform-cloud.html) for more details.
 
+* ### `--var-file-allowlist`
+  ```bash
+  atlantis server --var-file-allowlist='/path/to/tfvars/dir'
+  ```
+  Comma-separated list of additional directory paths where [variable definition files](https://www.terraform.io/language/values/variables#variable-definitions-tfvars-files) can be read from.
+  The paths in this argument should be absolute paths. Relative paths and globbing are currently not supported.
+  If this argument is not provided, it defaults to Atlantis' data directory, determined by the `--data-dir` argument.
+
 * ### `--vcs-status-name`
   ```bash
   atlantis server --vcs-status-name="atlantis-dev"

--- a/server/events/var_file_allowlist_checker.go
+++ b/server/events/var_file_allowlist_checker.go
@@ -1,0 +1,76 @@
+package events
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"path/filepath"
+	"strings"
+)
+
+// VarFileAllowlistChecker implements checking if paths are allowlisted to be used with
+// this Atlantis.
+type VarFileAllowlistChecker struct {
+	rules []string
+}
+
+// NewVarFileAllowlistChecker constructs a new checker and validates that the
+// allowlist isn't malformed.
+func NewVarFileAllowlistChecker(allowlist string) (*VarFileAllowlistChecker, error) {
+	var rules []string
+	paths := strings.Split(allowlist, ",")
+	if paths[0] != "" {
+		for _, path := range paths {
+			absPath, err := filepath.Abs(path)
+			if err != nil {
+				return nil, errors.Wrap(err, fmt.Sprintf("converting allowlist %q to absolute path", path))
+			}
+			rules = append(rules, absPath)
+		}
+	}
+	return &VarFileAllowlistChecker{
+		rules: rules,
+	}, nil
+}
+
+func (p *VarFileAllowlistChecker) Check(flags []string) error {
+	for i, flag := range flags {
+		var path string
+		if i < len(flags)-1 && flag == "-var-file" {
+			// Flags are in the format of []{"-var-file", "my-file.tfvars"}
+			path = flags[i+1]
+		} else {
+			flagSplit := strings.Split(flag, "=")
+			// Flags are in the format of []{"-var-file=my-file.tfvars"}
+			if len(flagSplit) == 2 && flagSplit[0] == "-var-file" {
+				path = flagSplit[1]
+			}
+		}
+
+		if path != "" && !p.isAllowedPath(path) {
+			return fmt.Errorf("var file path %s is not allowed by the current allowlist: [%s]",
+				path, strings.Join(p.rules, ", "))
+		}
+	}
+	return nil
+}
+
+func (p *VarFileAllowlistChecker) isAllowedPath(path string) bool {
+	path = filepath.Clean(path)
+
+	// If the path is within the repo directory, return true without checking the rules.
+	if !filepath.IsAbs(path) {
+		if !strings.HasPrefix(path, "..") && !strings.HasPrefix(path, "~") {
+			return true
+		}
+	}
+
+	// Check the path against the rules.
+	for _, rule := range p.rules {
+		rel, err := filepath.Rel(rule, path)
+		if err == nil && !strings.HasPrefix(rel, "..") {
+			return true
+		}
+	}
+
+	return false
+}

--- a/server/events/var_file_allowlist_checker_test.go
+++ b/server/events/var_file_allowlist_checker_test.go
@@ -1,0 +1,128 @@
+package events_test
+
+import (
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/events"
+	. "github.com/runatlantis/atlantis/testing"
+)
+
+func TestVarFileAllowlistChecker_IsAllowlisted(t *testing.T) {
+	cases := []struct {
+		Description string
+		Allowlist   string
+		Flags       []string
+		ExpErr      string
+	}{
+		{
+			"Empty Allowlist, no var file",
+			"",
+			[]string{""},
+			"",
+		},
+		{
+			"Empty Allowlist, single var file under the repo directory",
+			"",
+			[]string{"-var-file=test.tfvars"},
+			"",
+		},
+		{
+			"Empty Allowlist, single var file under the repo directory, specified in separate flags",
+			"",
+			[]string{"-var-file", "test.tfvars"},
+			"",
+		},
+		{
+			"Empty Allowlist, single var file under the subdirectory of the repo directory",
+			"",
+			[]string{"-var-file=sub/test.tfvars"},
+			"",
+		},
+		{
+			"Empty Allowlist, single var file outside the repo directory",
+			"",
+			[]string{"-var-file=/path/to/file"},
+			"var file path /path/to/file is not allowed by the current allowlist: []",
+		},
+		{
+			"Empty Allowlist, single var file under the parent directory of the repo directory",
+			"",
+			[]string{"-var-file=../test.tfvars"},
+			"var file path ../test.tfvars is not allowed by the current allowlist: []",
+		},
+		{
+			"Empty Allowlist, single var file under the home directory",
+			"",
+			[]string{"-var-file=~/test.tfvars"},
+			"var file path ~/test.tfvars is not allowed by the current allowlist: []",
+		},
+		{
+			"Single path in allowlist, no var file",
+			"/path",
+			[]string{""},
+			"",
+		},
+		{
+			"Single path in allowlist, single var file under the repo directory",
+			"/path",
+			[]string{"-var-file=test.tfvars"},
+			"",
+		},
+		{
+			"Single path in allowlist, single var file under the allowlisted directory",
+			"/path",
+			[]string{"-var-file=/path/test.tfvars"},
+			"",
+		},
+		{
+			"Single path with ending slash in allowlist, single var file under the allowlisted directory",
+			"/path/",
+			[]string{"-var-file=/path/test.tfvars"},
+			"",
+		},
+		{
+			"Single path in allowlist, single var file in the parent directory of the repo directory",
+			"/path",
+			[]string{"-var-file=../test.tfvars"},
+			"var file path ../test.tfvars is not allowed by the current allowlist: [/path]",
+		},
+		{
+			"Single path in allowlist, single var file outside the allowlisted directory",
+			"/path",
+			[]string{"-var-file=/path_not_allowed/test.tfvars"},
+			"var file path /path_not_allowed/test.tfvars is not allowed by the current allowlist: [/path]",
+		},
+		{
+			"Single path in allowlist, single var file in the parent directory of the allowlisted directory",
+			"/path",
+			[]string{"-var-file=/test.tfvars"},
+			"var file path /test.tfvars is not allowed by the current allowlist: [/path]",
+		},
+		{
+			"Root path in allowlist, with multiple var files",
+			"/",
+			[]string{"-var-file=test.tfvars", "-var-file=/path/test.tfvars", "-var-file=/test.tfvars"},
+			"",
+		},
+		{
+			"Multiple paths in allowlist, with multiple var files under allowlisted directories",
+			"/path,/another/path",
+			[]string{"-var-file=test.tfvars", "-var-file", "/path/test.tfvars", "unused-flag", "-var-file=/another/path/sub/test.tfvars"},
+			"",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Description, func(t *testing.T) {
+			v, err := events.NewVarFileAllowlistChecker(c.Allowlist)
+			Ok(t, err)
+
+			err = v.Check(c.Flags)
+			if c.ExpErr != "" {
+				ErrEquals(t, c.ExpErr, err)
+			} else {
+				Ok(t, err)
+			}
+		})
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -673,6 +673,10 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
+	varFileAllowlistChecker, err := events.NewVarFileAllowlistChecker(userConfig.VarFileAllowlist)
+	if err != nil {
+		return nil, err
+	}
 
 	commandRunner := &events.DefaultCommandRunner{
 		VCSClient:                      vcsClient,
@@ -694,6 +698,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		PostWorkflowHooksCommandRunner: postWorkflowHooksCommandRunner,
 		PullStatusFetcher:              boltdb,
 		TeamAllowlistChecker:           githubTeamAllowlistChecker,
+		VarFileAllowlistChecker:        varFileAllowlistChecker,
 	}
 	repoAllowlist, err := events.NewRepoAllowlistChecker(userConfig.RepoAllowlist)
 	if err != nil {

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -86,6 +86,7 @@ type UserConfig struct {
 	TFDownloadURL          string          `mapstructure:"tf-download-url"`
 	TFEHostname            string          `mapstructure:"tfe-hostname"`
 	TFEToken               string          `mapstructure:"tfe-token"`
+	VarFileAllowlist       string          `mapstructure:"var-file-allowlist"`
 	VCSStatusName          string          `mapstructure:"vcs-status-name"`
 	DefaultTFVersion       string          `mapstructure:"default-tf-version"`
 	Webhooks               []WebhookConfig `mapstructure:"webhooks"`


### PR DESCRIPTION
Add a new argument `--var-file-allowlist` in server configuration to limit the access of variable definitions files on Atlantis server. Previously, we don't have such check so users can access arbitrary files that the Atlantis process has access to, with PR comments like `atlantis plan -- -var-file=/path/to/file`.

The default value of this argument is currently set to `--data-dir`. This could be a breaking change since users who used to access files on Atlantis server outside of that directory need to pass in additional paths when running Atlantis. For users who only accessed files in repo directories, the behavior remains unchanged since files in the repo directory are still accessible as before.