### PR TITLE
feat: PR check status to show summary e.g. `Plan: 1 to add, 0 to change, 1 to destroy`

### DIFF
--- a/server/events/command/project_context.go
+++ b/server/events/command/project_context.go
@@ -20,6 +20,8 @@ const (
 // be executed for a project.
 type ProjectContext struct {
 	CommandName Name
+	// wip
+	CommandResult ProjectResult
 	// ApplyCmd is the command that users should run to apply this plan. If
 	// this is an apply then this will be empty.
 	ApplyCmd string

--- a/server/events/command/project_context.go
+++ b/server/events/command/project_context.go
@@ -20,7 +20,7 @@ const (
 // be executed for a project.
 type ProjectContext struct {
 	CommandName Name
-	// wip
+	// CommandResult represent the Terraform outputs after the command execution.
 	CommandResult ProjectResult
 	// ApplyCmd is the command that users should run to apply this plan. If
 	// this is an apply then this will be empty.

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -146,15 +146,15 @@ type ProjectOutputWrapper struct {
 }
 
 func (p *ProjectOutputWrapper) Plan(ctx command.ProjectContext) command.ProjectResult {
-	result := p.updateProjectPRStatus(command.Plan, ctx, p.ProjectCommandRunner.Plan)
+	ctx.CommandResult = p.updateProjectPRStatus(command.Plan, ctx, p.ProjectCommandRunner.Plan)
 	p.JobMessageSender.Send(ctx, "", OperationComplete)
-	return result
+	return ctx.CommandResult
 }
 
 func (p *ProjectOutputWrapper) Apply(ctx command.ProjectContext) command.ProjectResult {
-	result := p.updateProjectPRStatus(command.Apply, ctx, p.ProjectCommandRunner.Apply)
+	ctx.CommandResult = p.updateProjectPRStatus(command.Apply, ctx, p.ProjectCommandRunner.Apply)
 	p.JobMessageSender.Send(ctx, "", OperationComplete)
-	return result
+	return ctx.CommandResult
 }
 
 func (p *ProjectOutputWrapper) updateProjectPRStatus(commandName command.Name, ctx command.ProjectContext, execute func(ctx command.ProjectContext) command.ProjectResult) command.ProjectResult {
@@ -167,6 +167,7 @@ func (p *ProjectOutputWrapper) updateProjectPRStatus(commandName command.Name, c
 
 	// ensures we are differentiating between project level command and overall command
 	result := execute(ctx)
+	ctx.CommandResult = result
 
 	if result.Error != nil || result.Failure != "" {
 		if err := p.JobURLSetter.SetJobURLWithStatus(ctx, commandName, models.FailedCommitStatus); err != nil {

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -146,15 +146,15 @@ type ProjectOutputWrapper struct {
 }
 
 func (p *ProjectOutputWrapper) Plan(ctx command.ProjectContext) command.ProjectResult {
-	ctx.CommandResult = p.updateProjectPRStatus(command.Plan, ctx, p.ProjectCommandRunner.Plan)
+	result := p.updateProjectPRStatus(command.Plan, ctx, p.ProjectCommandRunner.Plan)
 	p.JobMessageSender.Send(ctx, "", OperationComplete)
-	return ctx.CommandResult
+	return result
 }
 
 func (p *ProjectOutputWrapper) Apply(ctx command.ProjectContext) command.ProjectResult {
-	ctx.CommandResult = p.updateProjectPRStatus(command.Apply, ctx, p.ProjectCommandRunner.Apply)
+	result := p.updateProjectPRStatus(command.Apply, ctx, p.ProjectCommandRunner.Apply)
 	p.JobMessageSender.Send(ctx, "", OperationComplete)
-	return ctx.CommandResult
+	return result
 }
 
 func (p *ProjectOutputWrapper) updateProjectPRStatus(commandName command.Name, ctx command.ProjectContext, execute func(ctx command.ProjectContext) command.ProjectResult) command.ProjectResult {


### PR DESCRIPTION
## what
`Plan contains no changes.`
![Screenshot 2022-11-20 at 1 25 34 PM](https://user-images.githubusercontent.com/8814890/202928790-6b76e55b-1c04-4294-b5a5-a25a3964b1e3.png)

`Plan: 1 to add, 0 to change, 0 to destroy`
![Screenshot 2022-11-20 at 1 26 20 PM](https://user-images.githubusercontent.com/8814890/202928794-38e7f85b-1227-4a8d-b71f-08275d1bee7a.png)

## why

## references
- Closes https://github.com/runatlantis/atlantis/issues/2625
- Closes https://github.com/runatlantis/atlantis/issues/1267
- Partially implements https://github.com/runatlantis/atlantis/issues/2069