### PR TITLE
testing-env: create default atlantis user

### DIFF
--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -25,3 +25,7 @@ RUN case $(uname -m) in x86_64|amd64) ARCH="x86_64" ;; aarch64|arm64|armv7l) ARC
     ln -s /usr/local/bin/cft/versions/${CONFTEST_VERSION}/conftest /usr/local/bin/conftest${CONFTEST_VERSION} && \
     rm conftest_${CONFTEST_VERSION}_Linux_${ARCH}.tar.gz && \
     rm checksums.txt
+
+RUN useradd -u 1001 -m atlantis
+
+USER atlantis


### PR DESCRIPTION
## what
- testing-env: create default atlantis user

## why
- Running tests on the testing-env fail because the negative tests create files that `root` can see and modify. However, if anyone runs the tests locally, in non-root, it passes fine.
- This issue only seems to affect the new golang 1.19 image and not the previous golang 1.17 image
- Approving and merging this will create a new testing-env image which can be set in our github workflow and circleci to allow bumping dependencies that require modern versions of golang.

## references
- Affects PR https://github.com/runatlantis/atlantis/pull/2521
- Affects PR https://github.com/runatlantis/atlantis/pull/2521
- https://snyk.io/blog/containerizing-go-applications-with-docker/

## commands

This command fails to run tests

```sh
$ docker run -it \
  -w /atlantis \
  -v $(pwd):/atlantis \
  ghcr.io/runatlantis/testing-env:2022.11.13 \
  sh -c "make test"
```

I built a local container and ran the tests using the `atlantis` user

```sh
$ docker build -t testing-env testing/
$ docker run -it \
  -w /atlantis \
  -v $(pwd):/atlantis \
  testing-env \
  sh -c "make test"
...
ok  	github.com/runatlantis/atlantis/server/events/vcs	8.845s
ok  	github.com/runatlantis/atlantis/server/events/vcs/bitbucketcloud	0.037s
ok  	github.com/runatlantis/atlantis/server/events/vcs/bitbucketserver	0.046s
ok  	github.com/runatlantis/atlantis/server/events/vcs/common	0.023s
?   	github.com/runatlantis/atlantis/server/events/vcs/fixtures	[no test files]
ok  	github.com/runatlantis/atlantis/server/events/webhooks	0.010s
ok  	github.com/runatlantis/atlantis/server/jobs	0.029s
ok  	github.com/runatlantis/atlantis/server/logging	0.034s
?   	github.com/runatlantis/atlantis/server/metrics	[no test files]
ok  	github.com/runatlantis/atlantis/server/recovery	0.004s [no tests to run]
?   	github.com/runatlantis/atlantis/server/scheduled	[no test files]
?   	github.com/runatlantis/atlantis/testdrive	[no test files]
```