### PR TITLE
(README) Use join.slack.com instead of custom heroku app

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 * How to get started: [www.runatlantis.io/guide](https://www.runatlantis.io/guide)
 * Full documentation: [www.runatlantis.io/docs](https://www.runatlantis.io/docs)
 * Download the latest release: [github.com/runatlantis/atlantis/releases/latest](https://github.com/runatlantis/atlantis/releases/latest)
-* Get help in our [Slack channel](https://thawing-headland-22460.herokuapp.com)
+* Get help in our [Slack channel](https://join.slack.com/t/atlantis-community/shared_invite/enQtNzc4NDM3OTA3ODI0LTA5NDQ4YTA3NTAxM2I3ZmIxMGNiYWJhNmY4YjBjZjM3OWMzNGI0NTcxNzY2NjRhODIyODA4YmNjOTBiOThhNTI)
 * Start Contributing: [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## What is Atlantis?


### PR DESCRIPTION
At the top of the README is a "badge" to join the slack channel and uses a [join.slack.com](https://join.slack.com/t/atlantis-community/shared_invite/enQtNzc4NDM3OTA3ODI0LTA5NDQ4YTA3NTAxM2I3ZmIxMGNiYWJhNmY4YjBjZjM3OWMzNGI0NTcxNzY2NjRhODIyODA4YmNjOTBiOThhNTI) address. Further down is another reference to join Slack but links to a custom Heroku app to send an invite to someone. I think the custom Heroku app is legacy link and could be replaced by the join.slack.com url?

Thanks