### PR TITLE
Adding Redis DB option

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -86,6 +86,7 @@ const (
 	StatsNamespace              = "stats-namespace"
 	AllowDraftPRs               = "allow-draft-prs"
 	PortFlag                    = "port"
+	RedisDB                     = "redis-db"
 	RedisHost                   = "redis-host"
 	RedisPassword               = "redis-password"
 	RedisPort                   = "redis-port"
@@ -134,6 +135,7 @@ const (
 	DefaultParallelPoolSize        = 15
 	DefaultStatsNamespace          = "atlantis"
 	DefaultPort                    = 4141
+	DefaultRedisDB                 = 0
 	DefaultRedisPort               = 6379
 	DefaultRedisTLSEnabled         = false
 	DefaultRedisInsecureSkipVerify = false
@@ -478,6 +480,10 @@ var intFlags = map[string]intFlag{
 		description:  "Port to bind to.",
 		defaultValue: DefaultPort,
 	},
+	RedisDB: {
+		description:  "The Redis Database to use when using a Locking DB type of 'redis'.",
+		defaultValue: DefaultRedisDB,
+	},
 	RedisPort: {
 		description:  "The Redis Port for when using a Locking DB type of 'redis'.",
 		defaultValue: DefaultRedisPort,
@@ -718,6 +724,9 @@ func (s *ServerCmd) setDefaults(c *server.UserConfig) {
 	}
 	if c.Port == 0 {
 		c.Port = DefaultPort
+	}
+	if c.RedisDB == 0 {
+		c.RedisDB = DefaultRedisDB
 	}
 	if c.RedisPort == 0 {
 		c.RedisPort = DefaultRedisPort

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -468,6 +468,12 @@ Values are chosen in this order:
   ```
   The Redis Port for when using a Locking DB type of `redis`. Defaults to `6379`.
 
+### `--redis-db`
+  ```bash
+  atlantis server --redis-db=0
+  ```
+  The Redis Database to use when using a Locking DB type of `redis`. Defaults to `0`.
+
 ### `--redis-tls-enabled`
   ```bash
   atlantis server --redis-tls-enabled=false

--- a/server/core/redis/redis.go
+++ b/server/core/redis/redis.go
@@ -26,7 +26,7 @@ const (
 	pullKeySeparator = "::"
 )
 
-func New(hostname string, port int, password string, tlsEnabled bool, insecureSkipVerify bool) (*RedisDB, error) {
+func New(hostname string, port int, password string, tlsEnabled bool, insecureSkipVerify bool, db int) (*RedisDB, error) {
 	var rdb *redis.Client
 
 	var tlsConfig *tls.Config
@@ -40,7 +40,7 @@ func New(hostname string, port int, password string, tlsEnabled bool, insecureSk
 	rdb = redis.NewClient(&redis.Options{
 		Addr:      fmt.Sprintf("%s:%d", hostname, port),
 		Password:  password,
-		DB:        0, // use default DB
+		DB:        db,
 		TLSConfig: tlsConfig,
 	})
 

--- a/server/core/redis/redis_test.go
+++ b/server/core/redis/redis_test.go
@@ -803,7 +803,7 @@ func TestPullStatus_UpdateMerge(t *testing.T) {
 }
 
 func newTestRedis(mr *miniredis.Miniredis) *redis.RedisDB {
-	r, err := redis.New(mr.Host(), mr.Server().Addr().Port, "", false, false)
+	r, err := redis.New(mr.Host(), mr.Server().Addr().Port, "", false, false, 0)
 	if err != nil {
 		panic(errors.Wrap(err, "failed to create test redis client"))
 	}
@@ -811,7 +811,7 @@ func newTestRedis(mr *miniredis.Miniredis) *redis.RedisDB {
 }
 
 func newTestRedisTLS(mr *miniredis.Miniredis) *redis.RedisDB {
-	r, err := redis.New(mr.Host(), mr.Server().Addr().Port, "", true, true)
+	r, err := redis.New(mr.Host(), mr.Server().Addr().Port, "", true, true, 0)
 	if err != nil {
 		panic(errors.Wrap(err, "failed to create test redis client"))
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -405,7 +405,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	switch dbtype := userConfig.LockingDBType; dbtype {
 	case "redis":
 		logger.Info("Utilizing Redis DB")
-		backend, err = redis.New(userConfig.RedisHost, userConfig.RedisPort, userConfig.RedisPassword, userConfig.RedisTLSEnabled, userConfig.RedisInsecureSkipVerify)
+		backend, err = redis.New(userConfig.RedisHost, userConfig.RedisPort, userConfig.RedisPassword, userConfig.RedisTLSEnabled, userConfig.RedisInsecureSkipVerify, userConfig.RedisDB)
 		if err != nil {
 			return nil, err
 		}

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -55,6 +55,7 @@ type UserConfig struct {
 	StatsNamespace                  string `mapstructure:"stats-namespace"`
 	PlanDrafts                      bool   `mapstructure:"allow-draft-prs"`
 	Port                            int    `mapstructure:"port"`
+	RedisDB                         int    `mapstructure:"redis-db"`
 	RedisHost                       string `mapstructure:"redis-host"`
 	RedisPassword                   string `mapstructure:"redis-password"`
 	RedisPort                       int    `mapstructure:"redis-port"`


### PR DESCRIPTION
This exposes the remaining Redis connection option, `DB`,  which was hard-coded to `0` in the initial Redis Locking DB work.

This allows selecting something other than the default database of `0`. Atlantis may now use a different numerical database if needed, while still defaulting to `0`. Common use case is multiple applications using the same redis server and using database as a mechanism for name spacing different applications. This could also allow multiple atlantis instances to share a single redis instance and separate locks by database. cc @SudoSpartanDan 