### PR TITLE
Fix the `bad indentation error` in the `atlantis-image.yaml` workflow

### DIFF
--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -61,7 +61,7 @@ jobs:
         startsWith(github.ref, 'refs/tags/')
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
-    - name: Build and push atlantis:${{ env.RELEASE_VERSION }} image for  ${{ contains(github.ref, 'pre') ? "pre" : "stable" }} release
+    - name: "Build and push atlantis:${{ env.RELEASE_VERSION }} image for ${{ contains(github.ref, 'pre') ? 'pre' : 'stable' }} release"
       if: |
         contains(fromJson('["push", "pull_request"]'), github.event_name) &&
         startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## what
- Changed double quotes to single quotes in `atlantis-image.yaml` workflow

## why
- This will fix the `bad indentation error` in the `atlantis-image.yaml` workflow
- This has been broken since the previous PR 😬 

## references
- Previous PR https://github.com/runatlantis/atlantis/pull/2703
