### PR TITLE
Update using-atlantis.md

### DIFF
--- a/runatlantis.io/docs/using-atlantis.md
+++ b/runatlantis.io/docs/using-atlantis.md
@@ -76,7 +76,7 @@ atlantis apply
 atlantis apply -d .
 
 # Runs apply in the `project1` directory of the repo with workspace `default`
-atlantis apply -d project1
+atlantis apply -p project1
 
 # Runs apply in the root directory of the repo with workspace `staging`
 atlantis apply -w staging

--- a/runatlantis.io/docs/using-atlantis.md
+++ b/runatlantis.io/docs/using-atlantis.md
@@ -76,6 +76,9 @@ atlantis apply
 atlantis apply -d .
 
 # Runs apply in the `project1` directory of the repo with workspace `default`
+atlantis apply -p dir/project1
+
+# Runs apply for project1 with workspace `default`
 atlantis apply -p project1
 
 # Runs apply in the root directory of the repo with workspace `staging`

--- a/runatlantis.io/docs/using-atlantis.md
+++ b/runatlantis.io/docs/using-atlantis.md
@@ -76,7 +76,7 @@ atlantis apply
 atlantis apply -d .
 
 # Runs apply in the `project1` directory of the repo with workspace `default`
-atlantis apply -p dir/project1
+atlantis apply -d dir/project1
 
 # Runs apply for project1 with workspace `default`
 atlantis apply -p project1


### PR DESCRIPTION
The `Options` section below shows that `-p` should be used when specifying a project. 