### PR TITLE
fix: Clarify Slack hook setup for Helm chart deployments. Add tidbit about Slack channel setup.

### DIFF
--- a/runatlantis.io/docs/using-slack-hooks.md
+++ b/runatlantis.io/docs/using-slack-hooks.md
@@ -28,6 +28,7 @@ For this you'll need to:
   * `incoming-webhook`
   * `mpim:read`
 * Install the app onto your Slack workspace
+* Create a channel in your Slack workspace (e.g. `my-channel`), and add the app to it
 
 ## Configuring Atlantis
 
@@ -42,5 +43,22 @@ webhooks:
   kind: slack
   channel: my-channel
 ```
+
+If you are deploying Atlantis as a Helm chart, this can be implemented via the `config` parameter available for [chart customizations](https://github.com/runatlantis/helm-charts/blob/main/README.md#customization):
+
+```
+
+## Use Server Side Config,
+## ref: https://www.runatlantis.io/docs/server-configuration.html
+config: |
+   ---
+   webhooks:
+     - event: apply
+       workspace-regex: .*
+       kind: slack
+       channel: my-channel
+```
+
+
 
 The `apply` event information will be sent to the `my-channel` Slack channel.


### PR DESCRIPTION
Clarify instructions on how to implement the webhook config changes when using a Helm chart deployment of Atlantis.

Add tidbit about adding the Slack app to the Slack channel used for notifications.