### PR TITLE
docs: fill all command line flags not in the document, and more.

### DIFF
--- a/runatlantis.io/docs/access-credentials.md
+++ b/runatlantis.io/docs/access-credentials.md
@@ -40,7 +40,7 @@ Available in Atlantis versions **newer** than 0.13.0.
 
 
 - Start Atlantis with fake github username and token (`atlantis server --gh-user fake --gh-token fake --repo-allowlist 'github.com/your-org/*' --atlantis-url https://$ATLANTIS_HOST`). If installing as an **Organization**, remember to add `--gh-org your-github-org` to this command.
-- Visit `https://$ATLANTIS_HOST/github-app/setup` and click on **Setup** to create the app on Github. You'll be redirected back to Atlantis
+- Visit `https://$ATLANTIS_HOST/github-app/setup` and click on **Setup** to create the app on GitHub. You'll be redirected back to Atlantis
 - A link to install your app, along with its secrets, will be shown on the screen. Record your app's credentials and install your app for your user/org by following said link.
 - Create a file with the contents of the GitHub App Key, e.g. `atlantis-app-key.pem`
 - Restart Atlantis with new flags: `atlantis server --gh-app-id <your id> --gh-app-key-file atlantis-app-key.pem --gh-webhook-secret <your secret> --write-git-creds --repo-allowlist 'github.com/your-org/*' --atlantis-url https://$ATLANTIS_HOST`.

--- a/runatlantis.io/docs/apply-requirements.md
+++ b/runatlantis.io/docs/apply-requirements.md
@@ -114,6 +114,10 @@ the Atlantis user needs to be part of that list in order for it to consider
 a pull request mergeable.
 :::
 
+::: warning
+If you set `atlantis/apply` to the mergeable requirement, use the `--gh-allow-mergeable-bypass-apply` flag or set the `ATLANTIS_GH_MERGEABLE_BYPASS_APPLY=true` environment variable. This flag and environment variable allow the mergeable check before executing `atlantis apply` to skip checking the status of `atlantis/apply`.
+:::
+
 #### GitLab
 For GitLab, a merge request will be merged if there are no conflicts, no unresolved discussions if it is a project requirement and if all necessary approvers have approved the pull request.
 

--- a/runatlantis.io/docs/configuring-webhooks.md
+++ b/runatlantis.io/docs/configuring-webhooks.md
@@ -18,7 +18,7 @@ If only some of the repos in your organization are to be managed by Atlantis, th
 may want to only install on specific repos for now.
 :::
 
-When authenticating as a Github App, Webhooks are automatically created and need no additional setup, beyond being installed to your organization/user account after creation. Refer to the [Github App setup](access-credentials.md#github-app) section for instructions on how to do so.
+When authenticating as a GitHub App, Webhooks are automatically created and need no additional setup, beyond being installed to your organization/user account after creation. Refer to the [GitHub App setup](access-credentials.md#github-app) section for instructions on how to do so.
 
 If you're installing on the organization, navigate to your organization's page and click **Settings**.
 If installing on a single repository, navigate to the repository home page and click **Settings**.

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -134,6 +134,12 @@ Values are chosen in this order:
   * Autoplan when any `*.tf` files or `.yml` files in subfolder of `project1` is modified.
     * `--autoplan-file-list='**/*.tf,project2/**/*.yml'`
 
+### `--azuredevops-hostname`
+  ```bash
+  atlantis server --azuredevops-hostname="dev.azure.com"
+  ```
+  Azure DevOps hostname to support cloud and self hosted instances. Defaults to `dev.azure.com`.
+
 ### `--azuredevops-webhook-password`
   ```bash
   atlantis server --azuredevops-webhook-password="password123"
@@ -253,6 +259,12 @@ Values are chosen in this order:
   ```
   Disable atlantis auto planning
 
+### `--disable-markdown-folding`
+  ```bash
+  atlantis server --disable-markdown-folding
+  ```
+  Disable folding in markdown output.
+
 ### `--disable-repo-locking`
   ```bash
   atlantis server --disable-repo-locking
@@ -346,6 +358,12 @@ Values are chosen in this order:
 
   After which Atlantis will display your new app's credentials: your app's ID, its generated `--gh-webhook-secret` and the contents of the file for `--gh-app-key-file`. Update your Atlantis config accordingly, and restart the server.
   :::
+
+### `--gh-app-slug`
+  ```bash
+  atlantis server --gh-app-slug="myappslug"
+  ```
+  A slugged version of GitHub app name shown in pull requests comments, etc (not `Atlantis App` but something like `atlantis-app`). Atlantis uses the value of this parameter to identify the comments it has left on GitHub pull requests. This is used for functions such as `--hide-prev-plan-comments`.
 
 ### `--gh-app-key-file`
   ```bash
@@ -724,3 +742,21 @@ Values are chosen in this order:
   ::: warning SECURITY WARNING
   This does write secrets to disk and should only be enabled in a secure environment.
   :::
+
+### `--web-basic-auth`
+  ```bash
+  atlantis server --web-basic-auth
+  ```
+  Enable Basic Authentication on the Atlantis web service.
+
+### `--web-username`
+  ```bash
+  atlantis server --web-username="atlantis"
+  ```
+  Username used for Basic Authentication on the Atlantis web service. Defaults to `atlantis`.
+
+### `--web-password`
+  ```bash
+  atlantis server --web-password="atlantis"
+  ```
+  Password used for Basic Authentication on the Atlantis web service. Defaults to `atlantis`.

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -295,13 +295,13 @@ Values are chosen in this order:
   ```
   Enable Atlantis to format Terraform plan output into a markdown-diff friendly format for color-coding purposes.
 
-  Useful to enable for use with Github.
+  Useful to enable for use with GitHub.
 
 ### `--gh-hostname`
   ```bash
   atlantis server --gh-hostname="my.github.enterprise.com"
   ```
-  Hostname of your GitHub Enterprise installation. If using [Github.com](https://github.com),
+  Hostname of your GitHub Enterprise installation. If using [GitHub.com](https://github.com),
   don't set. Defaults to `github.com`.
 
 ### `--gh-token`
@@ -335,7 +335,7 @@ Values are chosen in this order:
   ```bash
   atlantis server --gh-org="myorgname"
   ```
-  GitHub organization name. Set to enable creating a private Github app for this organization.
+  GitHub organization name. Set to enable creating a private GitHub app for this organization.
 
 ### `--gh-app-id`
   ```bash

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -387,7 +387,7 @@ Values are chosen in this order:
   ```
   Comma-separated list of GitHub team name (not a slug) and permission pairs. By default, any team can plan and apply.
 
-- ### `--gh-allow-mergeable-bypass-apply`
+### `--gh-allow-mergeable-bypass-apply`
   ```bash
   atlantis server --gh-allow-mergeable-bypass-apply
   ```

--- a/runatlantis.io/docs/webhook-secrets.md
+++ b/runatlantis.io/docs/webhook-secrets.md
@@ -17,7 +17,7 @@ Azure DevOps uses Basic authentication for webhooks rather than webhook secrets.
 :::
 
 ::: tip NOTE
-An app-wide token is generated during [Github App setup](access-credentials.html#github-app). You can recover it by navigating to the [Github app settings page](https://github.com/settings/apps) and selecting "Edit" next to your Atlantis app's name. Token appears after clicking "Edit" under the Webhook header.
+An app-wide token is generated during [GitHub App setup](access-credentials.html#github-app). You can recover it by navigating to the [GitHub app settings page](https://github.com/settings/apps) and selecting "Edit" next to your Atlantis app's name. Token appears after clicking "Edit" under the Webhook header.
 :::
 
 ::: warning


### PR DESCRIPTION
Add documents.

* Fill all command line flags not in the document from `server/server.go`, related: #1161 .
* Add document about #2436 .
* and misc.