### PR TITLE
bugfix: Initialize metrics with empty tags

### DIFF
--- a/server/events/command/project_context.go
+++ b/server/events/command/project_context.go
@@ -9,7 +9,6 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/logging"
-	"github.com/runatlantis/atlantis/server/metrics"
 	"github.com/uber-go/tally"
 )
 
@@ -115,7 +114,7 @@ func (p ProjectContext) SetProjectScopeTags(scope tally.Scope) tally.Scope {
 		Workspace:        p.Workspace,
 	}
 
-	return metrics.SetScopeTags(scope, tags.Loadtags())
+	return scope.Tagged(tags.Loadtags())
 }
 
 // GetShowResultFileName returns the filename (not the path) to store the tf show result

--- a/server/events/command/project_context.go
+++ b/server/events/command/project_context.go
@@ -106,7 +106,7 @@ func (p ProjectContext) SetProjectScopeTags(scope tally.Scope) tally.Scope {
 		v = p.TerraformVersion.String()
 	}
 
-	tags := ScopeTags{
+	tags := ProjectScopeTags{
 		BaseRepo:         p.BaseRepo.FullName,
 		PrNumber:         strconv.Itoa(p.Pull.Num),
 		Project:          p.ProjectName,

--- a/server/events/command/scope_tags.go
+++ b/server/events/command/scope_tags.go
@@ -1,0 +1,38 @@
+package command
+
+import (
+	"reflect"
+	"regexp"
+	"strings"
+)
+
+type ScopeTags struct {
+	BaseRepo         string
+	PrNumber         string
+	Project          string
+	ProjectPath      string
+	TerraformVersion string
+	Workspace        string
+}
+
+func (s ScopeTags) Loadtags() map[string]string {
+	tags := make(map[string]string)
+
+	v := reflect.ValueOf(s)
+	t := v.Type()
+
+	for i := 0; i < v.NumField(); i++ {
+		tags[toSnakeCase(t.Field(i).Name)] = v.Field(i).String()
+	}
+
+	return tags
+}
+
+func toSnakeCase(str string) string {
+	var matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
+	var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
+
+	snake := matchFirstCap.ReplaceAllString(str, "${1}_${2}")
+	snake = matchAllCap.ReplaceAllString(snake, "${1}_${2}")
+	return strings.ToLower(snake)
+}

--- a/server/events/command/scope_tags.go
+++ b/server/events/command/scope_tags.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-type ScopeTags struct {
+type ProjectScopeTags struct {
 	BaseRepo         string
 	PrNumber         string
 	Project          string
@@ -15,7 +15,7 @@ type ScopeTags struct {
 	Workspace        string
 }
 
-func (s ScopeTags) Loadtags() map[string]string {
+func (s ProjectScopeTags) Loadtags() map[string]string {
 	tags := make(map[string]string)
 
 	v := reflect.ValueOf(s)

--- a/server/events/instrumented_project_command_runner.go
+++ b/server/events/instrumented_project_command_runner.go
@@ -20,7 +20,7 @@ type InstrumentedProjectCommandRunner struct {
 
 func NewInstrumentedProjectCommandRunner(scope tally.Scope, projectCommandRunner ProjectCommandRunner) *InstrumentedProjectCommandRunner {
 	projectTags := command.ProjectScopeTags{}
-	scope = metrics.SetScopeTags(scope.SubScope("project"), projectTags.Loadtags())
+	scope = scope.Tagged(projectTags.Loadtags())
 
 	for _, m := range []string{metrics.ExecutionSuccessMetric, metrics.ExecutionErrorMetric, metrics.ExecutionFailureMetric} {
 		metrics.InitCounter(scope, m)

--- a/server/events/instrumented_project_command_runner.go
+++ b/server/events/instrumented_project_command_runner.go
@@ -19,7 +19,8 @@ type InstrumentedProjectCommandRunner struct {
 }
 
 func NewInstrumentedProjectCommandRunner(scope tally.Scope, projectCommandRunner ProjectCommandRunner) *InstrumentedProjectCommandRunner {
-	scope = scope.SubScope("project")
+	projectTags := command.ScopeTags{}
+	scope = metrics.SetScopeTags(scope.SubScope("project"), projectTags.Loadtags())
 
 	for _, m := range []string{metrics.ExecutionSuccessMetric, metrics.ExecutionErrorMetric, metrics.ExecutionFailureMetric} {
 		metrics.InitCounter(scope, m)
@@ -49,7 +50,7 @@ func (p *InstrumentedProjectCommandRunner) ApprovePolicies(ctx command.ProjectCo
 
 func RunAndEmitStats(commandName string, ctx command.ProjectContext, execute func(ctx command.ProjectContext) command.ProjectResult, scope tally.Scope) command.ProjectResult {
 	// ensures we are differentiating between project level command and overall command
-	scope = ctx.SetScopeTags(scope)
+	scope = ctx.SetProjectScopeTags(scope)
 	logger := ctx.Log
 
 	executionTime := scope.Timer(metrics.ExecutionTimeMetric).Start()

--- a/server/events/instrumented_project_command_runner.go
+++ b/server/events/instrumented_project_command_runner.go
@@ -19,7 +19,7 @@ type InstrumentedProjectCommandRunner struct {
 }
 
 func NewInstrumentedProjectCommandRunner(scope tally.Scope, projectCommandRunner ProjectCommandRunner) *InstrumentedProjectCommandRunner {
-	projectTags := command.ScopeTags{}
+	projectTags := command.ProjectScopeTags{}
 	scope = metrics.SetScopeTags(scope.SubScope("project"), projectTags.Loadtags())
 
 	for _, m := range []string{metrics.ExecutionSuccessMetric, metrics.ExecutionErrorMetric, metrics.ExecutionFailureMetric} {

--- a/server/events/project_command_context_builder.go
+++ b/server/events/project_command_context_builder.go
@@ -78,7 +78,7 @@ func (cb *CommandScopedStatsProjectCommandContextBuilder) BuildProjectContext(
 		// specifically use the command name in the context instead of the arg
 		// since we can return multiple commands worth of contexts for a given command name arg
 		// to effectively pipeline them.
-		cmd.Scope = cmd.SetScopeTags(cmd.Scope)
+		cmd.Scope = cmd.SetProjectScopeTags(cmd.Scope)
 		projectCmds = append(projectCmds, cmd)
 	}
 

--- a/server/metrics/scope.go
+++ b/server/metrics/scope.go
@@ -72,3 +72,7 @@ func newStatsReporter(cfg valid.Metrics, logger logging.SimpleLogging) (tally.St
 
 	return tallystatsd.NewReporter(client, tallystatsd.Options{}), nil
 }
+
+func SetScopeTags(scope tally.Scope, tags map[string]string) tally.Scope {
+	return scope.Tagged(tags)
+}

--- a/server/metrics/scope.go
+++ b/server/metrics/scope.go
@@ -72,7 +72,3 @@ func newStatsReporter(cfg valid.Metrics, logger logging.SimpleLogging) (tally.St
 
 	return tallystatsd.NewReporter(client, tallystatsd.Options{}), nil
 }
-
-func SetScopeTags(scope tally.Scope, tags map[string]string) tally.Scope {
-	return scope.Tagged(tags)
-}


### PR DESCRIPTION
## what

<!--
* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
* Use bullet points to be concise and to the point.
-->

Added empty tags to metrics initialization to avoid errors when running commands.

Tried to hide the implementation behind the `ProjectScopeTags` so we can have an easy way to implement empty tags like this: 

```
	projectTags := command.ProjectScopeTags{}
	scope = metrics.SetScopeTags(scope.SubScope("project"), projectTags.Loadtags())
```

Instead of this:

```
	scope = scope.SubScope("project")
	scope = scope.Tagged(map[string]string{
		"base_repo":         "",
		"pr_number":         "",
		"project":           "",
		"project_path":      "",
		"terraform_version": "",
		"workspace":         "",
	})
```

This should ensure that in the future if someone adds new tags to the `ProjectScopeTags` they still will be initialized empty while still can use the `SetProjectScopeTags` to add the values.

## why

<!--
* Provide the justifications for the changes (e.g. business case). 
* Describe why these changes were made (e.g. why do these commits fix the problem?)
* Use bullet points to be concise and to the point.
-->

- This PR https://github.com/runatlantis/atlantis/pull/2767 broke atlantis commands

## references

<!--
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Closes #2846
