### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -394,8 +394,7 @@ func TestGitHubWorkflow(t *testing.T) {
 
 			ctrl, vcsClient, githubGetter, atlantisWorkspace := setupE2E(t, c.RepoDir)
 			// Set the repo to be cloned through the testing backdoor.
-			repoDir, headSHA, cleanup := initializeRepo(t, c.RepoDir)
-			defer cleanup()
+			repoDir, headSHA := initializeRepo(t, c.RepoDir)
 			atlantisWorkspace.TestingOverrideHeadCloneURL = fmt.Sprintf("file://%s", repoDir)
 
 			// Setup test dependencies.
@@ -544,8 +543,7 @@ func TestSimlpleWorkflow_terraformLockFile(t *testing.T) {
 
 			ctrl, vcsClient, githubGetter, atlantisWorkspace := setupE2E(t, c.RepoDir)
 			// Set the repo to be cloned through the testing backdoor.
-			repoDir, headSHA, cleanup := initializeRepo(t, c.RepoDir)
-			defer cleanup()
+			repoDir, headSHA := initializeRepo(t, c.RepoDir)
 
 			oldLockFilePath, err := filepath.Abs(filepath.Join("testfixtures", "null_provider_lockfile_old_version"))
 			Ok(t, err)
@@ -789,8 +787,7 @@ func TestGitHubWorkflowWithPolicyCheck(t *testing.T) {
 			ctrl, vcsClient, githubGetter, atlantisWorkspace := setupE2E(t, c.RepoDir)
 
 			// Set the repo to be cloned through the testing backdoor.
-			repoDir, headSHA, cleanup := initializeRepo(t, c.RepoDir)
-			defer cleanup()
+			repoDir, headSHA := initializeRepo(t, c.RepoDir)
 			atlantisWorkspace.TestingOverrideHeadCloneURL = fmt.Sprintf("file://%s", repoDir)
 
 			// Setup test dependencies.
@@ -866,8 +863,7 @@ func TestGitHubWorkflowWithPolicyCheck(t *testing.T) {
 
 func setupE2E(t *testing.T, repoDir string) (events_controllers.VCSEventsController, *vcsmocks.MockClient, *mocks.MockGithubPullGetter, *events.FileWorkspace) {
 	allowForkPRs := false
-	dataDir, binDir, cacheDir, cleanup := mkSubDirs(t)
-	defer cleanup()
+	dataDir, binDir, cacheDir := mkSubDirs(t)
 
 	//env vars
 
@@ -1259,11 +1255,11 @@ func absRepoPath(t *testing.T, repoDir string) string {
 // The purpose of this function is to create a real git repository with a branch
 // called 'branch' from the files under repoDir. This is so we can check in
 // those files normally to this repo without needing a .git directory.
-func initializeRepo(t *testing.T, repoDir string) (string, string, func()) {
+func initializeRepo(t *testing.T, repoDir string) (string, string) {
 	originRepo := absRepoPath(t, repoDir)
 
 	// Copy the files to the temp dir.
-	destDir, cleanup := TempDir(t)
+	destDir := t.TempDir()
 	runCmd(t, "", "cp", "-r", fmt.Sprintf("%s/.", originRepo), destDir)
 
 	// Initialize the git repo.
@@ -1279,7 +1275,7 @@ func initializeRepo(t *testing.T, repoDir string) (string, string, func()) {
 	headSHA := runCmd(t, destDir, "git", "rev-parse", "HEAD")
 	headSHA = strings.Trim(headSHA, "\n")
 
-	return destDir, headSHA, cleanup
+	return destDir, headSHA
 }
 
 func runCmd(t *testing.T, dir string, name string, args ...string) string {
@@ -1348,8 +1344,8 @@ func assertCommentEquals(t *testing.T, expReplies []string, act string, repoDir 
 }
 
 // returns parent, bindir, cachedir, cleanup func
-func mkSubDirs(t *testing.T) (string, string, string, func()) {
-	tmp, cleanup := TempDir(t)
+func mkSubDirs(t *testing.T) (string, string, string) {
+	tmp := t.TempDir()
 	binDir := filepath.Join(tmp, "bin")
 	err := os.MkdirAll(binDir, 0700)
 	Ok(t, err)
@@ -1358,7 +1354,7 @@ func mkSubDirs(t *testing.T) (string, string, string, func()) {
 	err = os.MkdirAll(cachedir, 0700)
 	Ok(t, err)
 
-	return tmp, binDir, cachedir, cleanup
+	return tmp, binDir, cachedir
 }
 
 // Will fail test if conftest isn't in path and isn't version >= 0.25.0

--- a/server/controllers/locks_controller_test.go
+++ b/server/controllers/locks_controller_test.go
@@ -299,8 +299,7 @@ func TestDeleteLock_UpdateProjectStatus(t *testing.T) {
 		},
 	}, nil)
 	var backend locking.Backend
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 	backend, err := db.New(tmp)
 	Ok(t, err)
 	// Seed the DB with a successful plan for that project (that is later discarded).
@@ -354,8 +353,7 @@ func TestDeleteLock_CommentFailed(t *testing.T) {
 	workingDir := mocks2.NewMockWorkingDir()
 	workingDirLocker := events.NewDefaultWorkingDirLocker()
 	var backend locking.Backend
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 	backend, err := db.New(tmp)
 	Ok(t, err)
 	When(cp.CreateComment(AnyRepo(), AnyInt(), AnyString(), AnyString())).ThenReturn(errors.New("err"))
@@ -382,8 +380,7 @@ func TestDeleteLock_CommentSuccess(t *testing.T) {
 	workingDir := mocks2.NewMockWorkingDir()
 	workingDirLocker := events.NewDefaultWorkingDirLocker()
 	var backend locking.Backend
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 	backend, err := db.New(tmp)
 	Ok(t, err)
 	pull := models.PullRequest{

--- a/server/core/config/parser_validator_test.go
+++ b/server/core/config/parser_validator_test.go
@@ -31,8 +31,7 @@ func TestHasRepoCfg_DirDoesNotExist(t *testing.T) {
 }
 
 func TestHasRepoCfg_FileDoesNotExist(t *testing.T) {
-	tmpDir, cleanup := TempDir(t)
-	defer cleanup()
+	tmpDir := t.TempDir()
 	r := config.ParserValidator{}
 	exists, err := r.HasRepoCfg(tmpDir)
 	Ok(t, err)
@@ -40,8 +39,7 @@ func TestHasRepoCfg_FileDoesNotExist(t *testing.T) {
 }
 
 func TestHasRepoCfg_InvalidFileExtension(t *testing.T) {
-	tmpDir, cleanup := TempDir(t)
-	defer cleanup()
+	tmpDir := t.TempDir()
 	_, err := os.Create(filepath.Join(tmpDir, "atlantis.yml"))
 	Ok(t, err)
 
@@ -57,16 +55,14 @@ func TestParseRepoCfg_DirDoesNotExist(t *testing.T) {
 }
 
 func TestParseRepoCfg_FileDoesNotExist(t *testing.T) {
-	tmpDir, cleanup := TempDir(t)
-	defer cleanup()
+	tmpDir := t.TempDir()
 	r := config.ParserValidator{}
 	_, err := r.ParseRepoCfg(tmpDir, globalCfg, "", "")
 	Assert(t, os.IsNotExist(err), "exp not exist err")
 }
 
 func TestParseRepoCfg_BadPermissions(t *testing.T) {
-	tmpDir, cleanup := TempDir(t)
-	defer cleanup()
+	tmpDir := t.TempDir()
 	err := os.WriteFile(filepath.Join(tmpDir, "atlantis.yaml"), nil, 0000)
 	Ok(t, err)
 
@@ -96,8 +92,7 @@ func TestParseCfgs_InvalidYAML(t *testing.T) {
 		},
 	}
 
-	tmpDir, cleanup := TempDir(t)
-	defer cleanup()
+	tmpDir := t.TempDir()
 
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
@@ -1062,8 +1057,7 @@ workflows:
 		},
 	}
 
-	tmpDir, cleanup := TempDir(t)
-	defer cleanup()
+	tmpDir := t.TempDir()
 
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
@@ -1085,8 +1079,7 @@ workflows:
 // Test that we fail if the global validation fails. We test global validation
 // more completely in GlobalCfg.ValidateRepoCfg().
 func TestParseRepoCfg_GlobalValidation(t *testing.T) {
-	tmpDir, cleanup := TempDir(t)
-	defer cleanup()
+	tmpDir := t.TempDir()
 
 	repoCfg := `
 version: 3
@@ -1482,8 +1475,7 @@ workflows:
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
 			r := config.ParserValidator{}
-			tmp, cleanup := TempDir(t)
-			defer cleanup()
+			tmp := t.TempDir()
 			path := filepath.Join(tmp, "conf.yaml")
 			Ok(t, os.WriteFile(path, []byte(c.input), 0600))
 
@@ -1732,10 +1724,8 @@ func TestParseRepoCfg_V2ShellParsing(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.in, func(t *testing.T) {
-			v2Dir, cleanup2 := TempDir(t)
-			defer cleanup2()
-			v3Dir, cleanup3 := TempDir(t)
-			defer cleanup3()
+			v2Dir := t.TempDir()
+			v3Dir := t.TempDir()
 			v2Path := filepath.Join(v2Dir, "atlantis.yaml")
 			v3Path := filepath.Join(v3Dir, "atlantis.yaml")
 			cfg := fmt.Sprintf(`workflows:

--- a/server/core/config/valid/global_cfg_test.go
+++ b/server/core/config/valid/global_cfg_test.go
@@ -656,8 +656,7 @@ policies:
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			tmp, cleanup := TempDir(t)
-			defer cleanup()
+			tmp := t.TempDir()
 			var global valid.GlobalCfg
 			if c.gCfg != "" {
 				path := filepath.Join(tmp, "config.yaml")
@@ -857,8 +856,7 @@ repos:
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			tmp, cleanup := TempDir(t)
-			defer cleanup()
+			tmp := t.TempDir()
 			var global valid.GlobalCfg
 			if c.gCfg != "" {
 				path := filepath.Join(tmp, "config.yaml")

--- a/server/core/db/boltdb_test.go
+++ b/server/core/db/boltdb_test.go
@@ -432,8 +432,7 @@ func TestGetLock(t *testing.T) {
 
 // Test we can create a status and then getCommandLock it.
 func TestPullStatus_UpdateGet(t *testing.T) {
-	b, cleanup := newTestDB2(t)
-	defer cleanup()
+	b := newTestDB2(t)
 
 	pull := models.PullRequest{
 		Num:        1,
@@ -483,8 +482,7 @@ func TestPullStatus_UpdateGet(t *testing.T) {
 // Test we can create a status, delete it, and then we shouldn't be able to getCommandLock
 // it.
 func TestPullStatus_UpdateDeleteGet(t *testing.T) {
-	b, cleanup := newTestDB2(t)
-	defer cleanup()
+	b := newTestDB2(t)
 
 	pull := models.PullRequest{
 		Num:        1,
@@ -529,8 +527,7 @@ func TestPullStatus_UpdateDeleteGet(t *testing.T) {
 // pull status, and when we getCommandLock all the project statuses, that specific project
 // should be updated.
 func TestPullStatus_UpdateProject(t *testing.T) {
-	b, cleanup := newTestDB2(t)
-	defer cleanup()
+	b := newTestDB2(t)
 
 	pull := models.PullRequest{
 		Num:        1,
@@ -593,8 +590,7 @@ func TestPullStatus_UpdateProject(t *testing.T) {
 // Test that if we update an existing pull status and our new status is for a
 // different HeadSHA, that we just overwrite the old status.
 func TestPullStatus_UpdateNewCommit(t *testing.T) {
-	b, cleanup := newTestDB2(t)
-	defer cleanup()
+	b := newTestDB2(t)
 
 	pull := models.PullRequest{
 		Num:        1,
@@ -656,8 +652,7 @@ func TestPullStatus_UpdateNewCommit(t *testing.T) {
 // Test that if we update an existing pull status and our new status is for a
 // the same commit, that we merge the statuses.
 func TestPullStatus_UpdateMerge(t *testing.T) {
-	b, cleanup := newTestDB2(t)
-	defer cleanup()
+	b := newTestDB2(t)
 
 	pull := models.PullRequest{
 		Num:        1,
@@ -796,13 +791,11 @@ func newTestDB() (*bolt.DB, *db.BoltDB) {
 	return boltDB, b
 }
 
-func newTestDB2(t *testing.T) (*db.BoltDB, func()) {
-	tmp, cleanup := TempDir(t)
+func newTestDB2(t *testing.T) *db.BoltDB {
+	tmp := t.TempDir()
 	boltDB, err := db.New(tmp)
 	Ok(t, err)
-	return boltDB, func() {
-		cleanup()
-	}
+	return boltDB
 }
 
 func cleanupDB(db *bolt.DB) {

--- a/server/core/runtime/apply_step_runner_test.go
+++ b/server/core/runtime/apply_step_runner_test.go
@@ -36,8 +36,7 @@ func TestRun_NoDir(t *testing.T) {
 }
 
 func TestRun_NoPlanFile(t *testing.T) {
-	tmpDir, cleanup := TempDir(t)
-	defer cleanup()
+	tmpDir := t.TempDir()
 	o := runtime.ApplyStepRunner{
 		TerraformExecutor: nil,
 	}
@@ -49,8 +48,7 @@ func TestRun_NoPlanFile(t *testing.T) {
 }
 
 func TestRun_Success(t *testing.T) {
-	tmpDir, cleanup := TempDir(t)
-	defer cleanup()
+	tmpDir := t.TempDir()
 	planPath := filepath.Join(tmpDir, "workspace.tfplan")
 	err := os.WriteFile(planPath, nil, 0600)
 	logger := logging.NewNoopLogger(t)
@@ -80,8 +78,7 @@ func TestRun_Success(t *testing.T) {
 
 func TestRun_AppliesCorrectProjectPlan(t *testing.T) {
 	// When running for a project, the planfile has a different name.
-	tmpDir, cleanup := TempDir(t)
-	defer cleanup()
+	tmpDir := t.TempDir()
 	planPath := filepath.Join(tmpDir, "projectname-default.tfplan")
 	err := os.WriteFile(planPath, nil, 0600)
 
@@ -112,8 +109,7 @@ func TestRun_AppliesCorrectProjectPlan(t *testing.T) {
 }
 
 func TestRun_UsesConfiguredTFVersion(t *testing.T) {
-	tmpDir, cleanup := TempDir(t)
-	defer cleanup()
+	tmpDir := t.TempDir()
 	planPath := filepath.Join(tmpDir, "workspace.tfplan")
 	err := os.WriteFile(planPath, nil, 0600)
 	Ok(t, err)
@@ -199,8 +195,7 @@ func TestRun_UsingTarget(t *testing.T) {
 		descrip := fmt.Sprintf("comments flags: %s extra args: %s",
 			strings.Join(c.commentFlags, ", "), strings.Join(c.extraArgs, ", "))
 		t.Run(descrip, func(t *testing.T) {
-			tmpDir, cleanup := TempDir(t)
-			defer cleanup()
+			tmpDir := t.TempDir()
 			planPath := filepath.Join(tmpDir, "workspace.tfplan")
 			err := os.WriteFile(planPath, nil, 0600)
 			Ok(t, err)
@@ -227,8 +222,7 @@ func TestRun_UsingTarget(t *testing.T) {
 
 // Test that apply works for remote applies.
 func TestRun_RemoteApply_Success(t *testing.T) {
-	tmpDir, cleanup := TempDir(t)
-	defer cleanup()
+	tmpDir := t.TempDir()
 	planPath := filepath.Join(tmpDir, "workspace.tfplan")
 	planFileContents := `
 An execution plan has been generated and is shown below.
@@ -285,8 +279,7 @@ Apply complete! Resources: 0 added, 0 changed, 1 destroyed.
 
 // Test that if the plan is different, we error out.
 func TestRun_RemoteApply_PlanChanged(t *testing.T) {
-	tmpDir, cleanup := TempDir(t)
-	defer cleanup()
+	tmpDir := t.TempDir()
 	planPath := filepath.Join(tmpDir, "workspace.tfplan")
 	planFileContents := `
 An execution plan has been generated and is shown below.

--- a/server/core/runtime/common/common_test.go
+++ b/server/core/runtime/common/common_test.go
@@ -98,8 +98,8 @@ func runCmd(t *testing.T, dir string, name string, args ...string) string {
 	return string(cpOut)
 }
 
-func initRepo(t *testing.T) (string, func()) {
-	repoDir, cleanup := TempDir(t)
+func initRepo(t *testing.T) string {
+	repoDir := t.TempDir()
 	runCmd(t, repoDir, "git", "init")
 	runCmd(t, repoDir, "touch", ".gitkeep")
 	runCmd(t, repoDir, "git", "add", ".gitkeep")
@@ -108,13 +108,12 @@ func initRepo(t *testing.T) (string, func()) {
 	runCmd(t, repoDir, "git", "config", "--local", "commit.gpgsign", "false")
 	runCmd(t, repoDir, "git", "commit", "-m", "initial commit")
 	runCmd(t, repoDir, "git", "branch", "branch")
-	return repoDir, cleanup
+	return repoDir
 }
 
 func TestIsFileTracked(t *testing.T) {
 	// Initialize the git repo.
-	repoDir, cleanup := initRepo(t)
-	defer cleanup()
+	repoDir := initRepo(t)
 
 	// file1 should not be tracked
 	tracked, err := IsFileTracked(repoDir, "file1")

--- a/server/core/runtime/env_step_runner_test.go
+++ b/server/core/runtime/env_step_runner_test.go
@@ -52,8 +52,7 @@ func TestEnvStepRunner_Run(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.Command, func(t *testing.T) {
-			tmpDir, cleanup := TempDir(t)
-			defer cleanup()
+			tmpDir := t.TempDir()
 			ctx := command.ProjectContext{
 				BaseRepo: models.Repo{
 					Name:  "basename",

--- a/server/core/runtime/init_step_runner_test.go
+++ b/server/core/runtime/init_step_runner_test.go
@@ -103,8 +103,7 @@ func TestRun_ShowInitOutputOnError(t *testing.T) {
 
 func TestRun_InitOmitsUpgradeFlagIfLockFileTracked(t *testing.T) {
 	// Initialize the git repo.
-	repoDir, cleanup := initRepo(t)
-	defer cleanup()
+	repoDir := initRepo(t)
 
 	lockFilePath := filepath.Join(repoDir, ".terraform.lock.hcl")
 	err := os.WriteFile(lockFilePath, nil, 0600)
@@ -141,8 +140,7 @@ func TestRun_InitOmitsUpgradeFlagIfLockFileTracked(t *testing.T) {
 }
 
 func TestRun_InitKeepsUpgradeFlagIfLockFileNotPresent(t *testing.T) {
-	tmpDir, cleanup := TempDir(t)
-	defer cleanup()
+	tmpDir := t.TempDir()
 
 	RegisterMockTestingT(t)
 	terraform := mocks.NewMockClient()
@@ -171,8 +169,7 @@ func TestRun_InitKeepsUpgradeFlagIfLockFileNotPresent(t *testing.T) {
 }
 
 func TestRun_InitKeepUpgradeFlagIfLockFilePresentAndTFLessThanPoint14(t *testing.T) {
-	tmpDir, cleanup := TempDir(t)
-	defer cleanup()
+	tmpDir := t.TempDir()
 	lockFilePath := filepath.Join(tmpDir, ".terraform.lock.hcl")
 	err := os.WriteFile(lockFilePath, nil, 0600)
 	Ok(t, err)
@@ -274,8 +271,7 @@ func TestRun_InitExtraArgsDeDupe(t *testing.T) {
 
 func TestRun_InitDeletesLockFileIfPresentAndNotTracked(t *testing.T) {
 	// Initialize the git repo.
-	repoDir, cleanup := initRepo(t)
-	defer cleanup()
+	repoDir := initRepo(t)
 
 	lockFilePath := filepath.Join(repoDir, ".terraform.lock.hcl")
 	err := os.WriteFile(lockFilePath, nil, 0600)
@@ -318,8 +314,8 @@ func runCmd(t *testing.T, dir string, name string, args ...string) string {
 	return string(cpOut)
 }
 
-func initRepo(t *testing.T) (string, func()) {
-	repoDir, cleanup := TempDir(t)
+func initRepo(t *testing.T) string {
+	repoDir := t.TempDir()
 	runCmd(t, repoDir, "git", "init")
 	runCmd(t, repoDir, "touch", ".gitkeep")
 	runCmd(t, repoDir, "git", "add", ".gitkeep")
@@ -328,5 +324,5 @@ func initRepo(t *testing.T) (string, func()) {
 	runCmd(t, repoDir, "git", "config", "--local", "commit.gpgsign", "false")
 	runCmd(t, repoDir, "git", "commit", "-m", "initial commit")
 	runCmd(t, repoDir, "git", "branch", "branch")
-	return repoDir, cleanup
+	return repoDir
 }

--- a/server/core/runtime/multienv_step_runner_test.go
+++ b/server/core/runtime/multienv_step_runner_test.go
@@ -53,8 +53,7 @@ func TestMultiEnvStepRunner_Run(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.Command, func(t *testing.T) {
-			tmpDir, cleanup := TempDir(t)
-			defer cleanup()
+			tmpDir := t.TempDir()
 			ctx := command.ProjectContext{
 				BaseRepo: models.Repo{
 					Name:  "basename",

--- a/server/core/runtime/plan_step_runner_test.go
+++ b/server/core/runtime/plan_step_runner_test.go
@@ -378,8 +378,7 @@ func TestRun_AddsEnvVarFile(t *testing.T) {
 	terraform := mocks.NewMockClient()
 
 	// Create the env/workspace.tfvars file.
-	tmpDir, cleanup := TempDir(t)
-	defer cleanup()
+	tmpDir := t.TempDir()
 	err := os.MkdirAll(filepath.Join(tmpDir, "env"), 0700)
 	Ok(t, err)
 	envVarsFile := filepath.Join(tmpDir, "env/workspace.tfvars")
@@ -732,8 +731,7 @@ locally at this time.
 				AsyncTFExec:         asyncTf,
 				CommitStatusUpdater: updater,
 			}
-			absProjectPath, cleanup := TempDir(t)
-			defer cleanup()
+			absProjectPath := t.TempDir()
 
 			// First, terraform workspace gets run.
 			When(terraform.RunCommandWithVersion(

--- a/server/core/runtime/plan_type_step_runner_delegate_test.go
+++ b/server/core/runtime/plan_type_step_runner_delegate_test.go
@@ -41,8 +41,7 @@ func TestRunDelegate(t *testing.T) {
 	tfVersion, _ := version.NewVersion("0.12.0")
 
 	t.Run("Remote Runner Success", func(t *testing.T) {
-		tmpDir, cleanup := TempDir(t)
-		defer cleanup()
+		tmpDir := t.TempDir()
 		planPath := filepath.Join(tmpDir, "workspace.tfplan")
 		err := os.WriteFile(planPath, []byte("Atlantis: this plan was created by remote ops\n"+planFileContents), 0600)
 		Ok(t, err)
@@ -70,8 +69,7 @@ func TestRunDelegate(t *testing.T) {
 	})
 
 	t.Run("Remote Runner Failure", func(t *testing.T) {
-		tmpDir, cleanup := TempDir(t)
-		defer cleanup()
+		tmpDir := t.TempDir()
 		planPath := filepath.Join(tmpDir, "workspace.tfplan")
 		err := os.WriteFile(planPath, []byte("Atlantis: this plan was created by remote ops\n"+planFileContents), 0600)
 		Ok(t, err)
@@ -99,8 +97,7 @@ func TestRunDelegate(t *testing.T) {
 	})
 
 	t.Run("Local Runner Success", func(t *testing.T) {
-		tmpDir, cleanup := TempDir(t)
-		defer cleanup()
+		tmpDir := t.TempDir()
 		planPath := filepath.Join(tmpDir, "workspace.tfplan")
 		err := os.WriteFile(planPath, []byte(planFileContents), 0600)
 		Ok(t, err)
@@ -128,8 +125,7 @@ func TestRunDelegate(t *testing.T) {
 	})
 
 	t.Run("Local Runner Failure", func(t *testing.T) {
-		tmpDir, cleanup := TempDir(t)
-		defer cleanup()
+		tmpDir := t.TempDir()
 		planPath := filepath.Join(tmpDir, "workspace.tfplan")
 		err := os.WriteFile(planPath, []byte(planFileContents), 0600)
 		Ok(t, err)

--- a/server/core/runtime/post_workflow_hook_runner_test.go
+++ b/server/core/runtime/post_workflow_hook_runner_test.go
@@ -69,11 +69,10 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 			ThenReturn(nil)
 
 		logger := logging.NewNoopLogger(t)
+		tmpDir := t.TempDir()
 
 		r := runtime.DefaultPostWorkflowHookRunner{}
 		t.Run(c.Command, func(t *testing.T) {
-			tmpDir, cleanup := TempDir(t)
-			defer cleanup()
 			ctx := models.WorkflowHookCommandContext{
 				BaseRepo: models.Repo{
 					Name:  "basename",

--- a/server/core/runtime/pre_workflow_hook_runner_test.go
+++ b/server/core/runtime/pre_workflow_hook_runner_test.go
@@ -69,11 +69,10 @@ func TestPreWorkflowHookRunner_Run(t *testing.T) {
 			ThenReturn(nil)
 
 		logger := logging.NewNoopLogger(t)
+		tmpDir := t.TempDir()
 
 		r := runtime.DefaultPreWorkflowHookRunner{}
 		t.Run(c.Command, func(t *testing.T) {
-			tmpDir, cleanup := TempDir(t)
-			defer cleanup()
 			ctx := models.WorkflowHookCommandContext{
 				BaseRepo: models.Repo{
 					Name:  "basename",

--- a/server/core/runtime/run_step_runner_test.go
+++ b/server/core/runtime/run_step_runner_test.go
@@ -110,6 +110,7 @@ func TestRunStepRunner_Run(t *testing.T) {
 
 		logger := logging.NewNoopLogger(t)
 		projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
+		tmpDir := t.TempDir()
 
 		r := runtime.RunStepRunner{
 			TerraformExecutor:       terraform,
@@ -118,8 +119,6 @@ func TestRunStepRunner_Run(t *testing.T) {
 			ProjectCmdOutputHandler: projectCmdOutputHandler,
 		}
 		t.Run(c.Command, func(t *testing.T) {
-			tmpDir, cleanup := TempDir(t)
-			defer cleanup()
 			ctx := command.ProjectContext{
 				BaseRepo: models.Repo{
 					Name:  "basename",

--- a/server/core/runtime/show_step_runner_test.go
+++ b/server/core/runtime/show_step_runner_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestShowStepRunnner(t *testing.T) {
 	logger := logging.NewNoopLogger(t)
-	path, _ := os.MkdirTemp("", "")
+	path := t.TempDir()
 	resultPath := filepath.Join(path, "test-default.json")
 	envs := map[string]string{"key": "val"}
 	tfVersion, _ := version.NewVersion("0.12")

--- a/server/core/runtime/version_step_runner_test.go
+++ b/server/core/runtime/version_step_runner_test.go
@@ -35,8 +35,7 @@ func TestRunVersionStep(t *testing.T) {
 
 	terraform := mocks.NewMockClient()
 	tfVersion, _ := version.NewVersion("0.15.0")
-	tmpDir, cleanup := TempDir(t)
-	defer cleanup()
+	tmpDir := t.TempDir()
 
 	s := &VersionStepRunner{
 		TerraformExecutor: terraform,

--- a/server/core/terraform/terraform_client_internal_test.go
+++ b/server/core/terraform/terraform_client_internal_test.go
@@ -18,8 +18,7 @@ import (
 
 // Test that we write the file as expected
 func TestGenerateRCFile_WritesFile(t *testing.T) {
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 
 	err := generateRCFile("token", "hostname", tmp)
 	Ok(t, err)
@@ -35,8 +34,7 @@ func TestGenerateRCFile_WritesFile(t *testing.T) {
 // Test that if the file already exists and its contents will be modified if
 // we write our config that we error out.
 func TestGenerateRCFile_WillNotOverwrite(t *testing.T) {
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 
 	rcFile := filepath.Join(tmp, ".terraformrc")
 	err := os.WriteFile(rcFile, []byte("contents"), 0600)
@@ -50,8 +48,7 @@ func TestGenerateRCFile_WillNotOverwrite(t *testing.T) {
 // Test that if the file already exists and its contents will NOT be modified if
 // we write our config that we don't error.
 func TestGenerateRCFile_NoErrIfContentsSame(t *testing.T) {
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 
 	rcFile := filepath.Join(tmp, ".terraformrc")
 	contents := `credentials "app.terraform.io" {
@@ -67,8 +64,7 @@ func TestGenerateRCFile_NoErrIfContentsSame(t *testing.T) {
 // Test that if we can't read the existing file to see if the contents will be
 // the same that we just error out.
 func TestGenerateRCFile_ErrIfCannotRead(t *testing.T) {
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 
 	rcFile := filepath.Join(tmp, ".terraformrc")
 	err := os.WriteFile(rcFile, []byte("can't see me!"), 0000)
@@ -91,7 +87,7 @@ func TestGenerateRCFile_ErrIfCannotWrite(t *testing.T) {
 func TestDefaultClient_RunCommandWithVersion_EnvVars(t *testing.T) {
 	v, err := version.NewVersion("0.11.11")
 	Ok(t, err)
-	tmp, cleanup := TempDir(t)
+	tmp := t.TempDir()
 	logger := logging.NewNoopLogger(t)
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 
@@ -106,7 +102,6 @@ func TestDefaultClient_RunCommandWithVersion_EnvVars(t *testing.T) {
 			Num: 2,
 		},
 	}
-	defer cleanup()
 	client := &DefaultClient{
 		defaultVersion:          v,
 		terraformPluginCacheDir: tmp,
@@ -133,7 +128,7 @@ func TestDefaultClient_RunCommandWithVersion_EnvVars(t *testing.T) {
 func TestDefaultClient_RunCommandWithVersion_Error(t *testing.T) {
 	v, err := version.NewVersion("0.11.11")
 	Ok(t, err)
-	tmp, cleanup := TempDir(t)
+	tmp := t.TempDir()
 	logger := logging.NewNoopLogger(t)
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 
@@ -153,7 +148,6 @@ func TestDefaultClient_RunCommandWithVersion_Error(t *testing.T) {
 			Name:     "repo",
 		},
 	}
-	defer cleanup()
 	client := &DefaultClient{
 		defaultVersion:          v,
 		terraformPluginCacheDir: tmp,
@@ -176,7 +170,7 @@ func TestDefaultClient_RunCommandWithVersion_Error(t *testing.T) {
 func TestDefaultClient_RunCommandAsync_Success(t *testing.T) {
 	v, err := version.NewVersion("0.11.11")
 	Ok(t, err)
-	tmp, cleanup := TempDir(t)
+	tmp := t.TempDir()
 	logger := logging.NewNoopLogger(t)
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 
@@ -196,7 +190,6 @@ func TestDefaultClient_RunCommandAsync_Success(t *testing.T) {
 			Name:     "repo",
 		},
 	}
-	defer cleanup()
 	client := &DefaultClient{
 		defaultVersion:          v,
 		terraformPluginCacheDir: tmp,
@@ -223,7 +216,7 @@ func TestDefaultClient_RunCommandAsync_Success(t *testing.T) {
 func TestDefaultClient_RunCommandAsync_BigOutput(t *testing.T) {
 	v, err := version.NewVersion("0.11.11")
 	Ok(t, err)
-	tmp, cleanup := TempDir(t)
+	tmp := t.TempDir()
 	logger := logging.NewNoopLogger(t)
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 
@@ -243,7 +236,6 @@ func TestDefaultClient_RunCommandAsync_BigOutput(t *testing.T) {
 			Name:     "repo",
 		},
 	}
-	defer cleanup()
 	client := &DefaultClient{
 		defaultVersion:          v,
 		terraformPluginCacheDir: tmp,
@@ -271,7 +263,7 @@ func TestDefaultClient_RunCommandAsync_BigOutput(t *testing.T) {
 func TestDefaultClient_RunCommandAsync_StderrOutput(t *testing.T) {
 	v, err := version.NewVersion("0.11.11")
 	Ok(t, err)
-	tmp, cleanup := TempDir(t)
+	tmp := t.TempDir()
 	logger := logging.NewNoopLogger(t)
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 
@@ -291,7 +283,6 @@ func TestDefaultClient_RunCommandAsync_StderrOutput(t *testing.T) {
 			Name:     "repo",
 		},
 	}
-	defer cleanup()
 	client := &DefaultClient{
 		defaultVersion:          v,
 		terraformPluginCacheDir: tmp,
@@ -308,7 +299,7 @@ func TestDefaultClient_RunCommandAsync_StderrOutput(t *testing.T) {
 func TestDefaultClient_RunCommandAsync_ExitOne(t *testing.T) {
 	v, err := version.NewVersion("0.11.11")
 	Ok(t, err)
-	tmp, cleanup := TempDir(t)
+	tmp := t.TempDir()
 	logger := logging.NewNoopLogger(t)
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 
@@ -328,7 +319,6 @@ func TestDefaultClient_RunCommandAsync_ExitOne(t *testing.T) {
 			Name:     "repo",
 		},
 	}
-	defer cleanup()
 	client := &DefaultClient{
 		defaultVersion:          v,
 		terraformPluginCacheDir: tmp,
@@ -346,7 +336,7 @@ func TestDefaultClient_RunCommandAsync_ExitOne(t *testing.T) {
 func TestDefaultClient_RunCommandAsync_Input(t *testing.T) {
 	v, err := version.NewVersion("0.11.11")
 	Ok(t, err)
-	tmp, cleanup := TempDir(t)
+	tmp := t.TempDir()
 	logger := logging.NewNoopLogger(t)
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 
@@ -366,7 +356,6 @@ func TestDefaultClient_RunCommandAsync_Input(t *testing.T) {
 			Name:     "repo",
 		},
 	}
-	defer cleanup()
 	client := &DefaultClient{
 		defaultVersion:          v,
 		terraformPluginCacheDir: tmp,

--- a/server/core/terraform/terraform_client_test.go
+++ b/server/core/terraform/terraform_client_test.go
@@ -60,14 +60,13 @@ func TestNewClient_LocalTFOnly(t *testing.T) {
 Your version of Terraform is out of date! The latest version
 is 0.11.13. You can update by downloading from www.terraform.io/downloads.html
 `
-	tmp, binDir, cacheDir, cleanup := mkSubDirs(t)
+	tmp, binDir, cacheDir := mkSubDirs(t)
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 	ctx := command.ProjectContext{
 		Log:        logging.NewNoopLogger(t),
 		Workspace:  "default",
 		RepoRelDir: ".",
 	}
-	defer cleanup()
 
 	logger := logging.NewNoopLogger(t)
 
@@ -97,14 +96,13 @@ Your version of Terraform is out of date! The latest version
 is 0.11.13. You can update by downloading from www.terraform.io/downloads.html
 `
 	logger := logging.NewNoopLogger(t)
-	tmp, binDir, cacheDir, cleanup := mkSubDirs(t)
+	tmp, binDir, cacheDir := mkSubDirs(t)
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 	ctx := command.ProjectContext{
 		Log:        logging.NewNoopLogger(t),
 		Workspace:  "default",
 		RepoRelDir: ".",
 	}
-	defer cleanup()
 
 	// We're testing this by adding our own "fake" terraform binary to path that
 	// outputs what would normally come from terraform version.
@@ -127,9 +125,8 @@ is 0.11.13. You can update by downloading from www.terraform.io/downloads.html
 // that we error.
 func TestNewClient_NoTF(t *testing.T) {
 	logger := logging.NewNoopLogger(t)
-	tmp, binDir, cacheDir, cleanup := mkSubDirs(t)
+	tmp, binDir, cacheDir := mkSubDirs(t)
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
-	defer cleanup()
 
 	// Set PATH to only include our empty directory.
 	defer tempSetEnv(t, "PATH", tmp)()
@@ -143,14 +140,13 @@ func TestNewClient_NoTF(t *testing.T) {
 func TestNewClient_DefaultTFFlagInPath(t *testing.T) {
 	fakeBinOut := "Terraform v0.11.10\n"
 	logger := logging.NewNoopLogger(t)
-	tmp, binDir, cacheDir, cleanup := mkSubDirs(t)
+	tmp, binDir, cacheDir := mkSubDirs(t)
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 	ctx := command.ProjectContext{
 		Log:        logging.NewNoopLogger(t),
 		Workspace:  "default",
 		RepoRelDir: ".",
 	}
-	defer cleanup()
 
 	// We're testing this by adding our own "fake" terraform binary to path that
 	// outputs what would normally come from terraform version.
@@ -173,14 +169,13 @@ func TestNewClient_DefaultTFFlagInPath(t *testing.T) {
 // bin dir that we use it.
 func TestNewClient_DefaultTFFlagInBinDir(t *testing.T) {
 	fakeBinOut := "Terraform v0.11.10\n"
-	tmp, binDir, cacheDir, cleanup := mkSubDirs(t)
+	tmp, binDir, cacheDir := mkSubDirs(t)
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 	ctx := command.ProjectContext{
 		Log:        logging.NewNoopLogger(t),
 		Workspace:  "default",
 		RepoRelDir: ".",
 	}
-	defer cleanup()
 
 	// Add our fake binary to {datadir}/bin/terraform{version}.
 	err := os.WriteFile(filepath.Join(binDir, "terraform0.11.10"), []byte(fmt.Sprintf("#!/bin/sh\necho '%s'", fakeBinOut)), 0700) // #nosec G306
@@ -202,14 +197,13 @@ func TestNewClient_DefaultTFFlagInBinDir(t *testing.T) {
 func TestNewClient_DefaultTFFlagDownload(t *testing.T) {
 	RegisterMockTestingT(t)
 	logger := logging.NewNoopLogger(t)
-	tmp, binDir, cacheDir, cleanup := mkSubDirs(t)
+	tmp, binDir, cacheDir := mkSubDirs(t)
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 	ctx := command.ProjectContext{
 		Log:        logging.NewNoopLogger(t),
 		Workspace:  "default",
 		RepoRelDir: ".",
 	}
-	defer cleanup()
 
 	// Set PATH to empty so there's no TF available.
 	orig := os.Getenv("PATH")
@@ -244,9 +238,8 @@ func TestNewClient_DefaultTFFlagDownload(t *testing.T) {
 // Test that we get an error if the terraform version flag is malformed.
 func TestNewClient_BadVersion(t *testing.T) {
 	logger := logging.NewNoopLogger(t)
-	_, binDir, cacheDir, cleanup := mkSubDirs(t)
+	_, binDir, cacheDir := mkSubDirs(t)
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
-	defer cleanup()
 	_, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "malformed", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, nil, true, projectCmdOutputHandler)
 	ErrEquals(t, "Malformed version: malformed", err)
 }
@@ -255,14 +248,13 @@ func TestNewClient_BadVersion(t *testing.T) {
 func TestRunCommandWithVersion_DLsTF(t *testing.T) {
 	logger := logging.NewNoopLogger(t)
 	RegisterMockTestingT(t)
-	tmp, binDir, cacheDir, cleanup := mkSubDirs(t)
+	tmp, binDir, cacheDir := mkSubDirs(t)
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 	ctx := command.ProjectContext{
 		Log:        logging.NewNoopLogger(t),
 		Workspace:  "default",
 		RepoRelDir: ".",
 	}
-	defer cleanup()
 
 	mockDownloader := mocks.NewMockDownloader()
 	// Set up our mock downloader to write a fake tf binary when it's called.
@@ -294,9 +286,8 @@ func TestRunCommandWithVersion_DLsTF(t *testing.T) {
 func TestEnsureVersion_downloaded(t *testing.T) {
 	logger := logging.NewNoopLogger(t)
 	RegisterMockTestingT(t)
-	tmp, binDir, cacheDir, cleanup := mkSubDirs(t)
+	tmp, binDir, cacheDir := mkSubDirs(t)
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
-	defer cleanup()
 
 	mockDownloader := mocks.NewMockDownloader()
 
@@ -329,9 +320,9 @@ func tempSetEnv(t *testing.T, key string, value string) func() {
 	return func() { os.Setenv(key, orig) }
 }
 
-// returns parent, bindir, cachedir, cleanup func
-func mkSubDirs(t *testing.T) (string, string, string, func()) {
-	tmp, cleanup := TempDir(t)
+// returns parent, bindir, cachedir
+func mkSubDirs(t *testing.T) (string, string, string) {
+	tmp := t.TempDir()
 	binDir := filepath.Join(tmp, "bin")
 	err := os.MkdirAll(binDir, 0700)
 	Ok(t, err)
@@ -340,5 +331,5 @@ func mkSubDirs(t *testing.T) (string, string, string, func()) {
 	err = os.MkdirAll(cachedir, 0700)
 	Ok(t, err)
 
-	return tmp, binDir, cachedir, cleanup
+	return tmp, binDir, cachedir
 }

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -82,8 +82,7 @@ func setup(t *testing.T) *vcsmocks.MockClient {
 	workingDir = mocks.NewMockWorkingDir()
 	pendingPlanFinder = mocks.NewMockPendingPlanFinder()
 	commitUpdater = mocks.NewMockCommitStatusUpdater()
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 	defaultBoltDB, err := db.New(tmp)
 	Ok(t, err)
 
@@ -535,8 +534,7 @@ func TestRunUnlockCommandFail_VCSComment(t *testing.T) {
 
 func TestRunAutoplanCommand_DeletePlans(t *testing.T) {
 	setup(t)
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 	boltDB, err := db.New(tmp)
 	Ok(t, err)
 	dbUpdater.Backend = boltDB
@@ -563,8 +561,7 @@ func TestRunAutoplanCommand_DeletePlans(t *testing.T) {
 
 func TestRunGenericPlanCommand_DeletePlans(t *testing.T) {
 	setup(t)
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 	boltDB, err := db.New(tmp)
 	Ok(t, err)
 	dbUpdater.Backend = boltDB
@@ -586,8 +583,7 @@ func TestRunGenericPlanCommand_DeletePlans(t *testing.T) {
 
 func TestRunSpecificPlanCommandDoesnt_DeletePlans(t *testing.T) {
 	setup(t)
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 	boltDB, err := db.New(tmp)
 	Ok(t, err)
 	dbUpdater.Backend = boltDB
@@ -606,8 +602,7 @@ func TestRunSpecificPlanCommandDoesnt_DeletePlans(t *testing.T) {
 // we delete the plans.
 func TestRunAutoplanCommandWithError_DeletePlans(t *testing.T) {
 	setup(t)
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 	boltDB, err := db.New(tmp)
 	Ok(t, err)
 	dbUpdater.Backend = boltDB
@@ -654,8 +649,7 @@ func TestRunAutoplanCommandWithError_DeletePlans(t *testing.T) {
 func TestFailedApprovalCreatesFailedStatusUpdate(t *testing.T) {
 	t.Log("if \"atlantis approve_policies\" is run by non policy owner policy check status fails.")
 	setup(t)
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 	boltDB, err := db.New(tmp)
 	Ok(t, err)
 	dbUpdater.Backend = boltDB
@@ -700,8 +694,7 @@ func TestFailedApprovalCreatesFailedStatusUpdate(t *testing.T) {
 func TestApprovedPoliciesUpdateFailedPolicyStatus(t *testing.T) {
 	t.Log("if \"atlantis approve_policies\" is run by policy owner all policy checks are approved.")
 	setup(t)
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 	boltDB, err := db.New(tmp)
 	Ok(t, err)
 	dbUpdater.Backend = boltDB
@@ -756,8 +749,7 @@ func TestApprovedPoliciesUpdateFailedPolicyStatus(t *testing.T) {
 func TestApplyMergeablityWhenPolicyCheckFails(t *testing.T) {
 	t.Log("if \"atlantis apply\" is run with failing policy check then apply is not performed")
 	setup(t)
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 	boltDB, err := db.New(tmp)
 	Ok(t, err)
 	dbUpdater.Backend = boltDB
@@ -835,8 +827,7 @@ func TestRunApply_DiscardedProjects(t *testing.T) {
 	vcsClient := setup(t)
 	autoMerger.GlobalAutomerge = true
 	defer func() { autoMerger.GlobalAutomerge = false }()
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 	boltDB, err := db.New(tmp)
 	Ok(t, err)
 	dbUpdater.Backend = boltDB

--- a/server/events/delete_lock_command_test.go
+++ b/server/events/delete_lock_command_test.go
@@ -72,8 +72,7 @@ func TestDeleteLock_Success(t *testing.T) {
 			RepoFullName: "owner/repo",
 		},
 	}, nil)
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 	db, err := db.New(tmp)
 	Ok(t, err)
 	dlc := events.DefaultDeleteLockCommand{

--- a/server/events/git_cred_writer_test.go
+++ b/server/events/git_cred_writer_test.go
@@ -16,8 +16,7 @@ var logger logging.SimpleLogging
 
 // Test that we write the file as expected
 func TestWriteGitCreds_WriteFile(t *testing.T) {
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 
 	err := events.WriteGitCreds("user", "token", "hostname", tmp, logger, false)
 	Ok(t, err)
@@ -32,8 +31,7 @@ func TestWriteGitCreds_WriteFile(t *testing.T) {
 // Test that if the file already exists and it doesn't have the line we would
 // have written, we write it.
 func TestWriteGitCreds_Appends(t *testing.T) {
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 
 	credsFile := filepath.Join(tmp, ".git-credentials")
 	err := os.WriteFile(credsFile, []byte("contents"), 0600)
@@ -51,8 +49,7 @@ func TestWriteGitCreds_Appends(t *testing.T) {
 // Test that if the file already exists and it already has the line expected
 // we do nothing.
 func TestWriteGitCreds_NoModification(t *testing.T) {
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 
 	credsFile := filepath.Join(tmp, ".git-credentials")
 	contents := "line1\nhttps://user:token@hostname\nline2"
@@ -68,8 +65,7 @@ func TestWriteGitCreds_NoModification(t *testing.T) {
 
 // Test that the github app credentials get replaced.
 func TestWriteGitCreds_ReplaceApp(t *testing.T) {
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 
 	credsFile := filepath.Join(tmp, ".git-credentials")
 	contents := "line1\nhttps://x-access-token:v1.87dddddddddddddddd@github.com\nline2"
@@ -86,8 +82,7 @@ func TestWriteGitCreds_ReplaceApp(t *testing.T) {
 
 // Test that the github app credentials get updated when cred file is empty.
 func TestWriteGitCreds_AppendApp(t *testing.T) {
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 
 	credsFile := filepath.Join(tmp, ".git-credentials")
 	contents := ""
@@ -105,8 +100,7 @@ func TestWriteGitCreds_AppendApp(t *testing.T) {
 // Test that if we can't read the existing file to see if the contents will be
 // the same that we just error out.
 func TestWriteGitCreds_ErrIfCannotRead(t *testing.T) {
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 
 	credsFile := filepath.Join(tmp, ".git-credentials")
 	err := os.WriteFile(credsFile, []byte("can't see me!"), 0000)
@@ -127,8 +121,7 @@ func TestWriteGitCreds_ErrIfCannotWrite(t *testing.T) {
 
 // Test that git is actually configured to use the credentials
 func TestWriteGitCreds_ConfigureGitCredentialHelper(t *testing.T) {
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 
 	err := events.WriteGitCreds("user", "token", "hostname", tmp, logger, false)
 	Ok(t, err)
@@ -141,8 +134,7 @@ func TestWriteGitCreds_ConfigureGitCredentialHelper(t *testing.T) {
 
 // Test that git is configured to use https instead of ssh
 func TestWriteGitCreds_ConfigureGitUrlOverride(t *testing.T) {
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 
 	err := events.WriteGitCreds("user", "token", "hostname", tmp, logger, false)
 	Ok(t, err)

--- a/server/events/github_app_working_dir_test.go
+++ b/server/events/github_app_working_dir_test.go
@@ -18,12 +18,10 @@ import (
 // Test that if we don't have any existing files, we check out the repo with a github app.
 func TestClone_GithubAppNoneExisting(t *testing.T) {
 	// Initialize the git repo.
-	repoDir, cleanup := initRepo(t)
-	defer cleanup()
+	repoDir := initRepo(t)
 	expCommit := runCmd(t, repoDir, "git", "rev-parse", "HEAD")
 
-	dataDir, cleanup2 := TempDir(t)
-	defer cleanup2()
+	dataDir := t.TempDir()
 
 	wd := &events.FileWorkspace{
 		DataDir:                     dataDir,

--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -1085,13 +1085,12 @@ $$$
 
 // Run policy check with a custom template to validate custom template rendering.
 func TestRenderCustomPolicyCheckTemplate_DisableApplyAll(t *testing.T) {
-	tmpDir, cleanup := TempDir(t)
+	tmpDir := t.TempDir()
 	filePath := fmt.Sprintf("%s/templates.tmpl", tmpDir)
 	_, err := os.Create(filePath)
 	Ok(t, err)
 	err = os.WriteFile(filePath, []byte("{{ define \"policyCheckSuccessUnwrapped\" -}}somecustometext{{- end}}\n"), 0600)
 	Ok(t, err)
-	defer cleanup()
 	r := events.GetMarkdownRenderer(
 		false,  // GitlabSupportsCommonMark
 		true,   // DisableApplyAll

--- a/server/events/pending_plan_finder_test.go
+++ b/server/events/pending_plan_finder_test.go
@@ -185,8 +185,7 @@ func TestPendingPlanFinder_Find(t *testing.T) {
 	pf := &events.DefaultPendingPlanFinder{}
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
-			tmpDir, cleanup := DirStructure(t, c.files)
-			defer cleanup()
+			tmpDir := DirStructure(t, c.files)
 
 			// Create a git repo in each workspace directory.
 			for dirname, contents := range c.files {
@@ -212,12 +211,11 @@ func TestPendingPlanFinder_Find(t *testing.T) {
 
 // If a planfile is checked in to git, we shouldn't use it.
 func TestPendingPlanFinder_FindPlanCheckedIn(t *testing.T) {
-	tmpDir, cleanup := DirStructure(t, map[string]interface{}{
+	tmpDir := DirStructure(t, map[string]interface{}{
 		"default": map[string]interface{}{
 			"default.tfplan": nil,
 		},
 	})
-	defer cleanup()
 
 	// Add that file to git.
 	repoDir := filepath.Join(tmpDir, "default")
@@ -247,9 +245,7 @@ func TestPendingPlanFinder_DeletePlans(t *testing.T) {
 			},
 		},
 	}
-	tmp, cleanup := DirStructure(t,
-		files)
-	defer cleanup()
+	tmp := DirStructure(t, files)
 
 	// Create a git repo in each workspace directory.
 	for dirname, contents := range files {

--- a/server/events/project_command_builder_internal_test.go
+++ b/server/events/project_command_builder_internal_test.go
@@ -579,7 +579,7 @@ projects:
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			tmp, cleanup := DirStructure(t, map[string]interface{}{
+			tmp := DirStructure(t, map[string]interface{}{
 				"project1": map[string]interface{}{
 					"main.tf": nil,
 				},
@@ -589,7 +589,6 @@ projects:
 					},
 				},
 			})
-			defer cleanup()
 
 			workingDir := NewMockWorkingDir()
 			When(workingDir.Clone(matchers.AnyPtrToLoggingSimpleLogger(), matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest(), AnyString())).ThenReturn(tmp, false, nil)
@@ -784,7 +783,7 @@ projects:
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			tmp, cleanup := DirStructure(t, map[string]interface{}{
+			tmp := DirStructure(t, map[string]interface{}{
 				"project1": map[string]interface{}{
 					"main.tf": nil,
 				},
@@ -794,7 +793,6 @@ projects:
 					},
 				},
 			})
-			defer cleanup()
 
 			workingDir := NewMockWorkingDir()
 			When(workingDir.Clone(logging_matchers.AnyPtrToLoggingSimpleLogger(), matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest(), AnyString())).ThenReturn(tmp, false, nil)
@@ -1009,7 +1007,7 @@ workflows:
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			tmp, cleanup := DirStructure(t, map[string]interface{}{
+			tmp := DirStructure(t, map[string]interface{}{
 				"project1": map[string]interface{}{
 					"main.tf": nil,
 				},
@@ -1019,7 +1017,6 @@ workflows:
 					},
 				},
 			})
-			defer cleanup()
 
 			workingDir := NewMockWorkingDir()
 			When(workingDir.Clone(matchers.AnyPtrToLoggingSimpleLogger(), matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest(), AnyString())).ThenReturn(tmp, false, nil)

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -125,10 +125,9 @@ projects:
 	for _, c := range cases {
 		t.Run(c.Description, func(t *testing.T) {
 			RegisterMockTestingT(t)
-			tmpDir, cleanup := DirStructure(t, map[string]interface{}{
+			tmpDir := DirStructure(t, map[string]interface{}{
 				"main.tf": nil,
 			})
-			defer cleanup()
 
 			workingDir := mocks.NewMockWorkingDir()
 			When(workingDir.Clone(matchers.AnyPtrToLoggingSimpleLogger(), matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest(), AnyString())).ThenReturn(tmpDir, false, nil)
@@ -392,10 +391,9 @@ projects:
 		for _, cmdName := range []command.Name{command.Plan, command.Apply} {
 			t.Run(c.Description+"_"+cmdName.String(), func(t *testing.T) {
 				RegisterMockTestingT(t)
-				tmpDir, cleanup := DirStructure(t, map[string]interface{}{
+				tmpDir := DirStructure(t, map[string]interface{}{
 					"main.tf": nil,
 				})
-				defer cleanup()
 
 				workingDir := mocks.NewMockWorkingDir()
 				When(workingDir.Clone(matchers.AnyPtrToLoggingSimpleLogger(), matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest(), AnyString())).ThenReturn(tmpDir, false, nil)
@@ -549,8 +547,7 @@ projects:
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
 			RegisterMockTestingT(t)
-			tmpDir, cleanup := DirStructure(t, c.DirStructure)
-			defer cleanup()
+			tmpDir := DirStructure(t, c.DirStructure)
 
 			workingDir := mocks.NewMockWorkingDir()
 			When(workingDir.Clone(matchers.AnyPtrToLoggingSimpleLogger(), matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest(), AnyString())).ThenReturn(tmpDir, false, nil)
@@ -616,7 +613,7 @@ projects:
 // In this case we should apply all outstanding plans.
 func TestDefaultProjectCommandBuilder_BuildMultiApply(t *testing.T) {
 	RegisterMockTestingT(t)
-	tmpDir, cleanup := DirStructure(t, map[string]interface{}{
+	tmpDir := DirStructure(t, map[string]interface{}{
 		"workspace1": map[string]interface{}{
 			"project1": map[string]interface{}{
 				"main.tf":          nil,
@@ -638,7 +635,6 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply(t *testing.T) {
 			},
 		},
 	})
-	defer cleanup()
 	// Initialize git repos in each workspace so that the .tfplan files get
 	// picked up.
 	runCmd(t, filepath.Join(tmpDir, "workspace1"), "git", "init")
@@ -708,12 +704,11 @@ func TestDefaultProjectCommandBuilder_WrongWorkspaceName(t *testing.T) {
 	RegisterMockTestingT(t)
 	workingDir := mocks.NewMockWorkingDir()
 
-	tmpDir, cleanup := DirStructure(t, map[string]interface{}{
+	tmpDir := DirStructure(t, map[string]interface{}{
 		"pulldir": map[string]interface{}{
 			"notconfigured": map[string]interface{}{},
 		},
 	})
-	defer cleanup()
 	repoDir := filepath.Join(tmpDir, "pulldir/notconfigured")
 
 	yamlCfg := `version: 3
@@ -806,10 +801,9 @@ func TestDefaultProjectCommandBuilder_EscapeArgs(t *testing.T) {
 	for _, c := range cases {
 		t.Run(strings.Join(c.ExtraArgs, " "), func(t *testing.T) {
 			RegisterMockTestingT(t)
-			tmpDir, cleanup := DirStructure(t, map[string]interface{}{
+			tmpDir := DirStructure(t, map[string]interface{}{
 				"main.tf": nil,
 			})
-			defer cleanup()
 
 			workingDir := mocks.NewMockWorkingDir()
 			When(workingDir.Clone(matchers.AnyPtrToLoggingSimpleLogger(), matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest(), AnyString())).ThenReturn(tmpDir, false, nil)
@@ -982,9 +976,8 @@ projects:
 		t.Run(name, func(t *testing.T) {
 			RegisterMockTestingT(t)
 
-			tmpDir, cleanup := DirStructure(t, testCase.DirStructure)
+			tmpDir := DirStructure(t, testCase.DirStructure)
 
-			defer cleanup()
 			vcsClient := vcsmocks.NewMockClient()
 			When(vcsClient.GetModifiedFiles(matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest())).ThenReturn(testCase.ModifiedFiles, nil)
 
@@ -1110,10 +1103,9 @@ projects:
 
 func TestDefaultProjectCommandBuilder_WithPolicyCheckEnabled_BuildAutoplanCommand(t *testing.T) {
 	RegisterMockTestingT(t)
-	tmpDir, cleanup := DirStructure(t, map[string]interface{}{
+	tmpDir := DirStructure(t, map[string]interface{}{
 		"main.tf": nil,
 	})
-	defer cleanup()
 
 	logger := logging.NewNoopLogger(t)
 	scope, _, _ := metrics.NewLoggingScope(logger, "atlantis")
@@ -1170,7 +1162,7 @@ func TestDefaultProjectCommandBuilder_WithPolicyCheckEnabled_BuildAutoplanComman
 // Test building version command for multiple projects
 func TestDefaultProjectCommandBuilder_BuildVersionCommand(t *testing.T) {
 	RegisterMockTestingT(t)
-	tmpDir, cleanup := DirStructure(t, map[string]interface{}{
+	tmpDir := DirStructure(t, map[string]interface{}{
 		"workspace1": map[string]interface{}{
 			"project1": map[string]interface{}{
 				"main.tf":          nil,
@@ -1192,7 +1184,6 @@ func TestDefaultProjectCommandBuilder_BuildVersionCommand(t *testing.T) {
 			},
 		},
 	})
-	defer cleanup()
 	// Initialize git repos in each workspace so that the .tfplan files get
 	// picked up.
 	runCmd(t, filepath.Join(tmpDir, "workspace1"), "git", "init")

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -62,8 +62,7 @@ func TestDefaultProjectCommandRunner_Plan(t *testing.T) {
 		AggregateApplyRequirements: mockApplyReqHandler,
 	}
 
-	repoDir, cleanup := TempDir(t)
-	defer cleanup()
+	repoDir := t.TempDir()
 	When(mockWorkingDir.Clone(
 		matchers.AnyPtrToLoggingSimpleLogger(),
 		matchers.AnyModelsRepo(),
@@ -269,8 +268,7 @@ func TestDefaultProjectCommandRunner_ApplyNotApproved(t *testing.T) {
 	ctx := command.ProjectContext{
 		ApplyRequirements: []string{"approved"},
 	}
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 	When(mockWorkingDir.GetWorkingDir(ctx.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(tmp, nil)
 
 	res := runner.Apply(ctx)
@@ -294,8 +292,7 @@ func TestDefaultProjectCommandRunner_ApplyNotMergeable(t *testing.T) {
 		},
 		ApplyRequirements: []string{"mergeable"},
 	}
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 	When(mockWorkingDir.GetWorkingDir(ctx.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(tmp, nil)
 
 	res := runner.Apply(ctx)
@@ -316,8 +313,7 @@ func TestDefaultProjectCommandRunner_ApplyDiverged(t *testing.T) {
 	ctx := command.ProjectContext{
 		ApplyRequirements: []string{"undiverged"},
 	}
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 	When(mockWorkingDir.GetWorkingDir(ctx.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(tmp, nil)
 
 	res := runner.Apply(ctx)
@@ -431,8 +427,7 @@ func TestDefaultProjectCommandRunner_Apply(t *testing.T) {
 				WorkingDirLocker:           events.NewDefaultWorkingDirLocker(),
 				AggregateApplyRequirements: applyReqHandler,
 			}
-			repoDir, cleanup := TempDir(t)
-			defer cleanup()
+			repoDir := t.TempDir()
 			When(mockWorkingDir.GetWorkingDir(
 				matchers.AnyModelsRepo(),
 				matchers.AnyModelsPullRequest(),
@@ -503,8 +498,7 @@ func TestDefaultProjectCommandRunner_ApplyRunStepFailure(t *testing.T) {
 		AggregateApplyRequirements: applyReqHandler,
 		Webhooks:                   mockSender,
 	}
-	repoDir, cleanup := TempDir(t)
-	defer cleanup()
+	repoDir := t.TempDir()
 	When(mockWorkingDir.GetWorkingDir(
 		matchers.AnyModelsRepo(),
 		matchers.AnyModelsPullRequest(),
@@ -560,8 +554,7 @@ func TestDefaultProjectCommandRunner_RunEnvSteps(t *testing.T) {
 		WorkingDirLocker: events.NewDefaultWorkingDirLocker(),
 	}
 
-	repoDir, cleanup := TempDir(t)
-	defer cleanup()
+	repoDir := t.TempDir()
 	When(mockWorkingDir.Clone(
 		matchers.AnyPtrToLoggingSimpleLogger(),
 		matchers.AnyModelsRepo(),

--- a/server/events/project_finder_test.go
+++ b/server/events/project_finder_test.go
@@ -44,10 +44,8 @@ func setupTmpRepos(t *testing.T) {
 	//   terraform.tfstate.backup
 	//   modules/
 	//     main.tf
-	var err error
-	nestedModules1, err = os.MkdirTemp("", "")
-	Ok(t, err)
-	err = os.MkdirAll(filepath.Join(nestedModules1, "project1/modules"), 0700)
+	nestedModules1 = t.TempDir()
+	err := os.MkdirAll(filepath.Join(nestedModules1, "project1/modules"), 0700)
 	Ok(t, err)
 	files := []string{
 		"non-tf",
@@ -77,8 +75,7 @@ func setupTmpRepos(t *testing.T) {
 	//    main.tf
 	//  project2/
 	//    main.tf
-	topLevelModules, err = os.MkdirTemp("", "")
-	Ok(t, err)
+	topLevelModules = t.TempDir()
 	for _, path := range []string{"modules", "project1", "project2"} {
 		err = os.MkdirAll(filepath.Join(topLevelModules, path), 0700)
 		Ok(t, err)
@@ -92,8 +89,7 @@ func setupTmpRepos(t *testing.T) {
 	//   staging.tfvars
 	//   production.tfvars
 	//   global-env-config.auto.tfvars.json
-	envDir, err = os.MkdirTemp("", "")
-	Ok(t, err)
+	envDir = t.TempDir()
 	err = os.MkdirAll(filepath.Join(envDir, "env"), 0700)
 	Ok(t, err)
 	_, err = os.Create(filepath.Join(envDir, "env/staging.tfvars"))
@@ -337,7 +333,7 @@ func TestDefaultProjectFinder_DetermineProjectsViaConfig(t *testing.T) {
 	// modules/
 	//   module/
 	//	  main.tf
-	tmpDir, cleanup := DirStructure(t, map[string]interface{}{
+	tmpDir := DirStructure(t, map[string]interface{}{
 		"main.tf": nil,
 		"project1": map[string]interface{}{
 			"main.tf":               nil,
@@ -353,7 +349,6 @@ func TestDefaultProjectFinder_DetermineProjectsViaConfig(t *testing.T) {
 			},
 		},
 	})
-	defer cleanup()
 
 	cases := []struct {
 		description  string

--- a/server/events/pull_closed_executor_test.go
+++ b/server/events/pull_closed_executor_test.go
@@ -40,8 +40,7 @@ func TestCleanUpPullWorkspaceErr(t *testing.T) {
 	t.Log("when workspace.Delete returns an error, we return it")
 	RegisterMockTestingT(t)
 	w := mocks.NewMockWorkingDir()
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 	db, err := db.New(tmp)
 	Ok(t, err)
 	pce := events.PullClosedExecutor{
@@ -60,8 +59,7 @@ func TestCleanUpPullUnlockErr(t *testing.T) {
 	RegisterMockTestingT(t)
 	w := mocks.NewMockWorkingDir()
 	l := lockmocks.NewMockLocker()
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 	db, err := db.New(tmp)
 	Ok(t, err)
 	pce := events.PullClosedExecutor{
@@ -82,8 +80,7 @@ func TestCleanUpPullNoLocks(t *testing.T) {
 	w := mocks.NewMockWorkingDir()
 	l := lockmocks.NewMockLocker()
 	cp := vcsmocks.NewMockClient()
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
+	tmp := t.TempDir()
 	db, err := db.New(tmp)
 	Ok(t, err)
 	pce := events.PullClosedExecutor{
@@ -168,8 +165,7 @@ func TestCleanUpPullComments(t *testing.T) {
 			w := mocks.NewMockWorkingDir()
 			cp := vcsmocks.NewMockClient()
 			l := lockmocks.NewMockLocker()
-			tmp, cleanup := TempDir(t)
-			defer cleanup()
+			tmp := t.TempDir()
 			db, err := db.New(tmp)
 			Ok(t, err)
 			pce := events.PullClosedExecutor{

--- a/server/events/repo_branch_test.go
+++ b/server/events/repo_branch_test.go
@@ -2,7 +2,6 @@ package events
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -62,14 +61,10 @@ projects:
         - "**/*"
 `
 
-	tmp, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer func() {
-		os.RemoveAll(tmp)
-	}()
+	tmp := t.TempDir()
 
 	globalYAMLPath := filepath.Join(tmp, "config.yaml")
-	err = ioutil.WriteFile(globalYAMLPath, []byte(globalYAML), 0600)
+	err := ioutil.WriteFile(globalYAMLPath, []byte(globalYAML), 0600)
 	require.NoError(t, err)
 
 	globalCfgArgs := valid.GlobalCfgArgs{

--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -28,12 +28,10 @@ func disableSSLVerification() func() {
 // Test that if we don't have any existing files, we check out the repo.
 func TestClone_NoneExisting(t *testing.T) {
 	// Initialize the git repo.
-	repoDir, cleanup := initRepo(t)
-	defer cleanup()
+	repoDir := initRepo(t)
 	expCommit := runCmd(t, repoDir, "git", "rev-parse", "HEAD")
 
-	dataDir, cleanup2 := TempDir(t)
-	defer cleanup2()
+	dataDir := t.TempDir()
 
 	wd := &events.FileWorkspace{
 		DataDir:                     dataDir,
@@ -57,8 +55,7 @@ func TestClone_NoneExisting(t *testing.T) {
 // successfully when we're using the merge method.
 func TestClone_CheckoutMergeNoneExisting(t *testing.T) {
 	// Initialize the git repo.
-	repoDir, cleanup := initRepo(t)
-	defer cleanup()
+	repoDir := initRepo(t)
 
 	// Add a commit to branch 'branch' that's not on master.
 	runCmd(t, repoDir, "git", "checkout", "branch")
@@ -81,8 +78,7 @@ func TestClone_CheckoutMergeNoneExisting(t *testing.T) {
 	runCmd(t, repoDir, "git", "merge", "-m", "atlantis-merge", "branch")
 	expLsOutput := runCmd(t, repoDir, "ls")
 
-	dataDir, cleanup2 := TempDir(t)
-	defer cleanup2()
+	dataDir := t.TempDir()
 
 	overrideURL := fmt.Sprintf("file://%s", repoDir)
 	wd := &events.FileWorkspace{
@@ -116,8 +112,7 @@ func TestClone_CheckoutMergeNoneExisting(t *testing.T) {
 // the right commit, then we don't reclone.
 func TestClone_CheckoutMergeNoReclone(t *testing.T) {
 	// Initialize the git repo.
-	repoDir, cleanup := initRepo(t)
-	defer cleanup()
+	repoDir := initRepo(t)
 
 	// Add a commit to branch 'branch' that's not on master.
 	runCmd(t, repoDir, "git", "checkout", "branch")
@@ -132,8 +127,7 @@ func TestClone_CheckoutMergeNoReclone(t *testing.T) {
 	runCmd(t, repoDir, "git", "commit", "-m", "master-commit")
 
 	// Run the clone for the first time.
-	dataDir, cleanup2 := TempDir(t)
-	defer cleanup2()
+	dataDir := t.TempDir()
 	overrideURL := fmt.Sprintf("file://%s", repoDir)
 	wd := &events.FileWorkspace{
 		DataDir:                     dataDir,
@@ -172,8 +166,7 @@ func TestClone_CheckoutMergeNoReclone(t *testing.T) {
 // merged is a fast-forward merge. See #584.
 func TestClone_CheckoutMergeNoRecloneFastForward(t *testing.T) {
 	// Initialize the git repo.
-	repoDir, cleanup := initRepo(t)
-	defer cleanup()
+	repoDir := initRepo(t)
 
 	// Add a commit to branch 'branch' that's not on master.
 	// This will result in a fast-forwardable merge.
@@ -183,8 +176,7 @@ func TestClone_CheckoutMergeNoRecloneFastForward(t *testing.T) {
 	runCmd(t, repoDir, "git", "commit", "-m", "branch-commit")
 
 	// Run the clone for the first time.
-	dataDir, cleanup2 := TempDir(t)
-	defer cleanup2()
+	dataDir := t.TempDir()
 	overrideURL := fmt.Sprintf("file://%s", repoDir)
 	wd := &events.FileWorkspace{
 		DataDir:                     dataDir,
@@ -222,8 +214,7 @@ func TestClone_CheckoutMergeNoRecloneFastForward(t *testing.T) {
 // Test that if there's a conflict when merging we return a good error.
 func TestClone_CheckoutMergeConflict(t *testing.T) {
 	// Initialize the git repo.
-	repoDir, cleanup := initRepo(t)
-	defer cleanup()
+	repoDir := initRepo(t)
 
 	// Add a commit to branch 'branch' that's not on master.
 	runCmd(t, repoDir, "git", "checkout", "branch")
@@ -239,8 +230,7 @@ func TestClone_CheckoutMergeConflict(t *testing.T) {
 	runCmd(t, repoDir, "git", "commit", "-m", "commit")
 
 	// We're set up, now trigger the Atlantis clone.
-	dataDir, cleanup2 := TempDir(t)
-	defer cleanup2()
+	dataDir := t.TempDir()
 	overrideURL := fmt.Sprintf("file://%s", repoDir)
 	wd := &events.FileWorkspace{
 		DataDir:                     dataDir,
@@ -267,9 +257,8 @@ func TestClone_CheckoutMergeConflict(t *testing.T) {
 // Test that if the repo is already cloned and is at the right commit, we
 // don't reclone.
 func TestClone_NoReclone(t *testing.T) {
-	repoDir, _ := initRepo(t)
-	dataDir, cleanup2 := TempDir(t)
-	defer cleanup2()
+	repoDir := initRepo(t)
+	dataDir := t.TempDir()
 
 	runCmd(t, dataDir, "mkdir", "-p", "repos/0/")
 	runCmd(t, dataDir, "mv", repoDir, "repos/0/default")
@@ -297,10 +286,8 @@ func TestClone_NoReclone(t *testing.T) {
 // Test that if the repo is already cloned but is at the wrong commit, we
 // reclone.
 func TestClone_RecloneWrongCommit(t *testing.T) {
-	repoDir, cleanup := initRepo(t)
-	defer cleanup()
-	dataDir, cleanup2 := TempDir(t)
-	defer cleanup2()
+	repoDir := initRepo(t)
+	dataDir := t.TempDir()
 
 	// Copy the repo to our data dir.
 	runCmd(t, dataDir, "mkdir", "-p", "repos/0/")
@@ -336,8 +323,7 @@ func TestClone_RecloneWrongCommit(t *testing.T) {
 // checkout-strategy=merge, we warn the user (see #804).
 func TestClone_MasterHasDiverged(t *testing.T) {
 	// Initialize the git repo.
-	repoDir, cleanup := initRepo(t)
-	defer cleanup()
+	repoDir := initRepo(t)
 
 	// Simulate first PR.
 	runCmd(t, repoDir, "git", "checkout", "-b", "first-pr")
@@ -410,8 +396,7 @@ func TestClone_MasterHasDiverged(t *testing.T) {
 
 func TestHasDiverged_MasterHasDiverged(t *testing.T) {
 	// Initialize the git repo.
-	repoDir, cleanup := initRepo(t)
-	defer cleanup()
+	repoDir := initRepo(t)
 
 	// Simulate first PR.
 	runCmd(t, repoDir, "git", "checkout", "-b", "first-pr")
@@ -475,8 +460,8 @@ func TestHasDiverged_MasterHasDiverged(t *testing.T) {
 	Equals(t, hasDiverged, false)
 }
 
-func initRepo(t *testing.T) (string, func()) {
-	repoDir, cleanup := TempDir(t)
+func initRepo(t *testing.T) string {
+	repoDir := t.TempDir()
 	runCmd(t, repoDir, "git", "init", "--initial-branch=master")
 	runCmd(t, repoDir, "touch", ".gitkeep")
 	runCmd(t, repoDir, "git", "add", ".gitkeep")
@@ -485,5 +470,5 @@ func initRepo(t *testing.T) (string, func()) {
 	runCmd(t, repoDir, "git", "config", "--local", "commit.gpgsign", "false")
 	runCmd(t, repoDir, "git", "commit", "-m", "initial commit")
 	runCmd(t, repoDir, "git", "branch", "branch")
-	return repoDir, cleanup
+	return repoDir
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"testing"
 	"time"
 
@@ -37,9 +36,8 @@ import (
 
 func TestNewServer(t *testing.T) {
 	t.Log("Run through NewServer constructor")
-	tmpDir, err := os.MkdirTemp("", "")
-	Ok(t, err)
-	_, err = server.NewServer(server.UserConfig{
+	tmpDir := t.TempDir()
+	_, err := server.NewServer(server.UserConfig{
 		DataDir:     tmpDir,
 		AtlantisURL: "http://example.com",
 	}, server.Config{})
@@ -49,9 +47,8 @@ func TestNewServer(t *testing.T) {
 // todo: test what happens if we set different flags. The generated config should be different.
 
 func TestNewServer_InvalidAtlantisURL(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "")
-	Ok(t, err)
-	_, err = server.NewServer(server.UserConfig{
+	tmpDir := t.TempDir()
+	_, err := server.NewServer(server.UserConfig{
 		DataDir:     tmpDir,
 		AtlantisURL: "example.com",
 	}, server.Config{

--- a/testing/temp_files.go
+++ b/testing/temp_files.go
@@ -6,25 +6,12 @@ import (
 	"testing"
 )
 
-// TempDir creates a temporary directory and returns its path along
-// with a cleanup function to be called via defer, ex:
-//
-//	dir, cleanup := TempDir()
-//	defer cleanup()
-func TempDir(t *testing.T) (string, func()) {
-	tmpDir, err := os.MkdirTemp("", "")
-	Ok(t, err)
-	return tmpDir, func() {
-		os.RemoveAll(tmpDir) // nolint: errcheck
-	}
-}
-
 // DirStructure creates a directory structure in a temporary directory.
 // structure describes the dir structure. If the value is another map, then the
 // key is the name of a directory. If the value is nil, then the key is the name
 // of a file. If val is a string then key is a file name and val is the file's content.
 // It returns the path to the temp directory containing the defined
-// structure and a cleanup function to delete the directory.
+// structure.
 // Example usage:
 //
 //		versionConfig := `
@@ -32,7 +19,7 @@ func TempDir(t *testing.T) (string, func()) {
 //		  required_version = "= 0.12.8"
 //	 }
 //	 `
-//		tmpDir, cleanup := DirStructure(t, map[string]interface{}{
+//		tmpDir := DirStructure(t, map[string]interface{}{
 //			"pulldir": map[string]interface{}{
 //				"project1": map[string]interface{}{
 //					"main.tf": nil,
@@ -42,11 +29,10 @@ func TempDir(t *testing.T) (string, func()) {
 //				},
 //			},
 //		})
-//	 defer cleanup()
-func DirStructure(t *testing.T, structure map[string]interface{}) (string, func()) {
-	tmpDir, cleanup := TempDir(t)
+func DirStructure(t *testing.T, structure map[string]interface{}) string {
+	tmpDir := t.TempDir()
 	dirStructureGo(t, tmpDir, structure)
-	return tmpDir, cleanup
+	return tmpDir
 }
 
 func dirStructureGo(t *testing.T, parentDir string, structure map[string]interface{}) {


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	if err != nil {
		panic(err)
	}
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```