### PR TITLE
Fix concurrency in `atlantis-image` workflow

### DIFF
--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref || github.run_number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## what
- Set the concurrency to replace `head_ref` with `ref` 
- Set the concurrency to replace `run_id` with `run_number` 

## why
- Fix concurrency in atlantis-image workflow
- Use `ref` because `head_ref` is only for `pull_request` events and this workflow does not run on PRs
- Use `run_number` because the id is always unique whereas the number starts at 1 and continues for each workflow

## references
- Original commit https://github.com/runatlantis/atlantis/commit/317b922c8e4d18301169cb90d5ab282f52edac99
- https://docs.github.com/en/actions/learn-github-actions/contexts
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
- Run 2552
  - https://github.com/runatlantis/atlantis/actions/runs/3193021368/jobs/5211149751
  - https://github.com/runatlantis/atlantis/actions/runs/3193024995/jobs/5211157227

> `github.run_id`	`string`	A unique number for each workflow run within a repository. This number does not change if you re-run the workflow run.

> `github.run_number`	`string`	A unique number for each run of a particular workflow in a repository. This number begins at 1 for the workflow's first run, and increments with each new run. This number does not change if you re-run the workflow run.

Relevant `atlantis-image` workflow code

https://github.com/runatlantis/atlantis/blob/929a75992a6cd89e15054bf2c324a86184d837a1/.github/workflows/atlantis-image.yml#L3-L14

The `atlantis-base` workflow seems unaffected

https://github.com/runatlantis/atlantis/actions/workflows/atlantis-base.yml