### PR TITLE
docs: Explicit restrictions of atlantis user apply to the --data-dir flag

### DIFF
--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -317,11 +317,11 @@ and set `--autoplan-modules` to `false`.
   ATLANTIS_DATA_DIR="path/to/data/dir"
   ```
   Directory where Atlantis will store its data. Will be created if it doesn't exist.
-  Defaults to `/home/atlantis/`. Atlantis will store its database, checked out repos, Terraform plans and downloaded
+  Defaults to `~/atlantis`. Atlantis will store its database, checked out repos, Terraform plans and downloaded
   Terraform binaries here. If Atlantis loses this directory, [locks](locking.html)
   will be lost and unapplied plans will be lost.
 
-  Note that the atlantis user is restricted to `/home/atlantis/`. 
+  Note that the atlantis user is restricted to `~/atlantis`. 
   If you set the `--data-dir` flag to a path outside of Atlantis its home directory, ensure that you grant the atlantis user the correct permissions.
 
 ### `--default-tf-version`

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -317,7 +317,7 @@ and set `--autoplan-modules` to `false`.
   ATLANTIS_DATA_DIR="path/to/data/dir"
   ```
   Directory where Atlantis will store its data. Will be created if it doesn't exist.
-  Defaults to `~/.atlantis`. Atlantis will store its database, checked out repos, Terraform plans and downloaded
+  Defaults to `/home/atlantis/`. Atlantis will store its database, checked out repos, Terraform plans and downloaded
   Terraform binaries here. If Atlantis loses this directory, [locks](locking.html)
   will be lost and unapplied plans will be lost.
 

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -322,7 +322,7 @@ and set `--autoplan-modules` to `false`.
   will be lost and unapplied plans will be lost.
 
   Please note that the atlantis user is restricted to `/home/atlantis/`. 
-  If you set the --data-dir flag to a path outside of Atlantis' home directory, ensure that you grant the atlantis user the correct permissions.
+  If you set the `--data-dir` flag to a path outside of Atlantis' home directory, ensure that you grant the atlantis user the correct permissions.
 
 ### `--default-tf-version`
   ```bash

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -317,11 +317,11 @@ and set `--autoplan-modules` to `false`.
   ATLANTIS_DATA_DIR="path/to/data/dir"
   ```
   Directory where Atlantis will store its data. Will be created if it doesn't exist.
-  Defaults to `~/atlantis`. Atlantis will store its database, checked out repos, Terraform plans and downloaded
+  Defaults to `~/.atlantis`. Atlantis will store its database, checked out repos, Terraform plans and downloaded
   Terraform binaries here. If Atlantis loses this directory, [locks](locking.html)
   will be lost and unapplied plans will be lost.
 
-  Note that the atlantis user is restricted to `~/atlantis`. 
+  Note that the atlantis user is restricted to `~/.atlantis`. 
   If you set the `--data-dir` flag to a path outside of Atlantis its home directory, ensure that you grant the atlantis user the correct permissions.
 
 ### `--default-tf-version`

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -321,6 +321,9 @@ and set `--autoplan-modules` to `false`.
   Terraform binaries here. If Atlantis loses this directory, [locks](locking.html)
   will be lost and unapplied plans will be lost.
 
+  Please note that the atlantis user is restricted to `/home/atlantis/`. 
+  If you set the --data-dir flag to a path outside of Atlantis' home directory, ensure that you grant the atlantis user the correct permissions.
+
 ### `--default-tf-version`
   ```bash
   atlantis server --default-tf-version="v0.12.31"

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -321,8 +321,8 @@ and set `--autoplan-modules` to `false`.
   Terraform binaries here. If Atlantis loses this directory, [locks](locking.html)
   will be lost and unapplied plans will be lost.
 
-  Please note that the atlantis user is restricted to `/home/atlantis/`. 
-  If you set the `--data-dir` flag to a path outside of Atlantis' home directory, ensure that you grant the atlantis user the correct permissions.
+  Note that the atlantis user is restricted to `/home/atlantis/`. 
+  If you set the `--data-dir` flag to a path outside of Atlantis its home directory, ensure that you grant the atlantis user the correct permissions.
 
 ### `--default-tf-version`
   ```bash


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

As the atlantis user is restricted to the home directory of atlantis (`/home/atlantis`), setting the `--data-dir` flag to another path will result in a permission denied error. 

I've updated the documentation to be more explicit on this common pitfall.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

This is a common made mistake as we nowhere document how restricted the atlantis user is,[ I had to look at the docker-base](https://github.com/runatlantis/atlantis/blob/main/docker-base/Dockerfile.alpine#L7-L18) to understand why, what and where the atlantis user permissions were applied.

## tests

<!--
- [ ] I have tested my changes by ...
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Closes #2903 
- Previous PR https://github.com/runatlantis/atlantis/pull/2908
