### PR TITLE
Revert "Adding a check for deleted comments in AzureDevOps (#2804)"

### DIFF
--- a/server/controllers/events/events_controller.go
+++ b/server/controllers/events/events_controller.go
@@ -626,12 +626,6 @@ func (e *VCSEventsController) HandleAzureDevopsPullRequestCommentedEvent(w http.
 		e.respond(w, logging.Debug, http.StatusOK, "Ignoring comment event since no comment is linked to payload; %s", azuredevopsReqID)
 		return
 	}
-
-	if *resource.Comment.IsDeleted {
-		e.respond(w, logging.Debug, http.StatusOK, "Ignoring comment event since it is linked to deleting a pull request comment; %s", azuredevopsReqID)
-		return
-	}
-
 	strippedComment := bluemonday.StrictPolicy().SanitizeBytes([]byte(*resource.Comment.Content))
 
 	if resource.PullRequest == nil {

--- a/server/controllers/events/events_controller_test.go
+++ b/server/controllers/events/events_controller_test.go
@@ -556,68 +556,6 @@ func TestPost_AzureDevopsPullRequestIgnoreEvent(t *testing.T) {
 	}
 }
 
-func TestPost_AzureDevopsPullRequestDeletedCommentIgnoreEvent(t *testing.T) {
-	u := "user"
-	user := []byte(u)
-
-	t.Log("when the event is an azure devops pull request deleted comment event we ignore it")
-	RegisterMockTestingT(t)
-	v := mocks.NewMockAzureDevopsRequestValidator()
-	p := emocks.NewMockEventParsing()
-	cp := emocks.NewMockCommentParsing()
-	cr := emocks.NewMockCommandRunner()
-	c := emocks.NewMockPullCleaner()
-	vcsmock := vcsmocks.NewMockClient()
-	repoAllowlistChecker, err := events.NewRepoAllowlistChecker("*")
-	Ok(t, err)
-	logger := logging.NewNoopLogger(t)
-	scope, _, _ := metrics.NewLoggingScope(logger, "null")
-	e := events_controllers.VCSEventsController{
-		TestingMode:                     true,
-		Logger:                          logger,
-		Scope:                           scope,
-		ApplyDisabled:                   false,
-		AzureDevopsWebhookBasicUser:     user,
-		AzureDevopsWebhookBasicPassword: secret,
-		AzureDevopsRequestValidator:     v,
-		Parser:                          p,
-		CommentParser:                   cp,
-		CommandRunner:                   cr,
-		PullCleaner:                     c,
-		SupportedVCSHosts:               []models.VCSHostType{models.AzureDevops},
-		RepoAllowlistChecker:            repoAllowlistChecker,
-		VCSClient:                       vcsmock,
-	}
-
-	payload := `{
-		"subscriptionId": "11111111-1111-1111-1111-111111111111",
-		"notificationId": 1,
-		"id": "22222222-2222-2222-2222-222222222222",
-		"eventType": "ms.vss-code.git-pullrequest-comment-event",
-		"publisherId": "tfs",
-		"message": {
-			"text": "Dev has deleted a pull request comment"
-		},
-		"resource": {
-			"comment": {
-				"id": 1,
-				"isDeleted": true,
-				"commentType": "text"
-			}
-		}
-	}`
-
-	t.Run("Dev has deleted a pull request comment", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "", strings.NewReader(payload))
-		req.Header.Set(azuredevopsHeader, "reqID")
-		When(v.Validate(req, user, secret)).ThenReturn([]byte(payload), nil)
-		w := httptest.NewRecorder()
-		e.Parser = &events.EventParser{}
-		e.Post(w, req)
-		ResponseContains(t, w, http.StatusOK, "Ignoring comment event since it is linked to deleting a pull request comment")
-	})
-}
-
 func TestPost_GithubPullRequestClosedErrCleaningPull(t *testing.T) {
 	t.Skip("relies too much on mocks, should use real event parser")
 	t.Log("when the event is a closed pull request and we have an error calling CleanUpPull we return a 503")


### PR DESCRIPTION
## what

<!--
* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
* Use bullet points to be concise and to the point.
-->
- This reverts commit a96a88ec9725d82f0fa9a787a334fd4a9e0b8a4a.

## why

<!--
* Provide the justifications for the changes (e.g. business case). 
* Describe why these changes were made (e.g. why do these commits fix the problem?)
* Use bullet points to be concise and to the point.
-->
- Regression caught in pre-release

## references

<!--
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- From PR #2804
- Closes https://github.com/runatlantis/atlantis/issues/2834
