### PR TITLE
fix: typo in log message when running parallel plans

### DIFF
--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -206,7 +206,7 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 	// Only run commands in parallel if enabled
 	var result command.Result
 	if p.isParallelEnabled(projectCmds) {
-		ctx.Log.Info("Running applies in parallel")
+		ctx.Log.Info("Running plans in parallel")
 		result = runProjectCmdsParallelGroups(projectCmds, p.prjCmdRunner.Plan, p.parallelPoolSize)
 	} else {
 		result = runProjectCmds(projectCmds, p.prjCmdRunner.Plan)


### PR DESCRIPTION
Signed-off-by: Forest Oden <forest.oden@beatport.com>

This is a small PR to fix a typo in `plan_command_runner.go` that logs `Running applies in parallel` rather than an expected `Running plans in parallel`. 