### PR TITLE
docs: Add a new Azure deployment method

### DIFF
--- a/runatlantis.io/docs/deployment.md
+++ b/runatlantis.io/docs/deployment.md
@@ -564,7 +564,7 @@ If you need to modify the Docker image that we provide, for instance to add the 
 The standard [Kubernetes Helm Chart](#kubernetes-helm-chart) should work fine on [Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks/intro-kubernetes).
 
 
-Another option is [Azure Container Instances](https://docs.microsoft.com/en-us/azure/container-instances/). See this community member's [repo](https://github.com/jplane/atlantis-on-aci) or the new more up-to-date [Terraform module](https://github.com/getindata/terraform-azurerm-atlantis) for install scripts and more information on running Atlantis on ACI.    
+Another option is [Azure Container Instances](https://docs.microsoft.com/en-us/azure/container-instances/). See this community member's [repo](https://github.com/jplane/atlantis-on-aci) or the new and more up-to-date [Terraform module](https://github.com/getindata/terraform-azurerm-atlantis) for install scripts and more information on running Atlantis on ACI.    
 
 ### Roll Your Own
 If you want to roll your own Atlantis installation, you can get the `atlantis`

--- a/runatlantis.io/docs/deployment.md
+++ b/runatlantis.io/docs/deployment.md
@@ -563,7 +563,7 @@ If you need to modify the Docker image that we provide, for instance to add the 
 ### Microsoft Azure
 The standard [Kubernetes Helm Chart](#kubernetes-helm-chart) should work fine on [Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks/intro-kubernetes).
 
-Another option is [Azure Container Instances](https://docs.microsoft.com/en-us/azure/container-instances/). See this community member's [repo](https://github.com/jplane/atlantis-on-aci) for install scripts and more information on running Atlantis on ACI.
+Another option is [Azure Container Instances](https://docs.microsoft.com/en-us/azure/container-instances/). See this community member's [repo](https://github.com/getindata/terraform-azurerm-atlantis) for Terraform module and more information on running Atlantis on ACI.
 
 ### Roll Your Own
 If you want to roll your own Atlantis installation, you can get the `atlantis`

--- a/runatlantis.io/docs/deployment.md
+++ b/runatlantis.io/docs/deployment.md
@@ -563,7 +563,8 @@ If you need to modify the Docker image that we provide, for instance to add the 
 ### Microsoft Azure
 The standard [Kubernetes Helm Chart](#kubernetes-helm-chart) should work fine on [Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks/intro-kubernetes).
 
-Another option is [Azure Container Instances](https://docs.microsoft.com/en-us/azure/container-instances/). See this community member's [repo](https://github.com/getindata/terraform-azurerm-atlantis) for Terraform module and more information on running Atlantis on ACI.
+
+Another option is [Azure Container Instances](https://docs.microsoft.com/en-us/azure/container-instances/). See this community member's [repo](https://github.com/jplane/atlantis-on-aci) or the new more up-to-date [Terraform module](https://github.com/getindata/terraform-azurerm-atlantis) for install scripts and more information on running Atlantis on ACI.    
 
 ### Roll Your Own
 If you want to roll your own Atlantis installation, you can get the `atlantis`


### PR DESCRIPTION
## what
New method of deploying Atlantis in Azure Container Group with Terraform.


## why
The current method using a bash script and Azure CLI is not very configurable and is very limited when it comes to holistic deployment of the Azure infrastructure. 

## references
- https://github.com/jplane/atlantis-on-aci
- https://github.com/getindata/terraform-azurerm-atlantis