### PR TITLE
fix: Policy check summary not shown outside of "Show Output" details

### DIFF
--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -260,10 +260,15 @@ $$$
 			[]command.ProjectResult{
 				{
 					PolicyCheckSuccess: &models.PolicyCheckSuccess{
-						PolicyCheckOutput: "2 tests, 1 passed, 0 warnings, 0 failure, 0 exceptions",
-						LockURL:           "lock-url",
-						RePlanCmd:         "atlantis plan -d path -w workspace",
-						ApplyCmd:          "atlantis apply -d path -w workspace",
+						// strings.Repeat require to get wrapped result
+						PolicyCheckOutput: strings.Repeat("line\n", 13) + `Checking plan against the following policies:
+  test_policy
+FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibited.
+
+2 tests, 1 passed, 0 warnings, 0 failure, 0 exceptions`,
+						LockURL:   "lock-url",
+						RePlanCmd: "atlantis plan -d path -w workspace",
+						ApplyCmd:  "atlantis apply -d path -w workspace",
 					},
 					Workspace:   "workspace",
 					RepoRelDir:  "path",
@@ -273,7 +278,13 @@ $$$
 			models.Github,
 			`Ran Policy Check for project: $projectname$ dir: $path$ workspace: $workspace$
 
+<details><summary>Show Output</summary>
+
 $$$diff
+` + strings.Repeat("line\n", 13) + `Checking plan against the following policies:
+  test_policy
+FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibited.
+
 2 tests, 1 passed, 0 warnings, 0 failure, 0 exceptions
 $$$
 
@@ -282,6 +293,8 @@ $$$
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To re-run policies **plan** this project again by commenting:
     * $atlantis plan -d path -w workspace$
+</details>
+2 tests, 1 passed, 0 warnings, 0 failure, 0 exceptions
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -415,7 +415,7 @@ type PolicyCheckSuccess struct {
 func (p *PolicyCheckSuccess) Summary() string {
 	note := ""
 
-	r := regexp.MustCompile(`\d+ tests, \d+ passed, \d+ warnings, \d+ failures, \d+ exceptions`)
+	r := regexp.MustCompile(`\d+ tests?, \d+ passed, \d+ warnings?, \d+ failures?, \d+ exceptions?(, \d skipped)?`)
 	if match := r.FindString(p.PolicyCheckOutput); match != "" {
 		return note + match
 	}

--- a/server/events/models/models_test.go
+++ b/server/events/models/models_test.go
@@ -356,13 +356,19 @@ func TestAzureDevopsSplitRepoFullName(t *testing.T) {
 }
 
 func TestPolicyCheckSuccess_Summary(t *testing.T) {
-	pcs := models.PolicyCheckSuccess{
-		PolicyCheckOutput: `WARN - <redacted plan file> - main - example main package
-
-20 tests, 19 passed, 1 warnings, 0 failures, 0 exceptions`,
+	cases := []string{
+		"20 tests, 19 passed, 2 warnings, 0 failures, 0 exceptions",
+		"3 tests, 0 passed, 1 warning, 1 failure, 0 exceptions, 1 skipped",
+		"1 test, 0 passed, 1 warning, 1 failure, 1 exception",
 	}
-
-	Equals(t, "20 tests, 19 passed, 1 warnings, 0 failures, 0 exceptions", pcs.Summary())
+	for i, summary := range cases {
+		t.Run(fmt.Sprintf("summary %d", i), func(t *testing.T) {
+			pcs := models.PolicyCheckSuccess{
+				PolicyCheckOutput: `WARN - <redacted plan file> - main - example main package\n` + summary,
+			}
+			Equals(t, summary, pcs.Summary())
+		})
+	}
 }
 
 func TestPullStatus_StatusCount(t *testing.T) {

--- a/server/events/templates/policy_check_success_wrapped.tmpl
+++ b/server/events/templates/policy_check_success_wrapped.tmpl
@@ -10,5 +10,6 @@
 * :put_litter_in_its_place: To **delete** this plan click [here]({{.LockURL}})
 * :repeat: To re-run policies **plan** this project again by commenting:
     * `{{.RePlanCmd}}`
-</details>{{ template "diverged" . }}
+</details>
+{{.PolicyCheckSummary}}{{ template "diverged" . }}
 {{- end }}


### PR DESCRIPTION
## what

- Add `{{.PolicyCheckSummary}}` into tmpl
- fix PolicyCheckSummary extract regex

## why

- original impl doesn't show output summary

## references

- closes https://github.com/runatlantis/atlantis/issues/2756
