### PR TITLE
deps: bump terraform to 1.3.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
         # We do this instead of setting --default-tf-version because setting
         # that flag starts the download asynchronously so we'd have a race
         # condition.
-        TERRAFORM_VERSION: 1.3.3
+        TERRAFORM_VERSION: 1.3.4
     steps:
     - checkout
     - run: make build-service

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM ghcr.io/runatlantis/atlantis-base:2022.10.14 AS base
 ARG TARGETPLATFORM
 
 # install terraform binaries
-ENV DEFAULT_TERRAFORM_VERSION=1.3.3
+ENV DEFAULT_TERRAFORM_VERSION=1.3.4
 
 # In the official Atlantis image we only have the latest of each Terraform version.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/testdrive/utils.go
+++ b/testdrive/utils.go
@@ -34,7 +34,7 @@ import (
 )
 
 const hashicorpReleasesURL = "https://releases.hashicorp.com"
-const terraformVersion = "1.3.3"
+const terraformVersion = "1.3.4"
 const ngrokDownloadURL = "https://bin.equinox.io/c/4VmDzA7iaHb"
 const ngrokAPIURL = "localhost:41414" // We hope this isn't used.
 const atlantisPort = 4141

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.17
 RUN apt-get update && apt-get install unzip
 
 # Install Terraform
-ENV TERRAFORM_VERSION=1.3.3
+ENV TERRAFORM_VERSION=1.3.4
 RUN case $(uname -m) in x86_64|amd64) ARCH="amd64" ;; aarch64|arm64|armv7l) ARCH="arm64" ;; esac && \
     wget -nv -O terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${ARCH}.zip && \
     mkdir -p /usr/local/bin/tf/versions/${TERRAFORM_VERSION} && \


### PR DESCRIPTION
## what
- bump terraform to 1.3.4

## why
- Latest terraform

## references
- https://github.com/hashicorp/terraform/releases/tag/v1.3.4
- Previous PR https://github.com/runatlantis/atlantis/pull/2614