### PR TITLE
fix #2537: `if` with identical `then` and `else` branches

### DIFF
--- a/server/events/event_parser.go
+++ b/server/events/event_parser.go
@@ -923,10 +923,8 @@ func (e *EventParser) ParseAzureDevopsRepo(adRepo *azuredevops.GitRepository) (m
 
 		if strings.Contains(uri.Host, "visualstudio.com") {
 			owner = strings.Split(uri.Host, ".")[0]
-		} else if strings.Contains(uri.Host, "dev.azure.com") {
-			owner = strings.Split(uri.Path, "/")[1]
 		} else {
-			owner = strings.Split(uri.Path, "/")[1] // to support owner for self hosted
+			owner = strings.Split(uri.Path, "/")[1]
 		}
 	}
 


### PR DESCRIPTION
Fix #2537 by removing redundant conditional branch