### PR TITLE
Adding Redis TLS Option

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -89,6 +89,7 @@ const (
 	RedisHost                   = "redis-host"
 	RedisPassword               = "redis-password"
 	RedisPort                   = "redis-port"
+	RedisTLSEnabled             = "redis-tls-enabled"
 	RepoConfigFlag              = "repo-config"
 	RepoConfigJSONFlag          = "repo-config-json"
 	// RepoWhitelistFlag is deprecated for RepoAllowlistFlag.
@@ -133,6 +134,7 @@ const (
 	DefaultStatsNamespace   = "atlantis"
 	DefaultPort             = 4141
 	DefaultRedisPort        = 6379
+	DefaultRedisTLSEnabled  = false
 	DefaultTFDownloadURL    = "https://releases.hashicorp.com"
 	DefaultTFEHostname      = "app.terraform.io"
 	DefaultVCSStatusName    = "atlantis"
@@ -403,6 +405,10 @@ var boolFlags = map[string]boolFlag{
 		description: "Hide previous plan comments to reduce clutter in the PR. " +
 			"VCS support is limited to: GitHub.",
 		defaultValue: false,
+	},
+	RedisTLSEnabled: {
+		description:  "Enable TLS on the connection to Redis with a min TLS version of 1.2",
+		defaultValue: DefaultRedisTLSEnabled,
 	},
 	RequireApprovalFlag: {
 		description:  "Require pull requests to be \"Approved\" before allowing the apply command to be run.",

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -90,6 +90,7 @@ const (
 	RedisPassword               = "redis-password"
 	RedisPort                   = "redis-port"
 	RedisTLSEnabled             = "redis-tls-enabled"
+	RedisInsecureSkipVerify     = "redis-insecure-skip-verify"
 	RepoConfigFlag              = "repo-config"
 	RepoConfigJSONFlag          = "repo-config-json"
 	// RepoWhitelistFlag is deprecated for RepoAllowlistFlag.
@@ -119,28 +120,29 @@ const (
 	WebPasswordFlag            = "web-password"
 
 	// NOTE: Must manually set these as defaults in the setDefaults function.
-	DefaultADBasicUser      = ""
-	DefaultADBasicPassword  = ""
-	DefaultADHostname       = "dev.azure.com"
-	DefaultAutoplanFileList = "**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl"
-	DefaultCheckoutStrategy = "branch"
-	DefaultBitbucketBaseURL = bitbucketcloud.BaseURL
-	DefaultDataDir          = "~/.atlantis"
-	DefaultGHHostname       = "github.com"
-	DefaultGitlabHostname   = "gitlab.com"
-	DefaultLockingDBType    = "boltdb"
-	DefaultLogLevel         = "info"
-	DefaultParallelPoolSize = 15
-	DefaultStatsNamespace   = "atlantis"
-	DefaultPort             = 4141
-	DefaultRedisPort        = 6379
-	DefaultRedisTLSEnabled  = false
-	DefaultTFDownloadURL    = "https://releases.hashicorp.com"
-	DefaultTFEHostname      = "app.terraform.io"
-	DefaultVCSStatusName    = "atlantis"
-	DefaultWebBasicAuth     = false
-	DefaultWebUsername      = "atlantis"
-	DefaultWebPassword      = "atlantis"
+	DefaultADBasicUser             = ""
+	DefaultADBasicPassword         = ""
+	DefaultADHostname              = "dev.azure.com"
+	DefaultAutoplanFileList        = "**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl"
+	DefaultCheckoutStrategy        = "branch"
+	DefaultBitbucketBaseURL        = bitbucketcloud.BaseURL
+	DefaultDataDir                 = "~/.atlantis"
+	DefaultGHHostname              = "github.com"
+	DefaultGitlabHostname          = "gitlab.com"
+	DefaultLockingDBType           = "boltdb"
+	DefaultLogLevel                = "info"
+	DefaultParallelPoolSize        = 15
+	DefaultStatsNamespace          = "atlantis"
+	DefaultPort                    = 4141
+	DefaultRedisPort               = 6379
+	DefaultRedisTLSEnabled         = false
+	DefaultRedisInsecureSkipVerify = false
+	DefaultTFDownloadURL           = "https://releases.hashicorp.com"
+	DefaultTFEHostname             = "app.terraform.io"
+	DefaultVCSStatusName           = "atlantis"
+	DefaultWebBasicAuth            = false
+	DefaultWebUsername             = "atlantis"
+	DefaultWebPassword             = "atlantis"
 )
 
 var stringFlags = map[string]stringFlag{
@@ -409,6 +411,10 @@ var boolFlags = map[string]boolFlag{
 	RedisTLSEnabled: {
 		description:  "Enable TLS on the connection to Redis with a min TLS version of 1.2",
 		defaultValue: DefaultRedisTLSEnabled,
+	},
+	RedisInsecureSkipVerify: {
+		description:  "Controls whether the Redis client verifies the Redis server's certificate chain and host name. If true, accepts any certificate presented by the server and any host name in that certificate.",
+		defaultValue: DefaultRedisInsecureSkipVerify,
 	},
 	RequireApprovalFlag: {
 		description:  "Require pull requests to be \"Approved\" before allowing the apply command to be run.",

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -474,6 +474,16 @@ Values are chosen in this order:
   ```
   Enables a TLS connection, with min version of 1.2, to Redis when using a Locking DB type of `redis`. Defaults to `false`.
 
+### `--redis-insecure-skip-verify`
+  ```bash
+  atlantis server --redis-insecure-skip-verify=false
+  ```
+  Controls whether the Redis client verifies the Redis server's certificate chain and host name. If true, accepts any certificate presented by the server and any host name in that certificate. Defaults to `false`.
+
+  ::: warning SECURITY WARNING
+  If this is enabled, TLS is susceptible to machine-in-the-middle attacks unless custom verification is used.
+  :::
+
 ### `--repo-config`
   ```bash
   atlantis server --repo-config="path/to/repos.yaml"

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -468,6 +468,12 @@ Values are chosen in this order:
   ```
   The Redis Port for when using a Locking DB type of `redis`. Defaults to `6379`.
 
+### `--redis-tls-enabled`
+  ```bash
+  atlantis server --redis-tls-enabled=false
+  ```
+  Enables a TLS connection, with min version of 1.2, to Redis when using a Locking DB type of `redis`. Defaults to `false`.
+
 ### `--repo-config`
   ```bash
   atlantis server --repo-config="path/to/repos.yaml"

--- a/server/core/redis/redis.go
+++ b/server/core/redis/redis.go
@@ -26,13 +26,14 @@ const (
 	pullKeySeparator = "::"
 )
 
-func New(hostname string, port int, password string, tlsEnabled bool) (*RedisDB, error) {
+func New(hostname string, port int, password string, tlsEnabled bool, insecureSkipVerify bool) (*RedisDB, error) {
 	var rdb *redis.Client
 
 	var tlsConfig *tls.Config
 	if tlsEnabled {
 		tlsConfig = &tls.Config{
-			MinVersion: tls.VersionTLS12,
+			MinVersion:         tls.VersionTLS12,
+			InsecureSkipVerify: insecureSkipVerify,
 		}
 	}
 

--- a/server/core/redis/redis.go
+++ b/server/core/redis/redis.go
@@ -33,7 +33,7 @@ func New(hostname string, port int, password string, tlsEnabled bool, insecureSk
 	if tlsEnabled {
 		tlsConfig = &tls.Config{
 			MinVersion:         tls.VersionTLS12,
-			InsecureSkipVerify: insecureSkipVerify,
+			InsecureSkipVerify: insecureSkipVerify, //nolint:gosec // In some cases, users may want to use this at their own caution
 		}
 	}
 

--- a/server/core/redis/redis.go
+++ b/server/core/redis/redis.go
@@ -3,6 +3,7 @@ package redis
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -25,14 +26,28 @@ const (
 	pullKeySeparator = "::"
 )
 
-func New(hostname string, port int, password string) (*RedisDB, error) {
+func New(hostname string, port int, password string, tlsEnabled bool) (*RedisDB, error) {
+	var rdb *redis.Client
 
-	fmt.Println(hostname, port)
-	rdb := redis.NewClient(&redis.Options{
-		Addr:     fmt.Sprintf("%s:%d", hostname, port),
-		Password: password,
-		DB:       0, // use default DB
+	var tlsConfig *tls.Config
+	if tlsEnabled {
+		tlsConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
+	}
+
+	rdb = redis.NewClient(&redis.Options{
+		Addr:      fmt.Sprintf("%s:%d", hostname, port),
+		Password:  password,
+		DB:        0, // use default DB
+		TLSConfig: tlsConfig,
 	})
+
+	// Check if connection is valid
+	err := rdb.Ping(ctx).Err()
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to connect to redis instance at %s:%d", hostname, port))
+	}
 
 	return &RedisDB{
 		client: rdb,

--- a/server/core/redis/redis_test.go
+++ b/server/core/redis/redis_test.go
@@ -50,10 +50,12 @@ func TestRedisWithTLS(t *testing.T) {
 	certBytes, keyBytes, err := generateLocalhostCert()
 	Ok(t, err)
 	certOut := new(bytes.Buffer)
-	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
+	err = pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
+	Ok(t, err)
 	certData := certOut.Bytes()
 	keyOut := new(bytes.Buffer)
-	pem.Encode(keyOut, &pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes})
+	err = pem.Encode(keyOut, &pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes})
+	Ok(t, err)
 	cert, err = tls.X509KeyPair(certData, keyOut.Bytes())
 	Ok(t, err)
 	certFile, err := os.CreateTemp("", "cert.*.pem")
@@ -64,7 +66,7 @@ func TestRedisWithTLS(t *testing.T) {
 	defer certFile.Close()
 	tlsConfig := &tls.Config{
 		Certificates:       []tls.Certificate{cert},
-		InsecureSkipVerify: true,
+		InsecureSkipVerify: true, //nolint:gosec // This is purely for testing
 	}
 
 	// Start Server and Connect

--- a/server/core/redis/redis_test.go
+++ b/server/core/redis/redis_test.go
@@ -1,7 +1,16 @@
 package redis_test
 
 import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
 	"testing"
 	"time"
 
@@ -29,22 +38,43 @@ var lock = models.ProjectLock{
 	Time:      time.Now(),
 }
 
-func TestLockCommandNotSetWithTLS(t *testing.T) {
-	t.Log("retrieving apply lock when there are none should return empty LockCommand")
+var (
+	cert   tls.Certificate
+	caPath string
+)
+
+func TestRedisWithTLS(t *testing.T) {
+	t.Log("connecting to redis over TLS")
+
+	// Setup the Miniredis Server for TLS
+	certBytes, keyBytes, err := generateLocalhostCert()
+	Ok(t, err)
+	certOut := new(bytes.Buffer)
+	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
+	certData := certOut.Bytes()
+	keyOut := new(bytes.Buffer)
+	pem.Encode(keyOut, &pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes})
+	cert, err = tls.X509KeyPair(certData, keyOut.Bytes())
+	Ok(t, err)
+	certFile, err := os.CreateTemp("", "cert.*.pem")
+	Ok(t, err)
+	caPath = certFile.Name()
+	_, err = certFile.Write(certData)
+	Ok(t, err)
+	defer certFile.Close()
 	tlsConfig := &tls.Config{
-		Certificates:       make([]tls.Certificate, 1),
+		Certificates:       []tls.Certificate{cert},
 		InsecureSkipVerify: true,
 	}
+
+	// Start Server and Connect
 	s := miniredis.NewMiniRedis()
 	if err := s.StartTLS(tlsConfig); err != nil {
 		t.Fatalf("could not start miniredis: %s", err)
 		// not reached
 	}
 	t.Cleanup(s.Close)
-	r := newTestRedisTLS(s)
-	exists, err := r.CheckCommandLock(command.Apply)
-	Ok(t, err)
-	Assert(t, exists == nil, "exp nil")
+	_ = newTestRedisTLS(s)
 }
 
 func TestLockCommandNotSet(t *testing.T) {
@@ -771,7 +801,7 @@ func TestPullStatus_UpdateMerge(t *testing.T) {
 }
 
 func newTestRedis(mr *miniredis.Miniredis) *redis.RedisDB {
-	r, err := redis.New(mr.Host(), mr.Server().Addr().Port, "", false)
+	r, err := redis.New(mr.Host(), mr.Server().Addr().Port, "", false, false)
 	if err != nil {
 		panic(errors.Wrap(err, "failed to create test redis client"))
 	}
@@ -779,9 +809,45 @@ func newTestRedis(mr *miniredis.Miniredis) *redis.RedisDB {
 }
 
 func newTestRedisTLS(mr *miniredis.Miniredis) *redis.RedisDB {
-	r, err := redis.New(mr.Host(), mr.Server().Addr().Port, "", true)
+	r, err := redis.New(mr.Host(), mr.Server().Addr().Port, "", true, true)
 	if err != nil {
 		panic(errors.Wrap(err, "failed to create test redis client"))
 	}
 	return r
+}
+
+func generateLocalhostCert() ([]byte, []byte, error) {
+	var err error
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return nil, keyBytes, err
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, keyBytes, err
+	}
+
+	notBefore := time.Now()
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Atlantis Test Suite"},
+		},
+		NotBefore: notBefore,
+		NotAfter:  notBefore.Add(time.Hour),
+		KeyUsage:  x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+
+		IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	certBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	return certBytes, keyBytes, err
 }

--- a/server/server.go
+++ b/server/server.go
@@ -405,7 +405,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	switch dbtype := userConfig.LockingDBType; dbtype {
 	case "redis":
 		logger.Info("Utilizing Redis DB")
-		backend, err = redis.New(userConfig.RedisHost, userConfig.RedisPort, userConfig.RedisPassword)
+		backend, err = redis.New(userConfig.RedisHost, userConfig.RedisPort, userConfig.RedisPassword, userConfig.RedisTLSEnabled)
 		if err != nil {
 			return nil, err
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -405,7 +405,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	switch dbtype := userConfig.LockingDBType; dbtype {
 	case "redis":
 		logger.Info("Utilizing Redis DB")
-		backend, err = redis.New(userConfig.RedisHost, userConfig.RedisPort, userConfig.RedisPassword, userConfig.RedisTLSEnabled)
+		backend, err = redis.New(userConfig.RedisHost, userConfig.RedisPort, userConfig.RedisPassword, userConfig.RedisTLSEnabled, userConfig.RedisInsecureSkipVerify)
 		if err != nil {
 			return nil, err
 		}

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -59,6 +59,7 @@ type UserConfig struct {
 	RedisPassword                   string `mapstructure:"redis-password"`
 	RedisPort                       int    `mapstructure:"redis-port"`
 	RedisTLSEnabled                 bool   `mapstructure:"redis-tls-enabled"`
+	RedisInsecureSkipVerify         bool   `mapstructure:"redis-insecure-skip-verify"`
 	RepoConfig                      string `mapstructure:"repo-config"`
 	RepoConfigJSON                  string `mapstructure:"repo-config-json"`
 	RepoAllowlist                   string `mapstructure:"repo-allowlist"`

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -58,6 +58,7 @@ type UserConfig struct {
 	RedisHost                       string `mapstructure:"redis-host"`
 	RedisPassword                   string `mapstructure:"redis-password"`
 	RedisPort                       int    `mapstructure:"redis-port"`
+	RedisTLSEnabled                 bool   `mapstructure:"redis-tls-enabled"`
 	RepoConfig                      string `mapstructure:"repo-config"`
 	RepoConfigJSON                  string `mapstructure:"repo-config-json"`
 	RepoAllowlist                   string `mapstructure:"repo-allowlist"`


### PR DESCRIPTION
The current implementation works great so far for using Redis as a locking DB. A slight oversight on the initial work, though, was being able to enable TLS for the connection to Redis. This change adds the option to turn on TLS for Redis for those that so desire.

Additionally, this adds a PING test on the client creation to ensure the connection is good to go.