### PR TITLE
Update terraform-config-inspect

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/go-getter v1.6.2
 	github.com/hashicorp/go-version v1.6.0
-	github.com/hashicorp/terraform-config-inspect v0.0.0-20200806211835-c481b8bfa41e
+	github.com/hashicorp/terraform-config-inspect v0.0.0-20221012204812-413b69327090
 	github.com/mcdafydd/go-azuredevops v0.12.1
 	github.com/microcosm-cc/bluemonday v1.0.21
 	github.com/mitchellh/colorstring v0.0.0-20150917214807-8631ce90f286

--- a/go.sum
+++ b/go.sum
@@ -332,6 +332,8 @@ github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpT
 github.com/hashicorp/serf v0.9.7/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20200806211835-c481b8bfa41e h1:wIsEsIITggCC4FTO9PisDjy561UU7OPL6uTu7tnkHH8=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20200806211835-c481b8bfa41e/go.mod h1:Z0Nnk4+3Cy89smEbrq+sl1bxc9198gIP4I7wcQF6Kqs=
+github.com/hashicorp/terraform-config-inspect v0.0.0-20221012204812-413b69327090 h1:UnVTr6jkguxyA4OfL9kJOoe4hoWyicC+LRiS4e3EJl0=
+github.com/hashicorp/terraform-config-inspect v0.0.0-20221012204812-413b69327090/go.mod h1:Z0Nnk4+3Cy89smEbrq+sl1bxc9198gIP4I7wcQF6Kqs=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.1 h1:4jgBlKK6tLKFvO8u5pmYjG91cqytmDCDvGh7ECVFfFs=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=


### PR DESCRIPTION
Fixes #2598

This package was enough out of date that it wouldn't parse features in the language that were added in the last few releases of TF. This should get things into a state that supports the newer features.

The test suite mostly passes except for those requiring conftest. I installed the latest version using homebrew and it still wasn't found even though it is on `$PATH`. I looked at the failing test and surrounding code and while the error message says `>= 0.25.0` the tests are actually looking for a binary named with that exact version. Adding a symlink to my 0.34.0 installation with the exact name expected allowed the tests to fail with a new error. Fixing this is outside the scope of this PR.