### PR TITLE
chore(deps): atlantis-base: Update gosu and git-lfs

### DIFF
--- a/docker-base/Dockerfile.alpine
+++ b/docker-base/Dockerfile.alpine
@@ -18,8 +18,8 @@ RUN addgroup atlantis && \
     chmod g=u /etc/passwd
 
 # Install gosu and git-lfs.
-ENV GOSU_VERSION=1.14
 ENV GIT_LFS_VERSION=3.1.2
+ENV GOSU_VERSION=1.16
 
 # Automatically populated with the architecture the image is being built for.
 ARG TARGETPLATFORM

--- a/docker-base/Dockerfile.alpine
+++ b/docker-base/Dockerfile.alpine
@@ -30,7 +30,7 @@ RUN apk add --no-cache \
         curl=7.87.0-r0 \
         git=2.38.2-r0 \
         unzip=6.0-r13 \
-        bash=5.2.12-r0 \
+        bash=5.2.15-r0 \
         openssh=9.1_p1-r1 \
         libcap=2.66-r0 \
         dumb-init=1.2.5-r2 \

--- a/docker-base/Dockerfile.alpine
+++ b/docker-base/Dockerfile.alpine
@@ -26,7 +26,7 @@ ARG TARGETPLATFORM
 
 # Install packages needed for running Atlantis.
 RUN apk add --no-cache \
-        ca-certificates=20220614-r2 \
+        ca-certificates=20220614-r3 \
         curl=7.87.0-r0 \
         git=2.38.2-r0 \
         unzip=6.0-r13 \

--- a/docker-base/Dockerfile.alpine
+++ b/docker-base/Dockerfile.alpine
@@ -48,7 +48,7 @@ RUN apk add --no-cache \
         "linux/arm/v7") GIT_LFS_ARCH=arm ;; \
     esac && \
     curl -L -s --output git-lfs.tar.gz "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-${GIT_LFS_ARCH}-v${GIT_LFS_VERSION}.tar.gz" && \
-    tar -xf git-lfs.tar.gz && \
+    tar --strip-components=1 -xf git-lfs.tar.gz && \
     chmod +x git-lfs && \
     mv git-lfs /usr/bin/git-lfs && \
     git-lfs --version && \

--- a/docker-base/Dockerfile.alpine
+++ b/docker-base/Dockerfile.alpine
@@ -27,7 +27,7 @@ ARG TARGETPLATFORM
 # Install packages needed for running Atlantis.
 RUN apk add --no-cache \
         ca-certificates=20220614-r2 \
-        curl=7.86.0-r1 \
+        curl=7.87.0-r0 \
         git=2.38.2-r0 \
         unzip=6.0-r13 \
         bash=5.2.12-r0 \

--- a/docker-base/Dockerfile.alpine
+++ b/docker-base/Dockerfile.alpine
@@ -18,8 +18,8 @@ RUN addgroup atlantis && \
     chmod g=u /etc/passwd
 
 # Install gosu and git-lfs.
-ENV GIT_LFS_VERSION=3.1.2
 ENV GOSU_VERSION=1.16
+ENV GIT_LFS_VERSION=3.3.0
 
 # Automatically populated with the architecture the image is being built for.
 ARG TARGETPLATFORM

--- a/docker-base/Dockerfile.debian
+++ b/docker-base/Dockerfile.debian
@@ -1,7 +1,7 @@
 # This Dockerfile builds our base image with gosu, dumb-init and the atlantis
 # user. We split this from the main Dockerfile because this base doesn't change
 # and also because it kept breaking the build due to flakiness.
-FROM debian:bullseye-20221205-slim
+FROM debian:bullseye-20221219-slim
 
 # We use gosu to step down from root and run as the atlantis user so we need
 # to create that user and group.

--- a/docker-base/Dockerfile.debian
+++ b/docker-base/Dockerfile.debian
@@ -16,8 +16,8 @@ RUN useradd --create-home --user-group --shell /bin/bash atlantis && \
     chmod g=u /etc/passwd
 
 # Install gosu and git-lfs.
-ENV GIT_LFS_VERSION=3.1.2
 ENV GOSU_VERSION=1.16
+ENV GIT_LFS_VERSION=3.3.0
 
 # Automatically populated with the architecture the image is being built for.
 ARG TARGETPLATFORM

--- a/docker-base/Dockerfile.debian
+++ b/docker-base/Dockerfile.debian
@@ -46,7 +46,7 @@ RUN apt-get update \
         "linux/arm/v7") GIT_LFS_ARCH=arm ;; \
     esac && \
     curl -L -s --output git-lfs.tar.gz "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-${GIT_LFS_ARCH}-v${GIT_LFS_VERSION}.tar.gz" && \
-    tar -xf git-lfs.tar.gz && \
+    tar --strip-components=1 -xf git-lfs.tar.gz && \
     chmod +x git-lfs && \
     mv git-lfs /usr/bin/git-lfs && \
     git-lfs --version && \

--- a/docker-base/Dockerfile.debian
+++ b/docker-base/Dockerfile.debian
@@ -16,8 +16,8 @@ RUN useradd --create-home --user-group --shell /bin/bash atlantis && \
     chmod g=u /etc/passwd
 
 # Install gosu and git-lfs.
-ENV GOSU_VERSION=1.14
 ENV GIT_LFS_VERSION=3.1.2
+ENV GOSU_VERSION=1.16
 
 # Automatically populated with the architecture the image is being built for.
 ARG TARGETPLATFORM


### PR DESCRIPTION
## what
- Updates `gosu`, `git-lfs` to the latest version, along with `curl`, `bash` in alpine, and the debian base image.

## why
- `gosu` and `git-lfs` contains many CVEs, and haven't been update in a while. The other changes are more house keeping to keep them up to date as well.

## references
- [gosu releases](https://github.com/tianon/gosu/releases)
- [git-lfs releases](https://github.com/git-lfs/git-lfs/releases)
- https://hub.docker.com/r/amd64/debian/
- Relates to https://github.com/runatlantis/atlantis/issues/2883#issuecomment-1367241025