### PR TITLE
Fix server-configuration docs, missing newline

### DIFF
--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -605,6 +605,7 @@ Values are chosen in this order:
 ### `--silence-whitelist-errors`
   <Badge text="Deprecated" type="warn"/>
   Deprecated for `--silence-allowlist-errors`.
+
 ### `--silence-allowlist-errors`
   ```bash
   atlantis server --silence-allowlist-errors


### PR DESCRIPTION
A newline was missing which broke the markdown rendering.