### PR TITLE
docs: Mention `--enable-regexp-cmd` requires the project `name` key

### DIFF
--- a/runatlantis.io/docs/repo-level-atlantis-yaml.md
+++ b/runatlantis.io/docs/repo-level-atlantis-yaml.md
@@ -92,7 +92,7 @@ grep -P 'backend[\s]+"s3"' **/*.tf |
   sort |
   uniq |
   while read d; do \
-    echo '[ {"dir": "'"$d"'", "autoplan": {"when_modified": ["**/*.tf.*"] }} ]' | yq -PM; \
+    echo '[ {"name": "'"$d"'","dir": "'"$d"'", "autoplan": {"when_modified": ["**/*.tf.*"] }} ]' | yq -PM; \
   done
 ```
 

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -372,9 +372,9 @@ and set `--autoplan-modules` to `false`.
   # or
   ATLANTIS_ENABLE_REGEXP_CMD=true
   ```
-  Enable Atlantis to use regular expressions on plan/apply commands when `-p` flag is passed with it.
+  Enable Atlantis to use regular expressions to run plan/apply commands against defined project names when `-p` flag is passed with it.
   
-  This can be used to run all defined projects in `atlantis.yaml` using `atlantis plan -p .*`.
+  This can be used to run all defined projects (with the `name` key) in `atlantis.yaml` using `atlantis plan -p .*`.
 
   This will not work with `-d` yet and to use `-p` the repo projects must be defined in the repo `atlantis.yaml` file.
 


### PR DESCRIPTION
## what

<!--
* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
* Use bullet points to be concise and to the point.
-->
- Mention `--enable-regexp-cmd` requires the project `name` key

## why

<!--
* Provide the justifications for the changes (e.g. business case). 
* Describe why these changes were made (e.g. why do these commits fix the problem?)
* Use bullet points to be concise and to the point.
-->
- Without the optional `name` key defined, the `--enable-regexp-cmd` with `atlantis plan -p .*` will return nothing.

## references

<!--
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- https://www.runatlantis.io/docs/server-configuration.html#enable-regexp-cmd

https://github.com/runatlantis/atlantis/blob/bab5c62451c405c8e93e492b33683c9541208069/server/events/project_command_builder.go#L494-L500

https://github.com/runatlantis/atlantis/blob/bab5c62451c405c8e93e492b33683c9541208069/server/core/config/valid/repo_cfg.go#L64-L70
