### PR TITLE
Fix: Error when enabling prometheus metrics

### DIFF
--- a/server/controllers/events/events_controller.go
+++ b/server/controllers/events/events_controller.go
@@ -158,7 +158,7 @@ func (e *VCSEventsController) handleGithubPost(w http.ResponseWriter, r *http.Re
 
 	githubReqID := "X-Github-Delivery=" + r.Header.Get("X-Github-Delivery")
 	logger := e.Logger.With("gh-request-id", githubReqID)
-	scope := e.Scope.SubScope("github.event")
+	scope := e.Scope.SubScope("github_event")
 
 	logger.Debug("request valid")
 
@@ -169,10 +169,10 @@ func (e *VCSEventsController) handleGithubPost(w http.ResponseWriter, r *http.Re
 	switch event := event.(type) {
 	case *github.IssueCommentEvent:
 		resp = e.HandleGithubCommentEvent(event, githubReqID, logger)
-		scope = scope.SubScope(fmt.Sprintf("comment.%s", *event.Action))
+		scope = scope.SubScope(fmt.Sprintf("comment_%s", *event.Action))
 	case *github.PullRequestEvent:
 		resp = e.HandleGithubPullRequestEvent(logger, event, githubReqID)
-		scope = scope.SubScope(fmt.Sprintf("pr.%s", *event.Action))
+		scope = scope.SubScope(fmt.Sprintf("pr_%s", *event.Action))
 	default:
 		resp = HTTPResponse{
 			body: fmt.Sprintf("Ignoring unsupported event %s", githubReqID),

--- a/server/events/instrumented_pull_closed_executor.go
+++ b/server/events/instrumented_pull_closed_executor.go
@@ -20,7 +20,7 @@ func NewInstrumentedPullClosedExecutor(
 ) PullCleaner {
 
 	return &InstrumentedPullClosedExecutor{
-		scope:   scope.SubScope("pullclosed.cleanup"),
+		scope:   scope.SubScope("pullclosed_cleanup"),
 		log:     log,
 		cleaner: cleaner,
 	}


### PR DESCRIPTION
Prometheus metrics names have some restrictions that must match the regex `[a-zA-Z_:][a-zA-Z0-9_:]*`

The metric names have some restrictions which are documented here: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels

This resolves https://github.com/runatlantis/atlantis/issues/2379
Also, see https://github.com/runatlantis/atlantis/pull/2204#issuecomment-1205005094
