### PR TITLE
refactor: e2e test ensure conftest command to check conftest version is greater or equal to specific version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-    - image: ghcr.io/runatlantis/testing-env:2022.11.17
+    - image: ghcr.io/runatlantis/testing-env:2022.12.17
     steps:
     - checkout
     - run: make check-fmt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     if: github.event.pull_request.draft == false
     name: runner / gotest
     runs-on: ubuntu-22.04
-    container: ghcr.io/runatlantis/testing-env:2022.11.17
+    container: ghcr.io/runatlantis/testing-env:2022.12.17
     steps:
       - uses: actions/checkout@v3.0.2
       - run: make test-all

--- a/Makefile
+++ b/Makefile
@@ -36,14 +36,14 @@ test: ## Run tests
 
 .PHONY: docker/test
 docker/test: ## Run tests in docker
-	docker run -it -v $(pwd):/atlantis ghcr.io/runatlantis/testing-env:2022.11.17 sh -c "cd /atlantis && make test"
+	docker run -it -v $(pwd):/atlantis ghcr.io/runatlantis/testing-env:2022.12.17 sh -c "cd /atlantis && make test"
 
 test-all: ## Run tests including integration
 	@go test  $(PKG)
 
 .PHONY: docker/test-all
 docker/test-all: ## Run all tests in docker
-	docker run -it -v $(pwd):/atlantis ghcr.io/runatlantis/testing-env:2022.11.17 sh -c "cd /atlantis && make test-all"
+	docker run -it -v $(pwd):/atlantis ghcr.io/runatlantis/testing-env:2022.12.17 sh -c "cd /atlantis && make test-all"
 
 test-coverage:
 	@mkdir -p .cover

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -636,7 +636,7 @@ func TestGitHubWorkflowWithPolicyCheck(t *testing.T) {
 	}
 	// Ensure we have >= TF 0.14 locally.
 	ensureRunning014(t)
-	// Ensure we have >= Conftest 0.21 locally.
+	// Ensure we have conftest locally.
 	ensureRunningConftest(t)
 
 	cases := []struct {
@@ -1363,11 +1363,11 @@ func mkSubDirs(t *testing.T) (string, string, string) {
 	return tmp, binDir, cachedir
 }
 
-// Will fail test if conftest isn't in path and isn't version >= 0.25.0
+// Will fail test if conftest isn't in path or is version less than specific version
 func ensureRunningConftest(t *testing.T) {
-	localPath, err := exec.LookPath(fmt.Sprintf("conftest%s", ConftestVersion))
+	localPath, err := exec.LookPath("conftest")
 	if err != nil {
-		t.Logf("conftest >= %s must be installed to run this test", ConftestVersion)
+		t.Logf("conftest must be installed to run this test")
 		t.FailNow()
 	}
 	versionOutBytes, err := exec.Command(localPath, "--version").Output() // #nosec


### PR DESCRIPTION
## what

- change testing-env image which contains `conftest` command
  - https://github.com/runatlantis/atlantis/pull/2811 introduce it
- check e2e conftest ensure logic with `conftest` command, not `conftest$version` command.

## why

Based on https://github.com/runatlantis/atlantis/pull/2807#discussion_r1051488180 discussion, we want to remove e2e controller version specific conftest command like https://github.com/runatlantis/atlantis/blob/6a7f79e749a1604f54378e4920cf83c2888399ec/server/controllers/events/events_controller_e2e_test.go#L1366-L1372.

This version specific dependency is hard to upgrade conftest automatically.

To remove version dependency, I want remove `conftest$version` command.

## references

- https://github.com/runatlantis/atlantis/issues/2638
- https://github.com/runatlantis/atlantis/pull/2807#discussion_r1051488180
- https://github.com/runatlantis/atlantis/pull/2811
