### PR TITLE
docs(changelog): explicitly list the tf versions <1.x removal in the CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ Bugfixes and new Features
 
 https://github.com/runatlantis/atlantis/releases/tag/v0.21.0
 
-## Backwards Incompatibilities / Notes:
-* Terraform version prior 1.x have been removed to reduce the image size ([#2619](https://github.com/runatlantis/atlantis/pull/2619))
+## Breaking changes
+* Terraform version 1.x have been removed to deprecate beta versions of terraform and reduce the docker image size. Each version of terraform is about 80 MB. ([#2619](https://github.com/runatlantis/atlantis/pull/2619))
 
 # v0.20.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Bugfixes and new Features
 
 https://github.com/runatlantis/atlantis/releases/tag/v0.21.0
 
+## Backwards Incompatibilities / Notes:
+* Terraform version prior 1.x have been removed to reduce the image size ([#2619](https://github.com/runatlantis/atlantis/pull/2619))
+
 # v0.20.1
 
 Bugfixes and new Features


### PR DESCRIPTION
## what
* Explicitly write the old Terraform versions removal as a breaking change in the CHANGELOG

## why

* I've been surprised by this during upgrade to v0.21 

## references

* https://github.com/runatlantis/atlantis/pull/2619
