### PR TITLE
Revert "workflows: build image in parallel"

### DIFF
--- a/.github/workflows/atlantis-base.yml
+++ b/.github/workflows/atlantis-base.yml
@@ -18,14 +18,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  docker:
+  build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform:
-          - linux/arm64/v8
-          - linux/amd64
-          - linux/arm/v7
     steps:
     - uses: actions/checkout@v3
 
@@ -50,7 +44,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: docker-base
-        platforms: ${{ matrix.platform }}
+        platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
         push: true
         tags: |
           ghcr.io/${{ github.repository_owner }}/atlantis-base:${{env.TODAY}}

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -16,12 +16,6 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform:
-          - linux/arm64/v8
-          - linux/amd64
-          - linux/arm/v7
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
@@ -50,7 +44,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: .
-        platforms: ${{ matrix.platform }}
+        platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
         push: true
         tags: |
           ghcr.io/${{ github.repository_owner }}/atlantis:dev
@@ -65,7 +59,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: .
-        platforms: ${{ matrix.platform }}
+        platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
         push: true
         tags: |
           ghcr.io/${{ github.repository_owner }}/atlantis:${{ env.RELEASE_VERSION }}
@@ -76,7 +70,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: .
-        platforms: ${{ matrix.platform }}
+        platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
         push: true
         tags: |
           ghcr.io/${{ github.repository_owner }}/atlantis:${{ env.RELEASE_VERSION }}

--- a/.github/workflows/testing-env-image.yml
+++ b/.github/workflows/testing-env-image.yml
@@ -16,12 +16,6 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform:
-          - linux/arm64/v8
-          - linux/amd64
-          - linux/arm/v7
     steps:
     - uses: actions/checkout@v3
 
@@ -46,7 +40,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: testing
-        platforms: ${{ matrix.platform }}
+        platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
         push: true
         tags: |
            ghcr.io/runatlantis/testing-env:${{env.TODAY}}


### PR DESCRIPTION
Reverts runatlantis/atlantis#2361

fixes #2371 
<img width="821" alt="Screen Shot 2022-07-08 at 12 07 10 PM" src="https://user-images.githubusercontent.com/1580956/178029694-3a4905d7-9b8d-4010-8084-370ea6c1cdff.png">
<img width="796" alt="Screen Shot 2022-07-08 at 12 07 22 PM" src="https://user-images.githubusercontent.com/1580956/178029704-b8cb7734-6448-4a4f-b624-3c6a2c4cdb49.png">

