### PR TITLE
Updating diffKeywordRegex to properly handle new test case

### DIFF
--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -2222,6 +2222,41 @@ Terraform will perform the following actions:
       ]
     }
 
+# aws_api_gateway_rest_api.rest_api will be updated in-place
+~ resource "aws_api_gateway_rest_api" "rest_api" {
+~ body =
+		<<-EOT
+			  openapi: 3.0.0
+			  security:
+				- SomeAuth: []
+			  paths:
+				/someEndpoint:
+				  get:
+			-       operationId: someOperation
+			+       operationId: someOperation2
+					responses:
+					  204:
+						description: Empty response.
+			  components:
+				schemas:
+				  SomeEnum:
+					type: string
+					enum:
+					  - value1
+					  - value2
+				securitySchemes:
+				  SomeAuth:
+					type: apiKey
+					in: header
+					name: Authorization
+		EOT
+		  id                           = "4i5suz5c4l"
+		  name                         = "test"
+		  tags                         = {}
+		  # (9 unchanged attributes hidden)
+		  # (1 unchanged block hidden)
+	}
+
 Plan: 1 to add, 1 to change, 1 to destroy.
 `
 	cases := []struct {
@@ -2398,6 +2433,41 @@ Terraform will perform the following actions:
           EOT,
       ]
     }
+
+# aws_api_gateway_rest_api.rest_api will be updated in-place
+! resource "aws_api_gateway_rest_api" "rest_api" {
+! body =
+		<<-EOT
+			  openapi: 3.0.0
+			  security:
+				- SomeAuth: []
+			  paths:
+				/someEndpoint:
+				  get:
+			-       operationId: someOperation
+			+       operationId: someOperation2
+					responses:
+					  204:
+						description: Empty response.
+			  components:
+				schemas:
+				  SomeEnum:
+					type: string
+					enum:
+					  - value1
+					  - value2
+				securitySchemes:
+				  SomeAuth:
+					type: apiKey
+					in: header
+					name: Authorization
+		EOT
+		  id                           = "4i5suz5c4l"
+		  name                         = "test"
+		  tags                         = {}
+		  # (9 unchanged attributes hidden)
+		  # (1 unchanged block hidden)
+	}
 
 Plan: 1 to add, 1 to change, 1 to destroy.
 

--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -2224,40 +2224,39 @@ Terraform will perform the following actions:
 
 # aws_api_gateway_rest_api.rest_api will be updated in-place
 ~ resource "aws_api_gateway_rest_api" "rest_api" {
-~ body =
-		<<-EOT
-			  openapi: 3.0.0
-			  security:
-				- SomeAuth: []
-			  paths:
-				/someEndpoint:
-				  get:
-			-       operationId: someOperation
-			+       operationId: someOperation2
-					responses:
-					  204:
-						description: Empty response.
-			  components:
-				schemas:
-				  SomeEnum:
-					type: string
-					enum:
-					  - value1
-					  - value2
-				securitySchemes:
-				  SomeAuth:
-					type: apiKey
-					in: header
-					name: Authorization
-		EOT
-		  id                           = "4i5suz5c4l"
-		  name                         = "test"
-		  tags                         = {}
-		  # (9 unchanged attributes hidden)
-		  # (1 unchanged block hidden)
-	}
+    ~ body                         = <<-EOT
+          openapi: 3.0.0
+          security:
+            - SomeAuth: []
+          paths:
+            /someEndpoint:
+              get:
+        -       operationId: someOperation
+        +       operationId: someOperation2
+                responses:
+                  204:
+                    description: Empty response.
+          components:
+            schemas:
+              SomeEnum:
+                type: string
+                enum:
+                  - value1
+                  - value2
+            securitySchemes:
+              SomeAuth:
+                type: apiKey
+                in: header
+                name: Authorization
+      EOT
+      id                           = "4i5suz5c4l"
+      name                         = "test"
+      tags                         = {}
+      # (9 unchanged attributes hidden)
+      # (1 unchanged block hidden)
+  }
 
-Plan: 1 to add, 1 to change, 1 to destroy.
+Plan: 1 to add, 2 to change, 1 to destroy.
 `
 	cases := []struct {
 		Description    string
@@ -2436,40 +2435,39 @@ Terraform will perform the following actions:
 
 # aws_api_gateway_rest_api.rest_api will be updated in-place
 ! resource "aws_api_gateway_rest_api" "rest_api" {
-! body =
-		<<-EOT
-			  openapi: 3.0.0
-			  security:
-				- SomeAuth: []
-			  paths:
-				/someEndpoint:
-				  get:
-			-       operationId: someOperation
-			+       operationId: someOperation2
-					responses:
-					  204:
-						description: Empty response.
-			  components:
-				schemas:
-				  SomeEnum:
-					type: string
-					enum:
-					  - value1
-					  - value2
-				securitySchemes:
-				  SomeAuth:
-					type: apiKey
-					in: header
-					name: Authorization
-		EOT
-		  id                           = "4i5suz5c4l"
-		  name                         = "test"
-		  tags                         = {}
-		  # (9 unchanged attributes hidden)
-		  # (1 unchanged block hidden)
-	}
+!     body                         = <<-EOT
+          openapi: 3.0.0
+          security:
+            - SomeAuth: []
+          paths:
+            /someEndpoint:
+              get:
+-               operationId: someOperation
++               operationId: someOperation2
+                responses:
+                  204:
+                    description: Empty response.
+          components:
+            schemas:
+              SomeEnum:
+                type: string
+                enum:
+                  - value1
+                  - value2
+            securitySchemes:
+              SomeAuth:
+                type: apiKey
+                in: header
+                name: Authorization
+      EOT
+      id                           = "4i5suz5c4l"
+      name                         = "test"
+      tags                         = {}
+      # (9 unchanged attributes hidden)
+      # (1 unchanged block hidden)
+  }
 
-Plan: 1 to add, 1 to change, 1 to destroy.
+Plan: 1 to add, 2 to change, 1 to destroy.
 
 $$$
 
@@ -2477,7 +2475,7 @@ $$$
 * :repeat: To **plan** this project again, comment:
     * $atlantis plan -d path -w workspace$
 </details>
-Plan: 1 to add, 1 to change, 1 to destroy.
+Plan: 1 to add, 2 to change, 1 to destroy.
 
 
 `,

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -384,7 +384,7 @@ func (p *PlanSuccess) Summary() string {
 
 // DiffMarkdownFormattedTerraformOutput formats the Terraform output to match diff markdown format
 func (p PlanSuccess) DiffMarkdownFormattedTerraformOutput() string {
-	diffKeywordRegex := regexp.MustCompile(`(?m)^( +)([-+~]\s)(.*)(\s=\s|\s->\s|<<|\{|\(known after apply\))(.*)`)
+	diffKeywordRegex := regexp.MustCompile(`(?m)^( +)([-+~]\s)(.*)(\s=\s|\s->\s|<<|\{|\(known after apply\)| {2,}[^ ]+:.*)(.*)`)
 	diffListRegex := regexp.MustCompile(`(?m)^( +)([-+~]\s)(".*",)`)
 	diffTildeRegex := regexp.MustCompile(`(?m)^~`)
 

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -384,7 +384,7 @@ func (p *PlanSuccess) Summary() string {
 
 // DiffMarkdownFormattedTerraformOutput formats the Terraform output to match diff markdown format
 func (p PlanSuccess) DiffMarkdownFormattedTerraformOutput() string {
-	diffKeywordRegex := regexp.MustCompile(`(?m)^( +)([-+~]\s)(.*)(\s=\s|\s->\s|<<|\{|\(known after apply\)|\[)(.*)`)
+	diffKeywordRegex := regexp.MustCompile(`(?m)^( +)([-+~]\s)(.*)(\s=\s|\s->\s|<<|\{|\(known after apply\))(.*)`)
 	diffListRegex := regexp.MustCompile(`(?m)^( +)([-+~]\s)(".*",)`)
 	diffTildeRegex := regexp.MustCompile(`(?m)^~`)
 


### PR DESCRIPTION
### This PR related to the issue #1899
**Details**: Updated `diffKeywordRegex` to properly handle the following use cases related to YAML content in Terraform output:
- nested inline array, see SomeAuth element
- changes in simple key-value fields, see operationId element

**Testing**: Updated existing `TestRenderProjectResultsWithEnableDiffMarkdownFormat` test case with the following Terraform resource
````
  # aws_api_gateway_rest_api.rest_api will be updated in-place
  ~ resource "aws_api_gateway_rest_api" "rest_api" {
      ~ body                         = <<-EOT
            openapi: 3.0.0
            security:
              - SomeAuth: []
            paths:
              /someEndpoint:
                get:
          -       operationId: someOperation
          +       operationId: someOperation2
                  responses:
                    204:
                      description: Empty response.
            components:
              schemas:
                SomeEnum:
                  type: string
                  enum:
                    - value1
                    - value2
              securitySchemes:
                SomeAuth:
                  type: apiKey
                  in: header
                  name: Authorization
        EOT
        id                           = "4i5suz5c4l"
        name                         = "test"
        tags                         = {}
        # (9 unchanged attributes hidden)
        # (1 unchanged block hidden)
    }
````

