### PR TITLE
Fix GitHub app uses slug as user name to work --hide-prev-plan-comments correctly

### DIFF
--- a/server/events/vcs/github_credentials.go
+++ b/server/events/vcs/github_credentials.go
@@ -108,7 +108,7 @@ func (c *GithubAppCredentials) GetUser() (string, error) {
 	}
 	// Currently there is no way to get the bot's login info, so this is a
 	// hack until Github exposes that.
-	return fmt.Sprintf("%s[bot]", app.GetName()), nil
+	return fmt.Sprintf("%s[bot]", app.GetSlug()), nil
 }
 
 // GetToken returns a fresh installation token.

--- a/server/events/vcs/github_credentials_test.go
+++ b/server/events/vcs/github_credentials_test.go
@@ -30,7 +30,7 @@ func TestGithubClient_GetUser_AppSlug(t *testing.T) {
 	user, err := appCreds.GetUser()
 	Ok(t, err)
 
-	Assert(t, user == "Octocat App[bot]", "user should not empty")
+	Assert(t, user == "octoapp[bot]", "user should not empty")
 }
 
 func TestGithubClient_AppAuthentication(t *testing.T) {

--- a/server/events/vcs/github_credentials_test.go
+++ b/server/events/vcs/github_credentials_test.go
@@ -30,7 +30,7 @@ func TestGithubClient_GetUser_AppSlug(t *testing.T) {
 	user, err := appCreds.GetUser()
 	Ok(t, err)
 
-	Assert(t, user == "octoapp[bot]", "user should not empty")
+	Assert(t, user == "octoapp[bot]", "user should not be empty")
 }
 
 func TestGithubClient_AppAuthentication(t *testing.T) {


### PR DESCRIPTION
## Description

Currently `(c *GithubAppCredentials) GetUser()` is used only for `--hide-prev-plan-comments`.  However when using GitHub app, comments doesn't hide if we use spefic names which contains upper case, spaces and period. This is because GitHub use commend user name like `some-user-com[bot]`, not `Some User.com[bot]`.

We can get slug name from app.Slug.

## Check

- Create new GitHub App like `My Atlantis.app`

<img width="581" alt="image" src="https://user-images.githubusercontent.com/915731/202871765-0848d462-86c4-45c6-b03c-5248292303ec.png">

- Start local server with following options

```
export ATLANTIS_GH_APP_SLUG=my-atlantis-app
export ATLANTIS_HIDE_PREV_PLAN_COMMENTS=true
```

- Then hide comments successfully

<img width="716" alt="image" src="https://user-images.githubusercontent.com/915731/202871759-987419a4-ac99-4793-99c0-0665e06cecea.png">

----

- Closes #2695
- Closes #1161
