### PR TITLE
Implement shallow repo cloning in merge checkout strategy

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -52,6 +52,7 @@ const (
 	BitbucketUserFlag          = "bitbucket-user"
 	BitbucketWebhookSecretFlag = "bitbucket-webhook-secret"
 	ConfigFlag                 = "config"
+	CheckoutDepthFlag          = "checkout-depth"
 	CheckoutStrategyFlag       = "checkout-strategy"
 	DataDirFlag                = "data-dir"
 	DefaultTFVersionFlag       = "default-tf-version"
@@ -115,6 +116,7 @@ const (
 	DefaultADBasicPassword  = ""
 	DefaultADHostname       = "dev.azure.com"
 	DefaultAutoplanFileList = "**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl"
+	DefaultCheckoutDepth    = 50
 	DefaultCheckoutStrategy = "branch"
 	DefaultBitbucketBaseURL = bitbucketcloud.BaseURL
 	DefaultDataDir          = "~/.atlantis"
@@ -428,6 +430,12 @@ var boolFlags = map[string]boolFlag{
 	},
 }
 var intFlags = map[string]intFlag{
+	CheckoutDepthFlag: {
+		description: fmt.Sprintf("Used only if --%s=merge.", CheckoutStrategyFlag) +
+			" How many commits to include in each of base and feature branches when cloning repository." +
+			" If merge base is further behind than this number of commits from any of branches heads, full fetch will be performed.",
+		defaultValue: DefaultCheckoutDepth,
+	},
 	ParallelPoolSize: {
 		description:  "Max size of the wait group that runs parallel plans and applies (if enabled).",
 		defaultValue: DefaultParallelPoolSize,
@@ -643,6 +651,9 @@ func (s *ServerCmd) setDefaults(c *server.UserConfig) {
 	if c.AutoplanFileList == "" {
 		c.AutoplanFileList = DefaultAutoplanFileList
 	}
+	if c.CheckoutDepth == 0 {
+		c.CheckoutDepth = DefaultCheckoutDepth
+	}
 	if c.CheckoutStrategy == "" {
 		c.CheckoutStrategy = DefaultCheckoutStrategy
 	}
@@ -691,6 +702,10 @@ func (s *ServerCmd) validate(userConfig server.UserConfig) error {
 	userConfig.LogLevel = strings.ToLower(userConfig.LogLevel)
 	if !isValidLogLevel(userConfig.LogLevel) {
 		return fmt.Errorf("invalid log level: must be one of %v", ValidLogLevels)
+	}
+
+	if userConfig.CheckoutDepth <= 0 {
+		return errors.New("invalid checkout depth: should be positive")
 	}
 
 	checkoutStrategy := userConfig.CheckoutStrategy

--- a/runatlantis.io/docs/checkout-strategy.md
+++ b/runatlantis.io/docs/checkout-strategy.md
@@ -46,3 +46,11 @@ Atlantis doesn't actually commit this merge anywhere. It just uses it locally.
 Atlantis only performs this merge during the `terraform plan` phase. If another
 commit is pushed to `master` **after** Atlantis runs `plan`, nothing will happen.
 :::
+
+To optimize cloning time Atlantis does not fetch full repository in this mode. Instead, shallow clone of two branches is performed. The depth of clone is specified by `--checkout-depth` flag. Default value is 50 commits. The cloning is performed in a following manner:
+* Shallow clone of `master` branch is performed with depth of `--checkout-depth` value.
+* `branch` is retrieved, including the same amount of commits.
+* Merge base of `master` and `branch` is checked for existence in the shallow clone.
+* If the merge base is not present, it means that either of branches are ahead of merge base by more than `--checkout-depth` commits. In this case full repo history is fetched.
+
+If your commit history often diverges by more than 50 commits you could tune the `--checkout-depth` parameter to avoid full fetches.

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -205,6 +205,13 @@ Values are chosen in this order:
   This means that an attacker could spoof calls to Atlantis and cause it to perform malicious actions.
   :::
 
+* ### `--checkout-depth`
+  ```bash
+  atlantis server --checkout-depth=50
+  ```
+  How many commits from branches to fetch. Used only if `--checkout-strategy=merge`.
+  Defaults to `50`. See [Checkout Strategy](checkout-strategy.html) for more details.
+
 * ### `--checkout-strategy`
   ```bash
   atlantis server --checkout-strategy="<branch|merge>"

--- a/server/events/pending_plan_finder_test.go
+++ b/server/events/pending_plan_finder_test.go
@@ -286,3 +286,19 @@ func runCmd(t *testing.T, dir string, name string, args ...string) string {
 	Assert(t, err == nil, "err running %q: %s", strings.Join(append([]string{name}, args...), " "), cpOut)
 	return string(cpOut)
 }
+
+func runCmdErrCode(t *testing.T, dir string, errCode int, name string, args ...string) string {
+	t.Helper()
+	cpCmd := exec.Command(name, args...)
+	cpCmd.Dir = dir
+	cpOut, err := cpCmd.CombinedOutput()
+	cmd := strings.Join(append([]string{name}, args...), " ")
+	if err != nil {
+		if eerr, ok := err.(*exec.ExitError); ok {
+			Assert(t, errCode == eerr.ExitCode(), "unexpected exit code: want %v, got %v, running %q: %s", errCode, eerr.ExitCode(), cmd, cpCmd)
+			return string(cpOut)
+		}
+	}
+	Assert(t, false, "invalid exit code, running %q: %s", cmd, cpOut)
+	return string(cpOut)
+}

--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -56,6 +56,10 @@ type FileWorkspace struct {
 	// If this is false, then we will check out the head branch from the pull
 	// request.
 	CheckoutMerge bool
+	// CheckoutDepth is how many commits of feature branch and main branch we'll
+	// retrieve by default. If their merge base is not retrieved with this depth,
+	// full fetch will be performed. Only matters if CheckoutMerge=true.
+	CheckoutDepth int
 	// TestingOverrideHeadCloneURL can be used during testing to override the
 	// URL of the head repo to be cloned. If it's empty then we clone normally.
 	TestingOverrideHeadCloneURL string
@@ -220,53 +224,8 @@ func (w *FileWorkspace) forceClone(log logging.SimpleLogging,
 		baseCloneURL = w.TestingOverrideBaseCloneURL
 	}
 
-	var cmds [][]string
-	if w.CheckoutMerge {
-		// NOTE: We can't do a shallow clone when we're merging because we'll
-		// get merge conflicts if our clone doesn't have the commits that the
-		// branch we're merging branched off at.
-		// See https://groups.google.com/forum/#!topic/git-users/v3MkuuiDJ98.
-		fetchRef := fmt.Sprintf("+refs/heads/%s:", p.HeadBranch)
-		fetchRemote := "head"
-		if w.GithubAppEnabled {
-			fetchRef = fmt.Sprintf("pull/%d/head:", p.Num)
-			fetchRemote = "origin"
-		}
-		cmds = [][]string{
-			{
-				"git", "clone", "--branch", p.BaseBranch, "--single-branch", baseCloneURL, cloneDir,
-			},
-			{
-				"git", "remote", "add", "head", headCloneURL,
-			},
-			{
-				"git", "fetch", fetchRemote, fetchRef,
-			},
-		}
-		if w.GpgNoSigningEnabled {
-			cmds = append(cmds, []string{
-				"git", "config", "--local", "commit.gpgsign", "false",
-			})
-		}
-		// We use --no-ff because we always want there to be a merge commit.
-		// This way, our branch will look the same regardless if the merge
-		// could be fast forwarded. This is useful later when we run
-		// git rev-parse HEAD^2 to get the head commit because it will
-		// always succeed whereas without --no-ff, if the merge was fast
-		// forwarded then git rev-parse HEAD^2 would fail.
-		cmds = append(cmds, []string{
-			"git", "merge", "-q", "--no-ff", "-m", "atlantis-merge", "FETCH_HEAD",
-		})
-	} else {
-		cmds = [][]string{
-			{
-				"git", "clone", "--branch", p.HeadBranch, "--depth=1", "--single-branch", headCloneURL, cloneDir,
-			},
-		}
-	}
-
-	for _, args := range cmds {
-		cmd := exec.Command(args[0], args[1:]...) // nolint: gosec
+	runGit := func(args ...string) error {
+		cmd := exec.Command("git", args...) // nolint: gosec
 		cmd.Dir = cloneDir
 		// The git merge command requires these env vars are set.
 		cmd.Env = append(os.Environ(), []string{
@@ -283,8 +242,50 @@ func (w *FileWorkspace) forceClone(log logging.SimpleLogging,
 			return fmt.Errorf("running %s: %s: %s", cmdStr, sanitizedOutput, sanitizedErrMsg)
 		}
 		log.Debug("ran: %s. Output: %s", cmdStr, strings.TrimSuffix(sanitizedOutput, "\n"))
+		return nil
 	}
-	return nil
+
+	if !w.CheckoutMerge {
+		return runGit("clone", "--depth=1", "--branch", p.HeadBranch, "--single-branch", headCloneURL, cloneDir)
+	}
+
+	if err := runGit("clone", "--depth", fmt.Sprint(w.CheckoutDepth), "--branch", p.BaseBranch, "--single-branch", baseCloneURL, cloneDir); err != nil {
+		return err
+	}
+	if err := runGit("remote", "add", "head", headCloneURL); err != nil {
+		return err
+	}
+
+	fetchRef := fmt.Sprintf("+refs/heads/%s:", p.HeadBranch)
+	fetchRemote := "head"
+	if w.GithubAppEnabled {
+		fetchRef = fmt.Sprintf("pull/%d/head:", p.Num)
+		fetchRemote = "origin"
+	}
+	if err := runGit("fetch", "--depth", fmt.Sprint(w.CheckoutDepth), fetchRemote, fetchRef); err != nil {
+		return err
+	}
+
+	if w.GpgNoSigningEnabled {
+		if err := runGit("config", "--local", "commit.gpgsign", "false"); err != nil {
+			return err
+		}
+	}
+	if err := runGit("merge-base", p.BaseBranch, "FETCH_HEAD"); err != nil {
+		// git merge-base returning error means that we did not receive enough commits in shallow clone.
+		// Fall back to retrieving full repo history.
+		if err := runGit("fetch", "--unshallow"); err != nil {
+			return err
+		}
+	}
+
+	// We use --no-ff because we always want there to be a merge commit.
+	// This way, our branch will look the same regardless if the merge
+	// could be fast forwarded. This is useful later when we run
+	// git rev-parse HEAD^2 to get the head commit because it will
+	// always succeed whereas without --no-ff, if the merge was fast
+	// forwarded then git rev-parse HEAD^2 would fail.
+	return runGit("merge", "-q", "--no-ff", "-m", "atlantis-merge", "FETCH_HEAD")
 }
 
 // GetWorkingDir returns the path to the workspace for this repo and pull.

--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/runatlantis/atlantis/server/events"
@@ -88,6 +89,7 @@ func TestClone_CheckoutMergeNoneExisting(t *testing.T) {
 	wd := &events.FileWorkspace{
 		DataDir:                     dataDir,
 		CheckoutMerge:               true,
+		CheckoutDepth:               50,
 		TestingOverrideHeadCloneURL: overrideURL,
 		TestingOverrideBaseCloneURL: overrideURL,
 		GpgNoSigningEnabled:         true,
@@ -138,6 +140,7 @@ func TestClone_CheckoutMergeNoReclone(t *testing.T) {
 	wd := &events.FileWorkspace{
 		DataDir:                     dataDir,
 		CheckoutMerge:               true,
+		CheckoutDepth:               50,
 		TestingOverrideHeadCloneURL: overrideURL,
 		TestingOverrideBaseCloneURL: overrideURL,
 		GpgNoSigningEnabled:         true,
@@ -189,6 +192,7 @@ func TestClone_CheckoutMergeNoRecloneFastForward(t *testing.T) {
 	wd := &events.FileWorkspace{
 		DataDir:                     dataDir,
 		CheckoutMerge:               true,
+		CheckoutDepth:               50,
 		TestingOverrideHeadCloneURL: overrideURL,
 		TestingOverrideBaseCloneURL: overrideURL,
 		GpgNoSigningEnabled:         true,
@@ -245,6 +249,7 @@ func TestClone_CheckoutMergeConflict(t *testing.T) {
 	wd := &events.FileWorkspace{
 		DataDir:                     dataDir,
 		CheckoutMerge:               true,
+		CheckoutDepth:               50,
 		TestingOverrideHeadCloneURL: overrideURL,
 		TestingOverrideBaseCloneURL: overrideURL,
 		GpgNoSigningEnabled:         true,
@@ -262,6 +267,96 @@ func TestClone_CheckoutMergeConflict(t *testing.T) {
 	ErrContains(t, "Merge conflict in file", err)
 	ErrContains(t, "Automatic merge failed; fix conflicts and then commit the result.", err)
 	ErrContains(t, "exit status 1", err)
+}
+
+func TestClone_CheckoutMergeShallow(t *testing.T) {
+	// Initialize the git repo.
+	repoDir, cleanup := initRepo(t)
+	defer cleanup()
+
+	runCmd(t, repoDir, "git", "commit", "--allow-empty", "-m", "should not be cloned")
+	oldCommit := strings.TrimSpace(runCmd(t, repoDir, "git", "rev-parse", "HEAD"))
+
+	runCmd(t, repoDir, "git", "commit", "--allow-empty", "-m", "merge-base")
+	baseCommit := strings.TrimSpace(runCmd(t, repoDir, "git", "rev-parse", "HEAD"))
+
+	runCmd(t, repoDir, "git", "branch", "-f", "branch", "HEAD")
+
+	// Add a commit to branch 'branch' that's not on master.
+	runCmd(t, repoDir, "git", "checkout", "branch")
+	runCmd(t, repoDir, "touch", "branch-file")
+	runCmd(t, repoDir, "git", "add", "branch-file")
+	runCmd(t, repoDir, "git", "commit", "-m", "branch-commit")
+
+	// Now switch back to master and advance the master branch by another
+	// commit.
+	runCmd(t, repoDir, "git", "checkout", "master")
+	runCmd(t, repoDir, "touch", "master-file")
+	runCmd(t, repoDir, "git", "add", "master-file")
+	runCmd(t, repoDir, "git", "commit", "-m", "master-commit")
+
+	overrideURL := fmt.Sprintf("file://%s", repoDir)
+
+	// Test that we don't check out full repo if using CheckoutMerge strategy
+	t.Run("Shallow", func(t *testing.T) {
+		dataDir, cleanup2 := TempDir(t)
+		defer cleanup2()
+
+		wd := &events.FileWorkspace{
+			DataDir:       dataDir,
+			CheckoutMerge: true,
+			// retrieve two commits in each branch:
+			// master: master-commit, merge-base
+			// branch: branch-commit, merge-base
+			CheckoutDepth:               2,
+			TestingOverrideHeadCloneURL: overrideURL,
+			TestingOverrideBaseCloneURL: overrideURL,
+			GpgNoSigningEnabled:         true,
+		}
+
+		cloneDir, hasDiverged, err := wd.Clone(logging.NewNoopLogger(t), models.Repo{}, models.PullRequest{
+			BaseRepo:   models.Repo{},
+			HeadBranch: "branch",
+			BaseBranch: "master",
+		}, "default")
+		Ok(t, err)
+		Equals(t, false, hasDiverged)
+
+		gotBaseCommitType := runCmd(t, cloneDir, "git", "cat-file", "-t", baseCommit)
+		Assert(t, gotBaseCommitType == "commit\n", "should have merge-base in shallow repo")
+		gotOldCommitType := runCmdErrCode(t, cloneDir, 128, "git", "cat-file", "-t", oldCommit)
+		Assert(t, strings.Contains(gotOldCommitType, "could not get object info"), "should not have old commit in shallow repo")
+	})
+
+	// Test that we will check out full repo if CheckoutDepth is too small
+	t.Run("FullClone", func(t *testing.T) {
+		dataDir, cleanup2 := TempDir(t)
+		defer cleanup2()
+
+		wd := &events.FileWorkspace{
+			DataDir:       dataDir,
+			CheckoutMerge: true,
+			// 1 is not enough to retrieve merge-base, so full clone should be performed
+			CheckoutDepth:               1,
+			TestingOverrideHeadCloneURL: overrideURL,
+			TestingOverrideBaseCloneURL: overrideURL,
+			GpgNoSigningEnabled:         true,
+		}
+
+		cloneDir, hasDiverged, err := wd.Clone(logging.NewNoopLogger(t), models.Repo{}, models.PullRequest{
+			BaseRepo:   models.Repo{},
+			HeadBranch: "branch",
+			BaseBranch: "master",
+		}, "default")
+		Ok(t, err)
+		Equals(t, false, hasDiverged)
+
+		gotBaseCommitType := runCmd(t, cloneDir, "git", "cat-file", "-t", baseCommit)
+		Assert(t, gotBaseCommitType == "commit\n", "should have merge-base in full repo")
+		gotOldCommitType := runCmd(t, cloneDir, "git", "cat-file", "-t", oldCommit)
+		Assert(t, gotOldCommitType == "commit\n", "should have old commit in full repo")
+	})
+
 }
 
 // Test that if the repo is already cloned and is at the right commit, we
@@ -386,6 +481,7 @@ func TestClone_MasterHasDiverged(t *testing.T) {
 	wd := &events.FileWorkspace{
 		DataDir:             repoDir,
 		CheckoutMerge:       true,
+		CheckoutDepth:       50,
 		GpgNoSigningEnabled: true,
 	}
 	_, hasDiverged, err := wd.Clone(logging.NewNoopLogger(t), models.Repo{CloneURL: repoDir}, models.PullRequest{
@@ -463,6 +559,7 @@ func TestHasDiverged_MasterHasDiverged(t *testing.T) {
 	wd := &events.FileWorkspace{
 		DataDir:             repoDir,
 		CheckoutMerge:       true,
+		CheckoutDepth:       50,
 		GpgNoSigningEnabled: true,
 	}
 	hasDiverged := wd.HasDiverged(logging.NewNoopLogger(t), repoDir+"/repos/0/default")

--- a/server/server.go
+++ b/server/server.go
@@ -407,6 +407,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	var workingDir events.WorkingDir = &events.FileWorkspace{
 		DataDir:          userConfig.DataDir,
 		CheckoutMerge:    userConfig.CheckoutStrategy == "merge",
+		CheckoutDepth:    userConfig.CheckoutDepth,
 		GithubAppEnabled: githubAppEnabled,
 	}
 	// provide fresh tokens before clone from the GitHub Apps integration, proxy workingDir

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -22,6 +22,7 @@ type UserConfig struct {
 	BitbucketToken             string `mapstructure:"bitbucket-token"`
 	BitbucketUser              string `mapstructure:"bitbucket-user"`
 	BitbucketWebhookSecret     string `mapstructure:"bitbucket-webhook-secret"`
+	CheckoutDepth              int    `mapstructure:"checkout-depth"`
 	CheckoutStrategy           string `mapstructure:"checkout-strategy"`
 	DataDir                    string `mapstructure:"data-dir"`
 	DisableApplyAll            bool   `mapstructure:"disable-apply-all"`


### PR DESCRIPTION
When the repository is quite large clones are becoming slower. Previously Atlantis fetched full repository in --checkout-strategy=merge mode.
However, that's not required, we only should have enough commits in our clone to perform a merge between base and feature branches, not full history.

This implements rough guessing: fetch 50 (user-configurable) commits from each of base and feature branches, and if their merge base is not in these commits, fetch full repo history. This is not ideal solution and could be improved (e.g. increase the number of fetched commits in several attempts before full fetch), but I think it should be good enough in most cases.

I'm not sure about the flag name and enabling this behaviour by default. The flag could be renamed to something like `--checkout-merge-depth`, if that would be preferable. Also, I could change the default value to zero and treat it as "always fetch full repo", to comply with previous behaviour.