### PR TITLE
Reduce image size by rm'ing old tf versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV DEFAULT_TERRAFORM_VERSION=1.3.3
 
 # In the official Atlantis image we only have the latest of each Terraform version.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN AVAILABLE_TERRAFORM_VERSIONS="0.11.15 0.12.31 0.13.7 0.14.11 0.15.5 1.0.11 1.1.9 1.2.9 ${DEFAULT_TERRAFORM_VERSION}" && \
+RUN AVAILABLE_TERRAFORM_VERSIONS="1.0.11 1.1.9 1.2.9 ${DEFAULT_TERRAFORM_VERSION}" && \
     case "${TARGETPLATFORM}" in \
         "linux/amd64") TERRAFORM_ARCH=amd64 ;; \
         "linux/arm64") TERRAFORM_ARCH=arm64 ;; \


### PR DESCRIPTION
## what
- Remove 5 old tf versions

## why
- Reduce image size. Each binary is 80MB.
- This removes all terraform versions prior to 1.x.
- This will reduce the image size by 400MB.
- @jamengual and I worked on this and discussed this. Hoping this PR can be a discussion point with a wider audience.

## references
- Example terraform version to download to check file size https://releases.hashicorp.com/terraform/0.12.31/
- Closes https://github.com/runatlantis/atlantis/issues/2622