### PR TITLE
Fix some not-quite-links in docs

### DIFF
--- a/runatlantis.io/docs/server-side-repo-config.md
+++ b/runatlantis.io/docs/server-side-repo-config.md
@@ -459,9 +459,9 @@ If you set a workflow with the key `default`, it will override this.
 
 ### Metrics
 
-| Key                    | Type            | Default | Required  | Description                              |
-|------------------------|-----------------|---------|-----------|------------------------------------------|
-| statsd                 | Statsd(#Statsd) | none    | no        | Statsd metrics provider                  |
+| Key                    | Type              | Default | Required  | Description                              |
+|------------------------|-------------------|---------|-----------|------------------------------------------|
+| statsd                 | [Statsd](#statsd) | none    | no        | Statsd metrics provider                  |
 
 ### Statsd
 

--- a/runatlantis.io/docs/stats.md
+++ b/runatlantis.io/docs/stats.md
@@ -8,4 +8,4 @@ Only statsd is supported currently, but it should be relatively straightforward 
 
 ## Configuration
 
-Metrics are configured through the (server-side-repo-config.html#Metrics). 
+Metrics are configured through the [Server Side Config](server-side-repo-config.html#metrics).


### PR DESCRIPTION
There is clearly the intent to provide cross-links in these docs, but they needed proper Markdown formatting (and lowercase anchor tags).