### PR TITLE
fix: prevent commit status update in incorrect MR

### DIFF
--- a/server/events/vcs/gitlab_client.go
+++ b/server/events/vcs/gitlab_client.go
@@ -249,6 +249,7 @@ func (g *GitlabClient) UpdateStatus(repo models.Repo, pull models.PullRequest, s
 		Context:     gitlab.String(src),
 		Description: gitlab.String(description),
 		TargetURL:   &url,
+		Ref:         gitlab.String(pull.HeadBranch),
 	})
 	return err
 }

--- a/server/events/vcs/gitlab_client_test.go
+++ b/server/events/vcs/gitlab_client_test.go
@@ -212,7 +212,7 @@ func TestGitlabClient_UpdateStatus(t *testing.T) {
 
 						body, err := io.ReadAll(r.Body)
 						Ok(t, err)
-						exp := fmt.Sprintf(`{"state":"%s","context":"src","target_url":"https://google.com","description":"description"}`, c.expState)
+						exp := fmt.Sprintf(`{"state":"%s","ref":"test","context":"src","target_url":"https://google.com","description":"description"}`, c.expState)
 						Equals(t, exp, string(body))
 						defer r.Body.Close()  // nolint: errcheck
 						w.Write([]byte("{}")) // nolint: errcheck
@@ -241,6 +241,7 @@ func TestGitlabClient_UpdateStatus(t *testing.T) {
 				Num:        1,
 				BaseRepo:   repo,
 				HeadCommit: "sha",
+				HeadBranch: "test",
 			}, c.status, "src", "description", "https://google.com")
 			Ok(t, err)
 			Assert(t, gotRequest, "expected to get the request")


### PR DESCRIPTION
# Summary
Prevent Atlantis from updating the commit status on an incorrect Merge Request by passing the Ref (HeadBranch) in the CommitStatusOptions.
- GitLab API reference: https://docs.gitlab.com/ee/api/commits.html#post-the-build-status-to-a-commit
# Tests
Tested on gitlab.com (v15.x) and Self-hosted (v14.x)

Closes https://github.com/runatlantis/atlantis/issues/2484
