### PR TITLE
Added the creation of Atlantis minimal with the latest TF version

### DIFF
--- a/.github/workflows/atlantis-image-minimal.yml
+++ b/.github/workflows/atlantis-image-minimal.yml
@@ -1,0 +1,112 @@
+name: atlantis-image-minimal
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - v*.*.* # stable release like, v0.19.2
+      - v*.*.*-pre.* # pre release like, v0.19.0-pre.calendardate
+  pull_request:
+    paths:
+      - 'Dockerfile.minimal'
+      - '.github/workflows/atlantis-image-minimal.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        image_type: [alpine, debian]
+    runs-on: ubuntu-22.04
+    env:
+      RELEASE_TYPE: ${{ contains(github.ref, 'pre') && 'pre' || 'stable' }}
+      RELEASE_TAG: ${{ contains(github.ref, 'pre') && 'prerelease-latest' || 'latest' }}
+      IMAGE_BASE: ghcr.io/${{ github.repository_owner }}/atlantis
+      IMAGE_SUFFIX: ${{ matrix.image_type != 'alpine' && format('-{0}', matrix.image_type) || '' }}
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions/setup-go@v3
+      with:
+        go-version: 1.19
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+      with:
+        image: tonistiigi/binfmt:latest
+        platforms: arm64,arm
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: |
+          atlantis
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+
+    - name: Login to Packages Container registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    # Publish dev image to container registry
+    - name: Build and push atlantis:dev-minimal-${{ env.IMAGE_SUFFIX }} image
+      if: ${{ contains(fromJson('["push", "pull_request"]'), github.event_name) }}
+      uses: docker/build-push-action@v3
+      with:
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        context: .
+        build-args: ATLANTIS_BASE_TAG_TYPE=${{ matrix.image_type }}
+        platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: |
+          ghcr.io/${{ github.repository_owner }}/atlantis:dev-minimal-${{ env.IMAGE_SUFFIX }}
+          ghcr.io/${{ github.repository_owner }}/atlantis:dev-minimal-${{ matrix.image_type }}
+        labels: ${{ steps.meta.outputs.labels }}
+
+    # Publish release to container registry
+    - name: Populate release version
+      if: |
+        contains(fromJson('["push", "pull_request"]'), github.event_name) &&
+        startsWith(github.ref, 'refs/tags/')
+      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+    - name: "Build and push atlantis:${{ env.RELEASE_VERSION }}-minimal image for ${{ env.RELEASE_TYPE }} release"
+      if: |
+        contains(fromJson('["push", "pull_request"]'), github.event_name) &&
+        startsWith(github.ref, 'refs/tags/')
+      uses: docker/build-push-action@v3
+      with:
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        context: .
+        build-args: ATLANTIS_BASE_TAG_TYPE=${{ matrix.image_type }}
+        platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
+        push: ${{ github.event_name != 'pull_request' }}
+        # release version is the name of the tag i.e. v0.10.0
+        # release version also has the image type appended i.e. v0.10.0-alpine
+        # release tag is either pre-release or latest i.e. latest
+        # release tag also has the image type appended i.e. latest-alpine
+        # if it's v0.10.0 and alpine, it will do v0.10.0, v0.10.0-alpine, latest, latest-alpine
+        # if it's v0.10.0 and debian, it will do v0.10.0-debian, latest-debian
+        tags: |
+          ${{ env.IMAGE_BASE }}:${{ env.RELEASE_VERSION }}${{ env.IMAGE_SUFFIX }}-minimal
+          ${{ env.IMAGE_BASE }}:${{ env.RELEASE_VERSION }}-minimal-${{ matrix.image_type }}
+          ${{ env.IMAGE_BASE }}:${{ env.RELEASE_TAG }}${{ env.IMAGE_SUFFIX }}-minimal
+          ${{ env.IMAGE_BASE }}:${{ env.RELEASE_TAG }}-minimal-${{ matrix.image_type }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -1,0 +1,77 @@
+ARG ATLANTIS_BASE=ghcr.io/runatlantis/atlantis-base
+ARG ATLANTIS_BASE_TAG_DATE=2022.12.29
+ARG ATLANTIS_BASE_TAG_TYPE=alpine
+
+# Stage 1: build artifact
+
+FROM golang:1.19.4-alpine AS builder
+
+WORKDIR /app
+COPY . /app
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -v -o atlantis .
+
+# Stage 2
+# The runatlantis/atlantis-base is created by docker-base/Dockerfile
+FROM ${ATLANTIS_BASE}:${ATLANTIS_BASE_TAG_DATE}-${ATLANTIS_BASE_TAG_TYPE} AS base
+
+# Get the architecture the image is being built for
+ARG TARGETPLATFORM
+
+# install terraform binaries
+# renovate: datasource=github-releases depName=hashicorp/terraform versioning=hashicorp
+ENV DEFAULT_TERRAFORM_VERSION=1.3.6
+
+# In the official Atlantis image we only have the latest of each Terraform version.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN AVAILABLE_TERRAFORM_VERSIONS="${DEFAULT_TERRAFORM_VERSION}" && \
+    case "${TARGETPLATFORM}" in \
+        "linux/amd64") TERRAFORM_ARCH=amd64 ;; \
+        "linux/arm64") TERRAFORM_ARCH=arm64 ;; \
+        "linux/arm/v7") TERRAFORM_ARCH=arm ;; \
+        *) echo "ERROR: 'TARGETPLATFORM' value expected: ${TARGETPLATFORM}"; exit 1 ;; \
+    esac && \
+    for VERSION in ${AVAILABLE_TERRAFORM_VERSIONS}; do \
+        curl -LOs "https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_linux_${TERRAFORM_ARCH}.zip" && \
+        curl -LOs "https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_SHA256SUMS" && \
+        sed -n "/terraform_${VERSION}_linux_${TERRAFORM_ARCH}.zip/p" "terraform_${VERSION}_SHA256SUMS" | sha256sum -c && \
+        mkdir -p "/usr/local/bin/tf/versions/${VERSION}" && \
+        unzip "terraform_${VERSION}_linux_${TERRAFORM_ARCH}.zip" -d "/usr/local/bin/tf/versions/${VERSION}" && \
+        ln -s "/usr/local/bin/tf/versions/${VERSION}/terraform" "/usr/local/bin/terraform${VERSION}" && \
+        rm "terraform_${VERSION}_linux_${TERRAFORM_ARCH}.zip" && \
+        rm "terraform_${VERSION}_SHA256SUMS"; \
+    done && \
+    ln -s "/usr/local/bin/tf/versions/${DEFAULT_TERRAFORM_VERSION}/terraform" /usr/local/bin/terraform
+
+# renovate: datasource=github-releases depName=open-policy-agent/conftest
+ENV DEFAULT_CONFTEST_VERSION=0.37.0
+
+RUN AVAILABLE_CONFTEST_VERSIONS="${DEFAULT_CONFTEST_VERSION}" && \
+    case ${TARGETPLATFORM} in \
+        "linux/amd64") CONFTEST_ARCH=x86_64 ;; \
+        "linux/arm64") CONFTEST_ARCH=arm64 ;; \
+        # There is currently no compiled version of conftest for armv7
+        "linux/arm/v7") CONFTEST_ARCH=x86_64 ;; \
+    esac && \
+    for VERSION in ${AVAILABLE_CONFTEST_VERSIONS}; do \
+        curl -LOs https://github.com/open-policy-agent/conftest/releases/download/v${VERSION}/conftest_${VERSION}_Linux_${CONFTEST_ARCH}.tar.gz && \
+        curl -LOs https://github.com/open-policy-agent/conftest/releases/download/v${VERSION}/checksums.txt && \
+        sed -n "/conftest_${VERSION}_Linux_${CONFTEST_ARCH}.tar.gz/p" checksums.txt | sha256sum -c && \
+        mkdir -p /usr/local/bin/cft/versions/${VERSION} && \
+        tar -C /usr/local/bin/cft/versions/${VERSION} -xzf conftest_${VERSION}_Linux_${CONFTEST_ARCH}.tar.gz && \
+        ln -s /usr/local/bin/cft/versions/${VERSION}/conftest /usr/local/bin/conftest${VERSION} && \
+        rm conftest_${VERSION}_Linux_${CONFTEST_ARCH}.tar.gz && \
+        rm checksums.txt; \
+    done
+
+RUN ln -s /usr/local/bin/cft/versions/${DEFAULT_CONFTEST_VERSION}/conftest /usr/local/bin/conftest
+
+# copy binary
+COPY --from=builder /app/atlantis /usr/local/bin/atlantis
+
+# copy docker entrypoint
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["server"]


### PR DESCRIPTION
Added the creation of Atlantis minimal with only the latest TF version in order to avoid as much as possible the vulnerabilities of old TF versions.

## what

<!--
- 
-->
Remove all Terraform versions except the last one to avoid exposure to old vulnerabilities. 

## why

<!--
-  
-->

The support of very old Terraform versions expose Atlantis docker image to old vulnerabilities which aren't easy to solve. 

## tests

<!--
- [ ] I have tested my changes by ...
-->

## references

<!--
- https://github.com/runatlantis/atlantis/issues/2883
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- https://github.com/runatlantis/atlantis/issues/2883
