### PR TITLE
fix(docker-compose): update docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 !go.mod
 !go.sum
 !docker-entrypoint.sh
+!atlantis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
         ports:
         - 4040:4040
         environment:
+            # https://dashboard.ngrok.com/get-started/your-authtoken
+            NGROK_AUTH: REPLACE-WITH-YOUR-TOKEN
             NGROK_PROTOCOL: http
             NGROK_PORT: atlantis:4141
         depends_on:


### PR DESCRIPTION
This PR solves two issues.

1) Currently you need to pass a `NGROK_AUTH` to ngrok, otherwise you'll get following error when trying to use the connection:
![image](https://user-images.githubusercontent.com/461165/177423791-f2ef157f-33b0-469d-af50-d79673dca062.png)

2) `atlantis` executable must not be ignored by `.dockerignore` otherwise `docker-compose up` and `docker build -f Dockerfile.dev .` fails with:
```
[+] Building 1.0s (6/7)
 => [internal] load build definition from Dockerfile.dev 0.0s
 => => transferring dockerfile: 36B 0.0s
 => [internal] load .dockerignore 0.0s
 => => transferring context: 116B 0.0s
 => [internal] load metadata for ghcr.io/runatlantis/atlantis:latest 0.8s
 => [internal] load build context 0.0s
 => => transferring context: 2B 0.0s
 => [1/3] FROM ghcr.io/runatlantis/atlantis:latest@sha256:3765101d3ee2b9db27f140a4766222b400f63d3cb4659d64394bcc6a2eedcec7 0.0s
 => ERROR [2/3] COPY atlantis /usr/local/bin/atlantis 0.0s
------
 > [2/3] COPY atlantis /usr/local/bin/atlantis:
------
failed to solve: failed to compute cache key: "/atlantis" not found: not found
```