### PR TITLE
Adding a check for deleted comments in AzureDevOps event handler

### DIFF
--- a/server/controllers/events/events_controller.go
+++ b/server/controllers/events/events_controller.go
@@ -626,6 +626,12 @@ func (e *VCSEventsController) HandleAzureDevopsPullRequestCommentedEvent(w http.
 		e.respond(w, logging.Debug, http.StatusOK, "Ignoring comment event since no comment is linked to payload; %s", azuredevopsReqID)
 		return
 	}
+
+	if *resource.Comment.IsDeleted {
+		e.respond(w, logging.Debug, http.StatusOK, "Ignoring comment event since it is linked to deleting a pull request comment; %s", azuredevopsReqID)
+		return
+	}
+
 	strippedComment := bluemonday.StrictPolicy().SanitizeBytes([]byte(*resource.Comment.Content))
 
 	if resource.PullRequest == nil {


### PR DESCRIPTION
## what

Aims to fix bug #2803 which causes Atlantis to ungracefully close a web request when a comment is deleted in a PR. 
A simple check to see if the "IsDeleted" property is set to true and return a 200 OK message if so. (ignored)

I've built the project locally with this change and confirm the issue is no longer present when testing in our dev environment. 

## why

The bug causes Azure DevOps to disable the webhook connector when it sees a web request terminate ungracefully. Effectively bringing down the service until re-enabled.

## references

closes #2803

Please let me know if anything else is needed and I'm happy to add - I haven't contributed to any projects this big before 😨 


