### PR TITLE
Fix helm chart url in website_link_check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
         dockerize -wait tcp://localhost:8080 -- \
           muffet \
             -e 'https://github\.com/runatlantis/atlantis/edit/master/.*' \
-            -e 'https://github.com/helm/charts/tree/master/stable/atlantis#customization' \
+            -e 'https://github.com/runatlantis/helm-charts#customization' \
             --header 'Accept-Encoding:deflate, gzip' \
             --buffer-size 8192 \
             http://localhost:8080/


### PR DESCRIPTION
Follow up fix for https://github.com/runatlantis/atlantis/pull/2393 since [website_link_check](https://app.circleci.com/pipelines/github/runatlantis/atlantis/2460/workflows/797590b6-1c20-44fb-9111-2f0a59b5690d/jobs/10616) is failing.
<img width="932" alt="Screen Shot 2022-07-19 at 4 45 22 PM" src="https://user-images.githubusercontent.com/17621872/179866455-ce99cd12-38e3-4077-83d9-19ad138e7da6.png">