### PR TITLE
bugfix: add missing build-args to dev image

### DIFF
--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -59,6 +59,7 @@ jobs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
         context: .
+        build-args: ATLANTIS_BASE_TAG_TYPE=${{ matrix.image_type }}
         platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
         push: ${{ github.event_name != 'pull_request' }}
         tags: |


### PR DESCRIPTION
## what

<!--
* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
* Use bullet points to be concise and to the point.
-->
- add build-args to dev image

## why

<!--
* Provide the justifications for the changes (e.g. business case). 
* Describe why these changes were made (e.g. why do these commits fix the problem?)
* Use bullet points to be concise and to the point.
-->
- the most recent prerelease tagged both the dev-debian and dev-alpine as the same image


## references

<!--
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- https://github.com/runatlantis/atlantis/pkgs/container/atlantis
- Previous PR https://github.com/runatlantis/atlantis/pull/2775



