### PR TITLE
feat: Add flag to disable downloading tf for airgapped environments

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -117,6 +117,7 @@ const (
 	SSLCertFileFlag            = "ssl-cert-file"
 	SSLKeyFileFlag             = "ssl-key-file"
 	RestrictFileList           = "restrict-file-list"
+	TFDownloadFlag             = "tf-download"
 	TFDownloadURLFlag          = "tf-download-url"
 	VarFileAllowlistFlag       = "var-file-allowlist"
 	VCSStatusName              = "vcs-status-name"
@@ -151,6 +152,7 @@ const (
 	DefaultRedisTLSEnabled              = false
 	DefaultRedisInsecureSkipVerify      = false
 	DefaultTFDownloadURL                = "https://releases.hashicorp.com"
+	DefaultTFDownload                   = true
 	DefaultTFEHostname                  = "app.terraform.io"
 	DefaultVCSStatusName                = "atlantis"
 	DefaultWebBasicAuth                 = false
@@ -499,6 +501,10 @@ var boolFlags = map[string]boolFlag{
 	SkipCloneNoChanges: {
 		description:  "Skips cloning the PR repo if there are no projects were changed in the PR.",
 		defaultValue: false,
+	},
+	TFDownloadFlag: {
+		description:  "Allow Atlantis to list & download Terraform versions. Setting this to false can be helpful in air-gapped environments.",
+		defaultValue: DefaultTFDownload,
 	},
 	TFELocalExecutionModeFlag: {
 		description:  "Enable if you're using local execution mode (instead of TFE/C's remote execution mode).",

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -927,6 +927,13 @@ and set `--autoplan-modules` to `false`.
   environment where releases.hashicorp.com is not available. Directory structure of the custom
   endpoint should match that of releases.hashicorp.com.
 
+### `--tf-disable-downloads`
+  ```bash
+  atlantis server --tf-disable-downloads
+  ```
+  Prevent Atlantis from trying to list and download additional versions of Terraform.
+  Useful in an airgapped environment where a download mirror is not available.
+
 ### `--tfe-hostname`
   ```bash
   atlantis server --tfe-hostname="my-terraform-enterprise.company.com"

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -917,6 +917,15 @@ and set `--autoplan-modules` to `false`.
   ```
   Namespace for emitting stats/metrics. See [stats](stats.html) section.
 
+### `--tf--download`
+  ```bash
+  atlantis server --tf-download=false
+  # or
+  ATLANTIS_TF_DOWNLOAD=false
+  ```
+Defaults to `true`. Allow Atlantis to list and download additional versions of Terraform.
+Setting this to `false` can be useful in an air-gapped environment where a download mirror is not available.
+
 ### `--tf-download-url`
   ```bash
   atlantis server --tf-download-url="https://releases.company.com"
@@ -926,13 +935,8 @@ and set `--autoplan-modules` to `false`.
   An alternative URL to download Terraform versions if they are missing. Useful in an airgapped
   environment where releases.hashicorp.com is not available. Directory structure of the custom
   endpoint should match that of releases.hashicorp.com.
-
-### `--tf-disable-downloads`
-  ```bash
-  atlantis server --tf-disable-downloads
-  ```
-  Prevent Atlantis from trying to list and download additional versions of Terraform.
-  Useful in an airgapped environment where a download mirror is not available.
+  
+  This has no impact if `--tf-download` is set to `false`.
 
 ### `--tfe-hostname`
   ```bash

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -914,7 +914,7 @@ func setupE2E(t *testing.T, repoDir, repoConfigFile string) (events_controllers.
 		GitlabUser:     "gitlab-user",
 		ExecutableName: "atlantis",
 	}
-	terraformClient, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "", "default-tf-version", "https://releases.hashicorp.com", &NoopTFDownloader{}, false, projectCmdOutputHandler)
+	terraformClient, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "", "default-tf-version", "https://releases.hashicorp.com", &NoopTFDownloader{}, false, false, projectCmdOutputHandler)
 	Ok(t, err)
 	boltdb, err := db.New(dataDir)
 	Ok(t, err)
@@ -1010,6 +1010,7 @@ func setupE2E(t *testing.T, repoDir, repoConfigFile string) (events_controllers.
 		false,
 		statsScope,
 		logger,
+		terraformClient,
 	)
 
 	showStepRunner, err := runtime.NewShowStepRunner(terraformClient, defaultTFVersion)

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -914,7 +914,7 @@ func setupE2E(t *testing.T, repoDir, repoConfigFile string) (events_controllers.
 		GitlabUser:     "gitlab-user",
 		ExecutableName: "atlantis",
 	}
-	terraformClient, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "", "default-tf-version", "https://releases.hashicorp.com", &NoopTFDownloader{}, false, false, projectCmdOutputHandler)
+	terraformClient, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "", "default-tf-version", "https://releases.hashicorp.com", &NoopTFDownloader{}, true, false, projectCmdOutputHandler)
 	Ok(t, err)
 	boltdb, err := db.New(dataDir)
 	Ok(t, err)

--- a/server/core/terraform/mocks/mock_terraform_client.go
+++ b/server/core/terraform/mocks/mock_terraform_client.go
@@ -61,6 +61,25 @@ func (mock *MockClient) EnsureVersion(log logging.SimpleLogging, v *go_version.V
 	return ret0
 }
 
+func (mock *MockClient) ListAvailableVersions(log logging.SimpleLogging) ([]string, error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockClient().")
+	}
+	params := []pegomock.Param{log}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("ListAvailableVersions", params, []reflect.Type{reflect.TypeOf((*[]string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 []string
+	var ret1 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].([]string)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(error)
+		}
+	}
+	return ret0, ret1
+}
+
 func (mock *MockClient) VerifyWasCalledOnce() *VerifierMockClient {
 	return &VerifierMockClient{
 		mock:                   mock,
@@ -171,6 +190,33 @@ func (c *MockClient_EnsureVersion_OngoingVerification) GetAllCapturedArguments()
 		_param1 = make([]*go_version.Version, len(c.methodInvocations))
 		for u, param := range params[1] {
 			_param1[u] = param.(*go_version.Version)
+		}
+	}
+	return
+}
+
+func (verifier *VerifierMockClient) ListAvailableVersions(log logging.SimpleLogging) *MockClient_ListAvailableVersions_OngoingVerification {
+	params := []pegomock.Param{log}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "ListAvailableVersions", params, verifier.timeout)
+	return &MockClient_ListAvailableVersions_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockClient_ListAvailableVersions_OngoingVerification struct {
+	mock              *MockClient
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockClient_ListAvailableVersions_OngoingVerification) GetCapturedArguments() logging.SimpleLogging {
+	log := c.GetAllCapturedArguments()
+	return log[len(log)-1]
+}
+
+func (c *MockClient_ListAvailableVersions_OngoingVerification) GetAllCapturedArguments() (_param0 []logging.SimpleLogging) {
+	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(params) > 0 {
+		_param0 = make([]logging.SimpleLogging, len(c.methodInvocations))
+		for u, param := range params[0] {
+			_param0[u] = param.(logging.SimpleLogging)
 		}
 	}
 	return

--- a/server/core/terraform/mocks/mock_terraform_client.go
+++ b/server/core/terraform/mocks/mock_terraform_client.go
@@ -80,6 +80,21 @@ func (mock *MockClient) ListAvailableVersions(log logging.SimpleLogging) ([]stri
 	return ret0, ret1
 }
 
+func (mock *MockClient) DetectVersion(projectDirectory string, log logging.SimpleLogging) *go_version.Version {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockClient().")
+	}
+	params := []pegomock.Param{projectDirectory, log}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("DetectVersion", params, []reflect.Type{reflect.TypeOf((**go_version.Version)(nil)).Elem()})
+	var ret0 *go_version.Version
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(*go_version.Version)
+		}
+	}
+	return ret0
+}
+
 func (mock *MockClient) VerifyWasCalledOnce() *VerifierMockClient {
 	return &VerifierMockClient{
 		mock:                   mock,
@@ -217,6 +232,37 @@ func (c *MockClient_ListAvailableVersions_OngoingVerification) GetAllCapturedArg
 		_param0 = make([]logging.SimpleLogging, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(logging.SimpleLogging)
+		}
+	}
+	return
+}
+
+func (verifier *VerifierMockClient) DetectVersion(projectDirectory string, log logging.SimpleLogging) *MockClient_DetectVersion_OngoingVerification {
+	params := []pegomock.Param{projectDirectory, log}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "DetectVersion", params, verifier.timeout)
+	return &MockClient_DetectVersion_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockClient_DetectVersion_OngoingVerification struct {
+	mock              *MockClient
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockClient_DetectVersion_OngoingVerification) GetCapturedArguments() (string, logging.SimpleLogging) {
+	projectDirectory, log := c.GetAllCapturedArguments()
+	return projectDirectory[len(projectDirectory)-1], log[len(log)-1]
+}
+
+func (c *MockClient_DetectVersion_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []logging.SimpleLogging) {
+	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(params) > 0 {
+		_param0 = make([]string, len(c.methodInvocations))
+		for u, param := range params[0] {
+			_param0[u] = param.(string)
+		}
+		_param1 = make([]logging.SimpleLogging, len(c.methodInvocations))
+		for u, param := range params[1] {
+			_param1[u] = param.(logging.SimpleLogging)
 		}
 	}
 	return

--- a/server/core/terraform/mocks/mock_terraform_client.go
+++ b/server/core/terraform/mocks/mock_terraform_client.go
@@ -84,7 +84,7 @@ func (mock *MockClient) DetectVersion(log logging.SimpleLogging, projectDirector
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockClient().")
 	}
-	params := []pegomock.Param{projectDirectory, log}
+	params := []pegomock.Param{log, projectDirectory}
 	result := pegomock.GetGenericMockFrom(mock).Invoke("DetectVersion", params, []reflect.Type{reflect.TypeOf((**go_version.Version)(nil)).Elem()})
 	var ret0 *go_version.Version
 	if len(result) != 0 {
@@ -237,8 +237,8 @@ func (c *MockClient_ListAvailableVersions_OngoingVerification) GetAllCapturedArg
 	return
 }
 
-func (verifier *VerifierMockClient) DetectVersion(projectDirectory string, log logging.SimpleLogging) *MockClient_DetectVersion_OngoingVerification {
-	params := []pegomock.Param{projectDirectory, log}
+func (verifier *VerifierMockClient) DetectVersion(log logging.SimpleLogging, projectDirectory string) *MockClient_DetectVersion_OngoingVerification {
+	params := []pegomock.Param{log, projectDirectory}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "DetectVersion", params, verifier.timeout)
 	return &MockClient_DetectVersion_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -248,21 +248,21 @@ type MockClient_DetectVersion_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockClient_DetectVersion_OngoingVerification) GetCapturedArguments() (string, logging.SimpleLogging) {
-	projectDirectory, log := c.GetAllCapturedArguments()
-	return projectDirectory[len(projectDirectory)-1], log[len(log)-1]
+func (c *MockClient_DetectVersion_OngoingVerification) GetCapturedArguments() (logging.SimpleLogging, string) {
+	log, projectDirectory := c.GetAllCapturedArguments()
+	return log[len(log)-1], projectDirectory[len(projectDirectory)-1]
 }
 
-func (c *MockClient_DetectVersion_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []logging.SimpleLogging) {
+func (c *MockClient_DetectVersion_OngoingVerification) GetAllCapturedArguments() (_param0 []logging.SimpleLogging, _param1 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]string, len(c.methodInvocations))
+		_param0 = make([]logging.SimpleLogging, len(c.methodInvocations))
 		for u, param := range params[0] {
-			_param0[u] = param.(string)
+			_param0[u] = param.(logging.SimpleLogging)
 		}
-		_param1 = make([]logging.SimpleLogging, len(c.methodInvocations))
+		_param1 = make([]string, len(c.methodInvocations))
 		for u, param := range params[1] {
-			_param1[u] = param.(logging.SimpleLogging)
+			_param1[u] = param.(string)
 		}
 	}
 	return

--- a/server/core/terraform/mocks/mock_terraform_client.go
+++ b/server/core/terraform/mocks/mock_terraform_client.go
@@ -80,7 +80,7 @@ func (mock *MockClient) ListAvailableVersions(log logging.SimpleLogging) ([]stri
 	return ret0, ret1
 }
 
-func (mock *MockClient) DetectVersion(projectDirectory string, log logging.SimpleLogging) *go_version.Version {
+func (mock *MockClient) DetectVersion(log logging.SimpleLogging, projectDirectory string) *go_version.Version {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockClient().")
 	}

--- a/server/core/terraform/terraform_client.go
+++ b/server/core/terraform/terraform_client.go
@@ -292,7 +292,7 @@ func (c *DefaultClient) ListAvailableVersions(log logging.SimpleLogging) ([]stri
 	log.Debug("Listing Terraform versions available at: %s", url)
 	// terraform-switcher calls os.Exit(1) if it fails to successfully GET the configured URL.
 	// So, before calling it, test if we can connect. Then we can return an error instead if the request fails.
-	resp, err := http.Get(url)
+	resp, err := http.Get(url) // #nosec G107 -- terraform-switch makes this same call below. Also, we don't process the response payload.
 	if err != nil || resp.StatusCode != 200 {
 		return nil, fmt.Errorf("Unable to list Terraform versions: %s", err)
 	}

--- a/server/core/terraform/terraform_client.go
+++ b/server/core/terraform/terraform_client.go
@@ -70,8 +70,9 @@ type DefaultClient struct {
 	// with another binary, ex. echo.
 	overrideTF string
 	// downloader downloads terraform versions.
-	downloader      Downloader
-	downloadBaseURL string
+	downloader       Downloader
+	downloadBaseURL  string
+	disableDownloads bool
 	// versions maps from the string representation of a tf version (ex. 0.11.10)
 	// to the absolute path of that binary on disk (if it exists).
 	// Use versionsLock to control access.
@@ -114,6 +115,7 @@ func NewClientWithDefaultVersion(
 	defaultVersionFlagName string,
 	tfDownloadURL string,
 	tfDownloader Downloader,
+	disableDownloads bool,
 	usePluginCache bool,
 	fetchAsync bool,
 	projectCmdOutputHandler jobs.ProjectCommandOutputHandler,
@@ -150,7 +152,7 @@ func NewClientWithDefaultVersion(
 			// Since ensureVersion might end up downloading terraform,
 			// we call it asynchronously so as to not delay server startup.
 			versionsLock.Lock()
-			_, err := ensureVersion(log, tfDownloader, versions, defaultVersion, binDir, tfDownloadURL)
+			_, err := ensureVersion(log, tfDownloader, versions, defaultVersion, binDir, tfDownloadURL, disableDownloads)
 			versionsLock.Unlock()
 			if err != nil {
 				log.Err("could not download terraform %s: %s", defaultVersion.String(), err)
@@ -180,6 +182,7 @@ func NewClientWithDefaultVersion(
 		binDir:                  binDir,
 		downloader:              tfDownloader,
 		downloadBaseURL:         tfDownloadURL,
+		disableDownloads:        disableDownloads,
 		versionsLock:            &versionsLock,
 		versions:                versions,
 		usePluginCache:          usePluginCache,
@@ -198,6 +201,7 @@ func NewTestClient(
 	defaultVersionFlagName string,
 	tfDownloadURL string,
 	tfDownloader Downloader,
+	disableDownloads bool,
 	usePluginCache bool,
 	projectCmdOutputHandler jobs.ProjectCommandOutputHandler,
 ) (*DefaultClient, error) {
@@ -211,6 +215,7 @@ func NewTestClient(
 		defaultVersionFlagName,
 		tfDownloadURL,
 		tfDownloader,
+		disableDownloads,
 		usePluginCache,
 		false,
 		projectCmdOutputHandler,
@@ -235,6 +240,7 @@ func NewClient(
 	defaultVersionFlagName string,
 	tfDownloadURL string,
 	tfDownloader Downloader,
+	disableDownloads bool,
 	usePluginCache bool,
 	projectCmdOutputHandler jobs.ProjectCommandOutputHandler,
 ) (*DefaultClient, error) {
@@ -248,6 +254,7 @@ func NewClient(
 		defaultVersionFlagName,
 		tfDownloadURL,
 		tfDownloader,
+		disableDownloads,
 		usePluginCache,
 		true,
 		projectCmdOutputHandler,
@@ -268,6 +275,12 @@ func (c *DefaultClient) TerraformBinDir() string {
 // ListAvailableVersions returns all available version of Terraform. If downloads are disabled, this will return an empty list.
 func (c *DefaultClient) ListAvailableVersions(log logging.SimpleLogging) ([]string, error) {
 	url := fmt.Sprintf("%s/terraform", c.downloadBaseURL)
+
+	if c.disableDownloads {
+		log.Debug("Terraform downloads disabled. Won't list Terraform versions available at %s", url)
+		return []string{}, nil
+	}
+
 	log.Debug("Listing Terraform versions available at: %s", url)
 	versions, err := lib.GetTFList(url, true)
 	return versions, err
@@ -281,7 +294,7 @@ func (c *DefaultClient) EnsureVersion(log logging.SimpleLogging, v *version.Vers
 
 	var err error
 	c.versionsLock.Lock()
-	_, err = ensureVersion(log, c.downloader, c.versions, v, c.binDir, c.downloadBaseURL)
+	_, err = ensureVersion(log, c.downloader, c.versions, v, c.binDir, c.downloadBaseURL, c.disableDownloads)
 	c.versionsLock.Unlock()
 	if err != nil {
 		return err
@@ -358,7 +371,7 @@ func (c *DefaultClient) prepCmd(log logging.SimpleLogging, v *version.Version, w
 	} else {
 		var err error
 		c.versionsLock.Lock()
-		binPath, err = ensureVersion(log, c.downloader, c.versions, v, c.binDir, c.downloadBaseURL)
+		binPath, err = ensureVersion(log, c.downloader, c.versions, v, c.binDir, c.downloadBaseURL, c.disableDownloads)
 		c.versionsLock.Unlock()
 		if err != nil {
 			return "", nil, err
@@ -429,7 +442,7 @@ func MustConstraint(v string) version.Constraints {
 
 // ensureVersion returns the path to a terraform binary of version v.
 // It will download this version if we don't have it.
-func ensureVersion(log logging.SimpleLogging, dl Downloader, versions map[string]string, v *version.Version, binDir string, downloadURL string) (string, error) {
+func ensureVersion(log logging.SimpleLogging, dl Downloader, versions map[string]string, v *version.Version, binDir string, downloadURL string, downloadsDisabled bool) (string, error) {
 	if binPath, ok := versions[v.String()]; ok {
 		return binPath, nil
 	}
@@ -450,18 +463,23 @@ func ensureVersion(log logging.SimpleLogging, dl Downloader, versions map[string
 		versions[v.String()] = dest
 		return dest, nil
 	}
-	log.Info("could not find terraform version %s in PATH or %s, downloading from %s", v.String(), binDir, downloadURL)
-	urlPrefix := fmt.Sprintf("%s/terraform/%s/terraform_%s", downloadURL, v.String(), v.String())
-	binURL := fmt.Sprintf("%s_%s_%s.zip", urlPrefix, runtime.GOOS, runtime.GOARCH)
-	checksumURL := fmt.Sprintf("%s_SHA256SUMS", urlPrefix)
-	fullSrcURL := fmt.Sprintf("%s?checksum=file:%s", binURL, checksumURL)
-	if err := dl.GetFile(dest, fullSrcURL); err != nil {
-		return "", errors.Wrapf(err, "downloading terraform version %s at %q", v.String(), fullSrcURL)
-	}
+	if downloadsDisabled {
+		return "", fmt.Errorf("could not find terraform version %s in PATH or %s, and downloads are disabled", v.String(), binDir)
+	} else {
 
-	log.Info("downloaded terraform %s to %s", v.String(), dest)
-	versions[v.String()] = dest
-	return dest, nil
+		log.Info("could not find terraform version %s in PATH or %s, downloading from %s", v.String(), binDir, downloadURL)
+		urlPrefix := fmt.Sprintf("%s/terraform/%s/terraform_%s", downloadURL, v.String(), v.String())
+		binURL := fmt.Sprintf("%s_%s_%s.zip", urlPrefix, runtime.GOOS, runtime.GOARCH)
+		checksumURL := fmt.Sprintf("%s_SHA256SUMS", urlPrefix)
+		fullSrcURL := fmt.Sprintf("%s?checksum=file:%s", binURL, checksumURL)
+		if err := dl.GetFile(dest, fullSrcURL); err != nil {
+			return "", errors.Wrapf(err, "downloading terraform version %s at %q", v.String(), fullSrcURL)
+		}
+
+		log.Info("downloaded terraform %s to %s", v.String(), dest)
+		versions[v.String()] = dest
+		return dest, nil
+	}
 }
 
 // generateRCFile generates a .terraformrc file containing config for tfeToken

--- a/server/core/terraform/terraform_client.go
+++ b/server/core/terraform/terraform_client.go
@@ -30,6 +30,7 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
+	"github.com/warrensbox/terraform-switcher/lib"
 
 	"github.com/runatlantis/atlantis/server/core/runtime/models"
 	"github.com/runatlantis/atlantis/server/events/command"
@@ -53,6 +54,8 @@ type Client interface {
 
 	// EnsureVersion makes sure that terraform version `v` is available to use
 	EnsureVersion(log logging.SimpleLogging, v *version.Version) error
+
+	ListAvailableVersions(log logging.SimpleLogging) ([]string, error)
 }
 
 type DefaultClient struct {
@@ -260,6 +263,14 @@ func (c *DefaultClient) DefaultVersion() *version.Version {
 // TerraformBinDir returns the directory where we download Terraform binaries.
 func (c *DefaultClient) TerraformBinDir() string {
 	return c.binDir
+}
+
+// ListAvailableVersions returns all available version of Terraform. If downloads are disabled, this will return an empty list.
+func (c *DefaultClient) ListAvailableVersions(log logging.SimpleLogging) ([]string, error) {
+	url := fmt.Sprintf("%s/terraform", c.downloadBaseURL)
+	log.Debug("Listing Terraform versions available at: %s", url)
+	versions, err := lib.GetTFList(url, true)
+	return versions, err
 }
 
 // See Client.EnsureVersion.

--- a/server/core/terraform/terraform_client.go
+++ b/server/core/terraform/terraform_client.go
@@ -465,21 +465,20 @@ func ensureVersion(log logging.SimpleLogging, dl Downloader, versions map[string
 	}
 	if downloadsDisabled {
 		return "", fmt.Errorf("could not find terraform version %s in PATH or %s, and downloads are disabled", v.String(), binDir)
-	} else {
-
-		log.Info("could not find terraform version %s in PATH or %s, downloading from %s", v.String(), binDir, downloadURL)
-		urlPrefix := fmt.Sprintf("%s/terraform/%s/terraform_%s", downloadURL, v.String(), v.String())
-		binURL := fmt.Sprintf("%s_%s_%s.zip", urlPrefix, runtime.GOOS, runtime.GOARCH)
-		checksumURL := fmt.Sprintf("%s_SHA256SUMS", urlPrefix)
-		fullSrcURL := fmt.Sprintf("%s?checksum=file:%s", binURL, checksumURL)
-		if err := dl.GetFile(dest, fullSrcURL); err != nil {
-			return "", errors.Wrapf(err, "downloading terraform version %s at %q", v.String(), fullSrcURL)
-		}
-
-		log.Info("downloaded terraform %s to %s", v.String(), dest)
-		versions[v.String()] = dest
-		return dest, nil
 	}
+
+	log.Info("could not find terraform version %s in PATH or %s, downloading from %s", v.String(), binDir, downloadURL)
+	urlPrefix := fmt.Sprintf("%s/terraform/%s/terraform_%s", downloadURL, v.String(), v.String())
+	binURL := fmt.Sprintf("%s_%s_%s.zip", urlPrefix, runtime.GOOS, runtime.GOARCH)
+	checksumURL := fmt.Sprintf("%s_SHA256SUMS", urlPrefix)
+	fullSrcURL := fmt.Sprintf("%s?checksum=file:%s", binURL, checksumURL)
+	if err := dl.GetFile(dest, fullSrcURL); err != nil {
+		return "", errors.Wrapf(err, "downloading terraform version %s at %q", v.String(), fullSrcURL)
+	}
+
+	log.Info("downloaded terraform %s to %s", v.String(), dest)
+	versions[v.String()] = dest
+	return dest, nil
 }
 
 // generateRCFile generates a .terraformrc file containing config for tfeToken

--- a/server/core/terraform/terraform_client.go
+++ b/server/core/terraform/terraform_client.go
@@ -18,6 +18,7 @@ package terraform
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -289,6 +290,13 @@ func (c *DefaultClient) ListAvailableVersions(log logging.SimpleLogging) ([]stri
 	}
 
 	log.Debug("Listing Terraform versions available at: %s", url)
+	// terraform-switcher calls os.Exit(1) if it fails to successfully GET the configured URL.
+	// So, before calling it, test if we can connect. Then we can return an error instead if the request fails.
+	resp, err := http.Get(url)
+	if err != nil || resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Unable to list Terraform versions: %s", err)
+	}
+
 	versions, err := lib.GetTFList(url, true)
 	return versions, err
 }

--- a/server/core/terraform/terraform_client.go
+++ b/server/core/terraform/terraform_client.go
@@ -290,11 +290,17 @@ func (c *DefaultClient) ListAvailableVersions(log logging.SimpleLogging) ([]stri
 	}
 
 	log.Debug("Listing Terraform versions available at: %s", url)
+
 	// terraform-switcher calls os.Exit(1) if it fails to successfully GET the configured URL.
 	// So, before calling it, test if we can connect. Then we can return an error instead if the request fails.
 	resp, err := http.Get(url) // #nosec G107 -- terraform-switch makes this same call below. Also, we don't process the response payload.
-	if err != nil || resp.StatusCode != 200 {
+	if err != nil {
 		return nil, fmt.Errorf("Unable to list Terraform versions: %s", err)
+	}
+	defer resp.Body.Close() // nolint: errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Unable to list Terraform versions: response code %d from %s", resp.StatusCode, url)
 	}
 
 	versions, err := lib.GetTFList(url, true)

--- a/server/core/terraform/terraform_client_test.go
+++ b/server/core/terraform/terraform_client_test.go
@@ -332,7 +332,7 @@ func TestEnsureVersion_downloaded_downloadingDisabled(t *testing.T) {
 	Ok(t, err)
 
 	err = c.EnsureVersion(logger, v)
-	ErrContains(t, "could not find terraform version", err)
+	ErrContains(t, "Could not find terraform version", err)
 	ErrContains(t, "downloads are disabled", err)
 	mockDownloader.VerifyWasCalled(Never())
 }

--- a/server/core/terraform/terraform_client_test.go
+++ b/server/core/terraform/terraform_client_test.go
@@ -487,7 +487,7 @@ terraform {
 			tmpDir := DirStructure(t, testCase.DirStructure)
 
 			for project, expectedVersion := range testCase.Exp {
-				detectedVersion := c.DetectVersion(filepath.Join(tmpDir, project), logger)
+				detectedVersion := c.DetectVersion(logger, filepath.Join(tmpDir, project))
 
 				expectNil := expectedVersion == "" || (!testCase.IsExact && !downloadsAllowed)
 				if expectNil {

--- a/server/core/terraform/terraform_client_test.go
+++ b/server/core/terraform/terraform_client_test.go
@@ -76,7 +76,7 @@ is 0.11.13. You can update by downloading from developer.hashicorp.com/terraform
 	Ok(t, err)
 	defer tempSetEnv(t, "PATH", fmt.Sprintf("%s:%s", tmp, os.Getenv("PATH")))()
 
-	c, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, nil, true, projectCmdOutputHandler)
+	c, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, nil, false, true, projectCmdOutputHandler)
 	Ok(t, err)
 
 	Ok(t, err)
@@ -110,7 +110,7 @@ is 0.11.13. You can update by downloading from developer.hashicorp.com/terraform
 	Ok(t, err)
 	defer tempSetEnv(t, "PATH", fmt.Sprintf("%s:%s", tmp, os.Getenv("PATH")))()
 
-	c, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, nil, true, projectCmdOutputHandler)
+	c, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, nil, false, true, projectCmdOutputHandler)
 	Ok(t, err)
 
 	Ok(t, err)
@@ -131,8 +131,8 @@ func TestNewClient_NoTF(t *testing.T) {
 	// Set PATH to only include our empty directory.
 	defer tempSetEnv(t, "PATH", tmp)()
 
-	_, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, nil, true, projectCmdOutputHandler)
-	ErrEquals(t, "terraform not found in $PATH. Set --default-tf-version or download terraform from https://developer.hashicorp.com/terraform/downloads", err)
+	_, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, nil, false, true, projectCmdOutputHandler)
+	ErrEquals(t, "terraform not found in $PATH. Set --default-tf-version or download terraform from https://www.terraform.io/downloads.html", err)
 }
 
 // Test that if the default-tf flag is set and that binary is in our PATH
@@ -154,7 +154,7 @@ func TestNewClient_DefaultTFFlagInPath(t *testing.T) {
 	Ok(t, err)
 	defer tempSetEnv(t, "PATH", fmt.Sprintf("%s:%s", tmp, os.Getenv("PATH")))()
 
-	c, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, nil, true, projectCmdOutputHandler)
+	c, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, nil, false, true, projectCmdOutputHandler)
 	Ok(t, err)
 
 	Ok(t, err)
@@ -182,7 +182,7 @@ func TestNewClient_DefaultTFFlagInBinDir(t *testing.T) {
 	Ok(t, err)
 	defer tempSetEnv(t, "PATH", fmt.Sprintf("%s:%s", tmp, os.Getenv("PATH")))()
 
-	c, err := terraform.NewClient(logging.NewNoopLogger(t), binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, nil, true, projectCmdOutputHandler)
+	c, err := terraform.NewClient(logging.NewNoopLogger(t), binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, nil, false, true, projectCmdOutputHandler)
 	Ok(t, err)
 
 	Ok(t, err)
@@ -214,7 +214,7 @@ func TestNewClient_DefaultTFFlagDownload(t *testing.T) {
 		err := os.WriteFile(params[0].(string), []byte("#!/bin/sh\necho '\nTerraform v0.11.10\n'"), 0700) // #nosec G306
 		return []pegomock.ReturnValue{err}
 	})
-	c, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, "https://my-mirror.releases.mycompany.com", mockDownloader, true, projectCmdOutputHandler)
+	c, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, "https://my-mirror.releases.mycompany.com", mockDownloader, false, true, projectCmdOutputHandler)
 	Ok(t, err)
 
 	Ok(t, err)
@@ -240,7 +240,7 @@ func TestNewClient_BadVersion(t *testing.T) {
 	logger := logging.NewNoopLogger(t)
 	_, binDir, cacheDir := mkSubDirs(t)
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
-	_, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "malformed", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, nil, true, projectCmdOutputHandler)
+	_, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "malformed", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, nil, false, true, projectCmdOutputHandler)
 	ErrEquals(t, "Malformed version: malformed", err)
 }
 
@@ -269,7 +269,7 @@ func TestRunCommandWithVersion_DLsTF(t *testing.T) {
 		return []pegomock.ReturnValue{err}
 	})
 
-	c, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, mockDownloader, true, projectCmdOutputHandler)
+	c, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, mockDownloader, false, true, projectCmdOutputHandler)
 	Ok(t, err)
 	Equals(t, "0.11.10", c.DefaultVersion().String())
 
@@ -291,7 +291,7 @@ func TestEnsureVersion_downloaded(t *testing.T) {
 
 	mockDownloader := mocks.NewMockDownloader()
 
-	c, err := terraform.NewTestClient(logger, binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, mockDownloader, true, projectCmdOutputHandler)
+	c, err := terraform.NewTestClient(logger, binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, mockDownloader, false, true, projectCmdOutputHandler)
 	Ok(t, err)
 
 	Equals(t, "0.11.10", c.DefaultVersion().String())

--- a/server/core/terraform/terraform_client_test.go
+++ b/server/core/terraform/terraform_client_test.go
@@ -76,7 +76,7 @@ is 0.11.13. You can update by downloading from developer.hashicorp.com/terraform
 	Ok(t, err)
 	defer tempSetEnv(t, "PATH", fmt.Sprintf("%s:%s", tmp, os.Getenv("PATH")))()
 
-	c, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, nil, false, true, projectCmdOutputHandler)
+	c, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, nil, true, true, projectCmdOutputHandler)
 	Ok(t, err)
 
 	Ok(t, err)
@@ -110,7 +110,7 @@ is 0.11.13. You can update by downloading from developer.hashicorp.com/terraform
 	Ok(t, err)
 	defer tempSetEnv(t, "PATH", fmt.Sprintf("%s:%s", tmp, os.Getenv("PATH")))()
 
-	c, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, nil, false, true, projectCmdOutputHandler)
+	c, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, nil, true, true, projectCmdOutputHandler)
 	Ok(t, err)
 
 	Ok(t, err)
@@ -131,7 +131,7 @@ func TestNewClient_NoTF(t *testing.T) {
 	// Set PATH to only include our empty directory.
 	defer tempSetEnv(t, "PATH", tmp)()
 
-	_, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, nil, false, true, projectCmdOutputHandler)
+	_, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, nil, true, true, projectCmdOutputHandler)
 	ErrEquals(t, "terraform not found in $PATH. Set --default-tf-version or download terraform from https://developer.hashicorp.com/terraform/downloads", err)
 }
 
@@ -182,7 +182,7 @@ func TestNewClient_DefaultTFFlagInBinDir(t *testing.T) {
 	Ok(t, err)
 	defer tempSetEnv(t, "PATH", fmt.Sprintf("%s:%s", tmp, os.Getenv("PATH")))()
 
-	c, err := terraform.NewClient(logging.NewNoopLogger(t), binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, nil, false, true, projectCmdOutputHandler)
+	c, err := terraform.NewClient(logging.NewNoopLogger(t), binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, nil, true, true, projectCmdOutputHandler)
 	Ok(t, err)
 
 	Ok(t, err)
@@ -214,7 +214,7 @@ func TestNewClient_DefaultTFFlagDownload(t *testing.T) {
 		err := os.WriteFile(params[0].(string), []byte("#!/bin/sh\necho '\nTerraform v0.11.10\n'"), 0700) // #nosec G306
 		return []pegomock.ReturnValue{err}
 	})
-	c, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, "https://my-mirror.releases.mycompany.com", mockDownloader, false, true, projectCmdOutputHandler)
+	c, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, "https://my-mirror.releases.mycompany.com", mockDownloader, true, true, projectCmdOutputHandler)
 	Ok(t, err)
 
 	Ok(t, err)
@@ -240,7 +240,7 @@ func TestNewClient_BadVersion(t *testing.T) {
 	logger := logging.NewNoopLogger(t)
 	_, binDir, cacheDir := mkSubDirs(t)
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
-	_, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "malformed", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, nil, false, true, projectCmdOutputHandler)
+	_, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "malformed", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, nil, true, true, projectCmdOutputHandler)
 	ErrEquals(t, "Malformed version: malformed", err)
 }
 
@@ -269,7 +269,7 @@ func TestRunCommandWithVersion_DLsTF(t *testing.T) {
 		return []pegomock.ReturnValue{err}
 	})
 
-	c, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, mockDownloader, false, true, projectCmdOutputHandler)
+	c, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, mockDownloader, true, true, projectCmdOutputHandler)
 	Ok(t, err)
 	Equals(t, "0.11.10", c.DefaultVersion().String())
 
@@ -290,8 +290,8 @@ func TestEnsureVersion_downloaded(t *testing.T) {
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 
 	mockDownloader := mocks.NewMockDownloader()
-
-	c, err := terraform.NewTestClient(logger, binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, mockDownloader, false, true, projectCmdOutputHandler)
+	downloadsAllowed := true
+	c, err := terraform.NewTestClient(logger, binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, mockDownloader, downloadsAllowed, true, projectCmdOutputHandler)
 	Ok(t, err)
 
 	Equals(t, "0.11.10", c.DefaultVersion().String())
@@ -321,8 +321,8 @@ func TestEnsureVersion_downloaded_downloadingDisabled(t *testing.T) {
 
 	mockDownloader := mocks.NewMockDownloader()
 
-	disableDownloads := true
-	c, err := terraform.NewTestClient(logger, binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, mockDownloader, disableDownloads, true, projectCmdOutputHandler)
+	downloadsAllowed := false
+	c, err := terraform.NewTestClient(logger, binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, mockDownloader, downloadsAllowed, true, projectCmdOutputHandler)
 	Ok(t, err)
 
 	Equals(t, "0.11.10", c.DefaultVersion().String())

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -10,6 +10,7 @@ import (
 	"github.com/uber-go/tally"
 
 	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/core/terraform"
 	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/metrics"
 
@@ -54,6 +55,7 @@ func NewInstrumentedProjectCommandBuilder(
 	RestrictFileList bool,
 	scope tally.Scope,
 	logger logging.SimpleLogging,
+	terraformClient terraform.Client,
 ) *InstrumentedProjectCommandBuilder {
 	scope = scope.SubScope("builder")
 
@@ -79,6 +81,7 @@ func NewInstrumentedProjectCommandBuilder(
 			RestrictFileList,
 			scope,
 			logger,
+			terraformClient,
 		),
 		Logger: logger,
 		scope:  scope,
@@ -102,6 +105,7 @@ func NewProjectCommandBuilder(
 	RestrictFileList bool,
 	scope tally.Scope,
 	logger logging.SimpleLogging,
+	terraformClient terraform.Client,
 ) *DefaultProjectCommandBuilder {
 	return &DefaultProjectCommandBuilder{
 		ParserValidator:       parserValidator,
@@ -121,6 +125,7 @@ func NewProjectCommandBuilder(
 			commentBuilder,
 			scope,
 		),
+		TerraformExecutor: terraformClient,
 	}
 }
 
@@ -181,6 +186,7 @@ type DefaultProjectCommandBuilder struct {
 	AutoplanFileList             string
 	EnableDiffMarkdownFormat     bool
 	RestrictFileList             bool
+	TerraformExecutor            terraform.Client
 }
 
 // See ProjectCommandBuilder.BuildAutoplanCommands.
@@ -330,6 +336,7 @@ func (p *DefaultProjectCommandBuilder) buildPlanAllCommands(ctx *command.Context
 					repoCfg.ParallelApply,
 					repoCfg.ParallelPlan,
 					verbose,
+					p.TerraformExecutor,
 				)...)
 		}
 	} else {
@@ -367,6 +374,7 @@ func (p *DefaultProjectCommandBuilder) buildPlanAllCommands(ctx *command.Context
 					DefaultParallelApplyEnabled,
 					DefaultParallelPlanEnabled,
 					verbose,
+					p.TerraformExecutor,
 				)...)
 		}
 	}
@@ -701,6 +709,7 @@ func (p *DefaultProjectCommandBuilder) buildProjectCommandCtx(ctx *command.Conte
 					parallelApply,
 					parallelPlan,
 					verbose,
+					p.TerraformExecutor,
 				)...)
 		}
 	} else {
@@ -716,6 +725,7 @@ func (p *DefaultProjectCommandBuilder) buildProjectCommandCtx(ctx *command.Conte
 				parallelApply,
 				parallelPlan,
 				verbose,
+				p.TerraformExecutor,
 			)...)
 	}
 

--- a/server/events/project_command_builder_internal_test.go
+++ b/server/events/project_command_builder_internal_test.go
@@ -7,9 +7,9 @@ import (
 
 	version "github.com/hashicorp/go-version"
 	. "github.com/petergtz/pegomock"
-
 	"github.com/runatlantis/atlantis/server/core/config"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/core/terraform/mocks"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/matchers"
 	"github.com/runatlantis/atlantis/server/events/models"
@@ -621,6 +621,8 @@ projects:
 				Ok(t, os.WriteFile(filepath.Join(tmp, "atlantis.yaml"), []byte(c.repoCfg), 0600))
 			}
 
+			terraformClient := mocks.NewMockClient()
+
 			builder := NewProjectCommandBuilder(
 				false,
 				parser,
@@ -638,6 +640,7 @@ projects:
 				false,
 				statsScope,
 				logger,
+				terraformClient,
 			)
 
 			// We run a test for each type of command.
@@ -825,6 +828,8 @@ projects:
 			logger := logging.NewNoopLogger(t)
 			statsScope, _, _ := metrics.NewLoggingScope(logging.NewNoopLogger(t), "atlantis")
 
+			terraformClient := mocks.NewMockClient()
+
 			builder := NewProjectCommandBuilder(
 				false,
 				parser,
@@ -842,6 +847,7 @@ projects:
 				false,
 				statsScope,
 				logger,
+				terraformClient,
 			)
 
 			// We run a test for each type of command, again specific projects
@@ -1058,6 +1064,8 @@ workflows:
 			}
 			statsScope, _, _ := metrics.NewLoggingScope(logging.NewNoopLogger(t), "atlantis")
 
+			terraformClient := mocks.NewMockClient()
+
 			builder := NewProjectCommandBuilder(
 				true,
 				parser,
@@ -1075,6 +1083,7 @@ workflows:
 				false,
 				statsScope,
 				logger,
+				terraformClient,
 			)
 
 			cmd := command.PolicyCheck

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -1199,7 +1199,6 @@ projects:
 			}
 
 			terraformClient := terraform_mocks.NewMockClient()
-
 			When(terraformClient.DetectVersion(matchers.AnyLoggingSimpleLogging(), AnyString())).Then(func(params []Param) ReturnValues {
 				projectName := filepath.Base(params[1].(string))
 				testVersion := testCase.Exp[projectName]
@@ -1246,7 +1245,7 @@ projects:
 			Equals(t, len(testCase.Exp), len(actCtxs))
 			for _, actCtx := range actCtxs {
 				if testCase.Exp[actCtx.RepoRelDir] != "" {
-					Assert(t, actCtx.TerraformVersion != nil, "TerraformVersion is nil.")
+					Assert(t, actCtx.TerraformVersion != nil, "TerraformVersion is nil, not %s for %s", testCase.Exp[actCtx.RepoRelDir], actCtx.RepoRelDir)
 					Equals(t, testCase.Exp[actCtx.RepoRelDir], actCtx.TerraformVersion.String())
 				} else {
 					Assert(t, actCtx.TerraformVersion == nil, "TerraformVersion is supposed to be nil.")

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -125,6 +125,7 @@ projects:
 	scope, _, _ := metrics.NewLoggingScope(logger, "atlantis")
 
 	terraformClient := terraform_mocks.NewMockClient()
+	When(terraformClient.ListAvailableVersions(matchers.AnyLoggingSimpleLogging())).ThenReturn([]string{}, nil)
 
 	for _, c := range cases {
 		t.Run(c.Description, func(t *testing.T) {
@@ -420,6 +421,7 @@ projects:
 				}
 
 				terraformClient := terraform_mocks.NewMockClient()
+				When(terraformClient.ListAvailableVersions(matchers.AnyLoggingSimpleLogging())).ThenReturn([]string{}, nil)
 
 				builder := events.NewProjectCommandBuilder(
 					false,
@@ -596,6 +598,7 @@ projects:
 			}
 
 			terraformClient := terraform_mocks.NewMockClient()
+			When(terraformClient.ListAvailableVersions(matchers.AnyLoggingSimpleLogging())).ThenReturn([]string{}, nil)
 
 			builder := events.NewProjectCommandBuilder(
 				false,
@@ -769,6 +772,7 @@ projects:
 			}
 
 			terraformClient := terraform_mocks.NewMockClient()
+			When(terraformClient.ListAvailableVersions(matchers.AnyLoggingSimpleLogging())).ThenReturn([]string{}, nil)
 
 			builder := events.NewProjectCommandBuilder(
 				false,
@@ -864,6 +868,7 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply(t *testing.T) {
 	scope, _, _ := metrics.NewLoggingScope(logger, "atlantis")
 
 	terraformClient := terraform_mocks.NewMockClient()
+	When(terraformClient.ListAvailableVersions(matchers.AnyLoggingSimpleLogging())).ThenReturn([]string{}, nil)
 
 	builder := events.NewProjectCommandBuilder(
 		false,
@@ -952,6 +957,7 @@ projects:
 	logger := logging.NewNoopLogger(t)
 	scope, _, _ := metrics.NewLoggingScope(logger, "atlantis")
 	terraformClient := terraform_mocks.NewMockClient()
+	When(terraformClient.ListAvailableVersions(matchers.AnyLoggingSimpleLogging())).ThenReturn([]string{}, nil)
 
 	builder := events.NewProjectCommandBuilder(
 		false,
@@ -1035,6 +1041,7 @@ func TestDefaultProjectCommandBuilder_EscapeArgs(t *testing.T) {
 			}
 
 			terraformClient := terraform_mocks.NewMockClient()
+			When(terraformClient.ListAvailableVersions(matchers.AnyLoggingSimpleLogging())).ThenReturn([]string{}, nil)
 
 			builder := events.NewProjectCommandBuilder(
 				false,
@@ -1241,7 +1248,229 @@ projects:
 				ApprovedReq:   false,
 				UnDivergedReq: false,
 			}
+
+			var versions []string
+			for i := 0; i < 32; i++ {
+				versions = append(versions, fmt.Sprintf("0.12.%d", i))
+			}
 			terraformClient := terraform_mocks.NewMockClient()
+			When(terraformClient.ListAvailableVersions(matchers.AnyLoggingSimpleLogging())).ThenReturn(versions, nil)
+
+			builder := events.NewProjectCommandBuilder(
+				false,
+				&config.ParserValidator{},
+				&events.DefaultProjectFinder{},
+				vcsClient,
+				workingDir,
+				events.NewDefaultWorkingDirLocker(),
+				valid.NewGlobalCfgFromArgs(globalCfgArgs),
+				&events.DefaultPendingPlanFinder{},
+				&events.CommentParser{ExecutableName: "atlantis"},
+				false,
+				false,
+				"",
+				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl",
+				false,
+				scope,
+				logger,
+				terraformClient,
+			)
+
+			actCtxs, err := builder.BuildPlanCommands(
+				&command.Context{
+					Log:   logger,
+					Scope: scope,
+				},
+				&events.CommentCommand{
+					RepoRelDir: "",
+					Flags:      nil,
+					Name:       command.Plan,
+					Verbose:    false,
+				})
+
+			Ok(t, err)
+			Equals(t, len(testCase.Exp), len(actCtxs))
+			for _, actCtx := range actCtxs {
+				if testCase.Exp[actCtx.RepoRelDir] != nil {
+					Assert(t, actCtx.TerraformVersion != nil, "TerraformVersion is nil.")
+					Equals(t, testCase.Exp[actCtx.RepoRelDir], actCtx.TerraformVersion.Segments())
+				} else {
+					Assert(t, actCtx.TerraformVersion == nil, "TerraformVersion is supposed to be nil.")
+				}
+			}
+		})
+	}
+}
+
+// If TF downloads are disabled, test that terraform version is used when specified in terraform configuration only if an exact version
+func TestDefaultProjectCommandBuilder_TerraformVersion_DownloadsDisabled(t *testing.T) {
+	// For the following tests:
+	// If terraform configuration is used, result should be `0.12.8`.
+	// If project configuration is used, result should be `0.12.6`.
+	// If an inexact version is used, the result should be `nil`
+	// If default is to be used, result should be `nil`.
+
+	baseVersionConfig := `
+terraform {
+  required_version = "%s0.12.8"
+}
+`
+
+	atlantisYamlContent := `
+version: 3
+projects:
+- dir: project1 # project1 uses the defaults
+  terraform_version: v0.12.6
+`
+
+	exactSymbols := []string{"", "="}
+	// Depending on when the tests are run, the > and >= matching versions will have to be increased.
+	// It's probably not worth testing the terraform-switcher version here so we only test <, <=, and ~>.
+	// One way to test this in the future is to mock tfswitcher.GetTFList() to return the highest
+	// version of 1.3.5.
+	// nonExactSymbols := []string{">", ">=", "<", "<=", "~>"}
+	nonExactSymbols := []string{"<", "<=", "~>"}
+	nonExactVersions := map[string]map[string][]int{
+		// ">": {
+		// 	"project1": nil,
+		// },
+		// ">=": {
+		// 	"project1": nil,
+		// },
+		"<": {
+			"project1": nil,
+		},
+		"<=": {
+			"project1": nil,
+		},
+		"~>": {
+			"project1": nil,
+		},
+	}
+
+	type testCase struct {
+		DirStructure  map[string]interface{}
+		AtlantisYAML  string
+		ModifiedFiles []string
+		Exp           map[string][]int
+	}
+
+	testCases := make(map[string]testCase)
+
+	for _, exactSymbol := range exactSymbols {
+		testCases[fmt.Sprintf("exact version in terraform config using \"%s\"", exactSymbol)] = testCase{
+			DirStructure: map[string]interface{}{
+				"project1": map[string]interface{}{
+					"main.tf": fmt.Sprintf(baseVersionConfig, exactSymbol),
+				},
+			},
+			ModifiedFiles: []string{"project1/main.tf"},
+			Exp: map[string][]int{
+				"project1": {0, 12, 8},
+			},
+		}
+	}
+
+	for _, nonExactSymbol := range nonExactSymbols {
+		testCases[fmt.Sprintf("non-exact version in terraform config using \"%s\"", nonExactSymbol)] = testCase{
+			DirStructure: map[string]interface{}{
+				"project1": map[string]interface{}{
+					"main.tf": fmt.Sprintf(baseVersionConfig, nonExactSymbol),
+				},
+			},
+			ModifiedFiles: []string{"project1/main.tf"},
+			Exp:           nonExactVersions[nonExactSymbol],
+		}
+	}
+
+	// atlantis.yaml should take precedence over terraform config
+	testCases["with project config and terraform config"] = testCase{
+		DirStructure: map[string]interface{}{
+			"project1": map[string]interface{}{
+				"main.tf": fmt.Sprintf(baseVersionConfig, exactSymbols[0]),
+			},
+			valid.DefaultAtlantisFile: atlantisYamlContent,
+		},
+		ModifiedFiles: []string{"project1/main.tf", "project2/main.tf"},
+		Exp: map[string][]int{
+			"project1": {0, 12, 6},
+		},
+	}
+
+	testCases["with project config only"] = testCase{
+		DirStructure: map[string]interface{}{
+			"project1": map[string]interface{}{
+				"main.tf": nil,
+			},
+			valid.DefaultAtlantisFile: atlantisYamlContent,
+		},
+		ModifiedFiles: []string{"project1/main.tf"},
+		Exp: map[string][]int{
+			"project1": {0, 12, 6},
+		},
+	}
+
+	testCases["neither project config or terraform config"] = testCase{
+		DirStructure: map[string]interface{}{
+			"project1": map[string]interface{}{
+				"main.tf": nil,
+			},
+		},
+		ModifiedFiles: []string{"project1/main.tf", "project2/main.tf"},
+		Exp: map[string][]int{
+			"project1": nil,
+		},
+	}
+
+	testCases["project with different terraform config"] = testCase{
+		DirStructure: map[string]interface{}{
+			"project1": map[string]interface{}{
+				"main.tf": fmt.Sprintf(baseVersionConfig, exactSymbols[0]),
+			},
+			"project2": map[string]interface{}{
+				"main.tf": strings.Replace(fmt.Sprintf(baseVersionConfig, exactSymbols[0]), "0.12.8", "0.12.9", -1),
+			},
+		},
+		ModifiedFiles: []string{"project1/main.tf", "project2/main.tf"},
+		Exp: map[string][]int{
+			"project1": {0, 12, 8},
+			"project2": {0, 12, 9},
+		},
+	}
+
+	logger := logging.NewNoopLogger(t)
+	scope, _, _ := metrics.NewLoggingScope(logger, "atlantis")
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			RegisterMockTestingT(t)
+
+			tmpDir := DirStructure(t, testCase.DirStructure)
+
+			vcsClient := vcsmocks.NewMockClient()
+			When(vcsClient.GetModifiedFiles(matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest())).ThenReturn(testCase.ModifiedFiles, nil)
+
+			workingDir := mocks.NewMockWorkingDir()
+			When(workingDir.Clone(
+				matchers.AnyPtrToLoggingSimpleLogger(),
+				matchers.AnyModelsRepo(),
+				matchers.AnyModelsPullRequest(),
+				AnyString())).ThenReturn(tmpDir, false, nil)
+
+			When(workingDir.GetWorkingDir(
+				matchers.AnyModelsRepo(),
+				matchers.AnyModelsPullRequest(),
+				AnyString())).ThenReturn(tmpDir, nil)
+
+			globalCfgArgs := valid.GlobalCfgArgs{
+				AllowRepoCfg:  true,
+				MergeableReq:  false,
+				ApprovedReq:   false,
+				UnDivergedReq: false,
+			}
+
+			terraformClient := terraform_mocks.NewMockClient()
+			When(terraformClient.ListAvailableVersions(matchers.AnyLoggingSimpleLogging())).ThenReturn([]string{}, nil)
 
 			builder := events.NewProjectCommandBuilder(
 				false,
@@ -1334,6 +1563,7 @@ parallel_plan: true`,
 		}
 		scope, _, _ := metrics.NewLoggingScope(logger, "atlantis")
 		terraformClient := terraform_mocks.NewMockClient()
+		When(terraformClient.ListAvailableVersions(matchers.AnyLoggingSimpleLogging())).ThenReturn([]string{}, nil)
 
 		builder := events.NewProjectCommandBuilder(
 			false,
@@ -1396,6 +1626,7 @@ func TestDefaultProjectCommandBuilder_WithPolicyCheckEnabled_BuildAutoplanComman
 
 	globalCfg := valid.NewGlobalCfgFromArgs(globalCfgArgs)
 	terraformClient := terraform_mocks.NewMockClient()
+	When(terraformClient.ListAvailableVersions(matchers.AnyLoggingSimpleLogging())).ThenReturn([]string{}, nil)
 
 	builder := events.NewProjectCommandBuilder(
 		true,
@@ -1481,6 +1712,7 @@ func TestDefaultProjectCommandBuilder_BuildVersionCommand(t *testing.T) {
 		UnDivergedReq: false,
 	}
 	terraformClient := terraform_mocks.NewMockClient()
+	When(terraformClient.ListAvailableVersions(matchers.AnyLoggingSimpleLogging())).ThenReturn([]string{}, nil)
 
 	builder := events.NewProjectCommandBuilder(
 		false,

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -1200,8 +1200,8 @@ projects:
 
 			terraformClient := terraform_mocks.NewMockClient()
 
-			When(terraformClient.DetectVersion(AnyString(), matchers.AnyLoggingSimpleLogging())).Then(func(params []Param) ReturnValues {
-				projectName := filepath.Base(params[0].(string))
+			When(terraformClient.DetectVersion(matchers.AnyLoggingSimpleLogging(), AnyString())).Then(func(params []Param) ReturnValues {
+				projectName := filepath.Base(params[1].(string))
 				testVersion := testCase.Exp[projectName]
 				if testVersion != "" {
 					v, _ := version.NewVersion(testVersion)

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	. "github.com/petergtz/pegomock"
+	terraform_mocks "github.com/runatlantis/atlantis/server/core/terraform/mocks"
 
 	"github.com/runatlantis/atlantis/server/core/config"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
@@ -123,6 +124,8 @@ projects:
 	logger := logging.NewNoopLogger(t)
 	scope, _, _ := metrics.NewLoggingScope(logger, "atlantis")
 
+	terraformClient := terraform_mocks.NewMockClient()
+
 	for _, c := range cases {
 		t.Run(c.Description, func(t *testing.T) {
 			RegisterMockTestingT(t)
@@ -163,6 +166,7 @@ projects:
 				false,
 				scope,
 				logger,
+				terraformClient,
 			)
 
 			ctxs, err := builder.BuildAutoplanCommands(&command.Context{
@@ -415,6 +419,8 @@ projects:
 					UnDivergedReq: false,
 				}
 
+				terraformClient := terraform_mocks.NewMockClient()
+
 				builder := events.NewProjectCommandBuilder(
 					false,
 					&config.ParserValidator{},
@@ -432,6 +438,7 @@ projects:
 					false,
 					scope,
 					logger,
+					terraformClient,
 				)
 
 				var actCtxs []command.ProjectContext
@@ -588,6 +595,8 @@ projects:
 				UnDivergedReq: false,
 			}
 
+			terraformClient := terraform_mocks.NewMockClient()
+
 			builder := events.NewProjectCommandBuilder(
 				false,
 				&config.ParserValidator{},
@@ -605,6 +614,7 @@ projects:
 				true,
 				scope,
 				logger,
+				terraformClient,
 			)
 
 			var actCtxs []command.ProjectContext
@@ -758,6 +768,8 @@ projects:
 				UnDivergedReq: false,
 			}
 
+			terraformClient := terraform_mocks.NewMockClient()
+
 			builder := events.NewProjectCommandBuilder(
 				false,
 				&config.ParserValidator{},
@@ -775,6 +787,7 @@ projects:
 				false,
 				scope,
 				logger,
+				terraformClient,
 			)
 
 			ctxs, err := builder.BuildPlanCommands(
@@ -850,6 +863,8 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply(t *testing.T) {
 	}
 	scope, _, _ := metrics.NewLoggingScope(logger, "atlantis")
 
+	terraformClient := terraform_mocks.NewMockClient()
+
 	builder := events.NewProjectCommandBuilder(
 		false,
 		&config.ParserValidator{},
@@ -867,6 +882,7 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply(t *testing.T) {
 		false,
 		scope,
 		logger,
+		terraformClient,
 	)
 
 	ctxs, err := builder.BuildApplyCommands(
@@ -935,6 +951,7 @@ projects:
 	}
 	logger := logging.NewNoopLogger(t)
 	scope, _, _ := metrics.NewLoggingScope(logger, "atlantis")
+	terraformClient := terraform_mocks.NewMockClient()
 
 	builder := events.NewProjectCommandBuilder(
 		false,
@@ -953,6 +970,7 @@ projects:
 		false,
 		scope,
 		logger,
+		terraformClient,
 	)
 
 	ctx := &command.Context{
@@ -1016,6 +1034,8 @@ func TestDefaultProjectCommandBuilder_EscapeArgs(t *testing.T) {
 				UnDivergedReq: false,
 			}
 
+			terraformClient := terraform_mocks.NewMockClient()
+
 			builder := events.NewProjectCommandBuilder(
 				false,
 				&config.ParserValidator{},
@@ -1033,6 +1053,7 @@ func TestDefaultProjectCommandBuilder_EscapeArgs(t *testing.T) {
 				false,
 				scope,
 				logger,
+				terraformClient,
 			)
 
 			var actCtxs []command.ProjectContext
@@ -1220,6 +1241,7 @@ projects:
 				ApprovedReq:   false,
 				UnDivergedReq: false,
 			}
+			terraformClient := terraform_mocks.NewMockClient()
 
 			builder := events.NewProjectCommandBuilder(
 				false,
@@ -1238,6 +1260,7 @@ projects:
 				false,
 				scope,
 				logger,
+				terraformClient,
 			)
 
 			actCtxs, err := builder.BuildPlanCommands(
@@ -1310,6 +1333,7 @@ parallel_plan: true`,
 			UnDivergedReq: false,
 		}
 		scope, _, _ := metrics.NewLoggingScope(logger, "atlantis")
+		terraformClient := terraform_mocks.NewMockClient()
 
 		builder := events.NewProjectCommandBuilder(
 			false,
@@ -1328,6 +1352,7 @@ parallel_plan: true`,
 			false,
 			scope,
 			logger,
+			terraformClient,
 		)
 
 		var actCtxs []command.ProjectContext
@@ -1370,6 +1395,7 @@ func TestDefaultProjectCommandBuilder_WithPolicyCheckEnabled_BuildAutoplanComman
 	}
 
 	globalCfg := valid.NewGlobalCfgFromArgs(globalCfgArgs)
+	terraformClient := terraform_mocks.NewMockClient()
 
 	builder := events.NewProjectCommandBuilder(
 		true,
@@ -1388,6 +1414,7 @@ func TestDefaultProjectCommandBuilder_WithPolicyCheckEnabled_BuildAutoplanComman
 		false,
 		scope,
 		logger,
+		terraformClient,
 	)
 
 	ctxs, err := builder.BuildAutoplanCommands(&command.Context{
@@ -1453,6 +1480,7 @@ func TestDefaultProjectCommandBuilder_BuildVersionCommand(t *testing.T) {
 		ApprovedReq:   false,
 		UnDivergedReq: false,
 	}
+	terraformClient := terraform_mocks.NewMockClient()
 
 	builder := events.NewProjectCommandBuilder(
 		false,
@@ -1471,6 +1499,7 @@ func TestDefaultProjectCommandBuilder_BuildVersionCommand(t *testing.T) {
 		false,
 		scope,
 		logger,
+		terraformClient,
 	)
 
 	ctxs, err := builder.BuildVersionCommands(

--- a/server/events/project_command_context_builder.go
+++ b/server/events/project_command_context_builder.go
@@ -284,29 +284,6 @@ func escapeArgs(args []string) []string {
 	return escaped
 }
 
-/*
-    if len(module.RequiredCore) != 1 {
-		ctx.Log.Info("cannot determine which version to use from terraform configuration, detected %d possibilities.", len(module.RequiredCore))
-		return nil
-	}
-	requiredVersionSetting := module.RequiredCore[0]
-
-	// We allow `= x.y.z`, `=x.y.z` or `x.y.z` where `x`, `y` and `z` are integers.
-	re := regexp.MustCompile(`^=?\s*([^\s]+)\s*$`)
-	matched := re.FindStringSubmatch(requiredVersionSetting)
-	if len(matched) == 0 {
-		ctx.Log.Debug("did not specify exact version in terraform configuration, found %q", requiredVersionSetting)
-		return nil
-	}
-	ctx.Log.Debug("found required_version setting of %q", requiredVersionSetting)
-	version, err := version.NewVersion(matched[1])
-	if err != nil {
-		ctx.Log.Debug(err.Error())
-		return nil
-	}
-
-*/
-
 // Extracts required_version from Terraform configuration.
 // Returns nil if unable to determine version from configuration.
 func getTfVersion(ctx *command.Context, terraformClient terraform.Client, absProjDir string) *version.Version {

--- a/server/events/project_command_context_builder.go
+++ b/server/events/project_command_context_builder.go
@@ -108,7 +108,7 @@ func (cb *DefaultProjectCommandContextBuilder) BuildProjectContext(
 	// If TerraformVersion not defined in config file look for a
 	// terraform.require_version block.
 	if prjCfg.TerraformVersion == nil {
-		prjCfg.TerraformVersion = terraformClient.DetectVersion(filepath.Join(repoDir, prjCfg.RepoRelDir), ctx.Log)
+		prjCfg.TerraformVersion = terraformClient.DetectVersion(ctx.Log, filepath.Join(repoDir, prjCfg.RepoRelDir))
 	}
 
 	projectCmdContext := newProjectCommandContext(
@@ -152,7 +152,7 @@ func (cb *PolicyCheckProjectCommandContextBuilder) BuildProjectContext(
 	// If TerraformVersion not defined in config file look for a
 	// terraform.require_version block.
 	if prjCfg.TerraformVersion == nil {
-		prjCfg.TerraformVersion = terraformClient.DetectVersion(filepath.Join(repoDir, prjCfg.RepoRelDir), ctx.Log)
+		prjCfg.TerraformVersion = terraformClient.DetectVersion(ctx.Log, filepath.Join(repoDir, prjCfg.RepoRelDir))
 	}
 
 	projectCmds = cb.ProjectCommandContextBuilder.BuildProjectContext(

--- a/server/events/project_command_context_builder.go
+++ b/server/events/project_command_context_builder.go
@@ -330,7 +330,7 @@ func getTfVersion(ctx *command.Context, terraformClient terraform.Client, absPro
 	if len(tfVersions) == 0 {
 		// Fall back to an exact required version string
 		// We allow `= x.y.z`, `=x.y.z` or `x.y.z` where `x`, `y` and `z` are integers.
-		re := regexp.MustCompile(`^=?\s*([^\s]+)\s*$`)
+		re := regexp.MustCompile(`^=?\s*([0-9.]+)\s*$`)
 		matched := re.FindStringSubmatch(requiredVersionSetting)
 		if len(matched) == 0 {
 			ctx.Log.Debug("Did not specify exact version in terraform configuration, found %q", requiredVersionSetting)

--- a/server/events/project_command_context_builder_test.go
+++ b/server/events/project_command_context_builder_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/petergtz/pegomock"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
+	terraform_mocks "github.com/runatlantis/atlantis/server/core/terraform/mocks"
 	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/mocks"
@@ -46,6 +47,9 @@ func TestProjectCommandContextBuilder_PullStatus(t *testing.T) {
 	expectedApplyCmt := "Apply Comment"
 	expectedPlanCmt := "Plan Comment"
 
+	terraformClient := terraform_mocks.NewMockClient()
+	When(terraformClient.ListAvailableVersions(commandCtx.Log))
+
 	t.Run("with project name defined", func(t *testing.T) {
 		When(mockCommentBuilder.BuildPlanComment(projRepoRelDir, projWorkspace, projName, []string{})).ThenReturn(expectedPlanCmt)
 		When(mockCommentBuilder.BuildApplyComment(projRepoRelDir, projWorkspace, projName, false)).ThenReturn(expectedApplyCmt)
@@ -58,7 +62,7 @@ func TestProjectCommandContextBuilder_PullStatus(t *testing.T) {
 			},
 		}
 
-		result := subject.BuildProjectContext(commandCtx, command.Plan, projCfg, []string{}, "some/dir", false, false, false, false)
+		result := subject.BuildProjectContext(commandCtx, command.Plan, projCfg, []string{}, "some/dir", false, false, false, false, terraformClient)
 		assert.Equal(t, models.ErroredPolicyCheckStatus, result[0].ProjectPlanStatus)
 	})
 
@@ -77,7 +81,7 @@ func TestProjectCommandContextBuilder_PullStatus(t *testing.T) {
 			},
 		}
 
-		result := subject.BuildProjectContext(commandCtx, command.Plan, projCfg, []string{}, "some/dir", false, false, false, false)
+		result := subject.BuildProjectContext(commandCtx, command.Plan, projCfg, []string{}, "some/dir", false, false, false, false, terraformClient)
 
 		assert.Equal(t, models.ErroredPolicyCheckStatus, result[0].ProjectPlanStatus)
 	})
@@ -97,7 +101,7 @@ func TestProjectCommandContextBuilder_PullStatus(t *testing.T) {
 			},
 		}
 
-		result := subject.BuildProjectContext(commandCtx, command.Plan, projCfg, []string{}, "some/dir", false, true, false, false)
+		result := subject.BuildProjectContext(commandCtx, command.Plan, projCfg, []string{}, "some/dir", false, true, false, false, terraformClient)
 
 		assert.True(t, result[0].ParallelApplyEnabled)
 		assert.False(t, result[0].ParallelPlanEnabled)

--- a/server/server.go
+++ b/server/server.go
@@ -393,7 +393,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		config.DefaultTFVersionFlag,
 		userConfig.TFDownloadURL,
 		&terraform.DefaultDownloader{},
-		userConfig.TFDisableDownloads,
+		userConfig.TFDownload,
 		true,
 		projectCmdOutputHandler)
 	// The flag.Lookup call is to detect if we're running in a unit test. If we

--- a/server/server.go
+++ b/server/server.go
@@ -557,6 +557,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		userConfig.RestrictFileList,
 		statsScope,
 		logger,
+		terraformClient,
 	)
 
 	showStepRunner, err := runtime.NewShowStepRunner(terraformClient, defaultTfVersion)

--- a/server/server.go
+++ b/server/server.go
@@ -393,6 +393,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		config.DefaultTFVersionFlag,
 		userConfig.TFDownloadURL,
 		&terraform.DefaultDownloader{},
+		userConfig.TFDisableDownloads,
 		true,
 		projectCmdOutputHandler)
 	// The flag.Lookup call is to detect if we're running in a unit test. If we

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -100,7 +100,7 @@ type UserConfig struct {
 	SSLKeyFile             string          `mapstructure:"ssl-key-file"`
 	RestrictFileList       bool            `mapstructure:"restrict-file-list"`
 	TFDownloadURL          string          `mapstructure:"tf-download-url"`
-	TFDisableDownloads     bool            `mapstructure:"tf-disable-downloads""`
+	TFDisableDownloads     bool            `mapstructure:"tf-disable-downloads"`
 	TFEHostname            string          `mapstructure:"tfe-hostname"`
 	TFELocalExecutionMode  bool            `mapstructure:"tfe-local-execution-mode"`
 	TFEToken               string          `mapstructure:"tfe-token"`

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -100,6 +100,7 @@ type UserConfig struct {
 	SSLKeyFile             string          `mapstructure:"ssl-key-file"`
 	RestrictFileList       bool            `mapstructure:"restrict-file-list"`
 	TFDownloadURL          string          `mapstructure:"tf-download-url"`
+	TFDisableDownloads     bool            `mapstructure:"tf-disable-downloads""`
 	TFEHostname            string          `mapstructure:"tfe-hostname"`
 	TFELocalExecutionMode  bool            `mapstructure:"tfe-local-execution-mode"`
 	TFEToken               string          `mapstructure:"tfe-token"`

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -99,8 +99,8 @@ type UserConfig struct {
 	SSLCertFile            string          `mapstructure:"ssl-cert-file"`
 	SSLKeyFile             string          `mapstructure:"ssl-key-file"`
 	RestrictFileList       bool            `mapstructure:"restrict-file-list"`
+	TFDownload             bool            `mapstructure:"tf-download"`
 	TFDownloadURL          string          `mapstructure:"tf-download-url"`
-	TFDisableDownloads     bool            `mapstructure:"tf-disable-downloads"`
 	TFEHostname            string          `mapstructure:"tfe-hostname"`
 	TFELocalExecutionMode  bool            `mapstructure:"tfe-local-execution-mode"`
 	TFEToken               string          `mapstructure:"tfe-token"`


### PR DESCRIPTION
## what

- Move the TF version listing logic into `terraform_client.go`
- Add flag to enable or disable TF version listing & TF downloads
- Reuse tf download url

## why
- Moved logic so it can leverage the existing `--tf-download-url` configuration option
- If unable to list TF versions, fall back to the previous exact version regex to extract the version.

From #2701, this does **not** address the `os.Exit()` calls in https://github.com/warrensbox/terraform-switcher/blob/107631ffa4108d172909149d295c64c08cbedf00/lib/list_versions.go#L109-L139, though it does equip the code to handle it if an upstream change is made to return errors rather than exiting.

## references
- Closes #2701 
