### PR TITLE
refactor: add conftest command into testing-image for refactoring e2e conftest ensure logic to upgrade conftest upgrading

### DIFF
--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -22,7 +22,9 @@ RUN case $(uname -m) in x86_64|amd64) ARCH="x86_64" ;; aarch64|arm64|armv7l) ARC
     sed -n "/conftest_${CONFTEST_VERSION}_Linux_${ARCH}.tar.gz/p" checksums.txt | sha256sum -c && \
     mkdir -p /usr/local/bin/cft/versions/${CONFTEST_VERSION} && \
     tar -C  /usr/local/bin/cft/versions/${CONFTEST_VERSION} -xzf conftest_${CONFTEST_VERSION}_Linux_${ARCH}.tar.gz && \
+    # After migrating e2e test which use contest command instead of contest$version, you can remove contest$version command.
     ln -s /usr/local/bin/cft/versions/${CONFTEST_VERSION}/conftest /usr/local/bin/conftest${CONFTEST_VERSION} && \
+    ln -s /usr/local/bin/cft/versions/${CONFTEST_VERSION}/conftest /usr/local/bin/conftest && \
     rm conftest_${CONFTEST_VERSION}_Linux_${ARCH}.tar.gz && \
     rm checksums.txt
 


### PR DESCRIPTION
## what

- add `conftest` command in testing-image, not `conftest$version` command

## why

Based on https://github.com/runatlantis/atlantis/pull/2807#discussion_r1051488180 discussion, we want to remove e2e ocontroller version specific conftest command like https://github.com/runatlantis/atlantis/blob/6a7f79e749a1604f54378e4920cf83c2888399ec/server/controllers/events/events_controller_e2e_test.go#L1366-L1372.

This version specific dependency is hard to upgrade conftest automatically.

To remove version dependency, I just add `conftest` comand. I will change e2e by using this command in the next PR.

## references

- https://github.com/runatlantis/atlantis/issues/2638
- https://github.com/runatlantis/atlantis/pull/2807#discussion_r1051488180
