### PR TITLE
fix: renovate upgrade cimg/node with LTS version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,7 +39,7 @@
     {
       // use LTS node version for node docker image
       matchDatasources: ["docker"],
-      matchPackageNames: ["node"],
+      matchPackageNames: ["node", "cimg/node"],
       versioning: "node",
     },
   ],


### PR DESCRIPTION
## what

- change renovate setting to use node LTS version for `cimg/node` image which is circleci node image

## why

https://github.com/runatlantis/atlantis/pull/2862 try to upgrade cim/node image 19 with is not LTS version

## references

- debug https://github.com/krrrr38/atlantis/pull/45/files
- closes https://github.com/runatlantis/atlantis/pull/2862