### PR TITLE
Fix stale bot workflow yaml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,8 +8,9 @@ jobs:
     steps:
       - uses: actions/stale@v6
         with:
-          stale-pr-message: &message 'This issue is stale because it has been open for 6 months with no activity. Remove stale label or comment or this will be closed in 1 month.'
-          stale-issue-message: *message
+          stale-pr-message: 'This issue is stale because it has been open for 6 months with no activity. Remove stale label or comment or this will be closed in 1 month.'
+          stale-issue-message: This issue is stale because it has been open for 6 months with no activity. Remove stale label or comment or this will be closed in 1 month.'
+          remove-stale-when-updated: true
           # 6 months
           days-before-stale: 183
           # 1 month


### PR DESCRIPTION
## what
- rm unsupported anchor
- add remove-stale-when-uodated

## why
- fix stale bot workflow yaml

## references
- https://github.com/actions/stale#remove-stale-when-updated
- https://github.com/runatlantis/atlantis/actions/runs/3458003757
