### PR TITLE
deps: bump alpine to v3.16.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -v -o atlantis .
 
 # Stage 2
 # The runatlantis/atlantis-base is created by docker-base/Dockerfile.
-FROM ghcr.io/runatlantis/atlantis-base:2022.05.13 AS base
+FROM ghcr.io/runatlantis/atlantis-base:2022.08.05 AS base
 
 # Get the architecture the image is being built for
 ARG TARGETPLATFORM

--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile builds our base image with gosu, dumb-init and the atlantis
 # user. We split this from the main Dockerfile because this base doesn't change
 # and also because it kept breaking the build due to flakiness.
-FROM alpine:3.15.4
+FROM alpine:3.16.1
 LABEL authors="Anubhav Mishra, Luke Kysow"
 
 # We use gosu to step down from root and run as the atlantis user so we need


### PR DESCRIPTION
Bump alpine version to 3.16.1 in order to resolve several vulnerabilities around curl/pcre2/git.