### PR TITLE
Add custom templates support (#2481)

### DIFF
--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -15,6 +15,7 @@ package events
 
 import (
 	"bytes"
+	"embed"
 	"fmt"
 	"strings"
 	"text/template"
@@ -33,7 +34,19 @@ var (
 	// maxUnwrappedLines is the maximum number of lines the Terraform output
 	// can be before we wrap it in an expandable template.
 	maxUnwrappedLines = 12
+
+	//go:embed templates/*
+	templatesFS embed.FS
+	templates   *template.Template
 )
+
+func init() {
+	templates, _ = template.New("").Funcs(sprig.TxtFuncMap()).ParseFS(templatesFS, "templates/*.tmpl")
+	if overrides, err := templates.ParseFiles("templates/*"); err == nil {
+		// doesn't override if templates directory doesn't exist
+		templates = overrides
+	}
+}
 
 // MarkdownRenderer renders responses as markdown.
 type MarkdownRenderer struct {
@@ -113,10 +126,10 @@ func (m *MarkdownRenderer) Render(res command.Result, cmdName command.Name, log 
 		EnableDiffMarkdownFormat: m.EnableDiffMarkdownFormat,
 	}
 	if res.Error != nil {
-		return m.renderTemplate(unwrappedErrWithLogTmpl, errData{res.Error.Error(), common})
+		return m.renderTemplate(templates.Lookup("unwrappedErrWithLog"), errData{res.Error.Error(), common})
 	}
 	if res.Failure != "" {
-		return m.renderTemplate(failureWithLogTmpl, failureData{res.Failure, common})
+		return m.renderTemplate(templates.Lookup("failureWithLog"), failureData{res.Failure, common})
 	}
 	return m.renderProjectResults(res.ProjectResults, common, vcsHost)
 }
@@ -134,9 +147,9 @@ func (m *MarkdownRenderer) renderProjectResults(results []command.ProjectResult,
 			ProjectName: result.ProjectName,
 		}
 		if result.Error != nil {
-			tmpl := unwrappedErrTmpl
+			tmpl := templates.Lookup("unwrappedErr")
 			if m.shouldUseWrappedTmpl(vcsHost, result.Error.Error()) {
-				tmpl = wrappedErrTmpl
+				tmpl = templates.Lookup("wrappedErr")
 			}
 			resultData.Rendered = m.renderTemplate(tmpl, struct {
 				Command string
@@ -146,7 +159,7 @@ func (m *MarkdownRenderer) renderProjectResults(results []command.ProjectResult,
 				Error:   result.Error.Error(),
 			})
 		} else if result.Failure != "" {
-			resultData.Rendered = m.renderTemplate(failureTmpl, struct {
+			resultData.Rendered = m.renderTemplate(templates.Lookup("failure"), struct {
 				Command string
 				Failure string
 			}{
@@ -155,29 +168,29 @@ func (m *MarkdownRenderer) renderProjectResults(results []command.ProjectResult,
 			})
 		} else if result.PlanSuccess != nil {
 			if m.shouldUseWrappedTmpl(vcsHost, result.PlanSuccess.TerraformOutput) {
-				resultData.Rendered = m.renderTemplate(planSuccessWrappedTmpl, planSuccessData{PlanSuccess: *result.PlanSuccess, PlanSummary: result.PlanSuccess.Summary(), PlanWasDeleted: common.PlansDeleted, DisableApply: common.DisableApply, DisableRepoLocking: common.DisableRepoLocking, EnableDiffMarkdownFormat: common.EnableDiffMarkdownFormat})
+				resultData.Rendered = m.renderTemplate(templates.Lookup("planSuccessWrapped"), planSuccessData{PlanSuccess: *result.PlanSuccess, PlanSummary: result.PlanSuccess.Summary(), PlanWasDeleted: common.PlansDeleted, DisableApply: common.DisableApply, DisableRepoLocking: common.DisableRepoLocking, EnableDiffMarkdownFormat: common.EnableDiffMarkdownFormat})
 			} else {
-				resultData.Rendered = m.renderTemplate(planSuccessUnwrappedTmpl, planSuccessData{PlanSuccess: *result.PlanSuccess, PlanWasDeleted: common.PlansDeleted, DisableApply: common.DisableApply, DisableRepoLocking: common.DisableRepoLocking, EnableDiffMarkdownFormat: common.EnableDiffMarkdownFormat})
+				resultData.Rendered = m.renderTemplate(templates.Lookup("planSuccessUnwrapped"), planSuccessData{PlanSuccess: *result.PlanSuccess, PlanWasDeleted: common.PlansDeleted, DisableApply: common.DisableApply, DisableRepoLocking: common.DisableRepoLocking, EnableDiffMarkdownFormat: common.EnableDiffMarkdownFormat})
 			}
 			numPlanSuccesses++
 		} else if result.PolicyCheckSuccess != nil {
 			if m.shouldUseWrappedTmpl(vcsHost, result.PolicyCheckSuccess.PolicyCheckOutput) {
-				resultData.Rendered = m.renderTemplate(policyCheckSuccessWrappedTmpl, policyCheckSuccessData{PolicyCheckSuccess: *result.PolicyCheckSuccess})
+				resultData.Rendered = m.renderTemplate(templates.Lookup("policyCheckSuccessWrapped"), policyCheckSuccessData{PolicyCheckSuccess: *result.PolicyCheckSuccess})
 			} else {
-				resultData.Rendered = m.renderTemplate(policyCheckSuccessUnwrappedTmpl, policyCheckSuccessData{PolicyCheckSuccess: *result.PolicyCheckSuccess})
+				resultData.Rendered = m.renderTemplate(templates.Lookup("policyCheckSuccessUnwrapped"), policyCheckSuccessData{PolicyCheckSuccess: *result.PolicyCheckSuccess})
 			}
 			numPolicyCheckSuccesses++
 		} else if result.ApplySuccess != "" {
 			if m.shouldUseWrappedTmpl(vcsHost, result.ApplySuccess) {
-				resultData.Rendered = m.renderTemplate(applyWrappedSuccessTmpl, struct{ Output string }{result.ApplySuccess})
+				resultData.Rendered = m.renderTemplate(templates.Lookup("applyWrappedSuccess"), struct{ Output string }{result.ApplySuccess})
 			} else {
-				resultData.Rendered = m.renderTemplate(applyUnwrappedSuccessTmpl, struct{ Output string }{result.ApplySuccess})
+				resultData.Rendered = m.renderTemplate(templates.Lookup("applyUnwrappedSuccess"), struct{ Output string }{result.ApplySuccess})
 			}
 		} else if result.VersionSuccess != "" {
 			if m.shouldUseWrappedTmpl(vcsHost, result.VersionSuccess) {
-				resultData.Rendered = m.renderTemplate(versionWrappedSuccessTmpl, struct{ Output string }{result.VersionSuccess})
+				resultData.Rendered = m.renderTemplate(templates.Lookup("versionWrappedSuccess"), struct{ Output string }{result.VersionSuccess})
 			} else {
-				resultData.Rendered = m.renderTemplate(versionUnwrappedSuccessTmpl, struct{ Output string }{result.VersionSuccess})
+				resultData.Rendered = m.renderTemplate(templates.Lookup("versionUnwrappedSuccess"), struct{ Output string }{result.VersionSuccess})
 			}
 			numVersionSuccesses++
 		} else {
@@ -189,28 +202,28 @@ func (m *MarkdownRenderer) renderProjectResults(results []command.ProjectResult,
 	var tmpl *template.Template
 	switch {
 	case len(resultsTmplData) == 1 && common.Command == planCommandTitle && numPlanSuccesses > 0:
-		tmpl = singleProjectPlanSuccessTmpl
+		tmpl = templates.Lookup("singleProjectPlanSuccess")
 	case len(resultsTmplData) == 1 && common.Command == planCommandTitle && numPlanSuccesses == 0:
-		tmpl = singleProjectPlanUnsuccessfulTmpl
+		tmpl = templates.Lookup("singleProjectPlanUnsuccessful")
 	case len(resultsTmplData) == 1 && common.Command == policyCheckCommandTitle && numPolicyCheckSuccesses > 0:
-		tmpl = singleProjectPlanSuccessTmpl
+		tmpl = templates.Lookup("singleProjectPlanSuccess")
 	case len(resultsTmplData) == 1 && common.Command == policyCheckCommandTitle && numPolicyCheckSuccesses == 0:
-		tmpl = singleProjectPlanUnsuccessfulTmpl
+		tmpl = templates.Lookup("singleProjectPlanUnsuccessful")
 	case len(resultsTmplData) == 1 && common.Command == versionCommandTitle && numVersionSuccesses > 0:
-		tmpl = singleProjectVersionSuccessTmpl
+		tmpl = templates.Lookup("singleProjectVersionSuccess")
 	case len(resultsTmplData) == 1 && common.Command == versionCommandTitle && numVersionSuccesses == 0:
-		tmpl = singleProjectVersionUnsuccessfulTmpl
+		tmpl = templates.Lookup("singleProjectVersionUnsuccessful")
 	case len(resultsTmplData) == 1 && common.Command == applyCommandTitle:
-		tmpl = singleProjectApplyTmpl
+		tmpl = templates.Lookup("singleProjectApply")
 	case common.Command == planCommandTitle,
 		common.Command == policyCheckCommandTitle:
-		tmpl = multiProjectPlanTmpl
+		tmpl = templates.Lookup("multiProjectPlan")
 	case common.Command == approvePoliciesCommandTitle:
-		tmpl = approveAllProjectsTmpl
+		tmpl = templates.Lookup("approveAllProjects")
 	case common.Command == applyCommandTitle:
-		tmpl = multiProjectApplyTmpl
+		tmpl = templates.Lookup("multiProjectApply")
 	case common.Command == versionCommandTitle:
-		tmpl = multiProjectVersionTmpl
+		tmpl = templates.Lookup("multiProjectVersion")
 	default:
 		return "no template matched–this is a bug"
 	}
@@ -245,146 +258,3 @@ func (m *MarkdownRenderer) renderTemplate(tmpl *template.Template, data interfac
 	}
 	return buf.String()
 }
-
-// todo: refactor to remove duplication #refactor
-var singleProjectApplyTmpl = template.Must(template.New("").Parse(
-	"{{$result := index .Results 0}}Ran {{.Command}} for {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n\n{{$result.Rendered}}\n" + logTmpl))
-var singleProjectPlanSuccessTmpl = template.Must(template.New("").Parse(
-	"{{$result := index .Results 0}}Ran {{.Command}} for {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n\n{{$result.Rendered}}\n" +
-		"\n" +
-		"{{ if ne .DisableApplyAll true  }}---\n" +
-		"* :fast_forward: To **apply** all unapplied plans from this pull request, comment:\n" +
-		"    * `atlantis apply`\n" +
-		"* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:\n" +
-		"    * `atlantis unlock`{{ end }}" + logTmpl))
-var singleProjectPlanUnsuccessfulTmpl = template.Must(template.New("").Parse(
-	"{{$result := index .Results 0}}Ran {{.Command}} for dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n\n" +
-		"{{$result.Rendered}}\n" + logTmpl))
-var singleProjectVersionSuccessTmpl = template.Must(template.New("").Parse(
-	"{{$result := index .Results 0}}Ran {{.Command}} for {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n\n{{$result.Rendered}}\n" + logTmpl))
-var singleProjectVersionUnsuccessfulTmpl = template.Must(template.New("").Parse(
-	"{{$result := index .Results 0}}Ran {{.Command}} for dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n\n{{$result.Rendered}}\n" + logTmpl))
-var approveAllProjectsTmpl = template.Must(template.New("").Funcs(sprig.TxtFuncMap()).Parse(
-	"Approved Policies for {{ len .Results }} projects:\n\n" +
-		"{{ range $result := .Results }}" +
-		"1. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n" +
-		"{{end}}\n" + logTmpl))
-var multiProjectPlanTmpl = template.Must(template.New("").Funcs(sprig.TxtFuncMap()).Parse(
-	"Ran {{.Command}} for {{ len .Results }} projects:\n\n" +
-		"{{ range $result := .Results }}" +
-		"1. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n" +
-		"{{end}}\n" +
-		"{{ $disableApplyAll := .DisableApplyAll }}{{ range $i, $result := .Results }}" +
-		"### {{add $i 1}}. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n" +
-		"{{$result.Rendered}}\n\n" +
-		"{{ if ne $disableApplyAll true }}---\n{{end}}{{end}}{{ if ne .DisableApplyAll true }}{{ if and (gt (len .Results) 0) (not .PlansDeleted) }}* :fast_forward: To **apply** all unapplied plans from this pull request, comment:\n" +
-		"    * `atlantis apply`\n" +
-		"* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:\n" +
-		"    * `atlantis unlock`" +
-		"{{end}}{{end}}" +
-		logTmpl))
-var multiProjectApplyTmpl = template.Must(template.New("").Funcs(sprig.TxtFuncMap()).Parse(
-	"Ran {{.Command}} for {{ len .Results }} projects:\n\n" +
-		"{{ range $result := .Results }}" +
-		"1. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n" +
-		"{{end}}\n" +
-		"{{ range $i, $result := .Results }}" +
-		"### {{add $i 1}}. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n" +
-		"{{$result.Rendered}}\n\n" +
-		"---\n{{end}}" +
-		logTmpl))
-var multiProjectVersionTmpl = template.Must(template.New("").Funcs(sprig.TxtFuncMap()).Parse(
-	"Ran {{.Command}} for {{ len .Results }} projects:\n\n" +
-		"{{ range $result := .Results }}" +
-		"1. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n" +
-		"{{end}}\n" +
-		"{{ range $i, $result := .Results }}" +
-		"### {{add $i 1}}. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`\n" +
-		"{{$result.Rendered}}\n\n" +
-		"---\n{{end}}" +
-		logTmpl))
-var planSuccessUnwrappedTmpl = template.Must(template.New("").Parse(
-	"```diff\n" +
-		"{{ if .EnableDiffMarkdownFormat }}{{.DiffMarkdownFormattedTerraformOutput}}{{else}}{{.TerraformOutput}}{{end}}\n" +
-		"```\n\n" + planNextSteps +
-		"{{ if .HasDiverged }}\n\n:warning: The branch we're merging into is ahead, it is recommended to pull new commits first.{{end}}"))
-
-var planSuccessWrappedTmpl = template.Must(template.New("").Parse(
-	"<details><summary>Show Output</summary>\n\n" +
-		"```diff\n" +
-		"{{ if .EnableDiffMarkdownFormat }}{{.DiffMarkdownFormattedTerraformOutput}}{{else}}{{.TerraformOutput}}{{end}}\n" +
-		"```\n\n" +
-		planNextSteps + "\n" +
-		"</details>" + "\n" +
-		"{{.PlanSummary}}" +
-		"{{ if .HasDiverged }}\n\n:warning: The branch we're merging into is ahead, it is recommended to pull new commits first.{{end}}"))
-
-var policyCheckSuccessUnwrappedTmpl = template.Must(template.New("").Parse(
-	"```diff\n" +
-		"{{.PolicyCheckOutput}}\n" +
-		"```\n\n" + policyCheckNextSteps +
-		"{{ if .HasDiverged }}\n\n:warning: The branch we're merging into is ahead, it is recommended to pull new commits first.{{end}}"))
-
-var policyCheckSuccessWrappedTmpl = template.Must(template.New("").Parse(
-	"<details><summary>Show Output</summary>\n\n" +
-		"```diff\n" +
-		"{{.PolicyCheckOutput}}\n" +
-		"```\n\n" +
-		policyCheckNextSteps + "\n" +
-		"</details>" +
-		"{{ if .HasDiverged }}\n\n:warning: The branch we're merging into is ahead, it is recommended to pull new commits first.{{end}}"))
-
-// policyCheckNextSteps are instructions appended after successful plans as to what
-// to do next.
-var policyCheckNextSteps = "* :arrow_forward: To **apply** this plan, comment:\n" +
-	"    * `{{.ApplyCmd}}`\n" +
-	"* :put_litter_in_its_place: To **delete** this plan click [here]({{.LockURL}})\n" +
-	"* :repeat: To re-run policies **plan** this project again by commenting:\n" +
-	"    * `{{.RePlanCmd}}`"
-
-// planNextSteps are instructions appended after successful plans as to what
-// to do next.
-var planNextSteps = "{{ if .PlanWasDeleted }}This plan was not saved because one or more projects failed and automerge requires all plans pass.{{ else }}" +
-	"{{ if not .DisableApply }}* :arrow_forward: To **apply** this plan, comment:\n" +
-	"    * `{{.ApplyCmd}}`\n{{end}}" +
-	"{{ if not .DisableRepoLocking }}* :put_litter_in_its_place: To **delete** this plan click [here]({{.LockURL}})\n{{end}}" +
-	"* :repeat: To **plan** this project again, comment:\n" +
-	"    * `{{.RePlanCmd}}`{{end}}"
-var applyUnwrappedSuccessTmpl = template.Must(template.New("").Parse(
-	"```diff\n" +
-		"{{.Output}}\n" +
-		"```"))
-var applyWrappedSuccessTmpl = template.Must(template.New("").Parse(
-	"<details><summary>Show Output</summary>\n\n" +
-		"```diff\n" +
-		"{{.Output}}\n" +
-		"```\n" +
-		"</details>"))
-var versionUnwrappedSuccessTmpl = template.Must(template.New("").Parse("```\n{{.Output}}```"))
-var versionWrappedSuccessTmpl = template.Must(template.New("").Parse(
-	"<details><summary>Show Output</summary>\n\n" +
-		"```\n" +
-		"{{.Output}}" +
-		"```\n" +
-		"</details>"))
-var unwrappedErrTmplText = "**{{.Command}} Error**\n" +
-	"```\n" +
-	"{{.Error}}\n" +
-	"```" +
-	"{{ if eq .Command \"Policy Check\" }}" +
-	"\n* :heavy_check_mark: To **approve** failing policies an authorized approver can comment:\n" +
-	"    * `atlantis approve_policies`\n" +
-	"* :repeat: Or, address the policy failure by modifying the codebase and re-planning.\n" +
-	"{{ end }}"
-var wrappedErrTmplText = "**{{.Command}} Error**\n" +
-	"<details><summary>Show Output</summary>\n\n" +
-	"```\n" +
-	"{{.Error}}\n" +
-	"```\n</details>"
-var unwrappedErrTmpl = template.Must(template.New("").Parse(unwrappedErrTmplText))
-var unwrappedErrWithLogTmpl = template.Must(template.New("").Parse(unwrappedErrTmplText + logTmpl))
-var wrappedErrTmpl = template.Must(template.New("").Parse(wrappedErrTmplText))
-var failureTmplText = "**{{.Command}} Failed**: {{.Failure}}"
-var failureTmpl = template.Must(template.New("").Parse(failureTmplText))
-var failureWithLogTmpl = template.Must(template.New("").Parse(failureTmplText + logTmpl))
-var logTmpl = "{{if .Verbose}}\n<details><summary>Log</summary>\n  <p>\n\n```\n{{.Log}}```\n</p></details>{{end}}\n"

--- a/server/events/templates/apply_unwrapped_success.tmpl
+++ b/server/events/templates/apply_unwrapped_success.tmpl
@@ -1,0 +1,5 @@
+{{ define "applyUnwrappedSuccess" -}}
+```diff
+{{.Output}}
+```
+{{- end }}

--- a/server/events/templates/apply_wrapped_success.tmpl
+++ b/server/events/templates/apply_wrapped_success.tmpl
@@ -1,8 +1,6 @@
 {{ define "applyWrappedSuccess" -}}
 <details><summary>Show Output</summary>
 
-```diff
-{{.Output}}
-```
+{{ template "applyUnwrappedSuccess" . }}
 </details>
 {{- end }}

--- a/server/events/templates/apply_wrapped_success.tmpl
+++ b/server/events/templates/apply_wrapped_success.tmpl
@@ -1,0 +1,8 @@
+{{ define "applyWrappedSuccess" -}}
+<details><summary>Show Output</summary>
+
+```diff
+{{.Output}}
+```
+</details>
+{{- end }}

--- a/server/events/templates/approve_all_projects.tmpl
+++ b/server/events/templates/approve_all_projects.tmpl
@@ -1,0 +1,13 @@
+{{ define "approveAllProjects" -}}
+Approved Policies for {{ len .Results }} projects:
+
+{{ range $result := .Results }}1. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`
+{{end}}
+{{if .Verbose}}
+<details><summary>Log</summary>
+  <p>
+
+```
+{{.Log}}```
+</p></details>{{end}}
+{{ end }}

--- a/server/events/templates/diverged.tmpl
+++ b/server/events/templates/diverged.tmpl
@@ -1,0 +1,5 @@
+{{ define "diverged" -}}
+{{ if .HasDiverged }}
+
+:warning: The branch we're merging into is ahead, it is recommended to pull new commits first.{{end}}
+{{- end }}

--- a/server/events/templates/failure.tmpl
+++ b/server/events/templates/failure.tmpl
@@ -1,0 +1,3 @@
+{{ define "failure" -}}
+**{{.Command}} Failed**: {{.Failure}}
+{{- end }}

--- a/server/events/templates/failure_with_log.tmpl
+++ b/server/events/templates/failure_with_log.tmpl
@@ -1,9 +1,3 @@
 {{ define "failureWithLog" -}}
-**{{.Command}} Failed**: {{.Failure}}{{if .Verbose}}
-<details><summary>Log</summary>
-  <p>
-
-```
-{{.Log}}```
-</p></details>{{end}}
+{{ template "failure" . }}{{ template "log" . }}
 {{ end }}

--- a/server/events/templates/failure_with_log.tmpl
+++ b/server/events/templates/failure_with_log.tmpl
@@ -1,0 +1,9 @@
+{{ define "failureWithLog" -}}
+**{{.Command}} Failed**: {{.Failure}}{{if .Verbose}}
+<details><summary>Log</summary>
+  <p>
+
+```
+{{.Log}}```
+</p></details>{{end}}
+{{ end }}

--- a/server/events/templates/log.tmpl
+++ b/server/events/templates/log.tmpl
@@ -1,0 +1,9 @@
+{{ define "log" -}}
+{{if .Verbose}}
+<details><summary>Log</summary>
+  <p>
+
+```
+{{.Log}}```
+</p></details>{{end}}
+{{- end }}

--- a/server/events/templates/multi_project_apply.tmpl
+++ b/server/events/templates/multi_project_apply.tmpl
@@ -1,0 +1,17 @@
+{{ define "multiProjectApply" -}}
+Ran {{.Command}} for {{ len .Results }} projects:
+
+{{ range $result := .Results }}1. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`
+{{end}}
+{{ range $i, $result := .Results }}### {{add $i 1}}. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`
+{{$result.Rendered}}
+
+---
+{{end}}{{if .Verbose}}
+<details><summary>Log</summary>
+  <p>
+
+```
+{{.Log}}```
+</p></details>{{end}}
+{{ end }}

--- a/server/events/templates/multi_project_apply.tmpl
+++ b/server/events/templates/multi_project_apply.tmpl
@@ -1,17 +1,8 @@
 {{ define "multiProjectApply" -}}
-Ran {{.Command}} for {{ len .Results }} projects:
-
-{{ range $result := .Results }}1. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`
-{{end}}
+{{ template "multiProjectHeader" . }}
 {{ range $i, $result := .Results }}### {{add $i 1}}. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`
 {{$result.Rendered}}
 
 ---
-{{end}}{{if .Verbose}}
-<details><summary>Log</summary>
-  <p>
-
-```
-{{.Log}}```
-</p></details>{{end}}
+{{end}}{{ template "log" . }}
 {{ end }}

--- a/server/events/templates/multi_project_header.tmpl
+++ b/server/events/templates/multi_project_header.tmpl
@@ -1,7 +1,6 @@
-{{ define "approveAllProjects" -}}
-Approved Policies for {{ len .Results }} projects:
+{{ define "multiProjectHeader" -}}
+Ran {{.Command}} for {{ len .Results }} projects:
 
 {{ range $result := .Results }}1. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`
 {{end}}
-{{ template "log" . }}
-{{ end }}
+{{- end }}

--- a/server/events/templates/multi_project_plan.tmpl
+++ b/server/events/templates/multi_project_plan.tmpl
@@ -1,0 +1,20 @@
+{{ define "multiProjectPlan" -}}
+Ran {{.Command}} for {{ len .Results }} projects:
+
+{{ range $result := .Results }}1. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`
+{{end}}
+{{ $disableApplyAll := .DisableApplyAll }}{{ range $i, $result := .Results }}### {{add $i 1}}. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`
+{{$result.Rendered}}
+
+{{ if ne $disableApplyAll true }}---
+{{end}}{{end}}{{ if ne .DisableApplyAll true }}{{ if and (gt (len .Results) 0) (not .PlansDeleted) }}* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
+    * `atlantis apply`
+* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+    * `atlantis unlock`{{end}}{{end}}{{if .Verbose}}
+<details><summary>Log</summary>
+  <p>
+
+```
+{{.Log}}```
+</p></details>{{end}}
+{{ end }}

--- a/server/events/templates/multi_project_plan.tmpl
+++ b/server/events/templates/multi_project_plan.tmpl
@@ -1,8 +1,5 @@
 {{ define "multiProjectPlan" -}}
-Ran {{.Command}} for {{ len .Results }} projects:
-
-{{ range $result := .Results }}1. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`
-{{end}}
+{{ template "multiProjectHeader" . }}
 {{ $disableApplyAll := .DisableApplyAll }}{{ range $i, $result := .Results }}### {{add $i 1}}. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`
 {{$result.Rendered}}
 
@@ -10,11 +7,5 @@ Ran {{.Command}} for {{ len .Results }} projects:
 {{end}}{{end}}{{ if ne .DisableApplyAll true }}{{ if and (gt (len .Results) 0) (not .PlansDeleted) }}* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
 * :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
-    * `atlantis unlock`{{end}}{{end}}{{if .Verbose}}
-<details><summary>Log</summary>
-  <p>
-
-```
-{{.Log}}```
-</p></details>{{end}}
+    * `atlantis unlock`{{end}}{{end}}{{ template "log" . }}
 {{ end }}

--- a/server/events/templates/multi_project_version.tmpl
+++ b/server/events/templates/multi_project_version.tmpl
@@ -1,0 +1,17 @@
+{{ define "multiProjectVersion" -}}
+Ran {{.Command}} for {{ len .Results }} projects:
+
+{{ range $result := .Results }}1. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`
+{{end}}
+{{ range $i, $result := .Results }}### {{add $i 1}}. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`
+{{$result.Rendered}}
+
+---
+{{end}}{{if .Verbose}}
+<details><summary>Log</summary>
+  <p>
+
+```
+{{.Log}}```
+</p></details>{{end}}
+{{ end }}

--- a/server/events/templates/multi_project_version.tmpl
+++ b/server/events/templates/multi_project_version.tmpl
@@ -1,17 +1,3 @@
 {{ define "multiProjectVersion" -}}
-Ran {{.Command}} for {{ len .Results }} projects:
-
-{{ range $result := .Results }}1. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`
-{{end}}
-{{ range $i, $result := .Results }}### {{add $i 1}}. {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`
-{{$result.Rendered}}
-
----
-{{end}}{{if .Verbose}}
-<details><summary>Log</summary>
-  <p>
-
-```
-{{.Log}}```
-</p></details>{{end}}
-{{ end }}
+{{ template "multiProjectApply" . }}
+{{- end }}

--- a/server/events/templates/plan_success_unwrapped.tmpl
+++ b/server/events/templates/plan_success_unwrapped.tmpl
@@ -7,7 +7,5 @@
     * `{{.ApplyCmd}}`
 {{end}}{{ if not .DisableRepoLocking }}* :put_litter_in_its_place: To **delete** this plan click [here]({{.LockURL}})
 {{end}}* :repeat: To **plan** this project again, comment:
-    * `{{.RePlanCmd}}`{{end}}{{ if .HasDiverged }}
-
-:warning: The branch we're merging into is ahead, it is recommended to pull new commits first.{{end}}
+    * `{{.RePlanCmd}}`{{end}}{{ template "diverged" . }}
 {{- end }}

--- a/server/events/templates/plan_success_unwrapped.tmpl
+++ b/server/events/templates/plan_success_unwrapped.tmpl
@@ -1,0 +1,13 @@
+{{ define "planSuccessUnwrapped" -}}
+```diff
+{{ if .EnableDiffMarkdownFormat }}{{.DiffMarkdownFormattedTerraformOutput}}{{else}}{{.TerraformOutput}}{{end}}
+```
+
+{{ if .PlanWasDeleted }}This plan was not saved because one or more projects failed and automerge requires all plans pass.{{ else }}{{ if not .DisableApply }}* :arrow_forward: To **apply** this plan, comment:
+    * `{{.ApplyCmd}}`
+{{end}}{{ if not .DisableRepoLocking }}* :put_litter_in_its_place: To **delete** this plan click [here]({{.LockURL}})
+{{end}}* :repeat: To **plan** this project again, comment:
+    * `{{.RePlanCmd}}`{{end}}{{ if .HasDiverged }}
+
+:warning: The branch we're merging into is ahead, it is recommended to pull new commits first.{{end}}
+{{- end }}

--- a/server/events/templates/plan_success_wrapped.tmpl
+++ b/server/events/templates/plan_success_wrapped.tmpl
@@ -1,0 +1,17 @@
+{{ define "planSuccessWrapped" -}}
+<details><summary>Show Output</summary>
+
+```diff
+{{ if .EnableDiffMarkdownFormat }}{{.DiffMarkdownFormattedTerraformOutput}}{{else}}{{.TerraformOutput}}{{end}}
+```
+
+{{ if .PlanWasDeleted }}This plan was not saved because one or more projects failed and automerge requires all plans pass.{{ else }}{{ if not .DisableApply }}* :arrow_forward: To **apply** this plan, comment:
+    * `{{.ApplyCmd}}`
+{{end}}{{ if not .DisableRepoLocking }}* :put_litter_in_its_place: To **delete** this plan click [here]({{.LockURL}})
+{{end}}* :repeat: To **plan** this project again, comment:
+    * `{{.RePlanCmd}}`{{end}}
+</details>
+{{.PlanSummary}}{{ if .HasDiverged }}
+
+:warning: The branch we're merging into is ahead, it is recommended to pull new commits first.{{end}}
+{{- end }}

--- a/server/events/templates/plan_success_wrapped.tmpl
+++ b/server/events/templates/plan_success_wrapped.tmpl
@@ -11,7 +11,5 @@
 {{end}}* :repeat: To **plan** this project again, comment:
     * `{{.RePlanCmd}}`{{end}}
 </details>
-{{.PlanSummary}}{{ if .HasDiverged }}
-
-:warning: The branch we're merging into is ahead, it is recommended to pull new commits first.{{end}}
+{{.PlanSummary}}{{ template "diverged" . }}
 {{- end }}

--- a/server/events/templates/policy_check_success_unwrapped.tmpl
+++ b/server/events/templates/policy_check_success_unwrapped.tmpl
@@ -7,7 +7,5 @@
     * `{{.ApplyCmd}}`
 * :put_litter_in_its_place: To **delete** this plan click [here]({{.LockURL}})
 * :repeat: To re-run policies **plan** this project again by commenting:
-    * `{{.RePlanCmd}}`{{ if .HasDiverged }}
-
-:warning: The branch we're merging into is ahead, it is recommended to pull new commits first.{{end}}
+    * `{{.RePlanCmd}}`{{ template "diverged" . }}
 {{- end }}

--- a/server/events/templates/policy_check_success_unwrapped.tmpl
+++ b/server/events/templates/policy_check_success_unwrapped.tmpl
@@ -1,0 +1,13 @@
+{{ define "policyCheckSuccessUnwrapped" -}}
+```diff
+{{.PolicyCheckOutput}}
+```
+
+* :arrow_forward: To **apply** this plan, comment:
+    * `{{.ApplyCmd}}`
+* :put_litter_in_its_place: To **delete** this plan click [here]({{.LockURL}})
+* :repeat: To re-run policies **plan** this project again by commenting:
+    * `{{.RePlanCmd}}`{{ if .HasDiverged }}
+
+:warning: The branch we're merging into is ahead, it is recommended to pull new commits first.{{end}}
+{{- end }}

--- a/server/events/templates/policy_check_success_wrapped.tmpl
+++ b/server/events/templates/policy_check_success_wrapped.tmpl
@@ -1,0 +1,16 @@
+{{ define "policyCheckSuccessWrapped" -}}
+<details><summary>Show Output</summary>
+
+```diff
+{{.PolicyCheckOutput}}\n" +
+```
+
+* :arrow_forward: To **apply** this plan, comment:
+    * `{{.ApplyCmd}}`
+* :put_litter_in_its_place: To **delete** this plan click [here]({{.LockURL}})
+* :repeat: To re-run policies **plan** this project again by commenting:
+    * `{{.RePlanCmd}}`
+</details>{{ if .HasDiverged }}
+
+:warning: The branch we're merging into is ahead, it is recommended to pull new commits first.{{end}}
+{{- end }}

--- a/server/events/templates/policy_check_success_wrapped.tmpl
+++ b/server/events/templates/policy_check_success_wrapped.tmpl
@@ -2,7 +2,7 @@
 <details><summary>Show Output</summary>
 
 ```diff
-{{.PolicyCheckOutput}}\n" +
+{{.PolicyCheckOutput}}
 ```
 
 * :arrow_forward: To **apply** this plan, comment:
@@ -10,7 +10,5 @@
 * :put_litter_in_its_place: To **delete** this plan click [here]({{.LockURL}})
 * :repeat: To re-run policies **plan** this project again by commenting:
     * `{{.RePlanCmd}}`
-</details>{{ if .HasDiverged }}
-
-:warning: The branch we're merging into is ahead, it is recommended to pull new commits first.{{end}}
+</details>{{ template "diverged" . }}
 {{- end }}

--- a/server/events/templates/single_project_apply.tmpl
+++ b/server/events/templates/single_project_apply.tmpl
@@ -1,0 +1,12 @@
+{{ define "singleProjectApply" -}}
+{{$result := index .Results 0}}Ran {{.Command}} for {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`
+
+{{$result.Rendered}}
+{{if .Verbose}}
+<details><summary>Log</summary>
+  <p>
+
+```
+{{.Log}}```
+</p></details>{{end}}
+{{ end }}

--- a/server/events/templates/single_project_apply.tmpl
+++ b/server/events/templates/single_project_apply.tmpl
@@ -2,11 +2,5 @@
 {{$result := index .Results 0}}Ran {{.Command}} for {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`
 
 {{$result.Rendered}}
-{{if .Verbose}}
-<details><summary>Log</summary>
-  <p>
-
-```
-{{.Log}}```
-</p></details>{{end}}
+{{ template "log" . }}
 {{ end }}

--- a/server/events/templates/single_project_plan_success.tmpl
+++ b/server/events/templates/single_project_plan_success.tmpl
@@ -7,11 +7,5 @@
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
 * :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
-    * `atlantis unlock`{{ end }}{{if .Verbose}}
-<details><summary>Log</summary>
-  <p>
-
-```
-{{.Log}}```
-</p></details>{{end}}
+    * `atlantis unlock`{{ end }}{{ template "log" . }}
 {{ end }}

--- a/server/events/templates/single_project_plan_success.tmpl
+++ b/server/events/templates/single_project_plan_success.tmpl
@@ -1,0 +1,17 @@
+{{ define "singleProjectPlanSuccess" -}}
+{{$result := index .Results 0}}Ran {{.Command}} for {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`
+
+{{$result.Rendered}}
+
+{{ if ne .DisableApplyAll true  }}---
+* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
+    * `atlantis apply`
+* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+    * `atlantis unlock`{{ end }}{{if .Verbose}}
+<details><summary>Log</summary>
+  <p>
+
+```
+{{.Log}}```
+</p></details>{{end}}
+{{ end }}

--- a/server/events/templates/single_project_plan_unsuccessful.tmpl
+++ b/server/events/templates/single_project_plan_unsuccessful.tmpl
@@ -1,0 +1,12 @@
+{{ define "singleProjectPlanUnsuccessful" -}}
+{{$result := index .Results 0}}Ran {{.Command}} for dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`
+
+{{$result.Rendered}}
+{{if .Verbose}}
+<details><summary>Log</summary>
+  <p>
+
+```
+{{.Log}}```
+</p></details>{{end}}
+{{ end }}

--- a/server/events/templates/single_project_plan_unsuccessful.tmpl
+++ b/server/events/templates/single_project_plan_unsuccessful.tmpl
@@ -2,11 +2,5 @@
 {{$result := index .Results 0}}Ran {{.Command}} for dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`
 
 {{$result.Rendered}}
-{{if .Verbose}}
-<details><summary>Log</summary>
-  <p>
-
-```
-{{.Log}}```
-</p></details>{{end}}
+{{ template "log" . }}
 {{ end }}

--- a/server/events/templates/single_project_version_success.tmpl
+++ b/server/events/templates/single_project_version_success.tmpl
@@ -2,11 +2,5 @@
 {{$result := index .Results 0}}Ran {{.Command}} for {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`
 
 {{$result.Rendered}}
-{{if .Verbose}}
-<details><summary>Log</summary>
-  <p>
-
-```
-{{.Log}}```
-</p></details>{{end}}
+{{ template "log" . }}
 {{ end }}

--- a/server/events/templates/single_project_version_success.tmpl
+++ b/server/events/templates/single_project_version_success.tmpl
@@ -1,0 +1,12 @@
+{{ define "singleProjectVersionSuccess" -}}
+{{$result := index .Results 0}}Ran {{.Command}} for {{ if $result.ProjectName }}project: `{{$result.ProjectName}}` {{ end }}dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`
+
+{{$result.Rendered}}
+{{if .Verbose}}
+<details><summary>Log</summary>
+  <p>
+
+```
+{{.Log}}```
+</p></details>{{end}}
+{{ end }}

--- a/server/events/templates/single_project_version_unsuccessful.tmpl
+++ b/server/events/templates/single_project_version_unsuccessful.tmpl
@@ -1,0 +1,12 @@
+{{ define "singleProjectVersionUnsuccessful" -}}
+{{$result := index .Results 0}}Ran {{.Command}} for dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`
+
+{{$result.Rendered}}
+{{if .Verbose}}
+<details><summary>Log</summary>
+  <p>
+
+```
+{{.Log}}```
+</p></details>{{end}}
+{{ end }}

--- a/server/events/templates/single_project_version_unsuccessful.tmpl
+++ b/server/events/templates/single_project_version_unsuccessful.tmpl
@@ -1,12 +1,3 @@
 {{ define "singleProjectVersionUnsuccessful" -}}
-{{$result := index .Results 0}}Ran {{.Command}} for dir: `{{$result.RepoRelDir}}` workspace: `{{$result.Workspace}}`
-
-{{$result.Rendered}}
-{{if .Verbose}}
-<details><summary>Log</summary>
-  <p>
-
-```
-{{.Log}}```
-</p></details>{{end}}
-{{ end }}
+{{ template "singleProjectPlanUnsuccessful" . }}
+{{- end }}

--- a/server/events/templates/unwrapped_err.tmpl
+++ b/server/events/templates/unwrapped_err.tmpl
@@ -1,0 +1,10 @@
+{{ define "unwrappedErr" -}}
+**{{.Command}} Error**
+```
+{{.Error}}
+```{{ if eq .Command "Policy Check" }}
+* :heavy_check_mark: To **approve** failing policies an authorized approver can comment:
+    * `atlantis approve_policies`
+* :repeat: Or, address the policy failure by modifying the codebase and re-planning.
+{{ end }}
+{{- end }}

--- a/server/events/templates/unwrapped_err_with_log.tmpl
+++ b/server/events/templates/unwrapped_err_with_log.tmpl
@@ -1,0 +1,16 @@
+{{ define "unwrappedErrWithLog" -}}
+**{{.Command}} Error**
+```
+{{.Error}}
+```{{ if eq .Command "Policy Check" }}
+* :heavy_check_mark: To **approve** failing policies an authorized approver can comment:
+    * `atlantis approve_policies`
+* :repeat: Or, address the policy failure by modifying the codebase and re-planning.
+{{ end }}{{if .Verbose}}
+<details><summary>Log</summary>
+  <p>
+
+```
+{{.Log}}```
+</p></details>{{end}}
+{{ end }}

--- a/server/events/templates/unwrapped_err_with_log.tmpl
+++ b/server/events/templates/unwrapped_err_with_log.tmpl
@@ -1,16 +1,3 @@
 {{ define "unwrappedErrWithLog" -}}
-**{{.Command}} Error**
-```
-{{.Error}}
-```{{ if eq .Command "Policy Check" }}
-* :heavy_check_mark: To **approve** failing policies an authorized approver can comment:
-    * `atlantis approve_policies`
-* :repeat: Or, address the policy failure by modifying the codebase and re-planning.
-{{ end }}{{if .Verbose}}
-<details><summary>Log</summary>
-  <p>
-
-```
-{{.Log}}```
-</p></details>{{end}}
+{{ template "unwrappedErr" . }}{{ template "log" . }}
 {{ end }}

--- a/server/events/templates/version_unwrapped_success.tmpl
+++ b/server/events/templates/version_unwrapped_success.tmpl
@@ -1,4 +1,5 @@
 {{ define "versionUnwrappedSuccess" -}}
 ```
-{{.Output}}```
+{{.Output}}
+```
 {{ end }}

--- a/server/events/templates/version_unwrapped_success.tmpl
+++ b/server/events/templates/version_unwrapped_success.tmpl
@@ -1,0 +1,4 @@
+{{ define "versionUnwrappedSuccess" -}}
+```
+{{.Output}}```
+{{ end }}

--- a/server/events/templates/version_wrapped_success.tmpl
+++ b/server/events/templates/version_wrapped_success.tmpl
@@ -1,8 +1,6 @@
 {{ define "versionWrappedSuccess" -}}
 <details><summary>Show Output</summary>
 
-```
-{{.Output}}
-```
+{{ template "versionUnwrappedSuccess" . }}
 </details>
 {{- end }}

--- a/server/events/templates/version_wrapped_success.tmpl
+++ b/server/events/templates/version_wrapped_success.tmpl
@@ -1,0 +1,8 @@
+{{ define "versionWrappedSuccess" -}}
+<details><summary>Show Output</summary>
+
+```
+{{.Output}}
+```
+</details>
+{{- end }}

--- a/server/events/templates/wrapped_err.tmpl
+++ b/server/events/templates/wrapped_err.tmpl
@@ -1,0 +1,9 @@
+{{ define "wrappedErr" -}}
+**{{.Command}} Error**
+<details><summary>Show Output</summary>
+
+```
+{{.Error}}
+```
+</details>
+{{- end }}


### PR DESCRIPTION
This closes #2481 #2602

It embeds the default templates and adds the option to pass an optional `templates` directory (in Atlantis' working directory) where users can override the default ones.