### PR TITLE
feat: --allow-commands restricts available atlantis commands

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -137,7 +137,7 @@ const (
 	DefaultADBasicPassword              = ""
 	DefaultADHostname                   = "dev.azure.com"
 	DefaultAutoplanFileList             = "**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl"
-	DefaultAllowCommands                = "plan,apply,unlock"
+	DefaultAllowCommands                = "version,plan,apply,unlock,approve_policies"
 	DefaultCheckoutStrategy             = "branch"
 	DefaultBitbucketBaseURL             = bitbucketcloud.BaseURL
 	DefaultDataDir                      = "~/.atlantis"
@@ -187,7 +187,7 @@ var stringFlags = map[string]stringFlag{
 		defaultValue: "dev.azure.com",
 	},
 	AllowCommandsFlag: {
-		description:  "Comma separated list of acceptable atlantis command.",
+		description:  "Comma separated list of acceptable atlantis commands.",
 		defaultValue: DefaultAllowCommands,
 	},
 	AtlantisURLFlag: {
@@ -734,7 +734,6 @@ func (s *ServerCmd) run() error {
 	}
 	s.securityWarnings(&userConfig)
 	s.trimAtSymbolFromUsers(&userConfig)
-	s.setAllowCommands(&userConfig)
 
 	// Config looks good. Start the server.
 	server, err := s.ServerCreator.NewServer(userConfig, server.Config{
@@ -996,17 +995,6 @@ func (s *ServerCmd) trimAtSymbolFromUsers(userConfig *server.UserConfig) {
 	userConfig.GitlabUser = strings.TrimPrefix(userConfig.GitlabUser, "@")
 	userConfig.BitbucketUser = strings.TrimPrefix(userConfig.BitbucketUser, "@")
 	userConfig.AzureDevopsUser = strings.TrimPrefix(userConfig.AzureDevopsUser, "@")
-}
-
-// setAllowCommands replace allow commands using other configuration
-func (s *ServerCmd) setAllowCommands(userConfig *server.UserConfig) {
-	if userConfig.EnablePolicyChecksFlag {
-		if userConfig.AllowCommands != "" {
-			userConfig.AllowCommands += fmt.Sprintf(",%s", command.ApprovePolicies.String())
-		} else {
-			userConfig.AllowCommands += command.ApprovePolicies.String()
-		}
-	}
 }
 
 func (s *ServerCmd) securityWarnings(userConfig *server.UserConfig) {

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -57,7 +57,7 @@ var testFlags = map[string]interface{}{
 	ADWebhookPasswordFlag:            "ad-wh-pass",
 	ADWebhookUserFlag:                "ad-wh-user",
 	AtlantisURLFlag:                  "url",
-	AllowCommandsFlag:                "plan,apply,unlock,import",
+	AllowCommandsFlag:                "version,plan,unlock,import,approve_policies", // apply is disabled by DisableApply
 	AllowForkPRsFlag:                 true,
 	AllowRepoConfigFlag:              true,
 	AutomergeFlag:                    true,
@@ -869,29 +869,6 @@ func TestExecute_AutoplanFileList(t *testing.T) {
 		} else {
 			Ok(t, err)
 		}
-	}
-}
-
-func TestExecute_SetAllowCommands(t *testing.T) {
-	cases := []struct {
-		enablePolicyCheck bool
-		allowCommands     string
-		expAllowCommands  string
-	}{
-		{true, "", "plan,apply,unlock,approve_policies"},
-		{true, "plan,apply", "plan,apply,approve_policies"},
-		{false, "plan,apply", "plan,apply"},
-	}
-	for _, testCase := range cases {
-		t.Run(fmt.Sprintf("enablePolicyCheck=%t,allowCommands=%s", testCase.enablePolicyCheck, testCase.allowCommands), func(t *testing.T) {
-			c := setupWithDefaults(map[string]interface{}{
-				EnablePolicyChecksFlag: testCase.enablePolicyCheck,
-				AllowCommandsFlag:      testCase.allowCommands,
-			}, t)
-			err := c.Execute()
-			Ok(t, err)
-			Equals(t, testCase.expAllowCommands, passedConfig.AllowCommands)
-		})
 	}
 }
 

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -47,6 +47,19 @@ Values are chosen in this order:
 
 
 ## Flags
+### `--allow-commands`
+  ```bash
+  atlantis server --allow-commands=plan,apply,unlock
+  # or
+  ATLANTIS_ALLOW_COMMANDS='plan,apply,unlock'
+  ```
+  Atlantis requires you to specify an allowlist of repositories it will accept webhooks from.
+
+  Notes:
+  * Accepts a comma separated list, ex. `command1,command2`.
+  * `plan`, `apply`, `unlock`, `approve_policies` and `import` are available.
+  * When not set, defaults to `plan,apply,unlock`.
+
 ### `--allow-draft-prs`
   ```bash
   atlantis server --allow-draft-prs
@@ -318,11 +331,14 @@ and set `--autoplan-modules` to `false`.
   if not in `PATH`. See [Terraform Versions](terraform-versions.html) for more details.
 
 ### `--disable-apply`
+  <Badge text="Deprecated" type="warn"/>
   ```bash
   atlantis server --disable-apply
   # or
   ATLANTIS_DISABLE_APPLY=true
   ```
+  Deprecated for `--allow-commands`.
+
   Disable all `atlantis apply` commands, regardless of which flags are passed with it.
 
 ### `--disable-apply-all`
@@ -365,6 +381,7 @@ and set `--autoplan-modules` to `false`.
   ATLANTIS_ENABLE_POLICY_CHECKS=true
   ```
   Enables atlantis to run server side policies on the result of a terraform plan. Policies are defined in [server side repo config](https://www.runatlantis.io/docs/server-side-repo-config.html#reference).
+  When set to `true`, `approve_policies` command is allowed in [`--allow-commands`](#allow-commands).
 
 ### `--enable-regexp-cmd`
   ```bash

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -57,7 +57,8 @@ Values are chosen in this order:
 
   Notes:
   * Accepts a comma separated list, ex. `command1,command2`.
-  * `version`, `plan`, `apply`, `unlock`, `approve_policies` and `import` are available.
+  * `version`, `plan`, `apply`, `unlock`, `approve_policies`, `import` and `all` are available.
+  * `all` is a special parameter that allows all commands.
 
 ### `--allow-draft-prs`
   ```bash

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -58,7 +58,7 @@ Values are chosen in this order:
   Notes:
   * Accepts a comma separated list, ex. `command1,command2`.
   * `version`, `plan`, `apply`, `unlock`, `approve_policies`, `import` and `all` are available.
-  * `all` is a special parameter that allows all commands.
+  * `all` is a special keyword that allows all commands. If pass `all` then all other commands will be ignored.
 
 ### `--allow-draft-prs`
   ```bash

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -49,16 +49,15 @@ Values are chosen in this order:
 ## Flags
 ### `--allow-commands`
   ```bash
-  atlantis server --allow-commands=plan,apply,unlock
+  atlantis server --allow-commands=version,plan,apply,unlock,approve_policies
   # or
-  ATLANTIS_ALLOW_COMMANDS='plan,apply,unlock'
+  ATLANTIS_ALLOW_COMMANDS='version,plan,apply,unlock,approve_policies'
   ```
-  Atlantis requires you to specify an allowlist of repositories it will accept webhooks from.
+  List of allowed commands to be run on the Atlantis server, Defaults to `version,plan,apply,unlock,approve_policies`
 
   Notes:
   * Accepts a comma separated list, ex. `command1,command2`.
-  * `plan`, `apply`, `unlock`, `approve_policies` and `import` are available.
-  * When not set, defaults to `plan,apply,unlock`.
+  * `version`, `plan`, `apply`, `unlock`, `approve_policies` and `import` are available.
 
 ### `--allow-draft-prs`
   ```bash
@@ -381,7 +380,6 @@ and set `--autoplan-modules` to `false`.
   ATLANTIS_ENABLE_POLICY_CHECKS=true
   ```
   Enables atlantis to run server side policies on the result of a terraform plan. Policies are defined in [server side repo config](https://www.runatlantis.io/docs/server-side-repo-config.html#reference).
-  When set to `true`, `approve_policies` command is allowed in [`--allow-commands`](#allow-commands).
 
 ### `--enable-regexp-cmd`
   ```bash

--- a/runatlantis.io/docs/using-atlantis.md
+++ b/runatlantis.io/docs/using-atlantis.md
@@ -133,7 +133,7 @@ atlantis import [options] ADDRESS ID -- [terraform import flags]
 Runs `terraform import` that matches the directory/project/workspace.
 This command discards the terraform plan result. After an import and before an apply, another `atlantis plan` must be run again.
 
-Activate `import` command requires [--allow-commands](/docs/server-configuration.html#allow-commands) configuration.
+To allow the `import` command requires [--allow-commands](/docs/server-configuration.html#allow-commands) configuration.
 
 ### Examples
 ```bash
@@ -189,8 +189,6 @@ atlantis approve_policies
 Approves all current policy checking failures for the PR.
 
 See also [policy checking](/docs/policy-checking.html).
-
-Activate `approve_policies` command requires [--allow-commands](/docs/server-configuration.html#allow-commands) configuration.
 
 ### Options
 * `--verbose` Append Atlantis log to comment.

--- a/runatlantis.io/docs/using-atlantis.md
+++ b/runatlantis.io/docs/using-atlantis.md
@@ -133,6 +133,8 @@ atlantis import [options] ADDRESS ID -- [terraform import flags]
 Runs `terraform import` that matches the directory/project/workspace.
 This command discards the terraform plan result. After an import and before an apply, another `atlantis plan` must be run again.
 
+Activate `import` command requires [--allow-commands](/docs/server-configuration.html#allow-commands) configuration.
+
 ### Examples
 ```bash
 # Runs import
@@ -187,6 +189,8 @@ atlantis approve_policies
 Approves all current policy checking failures for the PR.
 
 See also [policy checking](/docs/policy-checking.html).
+
+Activate `approve_policies` command requires [--allow-commands](/docs/server-configuration.html#allow-commands) configuration.
 
 ### Options
 * `--verbose` Append Atlantis log to comment.

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -989,7 +989,14 @@ func setupE2E(t *testing.T, repoDir string, opt setupOption) (events_controllers
 		GitlabUser:  "gitlab-user",
 		GitlabToken: "gitlab-token",
 	}
-	allowCommands := []command.Name{command.Plan, command.Apply, command.Unlock, command.ApprovePolicies, command.Import}
+	allowCommands := []command.Name{
+		command.Version,
+		command.Plan,
+		command.Apply,
+		command.Unlock,
+		command.ApprovePolicies,
+		command.Import,
+	}
 	if opt.allowCommands != nil {
 		allowCommands = opt.allowCommands
 	}

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -989,14 +989,7 @@ func setupE2E(t *testing.T, repoDir string, opt setupOption) (events_controllers
 		GitlabUser:  "gitlab-user",
 		GitlabToken: "gitlab-token",
 	}
-	allowCommands := []command.Name{
-		command.Version,
-		command.Plan,
-		command.Apply,
-		command.Unlock,
-		command.ApprovePolicies,
-		command.Import,
-	}
+	allowCommands := command.AllCommentCommands
 	if opt.allowCommands != nil {
 		allowCommands = opt.allowCommands
 	}

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -93,6 +93,8 @@ func TestGitHubWorkflow(t *testing.T) {
 		DisableApply bool
 		// ApplyLock creates an apply lock that temporarily disables apply command
 		ApplyLock bool
+		// AllowCommands flag what kind of atlantis commands are available.
+		AllowCommands []command.Name
 		// ExpAutomerge is true if we expect Atlantis to automerge.
 		ExpAutomerge bool
 		// ExpAutoplan is true if we expect Atlantis to autoplan.
@@ -107,6 +109,10 @@ func TestGitHubWorkflow(t *testing.T) {
 		// Atlantis writes to the pull request in order. A reply from a parallel operation
 		// will be matched using a substring check.
 		ExpReplies [][]string
+		// ExpAllowResponseCommentBack allow http response content with "Commenting back on pull request"
+		ExpAllowResponseCommentBack bool
+		// ExpParseFailedCount represents how many times test sends invalid commands
+		ExpParseFailedCount int
 	}{
 		{
 			Description:   "simple",
@@ -191,6 +197,19 @@ func TestGitHubWorkflow(t *testing.T) {
 				{"exp-output-apply-var-all.txt"},
 				{"exp-output-merge-workspaces.txt"},
 			},
+		},
+		{
+			Description:   "simple with allow commands",
+			RepoDir:       "simple",
+			AllowCommands: []command.Name{command.Plan, command.Apply},
+			Comments: []string{
+				"atlantis import ADDRESS ID",
+			},
+			ExpReplies: [][]string{
+				{"exp-output-allow-command-unknown-import.txt"},
+			},
+			ExpAllowResponseCommentBack: true,
+			ExpParseFailedCount:         1,
 		},
 		{
 			Description:   "simple with atlantis.yaml",
@@ -471,7 +490,8 @@ func TestGitHubWorkflow(t *testing.T) {
 			userConfig = server.UserConfig{}
 			userConfig.DisableApply = c.DisableApply
 
-			ctrl, vcsClient, githubGetter, atlantisWorkspace := setupE2E(t, c.RepoDir, c.RepoConfigFile)
+			opt := setupOption{repoConfigFile: c.RepoConfigFile, allowCommands: c.AllowCommands}
+			ctrl, vcsClient, githubGetter, atlantisWorkspace := setupE2E(t, c.RepoDir, opt)
 			// Set the repo to be cloned through the testing backdoor.
 			repoDir, headSHA := initializeRepo(t, c.RepoDir)
 			atlantisWorkspace.TestingOverrideHeadCloneURL = fmt.Sprintf("file://%s", repoDir)
@@ -496,7 +516,11 @@ func TestGitHubWorkflow(t *testing.T) {
 				commentReq := GitHubCommentEvent(t, comment)
 				w = httptest.NewRecorder()
 				ctrl.Post(w, commentReq)
-				ResponseContains(t, w, 200, "Processing...")
+				if c.ExpAllowResponseCommentBack {
+					ResponseContains(t, w, 200, "Commenting back on pull request")
+				} else {
+					ResponseContains(t, w, 200, "Processing...")
+				}
 			}
 
 			// Send the "pull closed" event which would be triggered by the
@@ -506,17 +530,17 @@ func TestGitHubWorkflow(t *testing.T) {
 			ctrl.Post(w, pullClosedReq)
 			ResponseContains(t, w, 200, "Pull request cleaned successfully")
 
+			expNumHooks := len(c.Comments) + 1 - c.ExpParseFailedCount
 			// Let's verify the pre-workflow hook was called for each comment including the pull request opened event
-			mockPreWorkflowHookRunner.VerifyWasCalled(Times(len(c.Comments)+1)).Run(runtimematchers.AnyModelsWorkflowHookCommandContext(), EqString("some dummy command"), AnyString())
-
+			mockPreWorkflowHookRunner.VerifyWasCalled(Times(expNumHooks)).Run(runtimematchers.AnyModelsWorkflowHookCommandContext(), EqString("some dummy command"), AnyString())
 			// Let's verify the post-workflow hook was called for each comment including the pull request opened event
-			mockPostWorkflowHookRunner.VerifyWasCalled(Times(len(c.Comments)+1)).Run(runtimematchers.AnyModelsWorkflowHookCommandContext(), EqString("some post dummy command"), AnyString())
+			mockPostWorkflowHookRunner.VerifyWasCalled(Times(expNumHooks)).Run(runtimematchers.AnyModelsWorkflowHookCommandContext(), EqString("some post dummy command"), AnyString())
 
 			// Now we're ready to verify Atlantis made all the comments back (or
 			// replies) that we expect.  We expect each plan to have 1 comment,
 			// and apply have 1 for each comment plus one for the locks deleted at the
 			// end.
-			expNumReplies := len(c.Comments) + 1
+			expNumReplies := len(c.Comments) + 1 - c.ExpParseFailedCount
 
 			if c.ExpAutoplan {
 				expNumReplies++
@@ -542,7 +566,7 @@ func TestGitHubWorkflow(t *testing.T) {
 	}
 }
 
-func TestSimlpleWorkflow_terraformLockFile(t *testing.T) {
+func TestSimpleWorkflow_terraformLockFile(t *testing.T) {
 
 	if testing.Short() {
 		t.SkipNow()
@@ -620,7 +644,7 @@ func TestSimlpleWorkflow_terraformLockFile(t *testing.T) {
 			userConfig = server.UserConfig{}
 			userConfig.DisableApply = true
 
-			ctrl, vcsClient, githubGetter, atlantisWorkspace := setupE2E(t, c.RepoDir, "")
+			ctrl, vcsClient, githubGetter, atlantisWorkspace := setupE2E(t, c.RepoDir, setupOption{})
 			// Set the repo to be cloned through the testing backdoor.
 			repoDir, headSHA := initializeRepo(t, c.RepoDir)
 
@@ -863,7 +887,7 @@ func TestGitHubWorkflowWithPolicyCheck(t *testing.T) {
 			userConfig.EnablePolicyChecksFlag = true
 			userConfig.QuietPolicyChecks = c.ExpQuietPolicyChecks
 
-			ctrl, vcsClient, githubGetter, atlantisWorkspace := setupE2E(t, c.RepoDir, "")
+			ctrl, vcsClient, githubGetter, atlantisWorkspace := setupE2E(t, c.RepoDir, setupOption{})
 
 			// Set the repo to be cloned through the testing backdoor.
 			repoDir, headSHA := initializeRepo(t, c.RepoDir)
@@ -940,7 +964,12 @@ func TestGitHubWorkflowWithPolicyCheck(t *testing.T) {
 	}
 }
 
-func setupE2E(t *testing.T, repoDir, repoConfigFile string) (events_controllers.VCSEventsController, *vcsmocks.MockClient, *mocks.MockGithubPullGetter, *events.FileWorkspace) {
+type setupOption struct {
+	repoConfigFile string
+	allowCommands  []command.Name
+}
+
+func setupE2E(t *testing.T, repoDir string, opt setupOption) (events_controllers.VCSEventsController, *vcsmocks.MockClient, *mocks.MockGithubPullGetter, *events.FileWorkspace) {
 	allowForkPRs := false
 	dataDir, binDir, cacheDir := mkSubDirs(t)
 
@@ -960,10 +989,15 @@ func setupE2E(t *testing.T, repoDir, repoConfigFile string) (events_controllers.
 		GitlabUser:  "gitlab-user",
 		GitlabToken: "gitlab-token",
 	}
+	allowCommands := []command.Name{command.Plan, command.Apply, command.Unlock, command.ApprovePolicies, command.Import}
+	if opt.allowCommands != nil {
+		allowCommands = opt.allowCommands
+	}
 	commentParser := &events.CommentParser{
 		GithubUser:     "github-user",
 		GitlabUser:     "gitlab-user",
 		ExecutableName: "atlantis",
+		AllowCommands:  allowCommands,
 	}
 	terraformClient, err := terraform.NewClient(logger, binDir, cacheDir, "", "", "", "default-tf-version", "https://releases.hashicorp.com", &NoopTFDownloader{}, true, false, projectCmdOutputHandler)
 	Ok(t, err)
@@ -988,7 +1022,7 @@ func setupE2E(t *testing.T, repoDir, repoConfigFile string) (events_controllers.
 	parser := &config.ParserValidator{}
 
 	globalCfgArgs := valid.GlobalCfgArgs{
-		RepoConfigFile: repoConfigFile,
+		RepoConfigFile: opt.repoConfigFile,
 		AllowRepoCfg:   true,
 		MergeableReq:   false,
 		ApprovedReq:    false,

--- a/server/controllers/events/testfixtures/test-repos/simple/exp-output-allow-command-unknown-import.txt
+++ b/server/controllers/events/testfixtures/test-repos/simple/exp-output-allow-command-unknown-import.txt
@@ -1,0 +1,5 @@
+```
+Error: unknown command "import".
+Run 'atlantis --help' for usage.
+Available commands(--allow-commands): plan, apply
+```

--- a/server/events/command/name.go
+++ b/server/events/command/name.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"fmt"
 	"strings"
 
 	"golang.org/x/text/cases"
@@ -65,4 +66,25 @@ func (c Name) DefaultUsage() string {
 	default:
 		return c.String()
 	}
+}
+
+// ParseCommandName parses raw name into a command name.
+func ParseCommandName(name string) (Name, error) {
+	switch name {
+	case "apply":
+		return Apply, nil
+	case "plan":
+		return Plan, nil
+	case "unlock":
+		return Unlock, nil
+	case "policy_check":
+		return PolicyCheck, nil
+	case "approve_policies":
+		return ApprovePolicies, nil
+	case "version":
+		return Version, nil
+	case "import":
+		return Import, nil
+	}
+	return -1, fmt.Errorf("unknown command name: %s", name)
 }

--- a/server/events/command/name.go
+++ b/server/events/command/name.go
@@ -31,6 +31,16 @@ const (
 	// Adding more? Don't forget to update String() below
 )
 
+// AllCommentCommands are list of commands that can be run from a comment.
+var AllCommentCommands = []Name{
+	Version,
+	Plan,
+	Apply,
+	Unlock,
+	ApprovePolicies,
+	Import,
+}
+
 // TitleString returns the string representation in title form.
 // ie. policy_check becomes Policy Check
 func (c Name) TitleString() string {

--- a/server/events/command/name_test.go
+++ b/server/events/command/name_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestName_TitleString(t *testing.T) {
@@ -65,4 +66,31 @@ func TestName_DefaultUsage(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseCommandName(t *testing.T) {
+	tests := []struct {
+		exp  command.Name
+		name string
+	}{
+		{command.Apply, "apply"},
+		{command.Plan, "plan"},
+		{command.Unlock, "unlock"},
+		{command.PolicyCheck, "policy_check"},
+		{command.ApprovePolicies, "approve_policies"},
+		{command.Version, "version"},
+		{command.Import, "import"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := command.ParseCommandName(tt.name)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.exp, got)
+		})
+	}
+
+	t.Run("unknown command", func(t *testing.T) {
+		_, err := command.ParseCommandName("unknown")
+		assert.ErrorContains(t, err, "unknown command name: unknown")
+	})
 }

--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -81,15 +81,7 @@ type CommentParser struct {
 // NewCommentParser returns a CommentParser
 func NewCommentParser(githubUser, gitlabUser, bitbucketUser, azureDevopsUser, executableName string, allowCommands []command.Name) *CommentParser {
 	var commentAllowCommands []command.Name
-	acceptableCommands := []command.Name{
-		command.Version,
-		command.Plan,
-		command.Apply,
-		command.Unlock,
-		command.ApprovePolicies,
-		command.Import,
-	}
-	for _, acceptableCommand := range acceptableCommands {
+	for _, acceptableCommand := range command.AllCommentCommands {
 		for _, allowCommand := range allowCommands {
 			if acceptableCommand == allowCommand {
 				commentAllowCommands = append(commentAllowCommands, allowCommand)

--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -447,7 +447,7 @@ Usage:
 
 Examples:
   # show atlantis help
-  atlantis help
+  {{ .ExecutableName }} help
 {{- if .AllowPlan }}
 
   # run plan in the root directory passing the -target flag to terraform

--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -74,8 +74,31 @@ type CommentParser struct {
 	GitlabUser      string
 	BitbucketUser   string
 	AzureDevopsUser string
-	ApplyDisabled   bool
 	ExecutableName  string
+	AllowCommands   []command.Name
+}
+
+// NewCommentParser returns a CommentParser
+func NewCommentParser(githubUser, gitlabUser, bitbucketUser, azureDevopsUser, executableName string, allowCommands []command.Name) *CommentParser {
+	commentAllowCommands := []command.Name{command.Version} // version is always available
+	acceptableCommands := []command.Name{command.Plan, command.Apply, command.Unlock, command.ApprovePolicies, command.Import}
+	for _, acceptableCommand := range acceptableCommands {
+		for _, allowCommand := range allowCommands {
+			if acceptableCommand == allowCommand {
+				commentAllowCommands = append(commentAllowCommands, allowCommand)
+				break // for distinct
+			}
+		}
+	}
+
+	return &CommentParser{
+		GithubUser:      githubUser,
+		GitlabUser:      gitlabUser,
+		BitbucketUser:   bitbucketUser,
+		AzureDevopsUser: azureDevopsUser,
+		ExecutableName:  executableName,
+		AllowCommands:   commentAllowCommands,
+	}
 }
 
 // CommentParseResult describes the result of parsing a comment as a command.
@@ -160,18 +183,22 @@ func (e *CommentParser) Parse(rawComment string, vcsHost models.VCSHostType) Com
 	// If they've just typed the name of the executable then give them the help
 	// output.
 	if len(args) == 1 {
-		return CommentParseResult{CommentResponse: e.HelpComment(e.ApplyDisabled)}
+		return CommentParseResult{CommentResponse: e.HelpComment()}
 	}
 	cmd := args[1]
 
 	// Help output.
 	if e.stringInSlice(cmd, []string{"help", "-h", "--help"}) {
-		return CommentParseResult{CommentResponse: e.HelpComment(e.ApplyDisabled)}
+		return CommentParseResult{CommentResponse: e.HelpComment()}
 	}
 
-	// Need to have a plan, apply, approve_policy or unlock at this point.
-	if !e.stringInSlice(cmd, []string{command.Plan.String(), command.Apply.String(), command.Unlock.String(), command.ApprovePolicies.String(), command.Version.String(), command.Import.String()}) {
-		return CommentParseResult{CommentResponse: fmt.Sprintf("```\nError: unknown command %q.\nRun 'atlantis --help' for usage.\n```", cmd)}
+	// Need to have allow commands at this point.
+	if !e.isAllowedCommand(cmd) {
+		var allowCommandList []string
+		for _, allowCommand := range e.AllowCommands {
+			allowCommandList = append(allowCommandList, allowCommand.String())
+		}
+		return CommentParseResult{CommentResponse: fmt.Sprintf("```\nError: unknown command %q.\nRun '%s --help' for usage.\nAvailable commands(--allow-commands): %s\n```", cmd, e.ExecutableName, strings.Join(allowCommandList, ", "))}
 	}
 
 	var workspace string
@@ -374,22 +401,38 @@ func (e *CommentParser) stringInSlice(a string, list []string) bool {
 	return false
 }
 
+func (e *CommentParser) isAllowedCommand(cmd string) bool {
+	for _, allowed := range e.AllowCommands {
+		if allowed.String() == cmd {
+			return true
+		}
+	}
+	return false
+}
+
 func (e *CommentParser) errMarkdown(errMsg string, cmd string, flagSet *pflag.FlagSet) string {
 	return fmt.Sprintf("```\nError: %s.\nUsage of %s:\n%s```", errMsg, cmd, flagSet.FlagUsagesWrapped(usagesCols))
 }
 
-func (e *CommentParser) HelpComment(applyDisabled bool) string {
+func (e *CommentParser) HelpComment() string {
 	buf := &bytes.Buffer{}
 	var tmpl = template.Must(template.New("").Parse(helpCommentTemplate))
 	if err := tmpl.Execute(buf, struct {
-		ApplyDisabled bool
+		AllowPlan            bool
+		AllowApply           bool
+		AllowUnlock          bool
+		AllowApprovePolicies bool
+		AllowImport          bool
 	}{
-		ApplyDisabled: applyDisabled,
+		AllowPlan:            e.isAllowedCommand(command.Plan.String()),
+		AllowApply:           e.isAllowedCommand(command.Apply.String()),
+		AllowUnlock:          e.isAllowedCommand(command.Unlock.String()),
+		AllowApprovePolicies: e.isAllowedCommand(command.ApprovePolicies.String()),
+		AllowImport:          e.isAllowedCommand(command.Import.String()),
 	}); err != nil {
 		return fmt.Sprintf("Failed to render template, this is a bug: %v", err)
 	}
 	return buf.String()
-
 }
 
 var helpCommentTemplate = "```cmake\n" +
@@ -400,9 +443,14 @@ Usage:
   atlantis <command> [options] -- [terraform options]
 
 Examples:
+  # show terraform version
+  atlantis version
+{{- if .AllowPlan }}
+
   # run plan in the root directory passing the -target flag to terraform
   atlantis plan -d . -- -target=resource
-  {{- if not .ApplyDisabled }}
+{{- end }}
+{{- if .AllowApply }}
 
   # apply all unapplied plans from this pull request
   atlantis apply
@@ -412,19 +460,27 @@ Examples:
 {{- end }}
 
 Commands:
+{{- if .AllowPlan }}
   plan     Runs 'terraform plan' for the changes in this pull request.
            To plan a specific project, use the -d, -w and -p flags.
-{{- if not .ApplyDisabled }}
+{{- end }}
+{{- if .AllowApply }}
   apply    Runs 'terraform apply' on all unapplied plans from this pull request.
            To only apply a specific plan, use the -d, -w and -p flags.
 {{- end }}
+{{- if .AllowUnlock }}
   unlock   Removes all atlantis locks and discards all plans for this PR.
            To unlock a specific plan you can use the Atlantis UI.
+{{- end }}
+{{- if .AllowApprovePolicies }}
   approve_policies
            Approves all current policy checking failures for the PR.
+{{- end }}
   version  Print the output of 'terraform version'
+{{- if .AllowImport }}
   import   Runs 'terraform import' for the changes in this pull request.
            To plan a specific project, use the -d, -w and -p flags.
+{{- end }}
   help     View help.
 
 Flags:

--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -22,12 +22,80 @@ import (
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
 	. "github.com/runatlantis/atlantis/testing"
+	"github.com/stretchr/testify/assert"
 )
 
 var commentParser = events.CommentParser{
 	GithubUser:     "github-user",
 	GitlabUser:     "gitlab-user",
 	ExecutableName: "atlantis",
+	AllowCommands: []command.Name{
+		command.Plan,
+		command.Apply,
+		command.Unlock,
+		command.ApprovePolicies,
+		command.Import,
+	},
+}
+
+func TestNewCommentParser(t *testing.T) {
+	type args struct {
+		githubUser      string
+		gitlabUser      string
+		bitbucketUser   string
+		azureDevopsUser string
+		executableName  string
+		allowCommands   []command.Name
+	}
+	tests := []struct {
+		name string
+		args args
+		want *events.CommentParser
+	}{
+		{
+			name: "full fields",
+			args: args{
+				githubUser:      "github-user",
+				gitlabUser:      "gitlab-user",
+				bitbucketUser:   "bitbucket-user",
+				azureDevopsUser: "azure-devops-user",
+				executableName:  "executable-name",
+				allowCommands:   []command.Name{command.Plan, command.Apply, command.Unlock},
+			},
+			want: &events.CommentParser{
+				GithubUser:      "github-user",
+				GitlabUser:      "gitlab-user",
+				BitbucketUser:   "bitbucket-user",
+				AzureDevopsUser: "azure-devops-user",
+				ExecutableName:  "executable-name",
+				AllowCommands:   []command.Name{command.Version, command.Plan, command.Apply, command.Unlock},
+			},
+		},
+		{
+			name: "duplicate allow commands filtered",
+			args: args{
+				allowCommands: []command.Name{command.Plan, command.Plan, command.Plan},
+			},
+			want: &events.CommentParser{
+				AllowCommands: []command.Name{command.Version, command.Plan},
+			},
+		},
+		{
+			name: "comment un-available commands filtered",
+			args: args{
+				// PolicyCheck and Autoplan cannot be used on comment command, so filtered
+				allowCommands: []command.Name{command.Plan, command.Apply, command.Unlock, command.PolicyCheck, command.ApprovePolicies, command.Autoplan, command.Version, command.Import},
+			},
+			want: &events.CommentParser{
+				AllowCommands: []command.Name{command.Version, command.Plan, command.Apply, command.Unlock, command.ApprovePolicies, command.Import},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, events.NewCommentParser(tt.args.githubUser, tt.args.gitlabUser, tt.args.bitbucketUser, tt.args.azureDevopsUser, tt.args.executableName, tt.args.allowCommands), "NewCommentParser(%v, %v, %v, %v, %v, %v)", tt.args.githubUser, tt.args.gitlabUser, tt.args.bitbucketUser, tt.args.azureDevopsUser, tt.args.executableName, tt.args.allowCommands)
+		})
+	}
 }
 
 func TestParse_Ignored(t *testing.T) {
@@ -70,6 +138,16 @@ func TestParse_ExecutableName(t *testing.T) {
 }
 
 func TestParse_HelpResponse(t *testing.T) {
+	allowCommandsCases := [][]command.Name{
+		{
+			command.Plan,
+			command.Apply,
+			command.Unlock,
+			command.ApprovePolicies,
+			command.Import,
+		},
+		{}, // empty case
+	}
 	helpComments := []string{
 		"run",
 		"atlantis",
@@ -80,27 +158,18 @@ func TestParse_HelpResponse(t *testing.T) {
 		"atlantis help something else",
 		"atlantis help plan",
 	}
-	for _, c := range helpComments {
-		r := commentParser.Parse(c, models.Github)
-		Equals(t, commentParser.HelpComment(false), r.CommentResponse)
-	}
-}
-
-func TestParse_HelpResponseWithApplyDisabled(t *testing.T) {
-	helpComments := []string{
-		"run",
-		"atlantis",
-		"@github-user",
-		"atlantis help",
-		"atlantis --help",
-		"atlantis -h",
-		"atlantis help something else",
-		"atlantis help plan",
-	}
-	for _, c := range helpComments {
-		commentParser.ApplyDisabled = true
-		r := commentParser.Parse(c, models.Github)
-		Equals(t, commentParser.HelpComment(true), r.CommentResponse)
+	for _, allowCommandCase := range allowCommandsCases {
+		for _, c := range helpComments {
+			t.Run(fmt.Sprintf("%s with allow commands %v", c, allowCommandCase), func(t *testing.T) {
+				commentParser := events.CommentParser{
+					GithubUser:     "github-user",
+					ExecutableName: "atlantis",
+					AllowCommands:  allowCommandCase,
+				}
+				r := commentParser.Parse(c, models.Github)
+				Equals(t, commentParser.HelpComment(), r.CommentResponse)
+			})
+		}
 	}
 }
 
@@ -239,11 +308,24 @@ func TestParse_InvalidCommand(t *testing.T) {
 		"atlantis Plan",
 		"atlantis appely apply",
 	}
+	cp := events.NewCommentParser(
+		"github-user",
+		"gitlab-user",
+		"bitbucket-user",
+		"azure-devops-user",
+		"atlantis",
+		[]command.Name{
+			// command.Version // version is added by default
+			command.Unlock,
+			command.Apply,
+			command.Plan,
+			command.Apply, // duplicate command is filtered
+		},
+	)
 	for _, c := range comments {
-		r := commentParser.Parse(c, models.Github)
-		exp := fmt.Sprintf("```\nError: unknown command %q.\nRun 'atlantis --help' for usage.\n```", strings.Fields(c)[1])
-		Assert(t, r.CommentResponse == exp,
-			"For comment %q expected CommentResponse==%q but got %q", c, exp, r.CommentResponse)
+		r := cp.Parse(c, models.Github)
+		exp := fmt.Sprintf("```\nError: unknown command %q.\nRun 'atlantis --help' for usage.\nAvailable commands(--allow-commands): version, plan, apply, unlock\n```", strings.Fields(c)[1])
+		Equals(t, exp, r.CommentResponse)
 	}
 }
 
@@ -779,11 +861,19 @@ func TestBuildPlanApplyVersionComment(t *testing.T) {
 
 func TestCommentParser_HelpComment(t *testing.T) {
 	cases := []struct {
-		applyDisabled bool
+		name          string
+		allowCommands []command.Name
 		expectResult  string
 	}{
 		{
-			applyDisabled: false,
+			name: "all commands allowed",
+			allowCommands: []command.Name{
+				command.Plan,
+				command.Apply,
+				command.Unlock,
+				command.ApprovePolicies,
+				command.Import,
+			},
 			expectResult: "```cmake\n" +
 				`atlantis
 Terraform Pull Request Automation
@@ -792,6 +882,9 @@ Usage:
   atlantis <command> [options] -- [terraform options]
 
 Examples:
+  # show terraform version
+  atlantis version
+
   # run plan in the root directory passing the -target flag to terraform
   atlantis plan -d . -- -target=resource
 
@@ -822,7 +915,8 @@ Use "atlantis [command] --help" for more information about a command.` +
 				"\n```",
 		},
 		{
-			applyDisabled: true,
+			name:          "all commands disallowed",
+			allowCommands: []command.Name{},
 			expectResult: "```cmake\n" +
 				`atlantis
 Terraform Pull Request Automation
@@ -831,19 +925,48 @@ Usage:
   atlantis <command> [options] -- [terraform options]
 
 Examples:
-  # run plan in the root directory passing the -target flag to terraform
-  atlantis plan -d . -- -target=resource
+  # show terraform version
+  atlantis version
 
 Commands:
-  plan     Runs 'terraform plan' for the changes in this pull request.
-           To plan a specific project, use the -d, -w and -p flags.
+  version  Print the output of 'terraform version'
+  help     View help.
+
+Flags:
+  -h, --help   help for atlantis
+
+Use "atlantis [command] --help" for more information about a command.` +
+				"\n```",
+		},
+		{
+			name: "partial commands allowed",
+			allowCommands: []command.Name{
+				command.Apply,
+				command.Unlock,
+			},
+			expectResult: "```cmake\n" +
+				`atlantis
+Terraform Pull Request Automation
+
+Usage:
+  atlantis <command> [options] -- [terraform options]
+
+Examples:
+  # show terraform version
+  atlantis version
+
+  # apply all unapplied plans from this pull request
+  atlantis apply
+
+  # apply the plan for the root directory and staging workspace
+  atlantis apply -d . -w staging
+
+Commands:
+  apply    Runs 'terraform apply' on all unapplied plans from this pull request.
+           To only apply a specific plan, use the -d, -w and -p flags.
   unlock   Removes all atlantis locks and discards all plans for this PR.
            To unlock a specific plan you can use the Atlantis UI.
-  approve_policies
-           Approves all current policy checking failures for the PR.
   version  Print the output of 'terraform version'
-  import   Runs 'terraform import' for the changes in this pull request.
-           To plan a specific project, use the -d, -w and -p flags.
   help     View help.
 
 Flags:
@@ -855,8 +978,11 @@ Use "atlantis [command] --help" for more information about a command.` +
 	}
 
 	for _, c := range cases {
-		t.Run(fmt.Sprintf("ApplyDisabled: %v", c.applyDisabled), func(t *testing.T) {
-			Equals(t, commentParser.HelpComment(c.applyDisabled), c.expectResult)
+		t.Run(c.name, func(t *testing.T) {
+			commentParser := events.CommentParser{
+				AllowCommands: c.allowCommands,
+			}
+			Equals(t, commentParser.HelpComment(), c.expectResult)
 		})
 	}
 }
@@ -898,7 +1024,7 @@ func TestParse_VCSUsername(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.vcs.String(), func(t *testing.T) {
 			r := cp.Parse(fmt.Sprintf("@%s %s", c.user, "help"), c.vcs)
-			Equals(t, commentParser.HelpComment(false), r.CommentResponse)
+			Equals(t, cp.HelpComment(), r.CommentResponse)
 		})
 	}
 }

--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -53,31 +53,12 @@ func TestNewCommentParser(t *testing.T) {
 		want *events.CommentParser
 	}{
 		{
-			name: "full fields",
-			args: args{
-				githubUser:      "github-user",
-				gitlabUser:      "gitlab-user",
-				bitbucketUser:   "bitbucket-user",
-				azureDevopsUser: "azure-devops-user",
-				executableName:  "executable-name",
-				allowCommands:   []command.Name{command.Plan, command.Apply, command.Unlock},
-			},
-			want: &events.CommentParser{
-				GithubUser:      "github-user",
-				GitlabUser:      "gitlab-user",
-				BitbucketUser:   "bitbucket-user",
-				AzureDevopsUser: "azure-devops-user",
-				ExecutableName:  "executable-name",
-				AllowCommands:   []command.Name{command.Version, command.Plan, command.Apply, command.Unlock},
-			},
-		},
-		{
 			name: "duplicate allow commands filtered",
 			args: args{
 				allowCommands: []command.Name{command.Plan, command.Plan, command.Plan},
 			},
 			want: &events.CommentParser{
-				AllowCommands: []command.Name{command.Version, command.Plan},
+				AllowCommands: []command.Name{command.Plan},
 			},
 		},
 		{
@@ -315,7 +296,7 @@ func TestParse_InvalidCommand(t *testing.T) {
 		"azure-devops-user",
 		"atlantis",
 		[]command.Name{
-			// command.Version // version is added by default
+			command.Version,
 			command.Unlock,
 			command.Apply,
 			command.Plan,
@@ -868,6 +849,7 @@ func TestCommentParser_HelpComment(t *testing.T) {
 		{
 			name: "all commands allowed",
 			allowCommands: []command.Name{
+				command.Version,
 				command.Plan,
 				command.Apply,
 				command.Unlock,
@@ -882,8 +864,8 @@ Usage:
   atlantis <command> [options] -- [terraform options]
 
 Examples:
-  # show terraform version
-  atlantis version
+  # show atlantis help
+  atlantis help
 
   # run plan in the root directory passing the -target flag to terraform
   atlantis plan -d . -- -target=resource
@@ -925,11 +907,10 @@ Usage:
   atlantis <command> [options] -- [terraform options]
 
 Examples:
-  # show terraform version
-  atlantis version
+  # show atlantis help
+  atlantis help
 
 Commands:
-  version  Print the output of 'terraform version'
   help     View help.
 
 Flags:
@@ -952,8 +933,8 @@ Usage:
   atlantis <command> [options] -- [terraform options]
 
 Examples:
-  # show terraform version
-  atlantis version
+  # show atlantis help
+  atlantis help
 
   # apply all unapplied plans from this pull request
   atlantis apply
@@ -966,7 +947,6 @@ Commands:
            To only apply a specific plan, use the -d, -w and -p flags.
   unlock   Removes all atlantis locks and discards all plans for this PR.
            To unlock a specific plan you can use the Atlantis UI.
-  version  Print the output of 'terraform version'
   help     View help.
 
 Flags:

--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -120,13 +120,7 @@ func TestParse_ExecutableName(t *testing.T) {
 
 func TestParse_HelpResponse(t *testing.T) {
 	allowCommandsCases := [][]command.Name{
-		{
-			command.Plan,
-			command.Apply,
-			command.Unlock,
-			command.ApprovePolicies,
-			command.Import,
-		},
+		command.AllCommentCommands,
 		{}, // empty case
 	}
 	helpComments := []string{
@@ -847,15 +841,8 @@ func TestCommentParser_HelpComment(t *testing.T) {
 		expectResult  string
 	}{
 		{
-			name: "all commands allowed",
-			allowCommands: []command.Name{
-				command.Version,
-				command.Plan,
-				command.Apply,
-				command.Unlock,
-				command.ApprovePolicies,
-				command.Import,
-			},
+			name:          "all commands allowed",
+			allowCommands: command.AllCommentCommands,
 			expectResult: "```cmake\n" +
 				`atlantis
 Terraform Pull Request Automation

--- a/server/server.go
+++ b/server/server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"github.com/uber-go/tally"
 	"github.com/uber-go/tally/prometheus"
+	"github.com/urfave/negroni/v3"
 
 	cfg "github.com/runatlantis/atlantis/server/core/config"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
@@ -47,8 +48,6 @@ import (
 	assetfs "github.com/elazarl/go-bindata-assetfs"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
-	"github.com/urfave/negroni/v3"
-
 	"github.com/runatlantis/atlantis/server/controllers"
 	events_controllers "github.com/runatlantis/atlantis/server/controllers/events"
 	"github.com/runatlantis/atlantis/server/controllers/templates"
@@ -174,6 +173,18 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	if userConfig.EnablePolicyChecksFlag {
 		logger.Info("Policy Checks are enabled")
 		policyChecksEnabled = true
+	}
+
+	allowCommands, err := userConfig.ToAllowCommandNames()
+	if err != nil {
+		return nil, err
+	}
+	disableApply := true
+	for _, allowCommand := range allowCommands {
+		if allowCommand == command.Apply {
+			disableApply = false
+			break
+		}
 	}
 
 	validator := &cfg.ParserValidator{}
@@ -405,7 +416,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		gitlabClient.SupportsCommonMark(),
 		userConfig.DisableApplyAll,
 		userConfig.DisableMarkdownFolding,
-		userConfig.DisableApply,
+		disableApply,
 		userConfig.DisableRepoLocking,
 		userConfig.EnableDiffMarkdownFormat,
 		userConfig.MarkdownTemplateOverridesDir,
@@ -438,7 +449,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		lockingClient = locking.NewClient(backend)
 	}
 
-	applyLockingClient = locking.NewApplyClient(backend, userConfig.DisableApply)
+	applyLockingClient = locking.NewApplyClient(backend, disableApply)
 	workingDirLocker := events.NewDefaultWorkingDirLocker()
 
 	var workingDir events.WorkingDir = &events.FileWorkspace{
@@ -496,14 +507,14 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		AzureDevopsUser:    userConfig.AzureDevopsUser,
 		AzureDevopsToken:   userConfig.AzureDevopsToken,
 	}
-	commentParser := &events.CommentParser{
-		GithubUser:      userConfig.GithubUser,
-		GitlabUser:      userConfig.GitlabUser,
-		BitbucketUser:   userConfig.BitbucketUser,
-		AzureDevopsUser: userConfig.AzureDevopsUser,
-		ApplyDisabled:   userConfig.DisableApply,
-		ExecutableName:  userConfig.ExecutableName,
-	}
+	commentParser := events.NewCommentParser(
+		userConfig.GithubUser,
+		userConfig.GitlabUser,
+		userConfig.BitbucketUser,
+		userConfig.AzureDevopsUser,
+		userConfig.ExecutableName,
+		allowCommands,
+	)
 	defaultTfVersion := terraformClient.DefaultVersion()
 	pendingPlanFinder := &events.DefaultPendingPlanFinder{}
 	runStepRunner := &runtime.RunStepRunner{
@@ -820,7 +831,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		CommentParser:                   commentParser,
 		Logger:                          logger,
 		Scope:                           statsScope,
-		ApplyDisabled:                   userConfig.DisableApply,
+		ApplyDisabled:                   disableApply,
 		GithubWebhookSecret:             []byte(userConfig.GithubWebhookSecret),
 		GithubRequestValidator:          &events_controllers.DefaultGithubRequestValidator{},
 		GitlabRequestParserValidator:    &events_controllers.DefaultGitlabRequestParserValidator{},

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -123,11 +123,13 @@ type UserConfig struct {
 func (u UserConfig) ToAllowCommandNames() ([]command.Name, error) {
 	var allowCommands []command.Name
 	for _, input := range strings.Split(u.AllowCommands, ",") {
-		cmd, err := command.ParseCommandName(input)
-		if err != nil {
-			return nil, err
+		if input != "" {
+			cmd, err := command.ParseCommandName(input)
+			if err != nil {
+				return nil, err
+			}
+			allowCommands = append(allowCommands, cmd)
 		}
-		allowCommands = append(allowCommands, cmd)
 	}
 	return allowCommands, nil
 }

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -122,7 +122,12 @@ type UserConfig struct {
 // ToAllowCommandNames parse AllowCommands into a slice of CommandName
 func (u UserConfig) ToAllowCommandNames() ([]command.Name, error) {
 	var allowCommands []command.Name
+	var hasAll bool
 	for _, input := range strings.Split(u.AllowCommands, ",") {
+		if input == "all" {
+			hasAll = true
+			continue
+		}
 		if input != "" {
 			cmd, err := command.ParseCommandName(input)
 			if err != nil {
@@ -130,6 +135,9 @@ func (u UserConfig) ToAllowCommandNames() ([]command.Name, error) {
 			}
 			allowCommands = append(allowCommands, cmd)
 		}
+	}
+	if hasAll {
+		return command.AllCommentCommands, nil
 	}
 	return allowCommands, nil
 }

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -1,6 +1,9 @@
 package server
 
 import (
+	"strings"
+
+	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/logging"
 )
 
@@ -10,6 +13,7 @@ import (
 type UserConfig struct {
 	AllowForkPRs                    bool   `mapstructure:"allow-fork-prs"`
 	AllowRepoConfig                 bool   `mapstructure:"allow-repo-config"`
+	AllowCommands                   string `mapstructure:"allow-commands"`
 	AtlantisURL                     string `mapstructure:"atlantis-url"`
 	Automerge                       bool   `mapstructure:"automerge"`
 	AutoplanFileList                string `mapstructure:"autoplan-file-list"`
@@ -113,6 +117,19 @@ type UserConfig struct {
 	WebPassword            string          `mapstructure:"web-password"`
 	WriteGitCreds          bool            `mapstructure:"write-git-creds"`
 	WebsocketCheckOrigin   bool            `mapstructure:"websocket-check-origin"`
+}
+
+// ToAllowCommandNames parse AllowCommands into a slice of CommandName
+func (u UserConfig) ToAllowCommandNames() ([]command.Name, error) {
+	var allowCommands []command.Name
+	for _, input := range strings.Split(u.AllowCommands, ",") {
+		cmd, err := command.ParseCommandName(input)
+		if err != nil {
+			return nil, err
+		}
+		allowCommands = append(allowCommands, cmd)
+	}
+	return allowCommands, nil
 }
 
 // ToLogLevel returns the LogLevel object corresponding to the user-passed

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -124,17 +124,18 @@ func (u UserConfig) ToAllowCommandNames() ([]command.Name, error) {
 	var allowCommands []command.Name
 	var hasAll bool
 	for _, input := range strings.Split(u.AllowCommands, ",") {
+		if input == "" {
+			continue
+		}
 		if input == "all" {
 			hasAll = true
 			continue
 		}
-		if input != "" {
-			cmd, err := command.ParseCommandName(input)
-			if err != nil {
-				return nil, err
-			}
-			allowCommands = append(allowCommands, cmd)
+		cmd, err := command.ParseCommandName(input)
+		if err != nil {
+			return nil, err
 		}
+		allowCommands = append(allowCommands, cmd)
 	}
 	if hasAll {
 		return command.AllCommentCommands, nil

--- a/server/user_config_test.go
+++ b/server/user_config_test.go
@@ -32,6 +32,13 @@ func TestUserConfig_ToAllowCommandNames(t *testing.T) {
 			},
 		},
 		{
+			name:          "all with others returns same with all result",
+			allowCommands: "all,plan",
+			want: []command.Name{
+				command.Version, command.Plan, command.Apply, command.Unlock, command.ApprovePolicies, command.Import,
+			},
+		},
+		{
 			name:          "empty",
 			allowCommands: "",
 			want:          nil,
@@ -39,6 +46,11 @@ func TestUserConfig_ToAllowCommandNames(t *testing.T) {
 		{
 			name:          "invalid command",
 			allowCommands: "plan,all,invalid",
+			wantErr:       "unknown command name: invalid",
+		},
+		{
+			name:          "invalid command",
+			allowCommands: "invalid,plan,all",
 			wantErr:       "unknown command name: invalid",
 		},
 	}

--- a/server/user_config_test.go
+++ b/server/user_config_test.go
@@ -4,9 +4,50 @@ import (
 	"testing"
 
 	"github.com/runatlantis/atlantis/server"
+	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/logging"
 	. "github.com/runatlantis/atlantis/testing"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestUserConfig_ToAllowCommandNames(t *testing.T) {
+	tests := []struct {
+		name          string
+		allowCommands string
+		want          []command.Name
+		wantErr       string
+	}{
+		{
+			name:          "full commands can be parsed by comma",
+			allowCommands: "apply,plan,unlock,policy_check,approve_policies,version,import",
+			want: []command.Name{
+				command.Apply, command.Plan, command.Unlock, command.PolicyCheck, command.ApprovePolicies, command.Version, command.Import,
+			},
+		},
+		{
+			name:          "empty",
+			allowCommands: "",
+			want:          nil,
+		},
+		{
+			name:          "invalid command",
+			allowCommands: "plan,invalid",
+			wantErr:       "unknown command name: invalid",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := server.UserConfig{
+				AllowCommands: tt.allowCommands,
+			}
+			got, err := u.ToAllowCommandNames()
+			if err != nil {
+				assert.ErrorContains(t, err, tt.wantErr, "ToAllowCommandNames()")
+			}
+			assert.Equalf(t, tt.want, got, "ToAllowCommandNames()")
+		})
+	}
+}
 
 func TestUserConfig_ToLogLevel(t *testing.T) {
 	cases := []struct {

--- a/server/user_config_test.go
+++ b/server/user_config_test.go
@@ -25,13 +25,20 @@ func TestUserConfig_ToAllowCommandNames(t *testing.T) {
 			},
 		},
 		{
+			name:          "all",
+			allowCommands: "all",
+			want: []command.Name{
+				command.Version, command.Plan, command.Apply, command.Unlock, command.ApprovePolicies, command.Import,
+			},
+		},
+		{
 			name:          "empty",
 			allowCommands: "",
 			want:          nil,
 		},
 		{
 			name:          "invalid command",
-			allowCommands: "plan,invalid",
+			allowCommands: "plan,all,invalid",
 			wantErr:       "unknown command name: invalid",
 		},
 	}


### PR DESCRIPTION
## what

- add `--allow-commands` whitelist server configuration
  - This flag checks comment_parser and `version,plan,apply,unlock,approve_policies` is default.
  - `--disable-apply` become deprecated. if set true, server remove `apply` command from `--allow-commands`.
  - for backward compatibility, if `--enable-policy-check` is true,  `approve_policies` is allowd in `--allow-commands`.

## why

- Users may not want to introduce a particular command such as `import`.
- Future commands may be added but required by `--allow-commands`.

## references

- I added [import command](https://github.com/runatlantis/atlantis/pull/2783).
- Closes https://github.com/runatlantis/atlantis/issues/2871
