### PR TITLE
docs(ha): wording update when using redis

### DIFF
--- a/runatlantis.io/docs/faq.md
+++ b/runatlantis.io/docs/faq.md
@@ -13,7 +13,7 @@ Terraform locking can be used alongside Atlantis locking since Atlantis is simpl
 
 A: Atlantis server can easily be run under the supervision of a init system like `upstart` or `systemd` to make sure `atlantis server` is always running.
 
-Atlantis, by default, stores all locking and Terraform plans locally on disk under the `--data-dir` directory (defaults to `~/.atlantis`). If you are planning to run multiple Atlantis hosts (utilizing a shared redis backend), you will want to make sure that the `data-dir` is using a shared filesystem between hosts.
+Atlantis, by default, stores all locking and Terraform plans locally on disk under the `--data-dir` directory (defaults to `~/.atlantis`). If multiple Atlantis hosts are run by utilizing a shared redis backend, then it's important that the `data-dir` is using a shared filesystem between hosts.
 
 However, if you were to lose the data, all you would need to do is run `atlantis plan` again on the pull requests that are open. If someone tries to run `atlantis apply` after the data has been lost then they will get an error back, so they will have to re-plan anyway.
 

--- a/runatlantis.io/docs/faq.md
+++ b/runatlantis.io/docs/faq.md
@@ -13,7 +13,7 @@ Terraform locking can be used alongside Atlantis locking since Atlantis is simpl
 
 A: Atlantis server can easily be run under the supervision of a init system like `upstart` or `systemd` to make sure `atlantis server` is always running.
 
-Atlantis currently stores all locking and Terraform plans locally on disk under the `--data-dir` directory (defaults to `~/.atlantis`). Because of this there is currently no way to run two or more Atlantis instances concurrently.
+Atlantis, by default, stores all locking and Terraform plans locally on disk under the `--data-dir` directory (defaults to `~/.atlantis`). If you are planning to run multiple Atlantis hosts (utilizing a shared redis backend), you will want to make sure that the `data-dir` is using a shared filesystem between hosts.
 
 However, if you were to lose the data, all you would need to do is run `atlantis plan` again on the pull requests that are open. If someone tries to run `atlantis apply` after the data has been lost then they will get an error back, so they will have to re-plan anyway.
 


### PR DESCRIPTION
## what

<!--
* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
* Use bullet points to be concise and to the point.
-->

* It is now possible to use redis as a backend locking DB for Atlantis, this FAQ should be updated.


## why

<!--
* Provide the justifications for the changes (e.g. business case). 
* Describe why these changes were made (e.g. why do these commits fix the problem?)
* Use bullet points to be concise and to the point.
-->
* The current FAQ is outdated after https://github.com/runatlantis/atlantis/pull/2491 was merged.

## references

<!--
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

