### PR TITLE
Add permission to allow GET `required_status_checks`, linked to #2310

### DIFF
--- a/server/controllers/github_app_controller.go
+++ b/server/controllers/github_app_controller.go
@@ -119,6 +119,7 @@ func (g *GithubAppController) New(w http.ResponseWriter, r *http.Request) {
 			"pull_requests":    "write",
 			"repository_hooks": "write",
 			"statuses":         "write",
+			"administration":   "read",
 		},
 	}
 


### PR DESCRIPTION
As described over the issue #2310 it seems like the permission required to check `required_status_checks` endpoint is allowed under the scope of `administration` > `branches`, check [github docs: permissions-required-for-github-apps#permission-on-administration](https://docs.github.com/en/rest/overview/permissions-required-for-github-apps#permission-on-administration).
```
[GET /repos/:owner/:repo/branches/:branch/protection/required_status_checks](https://docs.github.com/en/rest/reference/branches#get-status-checks-protection) (:read)
```

This pull-request adds the required extra permission to `read` under `administration` to check the desired endpoint.