### PR TITLE
Run docker pull before building images

### DIFF
--- a/.github/workflows/atlantis-base.yml
+++ b/.github/workflows/atlantis-base.yml
@@ -49,6 +49,7 @@ jobs:
       with:
         context: docker-base
         platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
+        pull: true
         push: ${{ github.event_name != 'pull_request' }}
         tags: |
           ghcr.io/${{ github.repository_owner }}/atlantis-base:${{env.TODAY}}

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -49,6 +49,7 @@ jobs:
       with:
         context: .
         platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
+        pull: true
         push: ${{ github.event_name != 'pull_request' }}
         tags: |
           ghcr.io/${{ github.repository_owner }}/atlantis:dev
@@ -68,6 +69,7 @@ jobs:
       with:
         context: .
         platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
+        pull: true
         push: ${{ github.event_name != 'pull_request' }}
         tags: |
           ghcr.io/${{ github.repository_owner }}/atlantis:${{ env.RELEASE_VERSION }}

--- a/.github/workflows/testing-env-image.yml
+++ b/.github/workflows/testing-env-image.yml
@@ -45,6 +45,7 @@ jobs:
       with:
         context: testing
         platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
+        pull: true
         push: ${{ github.event_name != 'pull_request' }}
         tags: |
            ghcr.io/runatlantis/testing-env:${{env.TODAY}}


### PR DESCRIPTION
## what
- Run docker pull before building images

## why
- This should speed up images by downloading the existing image first

## references
- https://github.com/docker/build-push-action