### PR TITLE
fix(command_parser): help text to use executable command

### DIFF
--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -226,7 +226,7 @@ func TestParse_DidYouMeanAtlantis(t *testing.T) {
 	}
 	for _, c := range comments {
 		r := commentParser.Parse(c, models.Github)
-		Assert(t, r.CommentResponse == events.DidYouMeanAtlantisComment,
+		Assert(t, r.CommentResponse == fmt.Sprintf(events.DidYouMeanAtlantisComment, "atlantis"),
 			"For comment %q expected CommentResponse==%q but got %q", c, events.DidYouMeanAtlantisComment, r.CommentResponse)
 	}
 }


### PR DESCRIPTION
## what

- Since pull #2805 makes the bot command customizable, this PR updates all the help text
to use the configured executable instead of always showing `atlantis`.

## why

- If the executable is not Atlantis it's confusing for the help text to show atlantis as the executable.

## references

- #2805

<!--
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

