### PR TITLE
docs: update notes to clarify where the environment variables are available

### DIFF
--- a/runatlantis.io/docs/custom-workflows.md
+++ b/runatlantis.io/docs/custom-workflows.md
@@ -421,6 +421,7 @@ Or a custom command
 
 ::: tip Notes
 * `run` steps in the main `workflow` are executed with the following environment variables:
+*  note: these variables are not available to `pre` or `post` workflows
   * `WORKSPACE` - The Terraform workspace used for this project, ex. `default`.
     * NOTE: if the step is executed before `init` then Atlantis won't have switched to this workspace yet.
   * `ATLANTIS_TERRAFORM_VERSION` - The version of Terraform used for this project, ex. `0.11.0`.

--- a/runatlantis.io/docs/custom-workflows.md
+++ b/runatlantis.io/docs/custom-workflows.md
@@ -420,7 +420,7 @@ Or a custom command
 | run | string | none    | no       | Run a custom command |
 
 ::: tip Notes
-* `run` steps are executed with the following environment variables:
+* `run` steps in the main `workflow` are executed with the following environment variables:
   * `WORKSPACE` - The Terraform workspace used for this project, ex. `default`.
     * NOTE: if the step is executed before `init` then Atlantis won't have switched to this workspace yet.
   * `ATLANTIS_TERRAFORM_VERSION` - The version of Terraform used for this project, ex. `0.11.0`.
@@ -497,4 +497,3 @@ The name-value pairs in the result are added as environment variables if success
 * `multienv` `command`'s can use any of the built-in environment variables available
   to `run` commands. 
 :::
-


### PR DESCRIPTION
These variables are available in the main `workflow` only. 