### PR TITLE
Release 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v0.22.0
+
+Bugfixes and new Features
+
+## What's Changed
+
+https://github.com/runatlantis/atlantis/releases/tag/v0.22.0
+
 # v0.21.0
 
 Bugfixes and new Features

--- a/kustomize/bundle.yaml
+++ b/kustomize/bundle.yaml
@@ -22,7 +22,7 @@ spec:
         fsGroup: 1000 # Atlantis group (1000) read/write access to volumes.
       containers:
       - name: atlantis
-        image: ghcr.io/runatlantis/atlantis:v0.21.0
+        image: ghcr.io/runatlantis/atlantis:v0.22.0
         env:
         - name: ATLANTIS_DATA_DIR
           value: /atlantis

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const atlantisVersion = "0.21.0"
+const atlantisVersion = "0.22.0"
 
 func main() {
 	v := viper.New()


### PR DESCRIPTION
## what
atlantis version has been changed to v0.22.0
<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->


## why
atlantis version is not matching with release version and tests are failing when building custom image using atlantis as base image due to image and atlantis version mismatch.
<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## tests

<!--
- [ ] I have tested my changes by ...
-->

## references
- closes  #2909
- previous pr https://github.com/runatlantis/atlantis/pull/2734
<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

