### PR TITLE
Use correct image suffix for alpine/debian

### DIFF
--- a/.github/workflows/atlantis-base.yml
+++ b/.github/workflows/atlantis-base.yml
@@ -30,7 +30,7 @@ jobs:
     env:
       DOCKERFILE: "Dockerfile.${{ matrix.image_type }}"
       IMAGE_BASE: ghcr.io/${{ github.repository_owner }}/atlantis-base
-      IMAGE_SUFFIX: ${{ !contains(matrix.image_type, 'alpine') && '-alpine' || '' }}
+      IMAGE_SUFFIX: ${{ contains(matrix.image_type, 'alpine') && '-alpine' || '' }}
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -27,7 +27,7 @@ jobs:
       RELEASE_TYPE: ${{ contains(github.ref, 'pre') && 'pre' || 'stable' }}
       RELEASE_TAG: ${{ contains(github.ref, 'pre') && 'prerelease-latest' || 'latest' }}
       IMAGE_BASE: ghcr.io/${{ github.repository_owner }}/atlantis
-      IMAGE_SUFFIX: ${{ !contains(matrix.image_type, 'alpine') && '-alpine' || '' }}
+      IMAGE_SUFFIX: ${{ contains(matrix.image_type, 'alpine') && '-alpine' || '' }}
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
## what

<!--
* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
* Use bullet points to be concise and to the point.
-->
- Use correct image suffix for alpine/debian

## why

<!--
* Provide the justifications for the changes (e.g. business case). 
* Describe why these changes were made (e.g. why do these commits fix the problem?)
* Use bullet points to be concise and to the point.
-->
- Used the `!` incorrectly. This will now tag the image as only `-alpine` when the `matrix.image_type` is `alpine`.

## references

<!--
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Previous PR https://github.com/runatlantis/atlantis/pull/2773
- Previous PR https://github.com/runatlantis/atlantis/pull/2770
