### PR TITLE
Disable activeHeaderLinks for VuePress. Remove bullet points in server config doc.

### DIFF
--- a/runatlantis.io/.vuepress/config.js
+++ b/runatlantis.io/.vuepress/config.js
@@ -26,6 +26,7 @@ module.exports = {
         ['meta', {name: 'google-site-verification', content: 'kTnsDBpHqtTNY8oscYxrQeeiNml2d2z-03Ct9wqeCeE' }]
     ],
     themeConfig: {
+        activeHeaderLinks: false,
         algolia: {
           apiKey: '3b733dff1539ca3a210775860301fa86',
           indexName: 'runatlantis'

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -47,13 +47,13 @@ Values are chosen in this order:
 
 
 ## Flags
-* ### `--allow-draft-prs`
+### `--allow-draft-prs`
   ```bash
   atlantis server --allow-draft-prs
   ```
   Respond to pull requests from draft prs. Defaults to `false`.
 
-* ### `--allow-fork-prs`
+### `--allow-fork-prs`
   ```bash
   atlantis server --allow-fork-prs
   ```
@@ -67,7 +67,7 @@ Values are chosen in this order:
   which can run arbitrary code if given a malicious Terraform configuration.
   :::
 
-* ### `--allow-repo-config`
+### `--allow-repo-config`
   <Badge text="Deprecated" type="warn"/>
   ```bash
   atlantis server --allow-repo-config
@@ -93,7 +93,7 @@ Values are chosen in this order:
   Only enable in trusted settings.
   :::
 
-* ### `--atlantis-url`
+### `--atlantis-url`
   ```bash
   atlantis server --atlantis-url="https://my-domain.com:9090/basepath"
   # or
@@ -103,14 +103,14 @@ Values are chosen in this order:
   and in links from pull request comments. Defaults to `http://$(hostname):$port`
   where `$port` is from the [`--port`](#port) flag. Supports a basepath if you're hosting Atlantis under a path.
 
-* ### `--automerge`
+### `--automerge`
   ```bash
   atlantis server --automerge
   ```
   Automatically merge pull requests after all plans have been successfully applied.
   Defaults to `false`. See [Automerging](automerging.html) for more details.
 
-* ### `--autoplan-file-list`
+### `--autoplan-file-list`
   ```bash
   # NOTE: Use single quotes to avoid shell expansion of *.
   atlantis server --autoplan-file-list='**/*.tf,project1/*.pkr.hcl'
@@ -134,7 +134,7 @@ Values are chosen in this order:
   * Autoplan when any `*.tf` files or `.yml` files in subfolder of `project1` is modified.
     * `--autoplan-file-list='**/*.tf,project2/**/*.yml'`
 
-* ### `--azuredevops-webhook-password`
+### `--azuredevops-webhook-password`
   ```bash
   atlantis server --azuredevops-webhook-password="password123"
   ```
@@ -149,27 +149,27 @@ Values are chosen in this order:
   variable.
   :::
 
-* ### `--azuredevops-webhook-user`
+### `--azuredevops-webhook-user`
   ```bash
   atlantis server --azuredevops-webhook-user="username@example.com"
   ```
   Azure DevOps basic authentication username for inbound webhooks. Can also be specified via the ATLANTIS_AZUREDEVOPS_WEBHOOK_USER
   environment variable.
 
-* ### `--azuredevops-token`
+### `--azuredevops-token`
   ```bash
   atlantis server --azuredevops-token="RandomStringProducedByAzureDevOps"
   ```
   Azure DevOps token of API user. Can also be specified via the ATLANTIS_AZUREDEVOPS_TOKEN
   environment variable.
 
-* ### `--azuredevops-user`
+### `--azuredevops-user`
   ```bash
   atlantis server --azuredevops-user="username@example.com"
   ```
   Azure DevOps username of API user.
 
-* ### `--bitbucket-base-url`
+### `--bitbucket-base-url`
   ```bash
   atlantis server --bitbucket-base-url="http://bitbucket.corp:7990/basepath"
   ```
@@ -177,7 +177,7 @@ Values are chosen in this order:
   `http://` or `https://`. If using Bitbucket Cloud (bitbucket.org), do not set. Defaults to
   `https://api.bitbucket.org`.
 
-* ### `--bitbucket-token`
+### `--bitbucket-token`
   ```bash
   atlantis server --bitbucket-token="token"
   # or (recommended)
@@ -185,13 +185,13 @@ Values are chosen in this order:
   ```
   Bitbucket app password of API user.
 
-* ### `--bitbucket-user`
+### `--bitbucket-user`
   ```bash
   atlantis server --bitbucket-user="myuser"
   ```
   Bitbucket username of API user.
 
-* ### `--bitbucket-webhook-secret`
+### `--bitbucket-webhook-secret`
   ```bash
   atlantis server --bitbucket-webhook-secret="secret"
   # or (recommended)
@@ -205,20 +205,20 @@ Values are chosen in this order:
   This means that an attacker could spoof calls to Atlantis and cause it to perform malicious actions.
   :::
 
-* ### `--checkout-strategy`
+### `--checkout-strategy`
   ```bash
   atlantis server --checkout-strategy="<branch|merge>"
   ```
   How to check out pull requests.
   Defaults to `branch`. See [Checkout Strategy](checkout-strategy.html) for more details.
 
-* ### `--config`
+### `--config`
   ```bash
   atlantis server --config="my/config/file.yaml"
   ```
   YAML config file where flags can also be set. See [Config File](#config-file) for more details.
 
-* ### `--data-dir`
+### `--data-dir`
   ```bash
   atlantis server --data-dir="path/to/data/dir"
   ```
@@ -227,46 +227,46 @@ Values are chosen in this order:
   Terraform binaries here. If Atlantis loses this directory, [locks](locking.html)
   will be lost and unapplied plans will be lost.
 
-* ### `--default-tf-version`
+### `--default-tf-version`
   ```bash
   atlantis server --default-tf-version="v0.12.0"
   ```
   Terraform version to default to. Will download to `<data-dir>/bin/terraform<version>`
   if not in `PATH`. See [Terraform Versions](terraform-versions.html) for more details.
 
-* ### `--disable-apply`
+### `--disable-apply`
   ```bash
   atlantis server --disable-apply
   ```
   Disable all \"atlantis apply\" commands, regardless of which flags are passed with it.
 
-* ### `--disable-apply-all`
+### `--disable-apply-all`
   ```bash
   atlantis server --disable-apply-all
   ```
   Disable \"atlantis apply\" command so a specific project/workspace/directory has to
   be specified for applies.
 
-* ### `--disable-autoplan`
+### `--disable-autoplan`
   ```bash
   atlantis server --disable-autoplan
   ```
   Disable atlantis auto planning
 
-* ### `--disable-repo-locking`
+### `--disable-repo-locking`
   ```bash
   atlantis server --disable-repo-locking
   ```
   Stops atlantis locking projects and or workspaces when running terraform
 
-* ### `--enable-policy-checks`
+### `--enable-policy-checks`
   <Badge text="beta" type="warn"/>
   ```bash
   atlantis server --enable-policy-checks
   ```
   Enables atlantis to run server side policies on the result of a terraform plan. Policies are defined in [server side repo config](https://www.runatlantis.io/docs/server-side-repo-config.html#reference).
 
-* ### `--enable-regexp-cmd`
+### `--enable-regexp-cmd`
   ```bash
   atlantis server --enable-regexp-cmd
   ```
@@ -277,7 +277,7 @@ Values are chosen in this order:
   The command `atlantis apply -p .*` will bypass the restriction and run apply on every projects
   :::
 
-* ### `--enable-diff-markdown-format`
+### `--enable-diff-markdown-format`
   ```bash
   atlantis server --enable-diff-markdown-format
   ```
@@ -285,14 +285,14 @@ Values are chosen in this order:
 
   Useful to enable for use with Github.
 
-* ### `--gh-hostname`
+### `--gh-hostname`
   ```bash
   atlantis server --gh-hostname="my.github.enterprise.com"
   ```
   Hostname of your GitHub Enterprise installation. If using [Github.com](https://github.com),
   don't set. Defaults to `github.com`.
 
-* ### `--gh-token`
+### `--gh-token`
   ```bash
   atlantis server --gh-token="token"
   # or (recommended)
@@ -300,13 +300,13 @@ Values are chosen in this order:
   ```
   GitHub token of API user.
 
-* ### `--gh-user`
+### `--gh-user`
   ```bash
   atlantis server --gh-user="myuser"
   ```
    GitHub username of API user.
 
-* ### `--gh-webhook-secret`
+### `--gh-webhook-secret`
   ```bash
   atlantis server --gh-webhook-secret="secret"
   # or (recommended)
@@ -319,13 +319,13 @@ Values are chosen in this order:
   This means that an attacker could spoof calls to Atlantis and cause it to perform malicious actions.
   :::
 
-- ### `--gh-org`
+### `--gh-org`
   ```bash
   atlantis server --gh-org="myorgname"
   ```
   GitHub organization name. Set to enable creating a private Github app for this organization.
 
-- ### `--gh-app-id`
+### `--gh-app-id`
   ```bash
   atlantis server --gh-app-id="00000"
   ```
@@ -347,13 +347,13 @@ Values are chosen in this order:
   After which Atlantis will display your new app's credentials: your app's ID, its generated `--gh-webhook-secret` and the contents of the file for `--gh-app-key-file`. Update your Atlantis config accordingly, and restart the server.
   :::
 
-- ### `--gh-app-key-file`
+### `--gh-app-key-file`
   ```bash
   atlantis server --gh-app-key-file="path/to/app-key.pem"
   ```
   Path to a GitHub App PEM encoded private key file. If set, GitHub authentication will be performed as [an installation](https://docs.github.com/en/rest/apps/installations).
 
-- ### `--gh-app-key`
+### `--gh-app-key`
   ```bash
   atlantis server --gh-app-key="-----BEGIN RSA PRIVATE KEY-----(...)"
   ```
@@ -362,21 +362,21 @@ Values are chosen in this order:
   ::: warning SECURITY WARNING
   The contents of the private key will be visible by anyone that can run `ps` or look at the shell history of the machine where Atlantis is running. Use `--gh-app-key-file` to mitigate that risk.
   :::
--
-- ### `--gh-team-allowlist`
+
+### `--gh-team-allowlist`
   ```bash
   atlantis server --gh-team-allowlist="myteam:plan, secteam:apply"
   ```
   Comma-separated list of GitHub team name (not a slug) and permission pairs. By default, any team can plan and apply.
 
-* ### `--gitlab-hostname`
+### `--gitlab-hostname`
   ```bash
   atlantis server --gitlab-hostname="my.gitlab.enterprise.com"
   ```
   Hostname of your GitLab Enterprise installation. If using [Gitlab.com](https://gitlab.com),
   don't set. Defaults to `gitlab.com`.
 
-* ### `--gitlab-token`
+### `--gitlab-token`
   ```bash
   atlantis server --gitlab-token="token"
   # or (recommended)
@@ -384,13 +384,13 @@ Values are chosen in this order:
   ```
   GitLab token of API user.
 
-* ### `--gitlab-user`
+### `--gitlab-user`
   ```bash
   atlantis server --gitlab-user="myuser"
   ```
    GitLab username of API user.
 
-* ### `--gitlab-webhook-secret`
+### `--gitlab-webhook-secret`
   ```bash
   atlantis server --gitlab-webhook-secret="secret"
   # or (recommended)
@@ -403,44 +403,44 @@ Values are chosen in this order:
   This means that an attacker could spoof calls to Atlantis and cause it to perform malicious actions.
   :::
 
-* ### `--help`
+### `--help`
   ```bash
   atlantis server --help
   ```
   View help.
 
-* ### `--hide-prev-plan-comments`
+### `--hide-prev-plan-comments`
   ```bash
   atlantis server --hide-prev-plan-comments
   ```
   Hide previous plan comments to declutter PRs. This is only supported in
   GitHub currently.
 
-* ### `--log-level`
+### `--log-level`
   ```bash
   atlantis server --log-level="<debug|info|warn|error>"
   ```
   Log level. Defaults to `info`.
 
-* ### `--parallel-pool-size`
+### `--parallel-pool-size`
   ```bash
   atlantis server --parallel-pool-size=100
   ```
   Max size of the wait group that runs parallel plans and applies (if enabled). Defaults to `15`
 
-* ### `--port`
+### `--port`
   ```bash
   atlantis server --port=8080
   ```
   Port to bind to. Defaults to `4141`.
 
-* ### `--repo-config`
+### `--repo-config`
   ```bash
   atlantis server --repo-config="path/to/repos.yaml"
   ```
   Path to a YAML server-side repo config file. See [Server Side Repo Config](server-side-repo-config.html).
 
-* ### `--repo-config-json`
+### `--repo-config-json`
   ```bash
   atlantis server --repo-config-json='{"repos":[{"id":"/.*/", "apply_requirements":["mergeable"]}]}'
   ```
@@ -474,10 +474,10 @@ Values are chosen in this order:
   ```
   :::
 
-* ### `--repo-whitelist`
+### `--repo-whitelist`
   <Badge text="Deprecated" type="warn"/>
   Deprecated for `--repo-allowlist`.
-* ### `--repo-allowlist`
+### `--repo-allowlist`
   ```bash
   # NOTE: Use single quotes to avoid shell expansion of *.
   atlantis server --repo-allowlist='github.com/myorg/*'
@@ -505,7 +505,7 @@ Values are chosen in this order:
   * Allowlist all repositories
     * `--repo-allowlist='*'`
 
-* ### `--require-approval`
+### `--require-approval`
   <Badge text="Deprecated" type="warn"/>
   ```bash
   atlantis server --require-approval
@@ -522,7 +522,7 @@ Values are chosen in this order:
   ```
   Or use `--repo-config-json='{"repos":[{"id":"/.*/", "apply_requirements":["approved"]}]}'` instead.
 
-* ### `--require-mergeable`
+### `--require-mergeable`
   <Badge text="Deprecated" type="warn"/>
   ```bash
   atlantis server --require-mergeable
@@ -539,17 +539,17 @@ Values are chosen in this order:
   ```
   Or use `--repo-config-json='{"repos":[{"id":"/.*/", "apply_requirements":["mergeable"]}]}'` instead.
 
-* ### `--silence-fork-pr-errors`
+### `--silence-fork-pr-errors`
   ```bash
   atlantis server --silence-fork-pr-errors
   ```
   Normally, if Atlantis receives a pull request webhook from a fork and --allow-fork-prs is not set,
   it will comment back with an error. This flag disables that commenting.
 
-* ### `--silence-whitelist-errors`
+### `--silence-whitelist-errors`
   <Badge text="Deprecated" type="warn"/>
   Deprecated for `--silence-allowlist-errors`.
-* ### `--silence-allowlist-errors`
+### `--silence-allowlist-errors`
   ```bash
   atlantis server --silence-allowlist-errors
   ```
@@ -560,7 +560,7 @@ Values are chosen in this order:
   Some users find this useful because they prefer to add the Atlantis webhook
   at an organization level rather than on each repo.
 
-* ### `--silence-no-projects`
+### `--silence-no-projects`
   ```bash
   atlantis server --silence-no-projects
   ```
@@ -569,19 +569,19 @@ Values are chosen in this order:
   This is useful when running multiple Atlantis servers against a single repository so you can
   delegate work to each Atlantis server. Also useful when used with pre_workflow_hooks to dynamically generate an `atlantis.yaml` file.
 
-* ### `--silence-vcs-status-no-plans`
+### `--silence-vcs-status-no-plans`
   ```bash
   atlantis server --silence-vcs-status-no-plans
   ```
   `--silence-vcs-status-no-plans` will tell Atlantis to ignore setting VCS status if none of the modified files are part of a project defined in the `atlantis.yaml` file.
 
-* ### `--skip-clone-no-changes`
+### `--skip-clone-no-changes`
   ```bash
   atlantis server --skip-clone-no-changes
   ```
   `--skip-clone-no-changes` will skip cloning the repo during autoplan if there are no changes to Terraform projects. This will only apply for GitHub and GitLab and only for repos that have `atlantis.yaml` file. Defaults to `false`.
 
-* ### `--slack-token`
+### `--slack-token`
   ```bash
   atlantis server --slack-token=token
   # or (recommended)
@@ -589,7 +589,7 @@ Values are chosen in this order:
   ```
   API token for Slack notifications. Slack is not fully supported. TODO: Slack docs.
 
-* ### `--ssl-cert-file`
+### `--ssl-cert-file`
   ```bash
   atlantis server --ssl-cert-file="/etc/ssl/certs/my-cert.crt"
   ```
@@ -597,19 +597,19 @@ Values are chosen in this order:
   If the cert is signed by a CA, the file should be the concatenation
   of the server's certificate, any intermediates, and the CA's certificate.
 
-* ### `--ssl-key-file`
+### `--ssl-key-file`
   ```bash
   atlantis server --ssl-cert-file="/etc/ssl/private/my-cert.key"
   ```
   File containing x509 private key matching `--ssl-cert-file`.
 
-* ### `--stats-namespace`
+### `--stats-namespace`
   ```bash
   atlantis server --stats-namespace="myatlantis"
   ```
   Namespace for emitting stats/metrics. See (stats.html#Metrics/Stats)
 
-* ### `--tf-download-url`
+### `--tf-download-url`
   ```bash
   atlantis server --tf-download-url="https://releases.company.com"
   ```
@@ -617,7 +617,7 @@ Values are chosen in this order:
   environment where releases.hashicorp.com is not available. Directory structure of the custom
   endpoint should match that of releases.hashicorp.com.
 
-* ### `--tfe-hostname`
+### `--tfe-hostname`
   ```bash
   atlantis server --tfe-hostname="my-terraform-enterprise.company.com"
   ```
@@ -626,13 +626,13 @@ Values are chosen in this order:
   If using Terraform Cloud (i.e. you don't have your own Terraform Enterprise installation)
   no need to set since it defaults to `app.terraform.io`.
 
-* ### `--tfe-local-execution-mode`
+### `--tfe-local-execution-mode`
   ```bash
   atlantis server --tfe-local-execution-mode
   ```
   Enable if you're using local execution mode (instead of TFE/C's remote execution mode). See [Terraform Cloud](terraform-cloud.html) for more details.
 
-* ### `--tfe-token`
+### `--tfe-token`
   ```bash
   atlantis server --tfe-token="xxx.atlasv1.yyy"
   # or (recommended)
@@ -640,7 +640,7 @@ Values are chosen in this order:
   ```
   A token for Terraform Cloud/Terraform Enterprise integration. See [Terraform Cloud](terraform-cloud.html) for more details.
 
-* ### `--var-file-allowlist`
+### `--var-file-allowlist`
   ```bash
   atlantis server --var-file-allowlist='/path/to/tfvars/dir'
   ```
@@ -648,7 +648,7 @@ Values are chosen in this order:
   The paths in this argument should be absolute paths. Relative paths and globbing are currently not supported.
   If this argument is not provided, it defaults to Atlantis' data directory, determined by the `--data-dir` argument.
 
-* ### `--vcs-status-name`
+### `--vcs-status-name`
   ```bash
   atlantis server --vcs-status-name="atlantis-dev"
   ```
@@ -657,7 +657,7 @@ Values are chosen in this order:
   This is useful when running multiple Atlantis servers against a single repository so you can
   give each Atlantis server its own unique name to prevent the statuses clashing.
 
-* ### `--write-git-creds`
+### `--write-git-creds`
   ```bash
   atlantis server --write-git-creds
   # or


### PR DESCRIPTION
Small UI changes regarding anchor links.

## Disable activeHeaderLinks for VuePress
Currently, when clicking header links in server configuration doc, such as `--allow-fork-prs`, the expected anchor link https://www.runatlantis.io/docs/server-configuration.html#allow-fork-prs won't persist, but will be changed to https://www.runatlantis.io/docs/server-configuration.html#flags.

The reason is that we are enabling [Active Header Links](https://vuepress.vuejs.org/theme/default-theme-config.html#active-header-links) with a [`sidebarDepth`](https://vuepress.vuejs.org/theme/default-theme-config.html#nested-header-links) to be `1` by default. So once we jump to the `#allow-fork-prs` tag, we are immediately redirected to the parent tag within `sidebarDepth`, in this case, `#flags`.

One way to fix this is to increase the `sidebarDepth`, however, doing so will make our sidebar a bit cluttered as shown below (which might be fine).
<img width="277" alt="Screen Shot 2022-08-15 at 2 31 29 PM" src="https://user-images.githubusercontent.com/17621872/184722673-c7d0955d-ced4-4a0e-ba40-f1db9e373ed3.png"><img width="273" alt="Screen Shot 2022-08-15 at 2 31 10 PM" src="https://user-images.githubusercontent.com/17621872/184722657-86e638ea-1059-450b-bc9e-e84914e67c5c.png">

Another way is to disable the `activeHeaderLinks` behavior, so that the browser won't try to update the URL to the parent tag. Unless many of our users are relying on the behavior to get an anchor link, I feel it's a better option. It's less disruptive to our website layout and could be more flexible since we can have an arbitrarily deep anchor link without it being redirected to its parent tag anymore.

## Remove bullet points in server config doc
If we click through the link https://www.runatlantis.io/docs/server-configuration.html#allow-fork-prs, the page won't jump to the exact section, but with a small offset. 
<img width="828" alt="Screen Shot 2022-08-15 at 2 43 52 PM" src="https://user-images.githubusercontent.com/17621872/184723711-cba7dbe0-03ad-4c2c-8638-c4982491e226.png">

It's because we indented the headers with bullet points `* ###`, which inadvertently makes VuePress drop some of the styles it could have added to the headers. We could keep the bullet point and add some custom styles like https://github.com/vuejs/vuepress/issues/2771#issuecomment-811174030 suggested, but I think we might as well drop the bullet points so that the styles would be rendered correctly.
<img width="837" alt="Screen Shot 2022-08-15 at 3 02 13 PM" src="https://user-images.githubusercontent.com/17621872/184726029-99790cdd-2008-406f-b02c-0ff552d3aca5.png">


Also when we hover over the header, the hashtag and bullet point will overlap, so yet another reason to drop them in my opinion.
<img width="390" alt="Screen Shot 2022-08-15 at 2 17 21 PM" src="https://user-images.githubusercontent.com/17621872/184725697-4ccdd478-0585-4ddc-ad87-c8461ad92b4f.png">