### PR TITLE
Include *.tf files as inputs when running policy check

### DIFF
--- a/server/core/config/raw/global_cfg.go
+++ b/server/core/config/raw/global_cfg.go
@@ -15,6 +15,7 @@ type GlobalCfg struct {
 	Repos      []Repo              `yaml:"repos" json:"repos"`
 	Workflows  map[string]Workflow `yaml:"workflows" json:"workflows"`
 	PolicySets PolicySets          `yaml:"policies" json:"policies"`
+	PolicyCheckIncludeTfFiles bool `yaml:"policy_check_include_tf_files" json:"policy_check_include_tf_files"`
 	Metrics    Metrics             `yaml:"metrics" json:"metrics"`
 }
 

--- a/server/core/config/valid/global_cfg.go
+++ b/server/core/config/valid/global_cfg.go
@@ -35,6 +35,7 @@ type GlobalCfg struct {
 	Repos      []Repo
 	Workflows  map[string]Workflow
 	PolicySets PolicySets
+	PolicyCheckIncludeTfFiles bool
 	Metrics    Metrics
 }
 
@@ -83,6 +84,7 @@ type MergedProjectCfg struct {
 	TerraformVersion          *version.Version
 	RepoCfgVersion            int
 	PolicySets                PolicySets
+	PolicyCheckIncludeTfFiles bool
 	DeleteSourceBranchOnMerge bool
 	ExecutionOrderGroup       int
 }
@@ -308,6 +310,7 @@ func (g GlobalCfg) MergeProjectCfg(log logging.SimpleLogging, repoID string, pro
 		TerraformVersion:          proj.TerraformVersion,
 		RepoCfgVersion:            rCfg.Version,
 		PolicySets:                g.PolicySets,
+		PolicyCheckIncludeTfFiles: g.PolicyCheckIncludeTfFiles,
 		DeleteSourceBranchOnMerge: deleteSourceBranchOnMerge,
 		ExecutionOrderGroup:       proj.ExecutionOrderGroup,
 	}
@@ -327,6 +330,7 @@ func (g GlobalCfg) DefaultProjCfg(log logging.SimpleLogging, repoID string, repo
 		AutoplanEnabled:           DefaultAutoPlanEnabled,
 		TerraformVersion:          nil,
 		PolicySets:                g.PolicySets,
+		PolicyCheckIncludeTfFiles: false,
 		DeleteSourceBranchOnMerge: deleteSourceBranchOnMerge,
 	}
 }

--- a/server/core/runtime/policy/conftest_client.go
+++ b/server/core/runtime/policy/conftest_client.go
@@ -43,7 +43,7 @@ func NewPolicyArg(parameter string) Arg {
 type ConftestTestCommandArgs struct {
 	PolicyArgs []Arg
 	ExtraArgs  []string
-	InputFile  string
+	InputFiles []string
 	Command    string
 }
 
@@ -60,8 +60,13 @@ func (c ConftestTestCommandArgs) build() ([]string, error) {
 		commandArgs = append(commandArgs, a.build()...)
 	}
 
+
+	for _, inputFile := range c.InputFiles {
+		commandArgs = append(commandArgs, inputFile)	
+	}
+
 	// add hardcoded options
-	commandArgs = append(commandArgs, c.InputFile, "--no-color")
+	commandArgs = append(commandArgs, "--no-color")
 
 	// add extra args provided through server config
 	commandArgs = append(commandArgs, c.ExtraArgs...)
@@ -179,12 +184,16 @@ func (c *ConfTestExecutorWorkflow) Run(ctx command.ProjectContext, executablePat
 		policySetNames = append(policySetNames, policySet.Name)
 	}
 
-	inputFile := filepath.Join(workdir, ctx.GetShowResultFileName())
+	inputFiles := []string{filepath.Join(workdir, ctx.GetShowResultFileName())}
+
+	if ctx.PolicyCheckIncludeTfFiles {
+		inputFiles = append(inputFiles, filepath.Join(workdir, "*.tf"))
+	}
 
 	args := ConftestTestCommandArgs{
 		PolicyArgs: policyArgs,
 		ExtraArgs:  extraArgs,
-		InputFile:  inputFile,
+		InputFiles: inputFiles,
 		Command:    executablePath,
 	}
 

--- a/server/events/command/project_context.go
+++ b/server/events/command/project_context.go
@@ -86,6 +86,8 @@ type ProjectContext struct {
 	// PolicySets represent the policies that are run on the plan as part of the
 	// policy check stage
 	PolicySets valid.PolicySets
+	// PolicyCheckIncludeTfFiles will include all *.tf files as inputs when running conftest
+	PolicyCheckIncludeTfFiles bool
 	// DeleteSourceBranchOnMerge will attempt to allow a branch to be deleted when merged (AzureDevOps & GitLab Support Only)
 	DeleteSourceBranchOnMerge bool
 	// UUID for atlantis logs


### PR DESCRIPTION
creating PR as a draft to get feedback on this feature first. Will work on the config, and tests once maintainers are okay with the direction of this PR.

Other than the JSON-formatted Terraform plan files from `terraform show`, conftest also accepts plain Terraform files in HCL/HCL2. These files is usually suffixed with `*.tf`.

## Use case

used writing policies that check for the parameters passed into a custom Terraform module or any other values that are not directly accessible from the JSON plan file.

From the JSON Terraform file, the given input parameters to the module might be used in several places and the values might be combined with other values so it's not clear what the original value for the passed-in input parameters is. By having the option to run the policy check against the Terraform `*.tf` files directly, we can do this check easier. The same also applies to checking the value of `locals`.

## Changes

- include *.tf files when running the policy check
- WIP add config to enable conftest against *.tf files
