### PR TITLE
fix: allow to unlock closed PRs

### DIFF
--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -156,7 +156,7 @@ func (c *DefaultCommandRunner) RunAutoplanCommand(baseRepo models.Repo, headRepo
 		PullStatus: status,
 		Trigger:    command.AutoTrigger,
 	}
-	if !c.validateCtxAndComment(ctx) {
+	if !c.validateCtxAndComment(ctx, command.Autoplan) {
 		return
 	}
 	if c.DisableAutoplan {
@@ -281,7 +281,7 @@ func (c *DefaultCommandRunner) RunCommentCommand(baseRepo models.Repo, maybeHead
 		Trigger:    command.CommentTrigger,
 	}
 
-	if !c.validateCtxAndComment(ctx) {
+	if !c.validateCtxAndComment(ctx, cmd.Name) {
 		return
 	}
 
@@ -391,7 +391,7 @@ func (c *DefaultCommandRunner) ensureValidRepoMetadata(
 	return
 }
 
-func (c *DefaultCommandRunner) validateCtxAndComment(ctx *command.Context) bool {
+func (c *DefaultCommandRunner) validateCtxAndComment(ctx *command.Context, commandName command.Name) bool {
 	if !c.AllowForkPRs && ctx.HeadRepo.Owner != ctx.Pull.BaseRepo.Owner {
 		if c.SilenceForkPRErrors {
 			return false
@@ -403,7 +403,7 @@ func (c *DefaultCommandRunner) validateCtxAndComment(ctx *command.Context) bool 
 		return false
 	}
 
-	if ctx.Pull.State != models.OpenPullState {
+	if ctx.Pull.State != models.OpenPullState && commandName != command.Unlock {
 		ctx.Log.Info("command was run on closed pull request")
 		if err := c.VCSClient.CreateComment(ctx.Pull.BaseRepo, ctx.Pull.Num, "Atlantis commands can't be run on closed pull requests", ""); err != nil {
 			ctx.Log.Err("unable to comment: %s", err)


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

- As described in https://github.com/runatlantis/atlantis/issues/1202, it can happen that atlantis keeps lock open when a PR is closed mid-planning.
- This PR allows to comment "atlantis unlock" on closed PRs to bulk delete any leftover locks.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

- Ideally atlantis would signal any in-progress plans to gracefully terminate when a PR is closed before announcing that a PR has been closed, but this seems like a more complicated change.

## tests

- [x] I have tested my changes by building an image with this change, created a PR that changes a bunch of resources, closed it mid-planning. Waited for the "Ran Plan for " comment. Commented "atlantis unlock" and received "All Atlantis locks for this PR have been unlocked and plans discarded". Confirmed in the UI that all locks were gone.

## references
- https://github.com/runatlantis/atlantis/issues/1202