### PR TITLE
Add section for --var-file-allowlist in security doc

### DIFF
--- a/runatlantis.io/docs/security.md
+++ b/runatlantis.io/docs/security.md
@@ -63,6 +63,13 @@ To prevent this, you could:
    use of disallowed providers or data sources or PRs from not allowed users. You could also add in extra validation at this point, e.g.
    requiring a "thumbs-up" on the PR before allowing the `plan` to continue. Conftest could be of use here.
 
+### `--var-file-allowlist`
+The files on your Atlantis install may be accessible as [variable definition files](https://www.terraform.io/language/values/variables#variable-definitions-tfvars-files)
+from pull requests by adding  
+`atlantis plan -- -var-file=/path/to/file` comments. To mitigate this security risk, Atlantis has limited such access
+only to the files allowlisted by the `--var-file-allowlist` flag. If this argument is not provided, it defaults to
+Atlantis' data directory.
+
 ### Webhook Secrets
 Atlantis should be run with Webhook secrets set via the `$ATLANTIS_GH_WEBHOOK_SECRET`/`$ATLANTIS_GITLAB_WEBHOOK_SECRET` environment variables.
 Even with the `--repo-allowlist` flag set, without a webhook secret, attackers could make requests to Atlantis posing as a repository that is allowlisted.


### PR DESCRIPTION
Add section in security doc as a follow-up of https://github.com/runatlantis/atlantis/pull/2362. 