### PR TITLE
Improve plan summary performance

### DIFF
--- a/server/events/command/project_result_test.go
+++ b/server/events/command/project_result_test.go
@@ -225,3 +225,67 @@ func TestPlanSuccess_Summary(t *testing.T) {
 		})
 	}
 }
+
+var Summary string
+
+func BenchmarkPlanSuccess_Summary(b *testing.B) {
+	var s string
+
+	fixtures := map[string]string{
+		"changes": `
+					An execution plan has been generated and is shown below.
+					Resource actions are indicated with the following symbols:
+					  - destroy
+
+					Terraform will perform the following actions:
+
+					  - null_resource.hi[1]
+
+
+					Plan: 0 to add, 0 to change, 1 to destroy.`,
+		"no changes": `
+					An execution plan has been generated and is shown below.
+					Resource actions are indicated with the following symbols:
+
+					No changes. Infrastructure is up-to-date.`,
+		"changes outside Terraform": `
+					Note: Objects have changed outside of Terraform
+
+					Terraform detected the following changes made outside of Terraform since the
+					last "terraform apply":
+
+					No changes. Your infrastructure matches the configuration.`,
+		"changes and changes outside": `
+					Note: Objects have changed outside of Terraform
+
+					Terraform detected the following changes made outside of Terraform since the
+					last "terraform apply":
+
+					An execution plan has been generated and is shown below.
+					Resource actions are indicated with the following symbols:
+					  - destroy
+
+					Terraform will perform the following actions:
+
+					  - null_resource.hi[1]
+
+
+					Plan: 0 to add, 0 to change, 1 to destroy.`,
+		"empty summary, no matches": `No match, expect empty`,
+	}
+
+	for name, output := range fixtures {
+		p := &models.PlanSuccess{
+			TerraformOutput: output,
+		}
+
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				s = p.Summary()
+			}
+
+			Summary = s
+		})
+	}
+}

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -385,12 +385,15 @@ func (p *PlanSuccess) Summary() string {
 	return note + reNoChanges.FindString(p.TerraformOutput)
 }
 
+// Diff Markdown regexes
+var (
+	diffKeywordRegex = regexp.MustCompile(`(?m)^( +)([-+~]\s)(.*)(\s=\s|\s->\s|<<|\{|\(known after apply\)| {2,}[^ ]+:.*)(.*)`)
+	diffListRegex    = regexp.MustCompile(`(?m)^( +)([-+~]\s)(".*",)`)
+	diffTildeRegex   = regexp.MustCompile(`(?m)^~`)
+)
+
 // DiffMarkdownFormattedTerraformOutput formats the Terraform output to match diff markdown format
 func (p PlanSuccess) DiffMarkdownFormattedTerraformOutput() string {
-	diffKeywordRegex := regexp.MustCompile(`(?m)^( +)([-+~]\s)(.*)(\s=\s|\s->\s|<<|\{|\(known after apply\)| {2,}[^ ]+:.*)(.*)`)
-	diffListRegex := regexp.MustCompile(`(?m)^( +)([-+~]\s)(".*",)`)
-	diffTildeRegex := regexp.MustCompile(`(?m)^~`)
-
 	formattedTerraformOutput := diffKeywordRegex.ReplaceAllString(p.TerraformOutput, "$2$1$3$4$5")
 	formattedTerraformOutput = diffListRegex.ReplaceAllString(formattedTerraformOutput, "$2$1$3")
 	formattedTerraformOutput = diffTildeRegex.ReplaceAllString(formattedTerraformOutput, "!")

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -377,7 +377,7 @@ var (
 func (p *PlanSuccess) Summary() string {
 	note := ""
 	if match := reChangesOutside.FindString(p.TerraformOutput); match != "" {
-		note = fmt.Sprintf("\n**%s**\n", match)
+		note = "\n**" + match + "**\n"
 	}
 	if match := rePlanChanges.FindString(p.TerraformOutput); match != "" {
 		return note + match

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -366,20 +366,23 @@ type PlanSuccess struct {
 	HasDiverged bool
 }
 
+// Summary regexes
+var (
+	reChangesOutside = regexp.MustCompile(`Note: Objects have changed outside of Terraform`)
+	rePlanChanges    = regexp.MustCompile(`Plan: \d+ to add, \d+ to change, \d+ to destroy.`)
+	reNoChanges      = regexp.MustCompile(`No changes. (Infrastructure is up-to-date|Your infrastructure matches the configuration).`)
+)
+
 // Summary extracts one line summary of plan changes from TerraformOutput.
 func (p *PlanSuccess) Summary() string {
 	note := ""
-	r := regexp.MustCompile(`Note: Objects have changed outside of Terraform`)
-	if match := r.FindString(p.TerraformOutput); match != "" {
+	if match := reChangesOutside.FindString(p.TerraformOutput); match != "" {
 		note = fmt.Sprintf("\n**%s**\n", match)
 	}
-
-	r = regexp.MustCompile(`Plan: \d+ to add, \d+ to change, \d+ to destroy.`)
-	if match := r.FindString(p.TerraformOutput); match != "" {
+	if match := rePlanChanges.FindString(p.TerraformOutput); match != "" {
 		return note + match
 	}
-	r = regexp.MustCompile(`No changes. (Infrastructure is up-to-date|Your infrastructure matches the configuration).`)
-	return note + r.FindString(p.TerraformOutput)
+	return note + reNoChanges.FindString(p.TerraformOutput)
 }
 
 // DiffMarkdownFormattedTerraformOutput formats the Terraform output to match diff markdown format


### PR DESCRIPTION
## what
At Grafana Labs we have been using Atlantis for several months, and a typical PR could affect over 10 to 20 different projects; these PRs happen several times a day, meaning Atlantis reports back plan summaries very often.

While looking at how to override the templates to better accommodate them to our needs, I've found that the `*PlanSuccess.Summary` method could be made much faster by simply extracting the compilation of the regexes outside the method instead of compiling them every time.

## why
As described above we rely heavily on Atlantis giving us faster feedback. By improving the performance in speed and memory allocations the feedback cycle will be faster and also we will be reducing our carbon footprint.

## tests
I first introduced a benchmark for this method, and ran the tests and benchmark locally to take a baseline:

```
$ go test -bench=. ./server/events/command
goos: darwin
goarch: arm64
pkg: github.com/runatlantis/atlantis/server/events/command
BenchmarkPlanSuccess_Summary/empty_summary,_no_matches-10                  82564             12415 ns/op           27352 B/op        114 allocs/op
BenchmarkPlanSuccess_Summary/changes-10                                   167904              7148 ns/op           14309 B/op         69 allocs/op
BenchmarkPlanSuccess_Summary/no_changes-10                                 92410             12984 ns/op           27705 B/op        114 allocs/op
BenchmarkPlanSuccess_Summary/changes_outside_Terraform-10                  89256             13505 ns/op           27882 B/op        117 allocs/op
BenchmarkPlanSuccess_Summary/changes_and_changes_outside-10               159199              7527 ns/op           14493 B/op         72 allocs/op
PASS
ok      github.com/runatlantis/atlantis/server/events/command   7.536s
```

After introducing my changes, I've ran the benchmarks and the tests again, and got this:

```
$ go test -bench=. ./server/events/command 
goos: darwin
goarch: arm64
pkg: github.com/runatlantis/atlantis/server/events/command
BenchmarkPlanSuccess_Summary/changes_outside_Terraform-10                1412385               820.7 ns/op           193 B/op          3 allocs/op
BenchmarkPlanSuccess_Summary/changes_and_changes_outside-10              1587134               757.8 ns/op           177 B/op          3 allocs/op
BenchmarkPlanSuccess_Summary/empty_summary,_no_matches-10               90337636                13.15 ns/op            0 B/op          0 allocs/op
BenchmarkPlanSuccess_Summary/changes-10                                  3303454               363.9 ns/op             0 B/op          0 allocs/op
BenchmarkPlanSuccess_Summary/no_changes-10                               3318954               361.5 ns/op             0 B/op          0 allocs/op
PASS
ok      github.com/runatlantis/atlantis/server/events/command   9.102s
```

To have a better comparison I've ran all benchmarks with 200,000 iterations, 10 times each, and got the following result using `benchstat`:

```
$ benchstat orig.txt improv.txt
name                                                old time/op    new time/op    delta
PlanSuccess_Summary/empty_summary,_no_matches-10      12.6µs ± 2%     0.0µs ± 1%   -99.90%  (p=0.000 n=10+9)
PlanSuccess_Summary/changes-10                        7.19µs ± 0%    0.36µs ± 2%   -94.96%  (p=0.000 n=8+9)
PlanSuccess_Summary/no_changes-10                     13.2µs ± 2%     0.4µs ± 0%   -97.27%  (p=0.000 n=10+9)
PlanSuccess_Summary/changes_outside_Terraform-10      13.7µs ± 1%     0.8µs ± 0%   -94.02%  (p=0.000 n=9+9)
PlanSuccess_Summary/changes_and_changes_outside-10    7.71µs ± 5%    0.75µs ± 0%   -90.21%  (p=0.000 n=10+8)

name                                                old alloc/op   new alloc/op   delta
PlanSuccess_Summary/empty_summary,_no_matches-10      27.4kB ± 0%     0.0kB       -100.00%  (p=0.000 n=10+10)
PlanSuccess_Summary/changes-10                        14.3kB ± 0%     0.0kB       -100.00%  (p=0.000 n=9+10)
PlanSuccess_Summary/no_changes-10                     27.7kB ± 0%     0.0kB       -100.00%  (p=0.000 n=10+10)
PlanSuccess_Summary/changes_outside_Terraform-10      27.9kB ± 0%     0.2kB ± 0%   -99.31%  (p=0.000 n=10+7)
PlanSuccess_Summary/changes_and_changes_outside-10    14.5kB ± 0%     0.2kB ± 0%   -98.78%  (p=0.000 n=10+8)

name                                                old allocs/op  new allocs/op  delta
PlanSuccess_Summary/empty_summary,_no_matches-10         114 ± 0%         0       -100.00%  (p=0.000 n=10+10)
PlanSuccess_Summary/changes-10                          69.0 ± 0%       0.0       -100.00%  (p=0.000 n=10+10)
PlanSuccess_Summary/no_changes-10                        114 ± 0%         0       -100.00%  (p=0.000 n=10+10)
PlanSuccess_Summary/changes_outside_Terraform-10         117 ± 0%         3 ± 0%   -97.44%  (p=0.000 n=10+10)
PlanSuccess_Summary/changes_and_changes_outside-10      72.0 ± 0%       3.0 ± 0%   -95.83%  (p=0.000 n=10+10)
```

## references
* [`benchstat`](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat)
