### PR TITLE
fix: Log streaming broken with TFE local execution mode

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -103,6 +103,7 @@ const (
 	TFDownloadURLFlag          = "tf-download-url"
 	VCSStatusName              = "vcs-status-name"
 	TFEHostnameFlag            = "tfe-hostname"
+	TFELocalExecutionModeFlag  = "tfe-local-execution-mode"
 	TFETokenFlag               = "tfe-token"
 	WriteGitCredsFlag          = "write-git-creds"
 	WebBasicAuthFlag           = "web-basic-auth"
@@ -415,6 +416,10 @@ var boolFlags = map[string]boolFlag{
 	},
 	SkipCloneNoChanges: {
 		description:  "Skips cloning the PR repo if there are no projects were changed in the PR.",
+		defaultValue: false,
+	},
+	TFELocalExecutionModeFlag: {
+		description:  "Enable if you're using local execution mode (instead of TFE/C's remote execution mode).",
 		defaultValue: false,
 	},
 	WebBasicAuthFlag: {

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -102,6 +102,7 @@ var testFlags = map[string]interface{}{
 	SSLKeyFileFlag:             "key-file",
 	TFDownloadURLFlag:          "https://my-hostname.com",
 	TFEHostnameFlag:            "my-hostname",
+	TFELocalExecutionModeFlag:  true,
 	TFETokenFlag:               "my-token",
 	VCSStatusName:              "my-status",
 	WriteGitCredsFlag:          true,

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -626,6 +626,12 @@ Values are chosen in this order:
   If using Terraform Cloud (i.e. you don't have your own Terraform Enterprise installation)
   no need to set since it defaults to `app.terraform.io`.
 
+* ### `--tfe-local-execution-mode`
+  ```bash
+  atlantis server --tfe-local-execution-mode
+  ```
+  Enable if you're using local execution mode (instead of TFE/C's remote execution mode). See [Terraform Cloud](terraform-cloud.html) for more details.
+
 * ### `--tfe-token`
   ```bash
   atlantis server --tfe-token="xxx.atlasv1.yyy"

--- a/runatlantis.io/docs/terraform-cloud.md
+++ b/runatlantis.io/docs/terraform-cloud.md
@@ -74,6 +74,10 @@ That's it! Atlantis should be able to perform Terraform operations using Terrafo
 remote state backend now.
 
 :::warning
+If you're using local execution mode for your workspaces, remember to set the
+`--tfe-local-execution-mode`. Otherwise you won't see the logs in Atlantis.
+
+:::warning
 The Terraform Cloud/Enterprise integration only works with the built-in
 `plan` and `apply` steps. It does not work with custom `run` steps that replace
 plan or apply.

--- a/server/server.go
+++ b/server/server.go
@@ -351,9 +351,9 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	}
 
 	var projectCmdOutputHandler jobs.ProjectCommandOutputHandler
-	// When TFE is enabled log streaming is not necessary.
 
-	if userConfig.TFEToken != "" {
+	if userConfig.TFEToken != "" && !userConfig.TFELocalExecutionMode {
+		// When TFE is enabled and using remote execution mode log streaming is not necessary.
 		projectCmdOutputHandler = &jobs.NoopProjectOutputHandler{}
 	} else {
 		projectCmdOutput := make(chan *jobs.ProjectCmdOutputLine)

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -85,6 +85,7 @@ type UserConfig struct {
 	SSLKeyFile             string          `mapstructure:"ssl-key-file"`
 	TFDownloadURL          string          `mapstructure:"tf-download-url"`
 	TFEHostname            string          `mapstructure:"tfe-hostname"`
+	TFELocalExecutionMode  bool            `mapstructure:"tfe-local-execution-mode"`
 	TFEToken               string          `mapstructure:"tfe-token"`
 	VCSStatusName          string          `mapstructure:"vcs-status-name"`
 	DefaultTFVersion       string          `mapstructure:"default-tf-version"`


### PR DESCRIPTION
When using TFE just for storing states and not for remote execution mode, seeing the streaming plan logs in Atlantis is currently broken.

It's is due to when setting `--tfe-token` (or `ATLANTIS_TFE_TOKEN` env) then the `NoopProjectOutputHandler` is used instead of `NewAsyncProjectCommandOutputHandler`.

This PR implements a new option `--tfe-local-execution-mode` so Atlantis will keep using the `NewAsyncProjectCommandOutputHandler`.

This PR might be the fix for #2111 and #2129 