### PR TITLE
e2e image and testing fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,8 @@ jobs:
     - run: make check-lint
   e2e:
     docker:
-    - image: cimg/go:1.19 # If you update this, update it in the Makefile too
+    # TODO: use image: cimg/go:1.19
+    - image: circleci/golang:1.19 # If you update this, update it in the Makefile too
       environment:
         # This version of TF will be downloaded before Atlantis is started.
         # We do this instead of setting --default-tf-version because setting

--- a/.github/workflows/testing-env-image.yml
+++ b/.github/workflows/testing-env-image.yml
@@ -7,6 +7,10 @@ on:
       - ".github/workflows/testing-env-image.yml"
     branches:
       - "master"
+  pull_request:
+    paths:
+      - 'testing/**'
+      - '.github/workflows/testing-env-image.yml'
   workflow_dispatch:
 
 concurrency:
@@ -41,7 +45,7 @@ jobs:
       with:
         context: testing
         platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
-        push: true
+        push: ${{ github.event_name != 'pull_request' }}
         tags: |
            ghcr.io/runatlantis/testing-env:${{env.TODAY}}
            ghcr.io/runatlantis/testing-env:latest

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ dist: ## Package up everything in static/ using go-bindata-assetfs so it can be 
 	rm -f server/static/bindata_assetfs.go && go-bindata-assetfs -o bindata_assetfs.go -pkg static -prefix server server/static/... && mv bindata_assetfs.go server/static
 
 release: ## Create packages for a release
-	docker run -v $$(pwd):/go/src/github.com/runatlantis/atlantis cimg/go:1.19 sh -c 'cd /go/src/github.com/runatlantis/atlantis && scripts/binary-release.sh'
+	docker run -v $$(pwd):/go/src/github.com/runatlantis/atlantis circleci/golang:1.19 sh -c 'cd /go/src/github.com/runatlantis/atlantis && scripts/binary-release.sh'
 
 fmt: ## Run goimports (which also formats)
 	goimports -w $$(find . -type f -name '*.go' ! -path "./vendor/*" ! -path "./server/static/bindata_assetfs.go" ! -path "**/mocks/*")

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -1,6 +1,8 @@
 FROM golang:1.19
 
-RUN apt-get update && apt-get install unzip
+RUN apt-get update && apt-get --no-install-recommends -y install unzip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install Terraform
 ENV TERRAFORM_VERSION=1.3.4
@@ -13,6 +15,7 @@ RUN case $(uname -m) in x86_64|amd64) ARCH="amd64" ;; aarch64|arm64|armv7l) ARCH
 
 # Install conftest
 ENV CONFTEST_VERSION=0.35.0
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN case $(uname -m) in x86_64|amd64) ARCH="x86_64" ;; aarch64|arm64|armv7l) ARCH="arm64" ;; esac && \
     curl -LOs https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_${ARCH}.tar.gz && \
     curl -LOs https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/checksums.txt && \
@@ -22,5 +25,3 @@ RUN case $(uname -m) in x86_64|amd64) ARCH="x86_64" ;; aarch64|arm64|armv7l) ARC
     ln -s /usr/local/bin/cft/versions/${CONFTEST_VERSION}/conftest /usr/local/bin/conftest${CONFTEST_VERSION} && \
     rm conftest_${CONFTEST_VERSION}_Linux_${ARCH}.tar.gz && \
     rm checksums.txt
-
-RUN go get golang.org/x/tools/cmd/goimports


### PR DESCRIPTION
## what
- Remove `go get` downloading of `golang.org/x/tools/cmd/goimports` from testing/Dockerfile
- Add trigger for `testing-env-image` workflow if the `testing/**` dir is modified in PR
- Revert `cimg/go` back to `circleci/golang` image
- hadolint fixes

## why
- Using `go get` caused the testing image build failure.
- I saw the error with testing-env-image after merging the PR instead of before. THe new trigger will show the error prior to the merge.
- For some reason the new `cimg/go` image cannot download the terraform version and results in an [e2e error `initializing terraform: terraform not found in $PATH`](https://app.circleci.com/pipelines/github/runatlantis/atlantis/2842/workflows/fd9898b3-bc28-4d6e-81af-7ece0561e9f2/jobs/11532)
- Fixed a couple (not all) linting errors shown by hadolint for best practices.

## references
- Previous PR https://github.com/runatlantis/atlantis/pull/2670
- https://pkg.go.dev/golang.org/x/tools/cmd/goimports
- https://github.com/hadolint/hadolint