### PR TITLE
lint: remove deprecated io/util package

### DIFF
--- a/server/controllers/api_controller.go
+++ b/server/controllers/api_controller.go
@@ -3,7 +3,7 @@ package controllers
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -181,7 +181,7 @@ func (a *APIController) apiParseAndValidate(r *http.Request) (*APIRequest, *comm
 	}
 
 	// Parse the JSON payload
-	bytes, err := ioutil.ReadAll(r.Body)
+	bytes, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, nil, http.StatusBadRequest, fmt.Errorf("failed to read request")
 	}

--- a/server/core/runtime/apply_step_runner_test.go
+++ b/server/core/runtime/apply_step_runner_test.go
@@ -2,7 +2,6 @@ package runtime_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -53,7 +52,7 @@ func TestRun_Success(t *testing.T) {
 	tmpDir, cleanup := TempDir(t)
 	defer cleanup()
 	planPath := filepath.Join(tmpDir, "workspace.tfplan")
-	err := ioutil.WriteFile(planPath, nil, 0600)
+	err := os.WriteFile(planPath, nil, 0600)
 	logger := logging.NewNoopLogger(t)
 	ctx := command.ProjectContext{
 		Log:                logger,
@@ -84,7 +83,7 @@ func TestRun_AppliesCorrectProjectPlan(t *testing.T) {
 	tmpDir, cleanup := TempDir(t)
 	defer cleanup()
 	planPath := filepath.Join(tmpDir, "projectname-default.tfplan")
-	err := ioutil.WriteFile(planPath, nil, 0600)
+	err := os.WriteFile(planPath, nil, 0600)
 
 	logger := logging.NewNoopLogger(t)
 	ctx := command.ProjectContext{

--- a/server/events/event_parser_test.go
+++ b/server/events/event_parser_test.go
@@ -16,7 +16,6 @@ package events_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -500,7 +499,7 @@ func TestParseGitlabMergeEvent_Update_ActionType(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.filename, func(t *testing.T) {
 			path := filepath.Join("testdata", c.filename)
-			bytes, err := ioutil.ReadFile(path)
+			bytes, err := os.ReadFile(path)
 			Ok(t, err)
 
 			var event *gitlab.MergeEvent

--- a/server/events/pull_closed_executor_test.go
+++ b/server/events/pull_closed_executor_test.go
@@ -14,7 +14,7 @@
 package events_test
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -213,7 +213,7 @@ func TestCleanUpLogStreaming(t *testing.T) {
 		var configBucket = "configBucket"
 		var pullsBucketName = "pulls"
 
-		f, err := ioutil.TempFile("", "")
+		f, err := os.CreateTemp("", "")
 		if err != nil {
 			panic(errors.Wrap(err, "failed to create temp file"))
 		}

--- a/server/static/bindata_assetfs.go
+++ b/server/static/bindata_assetfs.go
@@ -17,7 +17,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -427,7 +426,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	err = os.WriteFile(_filePath(dir, name), data, info.Mode())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
As of go1.16, io/util package has been deprecated

- See issue, https://github.com/golang/go/issues/42026

- follow up of #1843