### PR TITLE
Bump testing-env and go-cty@v1.12.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@ version: 2
 jobs:
   test:
     docker:
-    # TODO: fix tests to use ghcr.io/runatlantis/testing-env:2022.11.13
-    - image: ghcr.io/runatlantis/testing-env:2022.11.13
+    # TODO: fix tests to use ghcr.io/runatlantis/testing-env:2022.11.17
+    - image: ghcr.io/runatlantis/testing-env:2022.11.17
     steps:
     - checkout
     - run: make test-all

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2
 jobs:
   test:
     docker:
-    # TODO: fix tests to use ghcr.io/runatlantis/testing-env:2022.11.17
     - image: ghcr.io/runatlantis/testing-env:2022.11.17
     steps:
     - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   test:
     docker:
     # TODO: fix tests to use ghcr.io/runatlantis/testing-env:2022.11.13
-    - image: ghcr.io/runatlantis/testing-env:2021.08.31
+    - image: ghcr.io/runatlantis/testing-env:2022.11.13
     steps:
     - checkout
     - run: make test-all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     name: runner / gotest
     runs-on: ubuntu-22.04
-    container: ghcr.io/runatlantis/testing-env:2021.08.31
+    container: ghcr.io/runatlantis/testing-env:2021.11.13
     steps:
       # user in image needs write access to do anything
       - name: setup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       # user in image needs write access to do anything
       - name: setup
-        run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
+        # run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
+        run: chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
       - uses: actions/checkout@v3.0.2
       - run: make test-all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     name: runner / gotest
     runs-on: ubuntu-22.04
-    container: ghcr.io/runatlantis/testing-env:2021.11.13
+    container: ghcr.io/runatlantis/testing-env:2022.11.13
     steps:
       # user in image needs write access to do anything
       - name: setup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     name: runner / gotest
     runs-on: ubuntu-22.04
-    container: ghcr.io/runatlantis/testing-env:2022.11.13
+    container: ghcr.io/runatlantis/testing-env:2022.11.17
     steps:
       # user in image needs write access to do anything
       - name: setup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,5 @@ jobs:
     runs-on: ubuntu-22.04
     container: ghcr.io/runatlantis/testing-env:2022.11.17
     steps:
-      # user in image needs write access to do anything
-      - name: setup
-        run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
       - uses: actions/checkout@v3.0.2
       - run: make test-all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ jobs:
     steps:
       # user in image needs write access to do anything
       - name: setup
-        # run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
-        run: chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
+        run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
       - uses: actions/checkout@v3.0.2
       - run: make test-all

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ build-service: ## Build the main Go service
 go-generate: ## Run go generate in all packages
 	./scripts/go-generate.sh
 
-regen-mocks: ## Delete all mocks and matchers and then run go generate to regen them.
+regen-mocks: ## Delete and regenerate all mocks
 	find . -type f | grep mocks/mock_ | xargs rm
 	find . -type f | grep mocks/matchers | xargs rm
 	@# not using $(PKG) here because that includes directories that have now
@@ -42,7 +42,7 @@ test-all: ## Run tests including integration
 	@go test  $(PKG)
 
 .PHONY: docker/test-all
-docker/test-all: ## Run tests in docker
+docker/test-all: ## Run all tests in docker
 	docker run -it -v $(pwd):/atlantis ghcr.io/runatlantis/testing-env:2022.11.13 sh -c "cd /atlantis && make test-all"
 
 test-coverage:
@@ -58,7 +58,7 @@ dev-docker:
 	GOOS=linux GOARCH=amd64 go build -o atlantis .
 	docker build -f Dockerfile.dev -t atlantis-dev .
 
-dist: ## Package up everything in static/ using go-bindata-assetfs so it can be served by a single binary
+dist: ## Package static/ using go-bindata-assetfs into a single binary
 	rm -f server/static/bindata_assetfs.go && go-bindata-assetfs -o bindata_assetfs.go -pkg static -prefix server server/static/... && mv bindata_assetfs.go server/static
 
 release: ## Create packages for a release

--- a/Makefile
+++ b/Makefile
@@ -36,14 +36,14 @@ test: ## Run tests
 
 .PHONY: docker/test
 docker/test: ## Run tests in docker
-	docker run -it -v $(pwd):/atlantis ghcr.io/runatlantis/testing-env:2022.11.13 sh -c "cd /atlantis && make test"
+	docker run -it -v $(pwd):/atlantis ghcr.io/runatlantis/testing-env:2022.11.17 sh -c "cd /atlantis && make test"
 
 test-all: ## Run tests including integration
 	@go test  $(PKG)
 
 .PHONY: docker/test-all
 docker/test-all: ## Run all tests in docker
-	docker run -it -v $(pwd):/atlantis ghcr.io/runatlantis/testing-env:2022.11.13 sh -c "cd /atlantis && make test-all"
+	docker run -it -v $(pwd):/atlantis ghcr.io/runatlantis/testing-env:2022.11.17 sh -c "cd /atlantis && make test-all"
 
 test-coverage:
 	@mkdir -p .cover

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,6 @@ PKG := $(shell go list ./... | grep -v e2e | grep -v static | grep -v mocks | gr
 PKG_COMMAS := $(shell go list ./... | grep -v e2e | grep -v static | grep -v mocks | grep -v testing | tr '\n' ',')
 IMAGE_NAME := runatlantis/atlantis
 
-.PHONY: test
-
 .DEFAULT_GOAL := help
 help: ## List targets & descriptions
 	@cat Makefile* | grep -E '^[a-zA-Z_-]+:.*?## .*$$' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -32,11 +30,20 @@ regen-mocks: ## Delete all mocks and matchers and then run go generate to regen 
 	@# been made empty, causing go generate to fail.
 	./scripts/go-generate.sh
 
+.PHONY: test
 test: ## Run tests
 	@go test -short $(PKG)
 
+.PHONY: docker/test
+docker/test: ## Run tests in docker
+	docker run -it -v $(pwd):/atlantis ghcr.io/runatlantis/testing-env:2022.11.13 sh -c "cd /atlantis && make test"
+
 test-all: ## Run tests including integration
 	@go test  $(PKG)
+
+.PHONY: docker/test-all
+docker/test-all: ## Run tests in docker
+	docker run -it -v $(pwd):/atlantis ghcr.io/runatlantis/testing-env:2022.11.13 sh -c "cd /atlantis && make test-all"
 
 test-coverage:
 	@mkdir -p .cover

--- a/go.mod
+++ b/go.mod
@@ -128,7 +128,7 @@ require (
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64 // indirect
-	github.com/zclconf/go-cty v1.12.1 // indirect
+	github.com/zclconf/go-cty v1.11.1 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/crypto v0.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -128,7 +128,7 @@ require (
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64 // indirect
-	github.com/zclconf/go-cty v1.8.0 // indirect
+	github.com/zclconf/go-cty v1.12.1 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/crypto v0.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	go.uber.org/zap v1.23.0
 	golang.org/x/sync v0.1.0
 	golang.org/x/term v0.2.0
+	golang.org/x/text v0.4.0
 	gopkg.in/go-playground/validator.v9 v9.31.0
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -135,7 +136,6 @@ require (
 	golang.org/x/net v0.2.0 // indirect
 	golang.org/x/oauth2 v0.2.0 // indirect
 	golang.org/x/sys v0.2.0 // indirect
-	golang.org/x/text v0.4.0 // indirect
 	golang.org/x/time v0.2.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/api v0.103.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -128,7 +128,7 @@ require (
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64 // indirect
-	github.com/zclconf/go-cty v1.11.1 // indirect
+	github.com/zclconf/go-cty v1.12.1 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/crypto v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -486,8 +486,6 @@ github.com/urfave/cli v1.22.10/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60Nt
 github.com/urfave/negroni v1.0.0 h1:kIimOitoypq34K7TG7DUaJ9kq/N4Ofuwi1sjz0KipXc=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
-github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/xanzy/go-gitlab v0.74.0 h1:Ha1cokbjn0PXy6B19t3W324dwM4AOT52fuHr7nERPrc=
 github.com/xanzy/go-gitlab v0.74.0/go.mod h1:d/a0vswScO7Agg1CZNz15Ic6SSvBG9vfw8egL99t4kA=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -498,10 +496,6 @@ github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5t
 github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64 h1:5mLPGnFdSsevFRFc9q3yYbBkB6tsm4aCwwQV/j1JQAQ=
 github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
-github.com/zclconf/go-cty v1.8.0 h1:s4AvqaeQzJIu3ndv4gVIhplVD0krU+bgrcLSVUnaWuA=
-github.com/zclconf/go-cty v1.8.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
-github.com/zclconf/go-cty v1.11.1 h1:UMMYDL4riBFaPdzjEWcDdWG7x/Adz8E8f9OX/MGR7V4=
-github.com/zclconf/go-cty v1.11.1/go.mod h1:s9IfD1LK5ccNMSWCVFCE2rJfHiZgi7JijgeWIMfhLvA=
 github.com/zclconf/go-cty v1.12.1 h1:PcupnljUm9EIvbgSHQnHhUr3fO6oFmkOrvs2BAFNXXY=
 github.com/zclconf/go-cty v1.12.1/go.mod h1:s9IfD1LK5ccNMSWCVFCE2rJfHiZgi7JijgeWIMfhLvA=
 go.etcd.io/bbolt v1.3.6 h1:/ecaJf0sk1l4l6V4awd65v2C3ILy7MSj+s/x1ADCIMU=
@@ -711,7 +705,6 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.4.0 h1:BrVqGRd7+k1DiOgtnFvAkoQEWQvBc25ouMJM6429SFg=

--- a/go.sum
+++ b/go.sum
@@ -500,6 +500,8 @@ github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64/go.mod h1:GBR0iDaN
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.8.0 h1:s4AvqaeQzJIu3ndv4gVIhplVD0krU+bgrcLSVUnaWuA=
 github.com/zclconf/go-cty v1.8.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
+github.com/zclconf/go-cty v1.12.1 h1:PcupnljUm9EIvbgSHQnHhUr3fO6oFmkOrvs2BAFNXXY=
+github.com/zclconf/go-cty v1.12.1/go.mod h1:s9IfD1LK5ccNMSWCVFCE2rJfHiZgi7JijgeWIMfhLvA=
 go.etcd.io/bbolt v1.3.6 h1:/ecaJf0sk1l4l6V4awd65v2C3ILy7MSj+s/x1ADCIMU=
 go.etcd.io/bbolt v1.3.6/go.mod h1:qXsaaIqmgQH0T+OPdb99Bf+PKfBBQVAdyD6TY9G8XM4=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/go.sum
+++ b/go.sum
@@ -500,6 +500,8 @@ github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64/go.mod h1:GBR0iDaN
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.8.0 h1:s4AvqaeQzJIu3ndv4gVIhplVD0krU+bgrcLSVUnaWuA=
 github.com/zclconf/go-cty v1.8.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
+github.com/zclconf/go-cty v1.11.1 h1:UMMYDL4riBFaPdzjEWcDdWG7x/Adz8E8f9OX/MGR7V4=
+github.com/zclconf/go-cty v1.11.1/go.mod h1:s9IfD1LK5ccNMSWCVFCE2rJfHiZgi7JijgeWIMfhLvA=
 github.com/zclconf/go-cty v1.12.1 h1:PcupnljUm9EIvbgSHQnHhUr3fO6oFmkOrvs2BAFNXXY=
 github.com/zclconf/go-cty v1.12.1/go.mod h1:s9IfD1LK5ccNMSWCVFCE2rJfHiZgi7JijgeWIMfhLvA=
 go.etcd.io/bbolt v1.3.6 h1:/ecaJf0sk1l4l6V4awd65v2C3ILy7MSj+s/x1ADCIMU=

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -41,7 +41,7 @@ import (
 	. "github.com/runatlantis/atlantis/testing"
 )
 
-const ConftestVersion = "0.45.0"
+const ConftestVersion = "0.35.0"
 
 var applyLocker locking.ApplyLocker
 var userConfig server.UserConfig

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1372,7 +1372,7 @@ func ensureRunningConftest(t *testing.T) {
 	versionOutput := string(versionOutBytes)
 	match := versionConftestRegex.FindStringSubmatch(versionOutput)
 	if len(match) <= 1 {
-		t.Logf("could not parse contest version from %s", versionOutput)
+		t.Logf("could not parse conftest version from %s", versionOutput)
 		t.FailNow()
 	}
 	localVersion, err := version.NewVersion(match[1])
@@ -1422,4 +1422,9 @@ func ensureRunning014(t *testing.T) {
 //		   => 0.11.10
 var versionRegex = regexp.MustCompile("Terraform v(.*?)(\\s.*)?\n")
 
-var versionConftestRegex = regexp.MustCompile("Version: (.*?)(\\s.*)?\n")
+/*
+ * Newer versions will return both Conftest and OPA
+ * Conftest: 0.35.0
+ * OPA: 0.45.0
+ */
+var versionConftestRegex = regexp.MustCompile("Conftest: (.*?)(\\s.*)?\n")

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -41,7 +41,7 @@ import (
 	. "github.com/runatlantis/atlantis/testing"
 )
 
-const ConftestVersion = "0.25.0"
+const ConftestVersion = "0.35.0"
 
 var applyLocker locking.ApplyLocker
 var userConfig server.UserConfig

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -41,7 +41,7 @@ import (
 	. "github.com/runatlantis/atlantis/testing"
 )
 
-const ConftestVersion = "0.35.0"
+const ConftestVersion = "0.45.0"
 
 var applyLocker locking.ApplyLocker
 var userConfig server.UserConfig

--- a/server/core/runtime/policy/conftest_client.go
+++ b/server/core/runtime/policy/conftest_client.go
@@ -15,6 +15,8 @@ import (
 	"github.com/runatlantis/atlantis/server/core/terraform"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/logging"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const (
@@ -107,7 +109,7 @@ func (c ConfTestVersionDownloader) downloadConfTestVersion(v *version.Version, d
 	versionURLPrefix := fmt.Sprintf("%s%s", conftestDownloadURLPrefix, v.Original())
 
 	// download binary in addition to checksum file
-	binURL := fmt.Sprintf("%s/conftest_%s_%s_%s.tar.gz", versionURLPrefix, v.Original(), strings.Title(runtime.GOOS), conftestArch)
+	binURL := fmt.Sprintf("%s/conftest_%s_%s_%s.tar.gz", versionURLPrefix, v.Original(), cases.Title(language.English).String(runtime.GOOS), conftestArch)
 	checksumURL := fmt.Sprintf("%s/checksums.txt", versionURLPrefix)
 
 	// underlying implementation uses go-getter so the URL is formatted as such.

--- a/server/core/runtime/policy/conftest_client_test.go
+++ b/server/core/runtime/policy/conftest_client_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/go-version"
@@ -18,6 +17,9 @@ import (
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/logging"
 	. "github.com/runatlantis/atlantis/testing"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 func TestConfTestVersionDownloader(t *testing.T) {
@@ -25,7 +27,7 @@ func TestConfTestVersionDownloader(t *testing.T) {
 	version, _ := version.NewVersion("0.25.0")
 	destPath := "some/path"
 
-	fullURL := fmt.Sprintf("https://github.com/open-policy-agent/conftest/releases/download/v0.25.0/conftest_0.25.0_%s_x86_64.tar.gz?checksum=file:https://github.com/open-policy-agent/conftest/releases/download/v0.25.0/checksums.txt", strings.Title(runtime.GOOS))
+	fullURL := fmt.Sprintf("https://github.com/open-policy-agent/conftest/releases/download/v0.25.0/conftest_0.25.0_%s_x86_64.tar.gz?checksum=file:https://github.com/open-policy-agent/conftest/releases/download/v0.25.0/checksums.txt", cases.Title(language.English).String(runtime.GOOS))
 
 	RegisterMockTestingT(t)
 

--- a/server/events/command/name.go
+++ b/server/events/command/name.go
@@ -1,6 +1,11 @@
 package command
 
-import "strings"
+import (
+	"strings"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
 
 // Name is which command to run.
 type Name int
@@ -26,7 +31,7 @@ const (
 // TitleString returns the string representation in title form.
 // ie. policy_check becomes Policy Check
 func (c Name) TitleString() string {
-	return strings.Title(strings.ReplaceAll(strings.ToLower(c.String()), "_", " "))
+	return cases.Title(language.English).String(strings.ReplaceAll(strings.ToLower(c.String()), "_", " "))
 }
 
 // String returns the string representation of c.

--- a/server/events/commit_status_updater.go
+++ b/server/events/commit_status_updater.go
@@ -15,11 +15,12 @@ package events
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/events/vcs"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 //go:generate pegomock generate -m --use-experimental-model-gen --package mocks -o mocks/mock_commit_status_updater.go CommitStatusUpdater
@@ -56,7 +57,7 @@ func (d *DefaultCommitStatusUpdater) UpdateCombined(repo models.Repo, pull model
 	case models.SuccessCommitStatus:
 		descripWords = "succeeded."
 	}
-	descrip := fmt.Sprintf("%s %s", strings.Title(cmdName.String()), descripWords)
+	descrip := fmt.Sprintf("%s %s", cases.Title(language.English).String(cmdName.String()), descripWords)
 	return d.Client.UpdateStatus(repo, pull, status, src, descrip, "")
 }
 
@@ -92,6 +93,6 @@ func (d *DefaultCommitStatusUpdater) UpdateProject(ctx command.ProjectContext, c
 		descripWords = "succeeded."
 	}
 
-	descrip := fmt.Sprintf("%s %s", strings.Title(cmdName.String()), descripWords)
+	descrip := fmt.Sprintf("%s %s", cases.Title(language.English).String(cmdName.String()), descripWords)
 	return d.Client.UpdateStatus(ctx.BaseRepo, ctx.Pull, status, src, descrip, url)
 }

--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -23,6 +23,8 @@ import (
 	"github.com/Masterminds/sprig/v3"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 var (
@@ -134,7 +136,7 @@ func GetMarkdownRenderer(
 // Render formats the data into a markdown string.
 // nolint: interfacer
 func (m *MarkdownRenderer) Render(res command.Result, cmdName command.Name, log string, verbose bool, vcsHost models.VCSHostType) string {
-	commandStr := strings.Title(strings.Replace(cmdName.String(), "_", " ", -1))
+	commandStr := cases.Title(language.English).String(strings.Replace(cmdName.String(), "_", " ", -1))
 	common := commonData{
 		Command:                  commandStr,
 		Verbose:                  verbose,

--- a/server/events/project_finder.go
+++ b/server/events/project_finder.go
@@ -15,7 +15,6 @@ package events
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -75,7 +74,7 @@ var cloudBlockSchema = &hcl.BodySchema{
 
 func (p *DefaultProjectFinder) DetermineWorkspaceFromHCL(log logging.SimpleLogging, absRepoDir string) (string, error) {
 	log.Info("looking for Terraform Cloud workspace from configuration in %q", absRepoDir)
-	infos, err := ioutil.ReadDir(absRepoDir)
+	infos, err := os.ReadDir(absRepoDir)
 	if err != nil {
 		return "", err
 	}

--- a/server/events/repo_branch_test.go
+++ b/server/events/repo_branch_test.go
@@ -1,7 +1,7 @@
 package events
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -64,7 +64,7 @@ projects:
 	tmp := t.TempDir()
 
 	globalYAMLPath := filepath.Join(tmp, "config.yaml")
-	err := ioutil.WriteFile(globalYAMLPath, []byte(globalYAML), 0600)
+	err := os.WriteFile(globalYAMLPath, []byte(globalYAML), 0600)
 	require.NoError(t, err)
 
 	globalCfgArgs := valid.GlobalCfgArgs{
@@ -79,7 +79,7 @@ projects:
 	require.NoError(t, err)
 
 	repoYAMLPath := filepath.Join(tmp, "atlantis.yaml")
-	err = ioutil.WriteFile(repoYAMLPath, []byte(repoYAML), 0600)
+	err = os.WriteFile(repoYAMLPath, []byte(repoYAML), 0600)
 	require.NoError(t, err)
 
 	repo, err := parser.ParseRepoCfg(tmp, global, "github.com/foo/bar", "main")


### PR DESCRIPTION
## what
- Bump testing-env
- Bump go-cty@v1.12.1
- Fixed linting issues for go 1.9

## why
- Latest version

## references
- Related PR https://github.com/runatlantis/atlantis/pull/2689
- Related PR https://github.com/lyft/atlantis/pull/454
- https://github.com/zclconf/go-cty