### PR TITLE
Cache downloaded Go dependencies and Atlantis compilation in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM golang:1.19.3-alpine AS builder
 
 WORKDIR /app
 COPY . /app
-RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -v -o atlantis .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -v -o atlantis .
 
 # Stage 2
 # The runatlantis/atlantis-base is created by docker-base/Dockerfile.


### PR DESCRIPTION
## what

<!--
* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
* Use bullet points to be concise and to the point.
-->

This has the potential to speed up rebuilds of the Atlantis container significantly, especially for non-x86 platforms which are emulated when done in GitHub Actions.

It works by using cache mounts:
https://docs.docker.com/engine/reference/builder/#run---mounttypecache. They mean we can have specific paths set that are carried over from one image build to the next, regardless of which files are changed in the project. The files are however at the same time not part of the final image, which reduces the generated "builder" image from 1.66 GB to just 386 MB on the current main branch.

## why

<!--
* Provide the justifications for the changes (e.g. business case). 
* Describe why these changes were made (e.g. why do these commits fix the problem?)
* Use bullet points to be concise and to the point.
-->

In my local tests, which doesn't make use of emulation, I saw a drop for the "go build" step going from taking just over 40 seconds with an empty cache to around 1 second when I make a one character change to a Go source file. That is otherwise a change that prior to this would cause a complete rebuild of the Docker image layer.


## references

<!--
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

- https://docs.docker.com/build/building/cache/#use-the-dedicated-run-cache
- Depends on PR https://github.com/runatlantis/atlantis/pull/2737