### PR TITLE
fix: syncing doc variable name with current code

### DIFF
--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -225,7 +225,7 @@ and set `--autoplan-modules` to `false`.
   If not specified, Atlantis won't be able to validate that the
   incoming webhook call came from your Azure DevOps org. This means that an
   attacker could spoof calls to Atlantis and cause it to perform malicious
-  actions. Should be specified via the `ATLANTIS_AZUREDEVOPS_BASIC_AUTH` environment
+  actions. Should be specified via the `ATLANTIS_AZUREDEVOPS_WEBHOOK_PASSWORD` environment
   variable.
   :::
 


### PR DESCRIPTION
Syncing doc environment variable name with the current code, as seen here (2022-12-30): https://github.com/demetriusmoro/atlantis/blob/main/cmd/server.go#L178

- Current var name in the doc (wrong): `ATLANTIS_AZUREDEVOPS_BASIC_AUTH`
- Current var name in code (correct): `ATLANTIS_AZUREDEVOPS_WEBHOOK_PASSWORD`

## what

Fixing a variable name typo in the docs, to make it same than the actual code that reads this parameter.

## why

The current variable name in the docs is not an actual valid parameter, people reading just the docs will get confused.

## tests

Doesn't actually have test, its is a doc-only related fix, the related code works as expected.

## references

- Code that actually reads the parameter: https://github.com/demetriusmoro/atlantis/blob/main/cmd/server.go
- Direct link to the variable declaration: https://github.com/demetriusmoro/atlantis/blob/main/cmd/server.go#L42
- Direct link to the row with the correct environment variable name, as in `2022-12-30`: https://github.com/demetriusmoro/atlantis/blob/main/cmd/server.go#L178