### PR TITLE
Run PR checks if the PR is moved to `ready_for_review` type

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,11 @@ name: linter
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
     branches:
       - "main"
     paths-ignore:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,12 @@ on:
     paths-ignore:
       - 'runatlantis.io/**'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
     branches:
       - "main"
     paths-ignore:


### PR DESCRIPTION
## what
- Add `ready_for_review` type to `test.yml` and `lint.yml` gha

## why
- Run PR checks if the PR is moved to `ready-to-review` type

## references
- Previous PR - Ignore if the PR is in draft - https://github.com/runatlantis/atlantis/pull/2711