### PR TITLE
chore(deps): update conftest to 0.37.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN AVAILABLE_TERRAFORM_VERSIONS="1.0.11 1.1.9 1.2.9 ${DEFAULT_TERRAFORM_VERSION
     ln -s "/usr/local/bin/tf/versions/${DEFAULT_TERRAFORM_VERSION}/terraform" /usr/local/bin/terraform
 
 # renovate: datasource=github-releases depName=open-policy-agent/conftest
-ENV DEFAULT_CONFTEST_VERSION=0.36.0
+ENV DEFAULT_CONFTEST_VERSION=0.37.0
 
 RUN AVAILABLE_CONFTEST_VERSIONS="${DEFAULT_CONFTEST_VERSION}" && \
     case ${TARGETPLATFORM} in \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,6 +2,6 @@ FROM ghcr.io/runatlantis/atlantis:latest
 COPY atlantis /usr/local/bin/atlantis
 # TODO: remove this once we get this in the base image
 # renovate: datasource=github-releases depName=open-policy-agent/conftest
-ENV DEFAULT_CONFTEST_VERSION=0.36.0
+ENV DEFAULT_CONFTEST_VERSION=0.37.0
 
 WORKDIR /atlantis/src

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -42,7 +42,7 @@ import (
 	. "github.com/runatlantis/atlantis/testing"
 )
 
-const ConftestVersion = "0.36.0" // renovate: datasource=github-releases depName=open-policy-agent/conftest
+const ConftestVersion = "0.37.0" // renovate: datasource=github-releases depName=open-policy-agent/conftest
 
 var applyLocker locking.ApplyLocker
 var userConfig server.UserConfig

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -42,7 +42,7 @@ import (
 	. "github.com/runatlantis/atlantis/testing"
 )
 
-const ConftestVersion = "0.37.0" // renovate: datasource=github-releases depName=open-policy-agent/conftest
+const ConftestVersion = "0.36.0" // renovate: datasource=github-releases depName=open-policy-agent/conftest
 
 var applyLocker locking.ApplyLocker
 var userConfig server.UserConfig

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -16,7 +16,7 @@ RUN case $(uname -m) in x86_64|amd64) ARCH="amd64" ;; aarch64|arm64|armv7l) ARCH
 
 # Install conftest
 # renovate: datasource=github-releases depName=open-policy-agent/conftest
-ENV CONFTEST_VERSION=0.36.0
+ENV CONFTEST_VERSION=0.37.0
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN case $(uname -m) in x86_64|amd64) ARCH="x86_64" ;; aarch64|arm64|armv7l) ARCH="arm64" ;; esac && \
     curl -LOs https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_${ARCH}.tar.gz && \


### PR DESCRIPTION
## what

update conftest to 0.37.0

## why

latest and greatest

## references

- https://github.com/open-policy-agent/conftest/releases/tag/v0.37.0
