### PR TITLE
CHANGED - update streaming-logs doc to mention terragrunt support

### DIFF
--- a/runatlantis.io/docs/streaming-logs.md
+++ b/runatlantis.io/docs/streaming-logs.md
@@ -6,7 +6,7 @@ Atlantis supports streaming terraform logs in real time by default. Currently, o
 * atlantis apply
 
 ::: warning
-As of now, custom workflow outputs and other terraform commands are not supported
+As of now, not all custom workflow outputs and other terraform commands are not supported.  Support for terragrunt has been added, see examples in [Custom Workflows](./custom-workflows.md#terragrunt).
 :::
 
 In order to view real-time terraform logs, a user can navigate through the *details* section of a given project's plan or apply status check.


### PR DESCRIPTION
We noticed https://github.com/runatlantis/atlantis/pull/2261 and https://github.com/runatlantis/atlantis/pull/2350 landed and thought it should be mentioned in this doc as well.