### PR TITLE
Allow `--gh-team-allowlist` to work with team names and slugs

### DIFF
--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -450,9 +450,13 @@ Values are chosen in this order:
   # or
   ATLANTIS_GH_TEAM_ALLOWLIST="myteam:plan, secteam:apply, DevOps Team:apply"
   ```
-  In versions v0.21.0 and below, the GitHub team name required the case sensitive team name. Future versions will allow name or slug.
+  In versions v0.21.0 and later, the GitHub team name can be a name or a slug.
   
-  Comma-separated list of GitHub team name or slug and permission pairs. By default, any team can plan and apply.
+  In versions v0.20.1 and below, the Github team name required the case sensitive team name.
+  
+  Comma-separated list of GitHub teams and permission pairs.
+  
+  By default, any team can plan and apply.
   
   ::: warning NOTE
   You should use the Team name as the variable, not the slug, even if it has spaces or special characters.

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -450,7 +450,9 @@ Values are chosen in this order:
   # or
   ATLANTIS_GH_TEAM_ALLOWLIST="myteam:plan, secteam:apply, DevOps Team:apply"
   ```
-  Comma-separated list of GitHub team name (not a slug) and permission pairs. By default, any team can plan and apply.
+  In versions v0.21.0 and below, the GitHub team name required the case sensitive team name. Future versions will allow name or slug.
+  
+  Comma-separated list of GitHub team name or slug and permission pairs. By default, any team can plan and apply.
   
   ::: warning NOTE
   You should use the Team name as the variable, not the slug, even if it has spaces or special characters.

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -534,6 +534,7 @@ func (g *GithubClient) GetTeamNamesForUser(repo models.Repo, user models.User) (
 				Edges []struct {
 					Node struct {
 						Name string
+						Slug string
 					}
 				}
 				PageInfo struct {
@@ -551,7 +552,7 @@ func (g *GithubClient) GetTeamNamesForUser(repo models.Repo, user models.User) (
 			return nil, err
 		}
 		for _, edge := range q.Organization.Teams.Edges {
-			teamNames = append(teamNames, edge.Node.Name)
+			teamNames = append(teamNames, edge.Node.Name, edge.Node.Slug)
 		}
 		if !q.Organization.Teams.PageInfo.HasNextPage {
 			break

--- a/server/events/vcs/github_client_test.go
+++ b/server/events/vcs/github_client_test.go
@@ -1134,8 +1134,8 @@ func TestGithubClient_GetTeamNamesForUser(t *testing.T) {
 		  "organization": {
 			"teams":{
 				"edges":[
-					{"node":{"name":"frontend-developers"}},
-					{"node":{"name":"employees"}}
+					{"node":{"name": "Frontend Developers", "slug":"frontend-developers"}},
+					{"node":{"name": "Employees", "slug":"employees"}}
 				],
 				"pageInfo":{
 					"endCursor":"Y3Vyc29yOnYyOpHOAFMoLQ==",
@@ -1168,5 +1168,5 @@ func TestGithubClient_GetTeamNamesForUser(t *testing.T) {
 		Username: "testuser",
 	})
 	Ok(t, err)
-	Equals(t, []string{"frontend-developers", "employees"}, teams)
+	Equals(t, []string{"Frontend Developers", "frontend-developers", "Employees", "employees"}, teams)
 }


### PR DESCRIPTION
## what
- [x] Append team slugs to team names
- [x] Add tests
- [x] Update docs

## why
- Allow `--gh-team-allowlist` to work with team names and slugs

## references
- Closes https://github.com/runatlantis/atlantis/issues/2717
- Related doc PR https://github.com/runatlantis/atlantis/pull/2664
- Related doc PR https://github.com/runatlantis/atlantis/pull/2005
- Previous PR https://github.com/runatlantis/atlantis/pull/1974
- Previous PR https://github.com/runatlantis/atlantis/pull/1694
- Related discussion https://github.com/runatlantis/atlantis/discussions/2716