### PR TITLE
chore: enable renovate gomodUpdateImportPaths

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,7 +6,7 @@
   automerge: false,
   platformAutomerge: false,
   labels: ["dependencies"],
-  postUpdateOptions: ["gomodTidy", "yarnDedupeHighest"],
+  postUpdateOptions: ["gomodTidy", "gomodUpdateImportPaths", "yarnDedupeHighest"],
   prHourlyLimit: 0,
   prConcurrentLimit: 5,
   packageRules: [


### PR DESCRIPTION
## what

enable renovate gomodUpdateImportPaths option.

> If the user has enabled the option gomodUpdateImportPaths in the [postUpdateOptions](https://docs.renovatebot.com/configuration-options/#postupdateoptions) array, then Renovate uses [mod](https://github.com/marwan-at-work/mod) to update import paths on major updates, which can update any Go source file

https://docs.renovatebot.com/golang/

## why

renovate major version up PR doesn't consider removing old version.

https://github.com/runatlantis/atlantis/pull/2928


## tests

- [x] I have tested on forked repository https://github.com/krrrr38/atlantis/pull/46/files

## references

- https://github.com/runatlantis/atlantis/pull/2928
