### PR TITLE
Add atlantis version to atlantis commands

### DIFF
--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -79,6 +79,7 @@ type CommentParser struct {
 	BitbucketUser   string
 	AzureDevopsUser string
 	ApplyDisabled   bool
+	AtlantisVersion string
 }
 
 // CommentParseResult describes the result of parsing a comment as a command.
@@ -372,9 +373,11 @@ func (e *CommentParser) HelpComment(applyDisabled bool) string {
 	buf := &bytes.Buffer{}
 	var tmpl = template.Must(template.New("").Parse(helpCommentTemplate))
 	if err := tmpl.Execute(buf, struct {
-		ApplyDisabled bool
+		ApplyDisabled   bool,
+		AtlantisVersion string,
 	}{
-		ApplyDisabled: applyDisabled,
+		ApplyDisabled:   applyDisabled,
+		AtlantisVersion: e.AtlantisVersion,
 	}); err != nil {
 		return fmt.Sprintf("Failed to render template, this is a bug: %v", err)
 	}
@@ -383,7 +386,7 @@ func (e *CommentParser) HelpComment(applyDisabled bool) string {
 }
 
 var helpCommentTemplate = "```cmake\n" +
-	`atlantis
+	`atlantis v{{ .AtlantisVersion }}
 Terraform Pull Request Automation
 
 Usage:

--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -373,8 +373,8 @@ func (e *CommentParser) HelpComment(applyDisabled bool) string {
 	buf := &bytes.Buffer{}
 	var tmpl = template.Must(template.New("").Parse(helpCommentTemplate))
 	if err := tmpl.Execute(buf, struct {
-		ApplyDisabled   bool,
-		AtlantisVersion string,
+		ApplyDisabled   bool
+		AtlantisVersion string
 	}{
 		ApplyDisabled:   applyDisabled,
 		AtlantisVersion: e.AtlantisVersion,

--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -705,13 +705,15 @@ func TestBuildPlanApplyVersionComment(t *testing.T) {
 
 func TestCommentParser_HelpComment(t *testing.T) {
 	cases := []struct {
-		applyDisabled bool
-		expectResult  string
+		applyDisabled   bool
+		atlantisVersion string
+		expectResult    string
 	}{
 		{
 			applyDisabled: false,
+			atlantisVersion: "1.0.0",
 			expectResult: "```cmake\n" +
-				`atlantis
+				`atlantis v1.0.0
 Terraform Pull Request Automation
 
 Usage:
@@ -747,8 +749,9 @@ Use "atlantis [command] --help" for more information about a command.` +
 		},
 		{
 			applyDisabled: true,
+			atlantisVersion: "1.0.0",
 			expectResult: "```cmake\n" +
-				`atlantis
+				`atlantis v1.0.0
 Terraform Pull Request Automation
 
 Usage:

--- a/server/server.go
+++ b/server/server.go
@@ -465,6 +465,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		BitbucketUser:   userConfig.BitbucketUser,
 		AzureDevopsUser: userConfig.AzureDevopsUser,
 		ApplyDisabled:   userConfig.DisableApply,
+		AtlantisVersion: config.AtlantisVersion,
 	}
 	defaultTfVersion := terraformClient.DefaultVersion()
 	pendingPlanFinder := &events.DefaultPendingPlanFinder{}


### PR DESCRIPTION
## what

- [x] Add atlantis version to `atlantis help`
- [ ] Add atlantis version to `atlantis version`

## why

- A way to see the current version by commenting on a PR

## references

- Previous PR https://github.com/runatlantis/atlantis/pull/2295