### PR TITLE
chore: rm duplicate make test-all, no push to latest on refs with "pre"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ jobs:
     - image: ghcr.io/runatlantis/testing-env:2022.11.17
     steps:
     - checkout
-    - run: make test-all
     - run: make check-fmt
     - run: make check-lint
   e2e:

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -70,7 +70,10 @@ jobs:
           ghcr.io/${{ github.repository_owner }}/atlantis:prerelease-latest
 
     - name: Build and push atlantis:${{ env.RELEASE_VERSION }} image for stable release
-      if: ${{ contains(fromJson('["push", "pull_request"]'), github.event_name) && startsWith(github.ref, 'refs/tags/') && (!contains(github.ref, '-pre.')) }}
+      if: |
+        contains(fromJson('["push", "pull_request"]'), github.event_name) &&
+        startsWith(github.ref, 'refs/tags/') &&
+        (!contains(github.ref, 'pre'))
       uses: docker/build-push-action@v3
       with:
         context: .

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -55,25 +55,15 @@ jobs:
 
     # Publish release to container registry
     - name: populate release version
-      if: ${{ contains(fromJson('["push", "pull_request"]'), github.event_name) && startsWith(github.ref, 'refs/tags/') }}
-      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-
-    - name: Build and push atlantis:${{ env.RELEASE_VERSION }} image for pre release
-      if: ${{ contains(fromJson('["push", "pull_request"]'), github.event_name) && startsWith(github.ref, 'refs/tags/') && contains(github.ref, '-pre.') }}
-      uses: docker/build-push-action@v3
-      with:
-        context: .
-        platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: |
-          ghcr.io/${{ github.repository_owner }}/atlantis:${{ env.RELEASE_VERSION }}
-          ghcr.io/${{ github.repository_owner }}/atlantis:prerelease-latest
-
-    - name: Build and push atlantis:${{ env.RELEASE_VERSION }} image for stable release
       if: |
         contains(fromJson('["push", "pull_request"]'), github.event_name) &&
-        startsWith(github.ref, 'refs/tags/') &&
-        (!contains(github.ref, 'pre'))
+        startsWith(github.ref, 'refs/tags/')
+      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+    - name: Build and push atlantis:${{ env.RELEASE_VERSION }} image for  ${{ contains(github.ref, 'pre') ? "pre" : "stable" }} release
+      if: |
+        contains(fromJson('["push", "pull_request"]'), github.event_name) &&
+        startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
         context: .
@@ -81,4 +71,4 @@ jobs:
         push: ${{ github.event_name != 'pull_request' }}
         tags: |
           ghcr.io/${{ github.repository_owner }}/atlantis:${{ env.RELEASE_VERSION }}
-          ghcr.io/${{ github.repository_owner }}/atlantis:latest
+          ghcr.io/${{ github.repository_owner }}/atlantis:${{ contains(github.ref, 'pre') ? "prerelease-latest" : "latest") }}


### PR DESCRIPTION
## what
- rm duplicate make test-all
- no push to latest on refs with "pre"

## why
- Remove redundant check since it's in both circleci and github actions

## references
- Related to https://github.com/runatlantis/atlantis/pull/1781
- [How to add multiline `if` in gha](https://github.com/orgs/community/discussions/25641#discussioncomment-3248571)
- [Conditional operator or function for expression syntax](https://github.com/actions/runner/issues/409)
