### PR TITLE
bug: Fix GitHub Markdown for added and deleted resources

### DIFF
--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -2188,7 +2188,7 @@ Terraform will perform the following actions:
       + name    = "redacted.redacted.redacted.io"
       + records = [
             "foo",
-      ]
+        ]
       + ttl     = 300
       + type    = "A"
       + zone_id = "redacted"

--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -2181,6 +2181,19 @@ Terraform will perform the following actions:
         zone_id = "redacted"
     }
 
+  # module.redacted.aws_route53_record.redacted_record_2 will be created
++ resource "aws_route53_record" "redacted_record" {
+      + fqdn    = "redacted.redacted.redacted.io"
+      + id      = "redacted_redacted.redacted.redacted.io_A"
+      + name    = "redacted.redacted.redacted.io"
+      + records = [
+            "foo",
+      ]
+      + ttl     = 300
+      + type    = "A"
+      + zone_id = "redacted"
+    }
+
 # helm_release.external_dns[0] will be updated in-place
 ~ resource "helm_release" "external_dns" {
       id                         = "external-dns"
@@ -2343,6 +2356,19 @@ Terraform will perform the following actions:
         ttl     = 300
         type    = "A"
         zone_id = "redacted"
+    }
+
+  # module.redacted.aws_route53_record.redacted_record_2 will be created
++ resource "aws_route53_record" "redacted_record" {
++       fqdn    = "redacted.redacted.redacted.io"
++       id      = "redacted_redacted.redacted.redacted.io_A"
++       name    = "redacted.redacted.redacted.io"
++       records = [
+            "foo",
+        ]
++       ttl     = 300
++       type    = "A"
++       zone_id = "redacted"
     }
 
 # helm_release.external_dns[0] will be updated in-place

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -380,7 +380,7 @@ func (p *PlanSuccess) Summary() string {
 
 // DiffMarkdownFormattedTerraformOutput formats the Terraform output to match diff markdown format
 func (p PlanSuccess) DiffMarkdownFormattedTerraformOutput() string {
-	diffKeywordRegex := regexp.MustCompile(`(?m)^( +)([-+~]\s)(.*)(\s->\s|<<|\{|\(known after apply\)|\[)(.*)`)
+	diffKeywordRegex := regexp.MustCompile(`(?m)^( +)([-+~]\s)(.*)(\s=\s|\s->\s|<<|\{|\(known after apply\)|\[)(.*)`)
 	diffListRegex := regexp.MustCompile(`(?m)^( +)([-+~]\s)(".*",)`)
 	diffTildeRegex := regexp.MustCompile(`(?m)^~`)
 


### PR DESCRIPTION
In https://github.com/runatlantis/atlantis/pull/2337, I modified the GitHub Markdown regex to correctly handle YAML in the Terraform output. Unfortunately, that broke highlighting for resources that were being created or deleted. The updated regex will now also accept an `=` sign with spaces either side. It might incorrectly highlight some plain text in plans, but it should fix the error.

Closes #2425 