### PR TITLE
Omit type declaration of vars

### DIFF
--- a/server/events/post_workflow_hooks_command_runner_test.go
+++ b/server/events/post_workflow_hooks_command_runner_test.go
@@ -72,7 +72,7 @@ func TestRunPostHooks_Clone(t *testing.T) {
 	t.Run("success hooks in cfg", func(t *testing.T) {
 		postWorkflowHooksSetup(t)
 
-		var unlockCalled *bool = newBool(false)
+		unlockCalled := newBool(false)
 		unlockFn := func() {
 			unlockCalled = newBool(true)
 		}
@@ -157,7 +157,7 @@ func TestRunPostHooks_Clone(t *testing.T) {
 	t.Run("error cloning", func(t *testing.T) {
 		postWorkflowHooksSetup(t)
 
-		var unlockCalled *bool = newBool(false)
+		unlockCalled := newBool(false)
 		unlockFn := func() {
 			unlockCalled = newBool(true)
 		}
@@ -189,7 +189,7 @@ func TestRunPostHooks_Clone(t *testing.T) {
 	t.Run("error running post hook", func(t *testing.T) {
 		postWorkflowHooksSetup(t)
 
-		var unlockCalled *bool = newBool(false)
+		unlockCalled := newBool(false)
 		unlockFn := func() {
 			unlockCalled = newBool(true)
 		}


### PR DESCRIPTION
Go has type inference, and it's considered non-idiomatic to specify types when declaring a var with an initial value.
```go
var name = "Joe"
var name string = "Joe" // string here is redundant
```