### PR TITLE
docs: terraform version usage after allowing additional `required_version` specifiers

### DIFF
--- a/runatlantis.io/docs/terraform-versions.md
+++ b/runatlantis.io/docs/terraform-versions.md
@@ -15,13 +15,17 @@ projects:
 See [atlantis.yaml Use Cases](repo-level-atlantis-yaml.html#terraform-versions) for more details.
 
 ## Via terraform config
-Alternatively, one can use the terraform configuration block's `required_version` key to specify an *exact* version:
+Alternatively, one can use the terraform configuration block's `required_version` key to [specify an exact version or version constraint](https://developer.hashicorp.com/terraform/language/expressions/version-constraints#version-constraint-syntax):
 ```tf
 terraform {
   required_version = "0.12.0"
 }
 ```
-See [Terraform `required_version`](https://www.terraform.io/language/settings) for reference.
+See [Terraform `required_version`](https://developer.hashicorp.com/terraform/language/settings#specifying-a-required-terraform-version) for reference.
+
+::: tip NOTE
+A `terraform_version` specified in the `atlantis.yaml` file takes precedence over both the default version and the `required_version` in the terraform config.
+:::
 
 ::: tip NOTE
 Atlantis will automatically download the version specified.

--- a/runatlantis.io/docs/terraform-versions.md
+++ b/runatlantis.io/docs/terraform-versions.md
@@ -1,7 +1,7 @@
 # Terraform Versions
 
 You can customize which version of Terraform Atlantis defaults to by setting
-the `--default-tf-version` flag (ex. `--default-tf-version=v0.12.0`).
+the `--default-tf-version` flag (ex. `--default-tf-version=v1.3.6`).
 
 ## Via `atlantis.yaml`
 If you wish to use a different version than the default for a specific repo or project, you need
@@ -10,25 +10,41 @@ to create an `atlantis.yaml` file and set the `terraform_version` key:
 version: 3
 projects:
 - dir: .
-  terraform_version: v0.10.5
+  terraform_version: v1.1.5
 ```
 See [atlantis.yaml Use Cases](repo-level-atlantis-yaml.html#terraform-versions) for more details.
 
 ## Via terraform config
-Alternatively, one can use the terraform configuration block's `required_version` key to [specify an exact version or version constraint](https://developer.hashicorp.com/terraform/language/expressions/version-constraints#version-constraint-syntax):
+Alternatively, one can use the terraform configuration block's `required_version` key to specify an exact version (`x.y.z` or `= x.y.z`), or as of [atlantis v0.21.0](https://github.com/runatlantis/atlantis/releases/tag/v0.21.0), a comparison or pessimistic [version constraint](https://developer.hashicorp.com/terraform/language/expressions/version-constraints#version-constraint-syntax):
+#### Exactly version 1.2.9
 ```tf
 terraform {
-  required_version = "0.12.0"
+  required_version = "= 1.2.9"
+}
+```
+#### Any patch/tiny version of minor version 1.2 (1.2.z)
+```tf
+terraform {
+  required_version = "~> 1.2.0"
+}
+```
+#### Any minor version of major version 1 (1.y.z)
+```tf
+terraform {
+  required_version = "~> 1.2"
+}
+```
+#### Any version that is at least 1.2.0
+```tf
+terraform {
+  required_version = ">= 1.2.0"
 }
 ```
 See [Terraform `required_version`](https://developer.hashicorp.com/terraform/language/settings#specifying-a-required-terraform-version) for reference.
 
 ::: tip NOTE
-A `terraform_version` specified in the `atlantis.yaml` file takes precedence over both the default version and the `required_version` in the terraform config.
-:::
-
-::: tip NOTE
-Atlantis will automatically download the version specified.
+Atlantis will automatically download the latest version that fulfills the constraint specified.
+A `terraform_version` specified in the `atlantis.yaml` file takes precedence over both the [`--default-tf-version`](server-configuration.html#default-tf-version) flag and the `required_version` in the terraform hcl.
 :::
 
 ::: tip NOTE


### PR DESCRIPTION
## what

<!--
* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
* Use bullet points to be concise and to the point.
-->
- Add docs on terraform version constaints and specifiers

## why

<!--
* Provide the justifications for the changes (e.g. business case). 
* Describe why these changes were made (e.g. why do these commits fix the problem?)
* Use bullet points to be concise and to the point.
-->
- Clarify the docs about setting the terraform version, especially since v0.21.0

## references

<!--
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Companian to PR https://github.com/runatlantis/atlantis/pull/1776