### PR TITLE
docs: add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## what
+
+<!--
+* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
+* Use bullet points to be concise and to the point.
+-->
+
+
+## why
+
+<!--
+* Provide the justifications for the changes (e.g. business case). 
+* Describe why these changes were made (e.g. why do these commits fix the problem?)
+* Use bullet points to be concise and to the point.
+-->
+
+
+## references
+
+<!--
+* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
+* Use `closes #123`, if this PR closes a GitHub issue `#123`
+-->
+


### PR DESCRIPTION
## what
- Propose a basic PR template

## why
- It's good to have some default prompts, otherwise it leads to getting PRs without understand exactly why the change is taking place.
- This can always be iterated on.

## references
- Borrowed [PR template from cloudposse](https://github.com/cloudposse/terraform-aws-ecr/edit/master/.github/PULL_REQUEST_TEMPLATE.md)