### PR TITLE
Bump to atlantis-base:2022.11.13 and use cimg/go:1.19

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-    - image: ghcr.io/runatlantis/testing-env:2021.08.31
+    - image: ghcr.io/runatlantis/testing-env:2022.11.13
     steps:
     - checkout
     - run: make test-all
@@ -10,7 +10,6 @@ jobs:
     - run: make check-lint
   e2e:
     docker:
-    # TODO: use image: cimg/go:1.19
     - image: cimg/go:1.19 # If you update this, update it in the Makefile too
       environment:
         # This version of TF will be downloaded before Atlantis is started.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,8 @@ version: 2
 jobs:
   test:
     docker:
-    - image: ghcr.io/runatlantis/testing-env:2022.11.13
+    # TODO: fix tests to use ghcr.io/runatlantis/testing-env:2022.11.13
+    - image: ghcr.io/runatlantis/testing-env:2021.08.31
     steps:
     - checkout
     - run: make test-all

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
   e2e:
     docker:
     # TODO: use image: cimg/go:1.19
-    - image: circleci/golang:1.19 # If you update this, update it in the Makefile too
+    - image: cimg/go:1.19 # If you update this, update it in the Makefile too
       environment:
         # This version of TF will be downloaded before Atlantis is started.
         # We do this instead of setting --default-tf-version because setting

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -v -o atlantis .
 
 # Stage 2
 # The runatlantis/atlantis-base is created by docker-base/Dockerfile.
-FROM ghcr.io/runatlantis/atlantis-base:2022.10.14 AS base
+FROM ghcr.io/runatlantis/atlantis-base:2022.11.13 AS base
 
 # Get the architecture the image is being built for
 ARG TARGETPLATFORM

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ dist: ## Package up everything in static/ using go-bindata-assetfs so it can be 
 	rm -f server/static/bindata_assetfs.go && go-bindata-assetfs -o bindata_assetfs.go -pkg static -prefix server server/static/... && mv bindata_assetfs.go server/static
 
 release: ## Create packages for a release
-	docker run -v $$(pwd):/go/src/github.com/runatlantis/atlantis circleci/golang:1.19 sh -c 'cd /go/src/github.com/runatlantis/atlantis && scripts/binary-release.sh'
+	docker run -v $$(pwd):/go/src/github.com/runatlantis/atlantis cimg/go:1.19 sh -c 'cd /go/src/github.com/runatlantis/atlantis && scripts/binary-release.sh'
 
 fmt: ## Run goimports (which also formats)
 	goimports -w $$(find . -type f -name '*.go' ! -path "./vendor/*" ! -path "./server/static/bindata_assetfs.go" ! -path "**/mocks/*")

--- a/scripts/e2e-deps.sh
+++ b/scripts/e2e-deps.sh
@@ -13,7 +13,7 @@ cd e2e/
 curl -LOk https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 chmod +x terraform
-cp terraform /go/bin/
+cp terraform /usr/local/go/bin
 # Download ngrok to create a tunnel to expose atlantis server
 wget https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip
 unzip ngrok-stable-linux-amd64.zip 

--- a/scripts/e2e-deps.sh
+++ b/scripts/e2e-deps.sh
@@ -16,7 +16,7 @@ cd e2e/
 curl -LOk https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 chmod +x terraform
-cp terraform /usr/bin
+cp terraform /home/circleci/go/bin
 # Download ngrok to create a tunnel to expose atlantis server
 wget https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip
 unzip ngrok-stable-linux-amd64.zip 

--- a/scripts/e2e-deps.sh
+++ b/scripts/e2e-deps.sh
@@ -13,7 +13,7 @@ cd e2e/
 curl -LOk https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 chmod +x terraform
-cp terraform /usr/local/go/bin
+cp terraform /usr/bin
 # Download ngrok to create a tunnel to expose atlantis server
 wget https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip
 unzip ngrok-stable-linux-amd64.zip 

--- a/scripts/e2e-deps.sh
+++ b/scripts/e2e-deps.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Exit immediately if a command returns a non-zero code
+set -e
+
 echo "Preparing to run e2e tests"
 if [ ! -f atlantis ]; then
     echo "atlantis binary not found. exiting...."


### PR DESCRIPTION
## what
- Bump to atlantis-base:2022.11.13
- Use cimg/go:1.19 image and corrected terraform path

## why
- Latest atlantis-base
- The circleci/golang image does not have a 1.19 tag

## references
- Previous PR https://github.com/runatlantis/atlantis/pull/2670
- https://github.com/runatlantis/atlantis/pkgs/container/atlantis-base/50131170?tag=2022.11.13

## notes

Note that `/go/bin` is in `circlci/golang` (debian 11.1 bullseye) missing from the `cimg/go` (debian 12-pre-release bookworm/sid) image.

```sh
✗ docker run -it circleci/golang:1.17 sh -c "echo \$PATH | tr ':' '\n'"
/home/circleci/.local/bin
/home/circleci/bin
/go/bin
/usr/local/go/bin
/usr/local/sbin
/usr/local/bin
/usr/sbin
/usr/bin
/sbin
/bin
✗ docker run -it cimg/go:1.19 sh -c "echo \$PATH | tr ':' '\n'"
/home/circleci/go/bin
/usr/local/go/bin
/home/circleci/bin
/home/circleci/.local/bin
/usr/local/sbin
/usr/local/bin
/usr/sbin
/usr/bin
/sbin
/bin
```
