### PR TITLE
Update documentation to reflect orgAllowlist changes in helm chart

### DIFF
--- a/runatlantis.io/docs/deployment.md
+++ b/runatlantis.io/docs/deployment.md
@@ -63,7 +63,7 @@ To install:
       token: bar
       secret: baz
     ```
-1. Edit `values.yaml` and set your `orgAllowlist` (see [Repo Allowlist](server-configuration.md#repo-allowlist) for more information)
+1. Edit `values.yaml` and set your `orgAllowlist` (see [Repo Allowlist](server-configuration.md#--repo-allowlist) for more information)
     ```yaml
     orgAllowlist: github.com/runatlantis/*
     ```

--- a/runatlantis.io/docs/deployment.md
+++ b/runatlantis.io/docs/deployment.md
@@ -63,10 +63,11 @@ To install:
       token: bar
       secret: baz
     ```
-1. Edit `values.yaml` and set your `orgWhitelist` (see [Repo Whitelist](server-configuration.html#repo-whitelist) for more information)
+1. Edit `values.yaml` and set your `orgAllowlist` (see [Repo Allowlist](server-configuration.md#repo-allowlist) for more information)
     ```yaml
-    orgWhitelist: github.com/runatlantis/*
+    orgAllowlist: github.com/runatlantis/*
     ```
+    **Note**: For helm chart version < `4.0.2`, `orgWhitelist` must be used instead. 
 1. Configure any other variables (see [https://github.com/runatlantis/helm-charts#customization](https://github.com/runatlantis/helm-charts#customization)
     for documentation)
 1. Run

--- a/runatlantis.io/docs/deployment.md
+++ b/runatlantis.io/docs/deployment.md
@@ -63,7 +63,7 @@ To install:
       token: bar
       secret: baz
     ```
-1. Edit `values.yaml` and set your `orgAllowlist` (see [Repo Allowlist](server-configuration.md#--repo-allowlist) for more information)
+1. Edit `values.yaml` and set your `orgAllowlist` (see [Repo Allowlist](server-configuration.md#repo-allowlist) for more information)
     ```yaml
     orgAllowlist: github.com/runatlantis/*
     ```


### PR DESCRIPTION
## Background
the helm chart parameter for `orgWhitelist` have been deprecated since version 4.0.2 and have been replaced by `orgAllowlist` since this commit: https://github.com/runatlantis/helm-charts/commit/89da1af324c27bbe608052a577d60957a030e9b4. But the deployment instruction is still referencing the old parameter

## Summary
* updated `orgWhitelist` to `orgAllowlist` in deployment.md
* updated the link in deployment.md pointing to `--repo-allowlist` in server-configuration.md (changed extension from `.html` to `.md` to make the link work when reading on GitHub, netlify will automatically convert to `.html`)
* added a note to indicate `orgWhitelist` should still be used for helm chart versions prior to 4.0.2