### PR TITLE
Remove archived and deprecated interfacer linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,6 @@ linters:
   - gosec
   - gosimple
   - ineffassign
-  - interfacer
   - staticcheck
   - structcheck
   - typecheck


### PR DESCRIPTION
## what
- Remove archived and deprecated interfacer linter

## why
- interfacer repo has been archived and is no longer maintained

```
WARN [runner] The linter 'interfacer' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner.  
```

## references
- PR https://github.com/runatlantis/atlantis/pull/2656 shows an interfacer error
- https://github.com/mvdan/interfacer