### PR TITLE
workflows: update runner to use ubuntu-22.04

### DIFF
--- a/.github/workflows/atlantis-base.yml
+++ b/.github/workflows/atlantis-base.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3

--- a/.github/workflows/ci-link-checker-image.yml
+++ b/.github/workflows/ci-link-checker-image.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Login to Packages Container registry

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   golangci-lint:
     name: runner / golangci-lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: golangci-lint
@@ -21,7 +21,7 @@ jobs:
   # Use revive via golangci-lint binary with "warning" level.
   revive:
     name: runner / revive
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
@@ -35,7 +35,7 @@ jobs:
   # You can add more and more supported linters with different config.
   errcheck:
     name: runner / errcheck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,7 +4,7 @@ on:
     - cron: '30 1 * * *'
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/stale@v5
         with:
@@ -12,4 +12,3 @@ jobs:
           days-before-stale: 30
           days-before-close: 5
           only-labels: 'waiting-on-response'
-  

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   test:
     name: runner / gotest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ghcr.io/runatlantis/testing-env:2021.08.31
     steps:
       # user in image needs write access to do anything

--- a/.github/workflows/testing-env-image.yml
+++ b/.github/workflows/testing-env-image.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
Recently, [ubuntu-22.04 went GA](https://github.blog/changelog/2022-08-09-github-actions-ubuntu-22-04-is-now-generally-available-on-github-hosted-runners/), thus, updating the runners.

For the OS installed software differences, see [this issue](https://github.com/actions/runner-images/issues/5490)