### PR TITLE
chore: set stale 6mo, close 1mo

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,10 @@ jobs:
     steps:
       - uses: actions/stale@v6
         with:
-          stale-pr-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
-          days-before-stale: 30
-          days-before-close: 5
+          stale-pr-message: &message 'This issue is stale because it has been open for 6 months with no activity. Remove stale label or comment or this will be closed in 1 month.'
+          stale-issue-message: *message
+          # 6 months
+          days-before-stale: 183
+          # 1 month
+          days-before-close: 31
           only-labels: 'waiting-on-response'


### PR DESCRIPTION
## what
- chore: set stale 6mo, close 1mo

## why
- Adjust stale bot so it doesn't close issues or PRs to soon

## references
- https://github.com/runatlantis/atlantis/issues/1575#issuecomment-1253899330
- https://github.com/actions/stale#stale-issue-message
