### PR TITLE
Release 0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
-# v0.20.0
+# v0.20.1
 
 Bugfixes and new Features
+
+## What's Changed
+
+https://github.com/runatlantis/atlantis/releases/tag/v0.20.1
+
+# v0.20.0
+
+Broken build due to github action issues
 
 ## What's Changed
 

--- a/kustomize/bundle.yaml
+++ b/kustomize/bundle.yaml
@@ -22,7 +22,7 @@ spec:
         fsGroup: 1000 # Atlantis group (1000) read/write access to volumes.
       containers:
       - name: atlantis
-        image: ghcr.io/runatlantis/atlantis:v0.20.0
+        image: ghcr.io/runatlantis/atlantis:v0.20.1
         env:
         - name: ATLANTIS_DATA_DIR
           value: /atlantis

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const atlantisVersion = "0.20.0"
+const atlantisVersion = "0.20.1"
 
 func main() {
 	v := viper.New()


### PR DESCRIPTION
Releasing `0.20.1` due to `0.20.0` failed due to github actions issues