### PR TITLE
Fix website link checker due to branch rename

### DIFF
--- a/runatlantis.io/.vuepress/config.js
+++ b/runatlantis.io/.vuepress/config.js
@@ -26,6 +26,7 @@ module.exports = {
         ['meta', {name: 'google-site-verification', content: 'kTnsDBpHqtTNY8oscYxrQeeiNml2d2z-03Ct9wqeCeE' }]
     ],
     themeConfig: {
+        docsBranch: "main",
         activeHeaderLinks: false,
         algolia: {
           apiKey: '3b733dff1539ca3a210775860301fa86',

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -469,7 +469,7 @@ Values are chosen in this order:
   Markdown template overrides may be specified either in individual files, or all together in a single file. All template
   override files _must_ have the `.tmpl` extension, otherwise they will not be parsed.
 
-  Markdown templates which may have overrides can be found [here](https://github.com/runatlantis/atlantis/tree/master/server/events/templates)
+  Markdown templates which may have overrides can be found [here](https://github.com/runatlantis/atlantis/tree/main/server/events/templates)
 
   Please be mindful that settings like `--enable-diff-markdown-format` depend on logic defined in the templates. It is
   possible to diverge from expected behavior, if care is not taken when overriding default templates.


### PR DESCRIPTION
## what
- Fix website link checker branch rename

## why
- Fix all the failures

## references
- Previous PR https://github.com/runatlantis/atlantis/pull/2662
- https://vuepress.vuejs.org/theme/default-theme-config.html#git-repository-and-edit-links