### PR TITLE
Use GitHub Actions cache when building Docker images

### DIFF
--- a/.github/workflows/atlantis-base.yml
+++ b/.github/workflows/atlantis-base.yml
@@ -47,9 +47,10 @@ jobs:
     - name: Build and push atlantis-base:${{env.TODAY}} image
       uses: docker/build-push-action@v3
       with:
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         context: docker-base
         platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
-        pull: true
         push: ${{ github.event_name != 'pull_request' }}
         tags: |
           ghcr.io/${{ github.repository_owner }}/atlantis-base:${{env.TODAY}}

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -50,9 +50,10 @@ jobs:
       if: ${{ contains(fromJson('["push", "pull_request"]'), github.event_name) }}
       uses: docker/build-push-action@v3
       with:
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         context: .
         platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
-        pull: true
         push: ${{ github.event_name != 'pull_request' }}
         tags: |
           ghcr.io/${{ github.repository_owner }}/atlantis:dev
@@ -70,9 +71,10 @@ jobs:
         startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         context: .
         platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
-        pull: true
         push: ${{ github.event_name != 'pull_request' }}
         tags: |
           ghcr.io/${{ github.repository_owner }}/atlantis:${{ env.RELEASE_VERSION }}

--- a/.github/workflows/testing-env-image.yml
+++ b/.github/workflows/testing-env-image.yml
@@ -43,9 +43,10 @@ jobs:
     - name: Build and push testing-env:${{env.TODAY}} image
       uses: docker/build-push-action@v3
       with:
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         context: testing
         platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
-        pull: true
         push: ${{ github.event_name != 'pull_request' }}
         tags: |
            ghcr.io/runatlantis/testing-env:${{env.TODAY}}

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19
+FROM golang:1.19.3
 
 RUN apt-get update && apt-get --no-install-recommends -y install unzip \
     && apt-get clean \


### PR DESCRIPTION
## what

This speeds up the Docker image builds by leveraging the GitHub Actions cache to avoid rebuilding unchanged layers.


## why

An attempt at speeding up the builds in #2714 was incorrect, because a misunderstanding of what the `pull` option meant.

This replaces that option with options that instead tell the `build-push-action` to use GitHub Actions cache system.

It should help speed up the builds quite a bit because there otherwise currently isn't any cache used at all.


## references

https://docs.docker.com/build/ci/github-actions/examples/#cache-backend-api