### PR TITLE
Removing the check about whether a slack channel exists

### DIFF
--- a/server/events/webhooks/mocks/mock_slack_client.go
+++ b/server/events/webhooks/mocks/mock_slack_client.go
@@ -56,25 +56,6 @@ func (mock *MockSlackClient) TokenIsSet() bool {
 	return ret0
 }
 
-func (mock *MockSlackClient) ChannelExists(channelName string) (bool, error) {
-	if mock == nil {
-		panic("mock must not be nil. Use myMock := NewMockSlackClient().")
-	}
-	params := []pegomock.Param{channelName}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("ChannelExists", params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 bool
-	var ret1 error
-	if len(result) != 0 {
-		if result[0] != nil {
-			ret0 = result[0].(bool)
-		}
-		if result[1] != nil {
-			ret1 = result[1].(error)
-		}
-	}
-	return ret0, ret1
-}
-
 func (mock *MockSlackClient) PostMessage(channel string, applyResult webhooks.ApplyResult) error {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockSlackClient().")
@@ -161,32 +142,7 @@ func (c *MockSlackClient_TokenIsSet_OngoingVerification) GetCapturedArguments() 
 func (c *MockSlackClient_TokenIsSet_OngoingVerification) GetAllCapturedArguments() {
 }
 
-func (verifier *VerifierMockSlackClient) ChannelExists(channelName string) *MockSlackClient_ChannelExists_OngoingVerification {
-	params := []pegomock.Param{channelName}
-	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "ChannelExists", params, verifier.timeout)
-	return &MockSlackClient_ChannelExists_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
-}
 
-type MockSlackClient_ChannelExists_OngoingVerification struct {
-	mock              *MockSlackClient
-	methodInvocations []pegomock.MethodInvocation
-}
-
-func (c *MockSlackClient_ChannelExists_OngoingVerification) GetCapturedArguments() string {
-	channelName := c.GetAllCapturedArguments()
-	return channelName[len(channelName)-1]
-}
-
-func (c *MockSlackClient_ChannelExists_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
-	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
-	if len(params) > 0 {
-		_param0 = make([]string, len(c.methodInvocations))
-		for u, param := range params[0] {
-			_param0[u] = param.(string)
-		}
-	}
-	return
-}
 
 func (verifier *VerifierMockSlackClient) PostMessage(channel string, applyResult webhooks.ApplyResult) *MockSlackClient_PostMessage_OngoingVerification {
 	params := []pegomock.Param{channel, applyResult}

--- a/server/events/webhooks/slack.go
+++ b/server/events/webhooks/slack.go
@@ -18,7 +18,6 @@ import (
 
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/logging"
 )
 
@@ -32,14 +31,6 @@ type SlackWebhook struct {
 func NewSlack(r *regexp.Regexp, channel string, client SlackClient) (*SlackWebhook, error) {
 	if err := client.AuthTest(); err != nil {
 		return nil, fmt.Errorf("testing slack authentication: %s. Verify your slack-token is valid", err)
-	}
-
-	channelExists, err := client.ChannelExists(channel)
-	if err != nil {
-		return nil, err
-	}
-	if !channelExists {
-		return nil, errors.Errorf("slack channel %q doesn't exist", channel)
 	}
 
 	return &SlackWebhook{

--- a/server/events/webhooks/slack_client.go
+++ b/server/events/webhooks/slack_client.go
@@ -30,7 +30,6 @@ const (
 type SlackClient interface {
 	AuthTest() error
 	TokenIsSet() bool
-	ChannelExists(channelName string) (bool, error)
 	PostMessage(channel string, applyResult ApplyResult) error
 }
 
@@ -63,31 +62,6 @@ func (d *DefaultSlackClient) AuthTest() error {
 
 func (d *DefaultSlackClient) TokenIsSet() bool {
 	return d.Token != ""
-}
-
-func (d *DefaultSlackClient) ChannelExists(channelName string) (bool, error) {
-	var (
-		cursor   string
-		channels []slack.Channel
-		err      error
-	)
-
-	for {
-		channels, cursor, err = d.Slack.GetConversations(&slack.GetConversationsParameters{Cursor: cursor})
-		if err != nil {
-			return false, err
-		}
-		for _, channel := range channels {
-			if channel.Name == channelName {
-				return true, nil
-			}
-		}
-		if cursor == "" {
-			break
-		}
-	}
-
-	return false, nil
 }
 
 func (d *DefaultSlackClient) PostMessage(channel string, applyResult ApplyResult) error {

--- a/server/events/webhooks/slack_client_test.go
+++ b/server/events/webhooks/slack_client_test.go
@@ -14,7 +14,6 @@
 package webhooks_test
 
 import (
-	"encoding/json"
 	"errors"
 	"testing"
 
@@ -56,41 +55,6 @@ func TestTokenIsSet(t *testing.T) {
 	t.Log("When the Token is not an empty string, function should return true")
 	c.Token = "random"
 	Equals(t, true, c.TokenIsSet())
-}
-
-func TestChannelExists_False(t *testing.T) {
-	t.Log("When the slack channel doesn't exist, function should return false")
-	setup(t)
-	When(underlying.GetConversations(new(slack.GetConversationsParameters))).ThenReturn(nil, "xyz", nil)
-	When(underlying.GetConversations(&slack.GetConversationsParameters{Cursor: "xyz"})).ThenReturn(nil, "", nil)
-	exists, err := client.ChannelExists("somechannel")
-	Ok(t, err)
-	Equals(t, false, exists)
-}
-
-func TestChannelExists_True(t *testing.T) {
-	t.Log("When the slack channel exists, function should return true")
-	setup(t)
-	channelJSON := `{"name":"existingchannel"}`
-	var channel slack.Channel
-	err := json.Unmarshal([]byte(channelJSON), &channel)
-	Ok(t, err)
-	When(underlying.GetConversations(new(slack.GetConversationsParameters))).ThenReturn(nil, "xyz", nil)
-	When(underlying.GetConversations(&slack.GetConversationsParameters{Cursor: "xyz"})).ThenReturn([]slack.Channel{channel}, "", nil)
-
-	exists, err := client.ChannelExists("existingchannel")
-	Ok(t, err)
-	Equals(t, true, exists)
-}
-
-func TestChannelExists_Error(t *testing.T) {
-	t.Log("When the underlying slack client errors, an error should be returned")
-	setup(t)
-	When(underlying.GetConversations(new(slack.GetConversationsParameters))).ThenReturn(nil, "xyz", nil)
-	When(underlying.GetConversations(&slack.GetConversationsParameters{Cursor: "xyz"})).ThenReturn(nil, "", errors.New(""))
-
-	_, err := client.ChannelExists("anychannel")
-	Assert(t, err != nil, "expected error")
 }
 
 func TestPostMessage_Success(t *testing.T) {

--- a/server/events/webhooks/webhooks_test.go
+++ b/server/events/webhooks/webhooks_test.go
@@ -46,7 +46,6 @@ func TestNewWebhooksManager_InvalidRegex(t *testing.T) {
 	t.Log("When given an invalid regex in a config, an error is returned")
 	RegisterMockTestingT(t)
 	client := mocks.NewMockSlackClient()
-	When(client.ChannelExists(validChannel)).ThenReturn(true, nil)
 
 	invalidRegex := "("
 	configs := validConfigs()
@@ -71,7 +70,6 @@ func TestNewWebhooksManager_UnsupportedEvent(t *testing.T) {
 	t.Log("When given an unsupported event in a config, an error is returned")
 	RegisterMockTestingT(t)
 	client := mocks.NewMockSlackClient()
-	When(client.ChannelExists(validChannel)).ThenReturn(true, nil)
 
 	unsupportedEvent := "badevent"
 	configs := validConfigs()
@@ -96,7 +94,6 @@ func TestNewWebhooksManager_UnsupportedKind(t *testing.T) {
 	t.Log("When given an unsupported kind in a config, an error is returned")
 	RegisterMockTestingT(t)
 	client := mocks.NewMockSlackClient()
-	When(client.ChannelExists(validChannel)).ThenReturn(true, nil)
 
 	unsupportedKind := "badkind"
 	configs := validConfigs()
@@ -125,7 +122,6 @@ func TestNewWebhooksManager_SingleConfigSuccess(t *testing.T) {
 	RegisterMockTestingT(t)
 	client := mocks.NewMockSlackClient()
 	When(client.TokenIsSet()).ThenReturn(true)
-	When(client.ChannelExists(validChannel)).ThenReturn(true, nil)
 
 	configs := validConfigs()
 	m, err := webhooks.NewMultiWebhookSender(configs, client)
@@ -138,7 +134,6 @@ func TestNewWebhooksManager_MultipleConfigSuccess(t *testing.T) {
 	RegisterMockTestingT(t)
 	client := mocks.NewMockSlackClient()
 	When(client.TokenIsSet()).ThenReturn(true)
-	When(client.ChannelExists(validChannel)).ThenReturn(true, nil)
 
 	var configs []webhooks.Config
 	nConfigs := 5


### PR DESCRIPTION
This PR removes the check about the existence of a slack channel.

This is done to:

- avoid the necessity of `channels:read` scope to the corresponding bot (this is a broad scope and many orgs may be reluctant providing it)
- the specific check hits the `conversations.list` [endpoint](https://api.slack.com/methods/conversations.list) that has a lower rate [limit](https://api.slack.com/docs/rate-limits#tier_t2) that **may** be also related to this [issue](https://github.com/runatlantis/atlantis/issues/1420)