### PR TITLE
hadolint: base: pin all dependencies

### DIFF
--- a/.github/workflows/atlantis-base.yml
+++ b/.github/workflows/atlantis-base.yml
@@ -49,7 +49,7 @@ jobs:
       with:
         context: docker-base
         platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
-        push: true
+        push: ${{ github.event_name != 'pull_request' }}
         tags: |
           ghcr.io/${{ github.repository_owner }}/atlantis-base:${{env.TODAY}}
           ghcr.io/${{ github.repository_owner }}/atlantis-base:latest

--- a/.github/workflows/atlantis-base.yml
+++ b/.github/workflows/atlantis-base.yml
@@ -7,6 +7,10 @@ on:
       - '.github/workflows/atlantis-base.yml'
     branches:
       - "master"
+  pull_request:
+    paths:
+      - 'docker-base/**'
+      - '.github/workflows/atlantis-base.yml'
   workflow_dispatch:
 
 defaults:

--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -25,9 +25,20 @@ ENV GIT_LFS_VERSION=3.1.2
 ARG TARGETPLATFORM
 
 # Install packages needed for running Atlantis.
-RUN apk add --no-cache ca-certificates curl git unzip bash openssh libcap dumb-init gcompat && \
+RUN apk add --no-cache \
+        ca-certificates=20220614-r0 \
+        curl=7.83.1-r3 \
+        git=2.36.2-r0 \
+        unzip=6.0-r9 \
+        bash=5.1.16-r2 \
+        openssh=9.0_p1-r2 \
+        libcap=2.64-r0 \
+        dumb-init=1.2.5-r1 \
+        gcompat=1.0.0-r4 && \
     # Install packages needed for building dependencies.
-    apk add --no-cache --virtual .build-deps gnupg openssl && \
+    apk add --no-cache --virtual .build-deps \
+        gnupg=2.2.35-r4 \
+        openssl=1.1.1q-r0 && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
 


### PR DESCRIPTION
## what

- pinned the dependencies to the latest base image

## why

- This will allow the atlantis images more immutability. We'll also be able to control when we update base packages when necessary instead of always retrieving the latest.
- Fixed another hadolint issue

## references

- https://github.com/hadolint/hadolint
- https://github.com/hadolint/hadolint/wiki/DL3018
- https://github.com/runatlantis/atlantis/pkgs/container/atlantis-base/44682219?tag=2022.10.06

```
$ hadolint docker-base/Dockerfile
docker-base/Dockerfile:28 DL3003 warning: Use WORKDIR to switch to a directory
docker-base/Dockerfile:28 DL3018 warning: Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`
```

<details><summary>Get package versions of atlantis-base:2022.10.06</summary>

```sh
$ docker run \
  -it --rm --entrypoint sh \
  ghcr.io/runatlantis/atlantis-base:2022.10.06 \
  -c "apk update && apk list ca-certificates curl git unzip bash openssh libcap dumb-init gcompat gnupg openssl"

fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/aarch64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/aarch64/APKINDEX.tar.gz
v3.16.2-289-gc5f9b7933b [https://dl-cdn.alpinelinux.org/alpine/v3.16/main]
v3.16.2-290-ge87fadc38b [https://dl-cdn.alpinelinux.org/alpine/v3.16/community]
OK: 16892 distinct packages available

ca-certificates-20220614-r0 aarch64 {ca-certificates} (MPL-2.0 AND MIT) [installed]
curl-7.83.1-r3 aarch64 {curl} (curl) [installed]
git-2.36.2-r0 aarch64 {git} (GPL-2.0-or-later) [installed]
unzip-6.0-r9 aarch64 {unzip} (custom) [installed]
bash-5.1.16-r2 aarch64 {bash} (GPL-3.0-or-later) [installed]
openssh-9.0_p1-r2 aarch64 {openssh} (BSD) [installed]
libcap-2.64-r0 aarch64 {libcap} (BSD-3-Clause OR GPL-2.0-only) [installed]
dumb-init-1.2.5-r1 aarch64 {dumb-init} (MIT) [installed]
gcompat-1.0.0-r4 aarch64 {gcompat} (NCSA) [installed]
gnupg-2.2.35-r4 aarch64 {gnupg} (GPL-3.0-or-later)
openssl-1.1.1q-r0 aarch64 {openssl} (OpenSSL)
```

</details>

<details><summary>Build locally and verify package versions match</summary>

```sh
$ docker buildx build --load --platform=linux/amd64 . -t atlantis:hadolint-base

$ docker run --platform=linux/amd64 \
  -it --rm --entrypoint sh \
  ghcr.io/runatlantis/atlantis-base:2022.10.06 \
  -c "apk update && apk list ca-certificates curl git unzip bash openssh libcap dumb-init gcompat gnupg openssl"

fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/aarch64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/aarch64/APKINDEX.tar.gz
v3.16.2-289-gc5f9b7933b [https://dl-cdn.alpinelinux.org/alpine/v3.16/main]
v3.16.2-290-ge87fadc38b [https://dl-cdn.alpinelinux.org/alpine/v3.16/community]
OK: 16892 distinct packages available

ca-certificates-20220614-r0 x86_64 {ca-certificates} (MPL-2.0 AND MIT) [installed]
curl-7.83.1-r3 x86_64 {curl} (curl) [installed]
git-2.36.2-r0 x86_64 {git} (GPL-2.0-or-later) [installed]
unzip-6.0-r9 x86_64 {unzip} (custom) [installed]
bash-5.1.16-r2 x86_64 {bash} (GPL-3.0-or-later) [installed]
openssh-9.0_p1-r2 x86_64 {openssh} (BSD) [installed]
libcap-2.64-r0 x86_64 {libcap} (BSD-3-Clause OR GPL-2.0-only) [installed]
dumb-init-1.2.5-r1 x86_64 {dumb-init} (MIT) [installed]
gcompat-1.0.0-r4 x86_64 {gcompat} (NCSA) [installed]
gnupg-2.2.35-r4 x86_64 {gnupg} (GPL-3.0-or-later)
openssl-1.1.1q-r0 x86_64 {openssl} (OpenSSL)
```

</details>