### PR TITLE
Bump alpine to 3.16.2

### DIFF
--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile builds our base image with gosu, dumb-init and the atlantis
 # user. We split this from the main Dockerfile because this base doesn't change
 # and also because it kept breaking the build due to flakiness.
-FROM alpine:3.16.1
+FROM alpine:3.16.2
 LABEL authors="Anubhav Mishra, Luke Kysow"
 
 # We use gosu to step down from root and run as the atlantis user so we need


### PR DESCRIPTION
Includes fixes for:

CVE-2022-40674
CVE-2022-37434

Dockerfile also needs updating to build on new base image, after merging this. 