### PR TITLE
fix: allow requests to /api/* without authentication

### DIFF
--- a/server/middleware.go
+++ b/server/middleware.go
@@ -15,6 +15,7 @@ package server
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/urfave/negroni"
@@ -46,7 +47,8 @@ func (l *RequestLogger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 	if !l.WebAuthentication ||
 		r.URL.Path == "/events" ||
 		r.URL.Path == "/healthz" ||
-		r.URL.Path == "/status" {
+		r.URL.Path == "/status" ||
+		strings.HasPrefix(r.URL.Path, "/api/") {
 		allowed = true
 	} else {
 		user, pass, ok := r.BasicAuth()


### PR DESCRIPTION
## Problem

If WebAuthentication is enabled, API Endpoints can't be hit without Basic Auth on top of API Secret.

Not sure if this is by design, but I'd assume API Tokens should be decoupled from the WebAuthentication?

## Expected

```sh
curl -vH "X-Atlantis-Token: ${ATLANTIS_API_SECRET}" \
  -H "Accept: application/json" \
  -H "Content-Type: application/json"  \
  http://localhost:4141/api/plan \
  -d '{ "repository": "...","ref":"...","type":"...","projects":["..."]}'
 > OK
```

## Actual

```sh

curl -vH "X-Atlantis-Token: ${ATLANTIS_API_SECRET}" \
  -H "Accept: application/json" \
  -H "Content-Type: application/json"  \
  http://localhost:4141/api/plan \
  -d '{ "repository": "...","ref":"...","type":"...","projects":["..."]}'
 > Unauthorized
```

Work Around:

```sh
curl -vH "X-Atlantis-Token: ${ATLANTIS_API_SECRET}" \
  -H "Authorization: Basic ${ATLANTIS_BASIC_AUTH_BASE64}" 
  -H "Accept: application/json" \
  -H "Content-Type: application/json"  \
  http://localhost:4141/api/plan \
  -d '{ "repository": "...","ref":"...","type":"...","projects":["..."]}'
> OK
```

Related to:

- https://github.com/runatlantis/atlantis/issues/937
- https://github.com/runatlantis/atlantis/pull/1896