### PR TITLE
docs: add Google Cloud module to deployment

### DIFF
--- a/runatlantis.io/docs/deployment.md
+++ b/runatlantis.io/docs/deployment.md
@@ -539,7 +539,7 @@ Once you're done, see [Next Steps](#next-steps).
 ### Google Compute Engine (CCE)
 It's also possible to run Atlantis on Google Compute Engine.
 
-There's a Terraform module available that runs Atlantis as a Docker container on a Compute Engine VM.
+There's a Terraform module available that deploys Atlantis as a Docker container on a managed Compute Engine instance.
 
 The Terraform module features creation of a Cloud load balancer, Container-Optimized OS based VM, a persistent data disk and a managed instance group: [https://github.com/bschaatsbergen/terraform-gce-atlantis](https://github.com/bschaatsbergen/terraform-gce-atlantis).
 

--- a/runatlantis.io/docs/deployment.md
+++ b/runatlantis.io/docs/deployment.md
@@ -537,11 +537,11 @@ Cloud Storage Backend and TLS certs: [https://github.com/sethvargo/atlantis-on-g
 Once you're done, see [Next Steps](#next-steps).
 
 ### Google Compute Engine (GCE)
-Atlantis can also be run on Google Compute Engine using a Terraform module that deploys it as a Docker container on a managed Compute Engine instance. 
+Atlantis can be run on Google Compute Engine using a Terraform module that deploys it as a Docker container on a managed Compute Engine instance. 
 
-This Terraform module features the creation of a Cloud load balancer, a Container-Optimized OS-based VM, a persistent data disk, and a managed instance group. [https://registry.terraform.io/modules/bschaatsbergen/atlantis/gce/latest](https://registry.terraform.io/modules/bschaatsbergen/atlantis/gce/latest).
+This [Terraform module](https://registry.terraform.io/modules/bschaatsbergen/atlantis/gce/latest) features the creation of a Cloud load balancer, a Container-Optimized OS-based VM, a persistent data disk, and a managed instance group. .
 
-When you're finished, see [Next Steps](#next-steps).
+After it is deployed, see [Next Steps](#next-steps).
 
 ### Docker
 Atlantis has an [official](https://ghcr.io/runatlantis/atlantis) Docker image: `ghcr.io/runatlantis/atlantis`.

--- a/runatlantis.io/docs/deployment.md
+++ b/runatlantis.io/docs/deployment.md
@@ -539,7 +539,7 @@ Once you're done, see [Next Steps](#next-steps).
 ### Google Compute Engine (GCE)
 Atlantis can be run on Google Compute Engine using a Terraform module that deploys it as a Docker container on a managed Compute Engine instance. 
 
-This [Terraform module](https://registry.terraform.io/modules/bschaatsbergen/atlantis/gce/latest) features the creation of a Cloud load balancer, a Container-Optimized OS-based VM, a persistent data disk, and a managed instance group. .
+This [Terraform module](https://registry.terraform.io/modules/bschaatsbergen/atlantis/gce/latest) features the creation of a Cloud load balancer, a Container-Optimized OS-based VM, a persistent data disk, and a managed instance group.
 
 After it is deployed, see [Next Steps](#next-steps).
 

--- a/runatlantis.io/docs/deployment.md
+++ b/runatlantis.io/docs/deployment.md
@@ -539,7 +539,7 @@ Once you're done, see [Next Steps](#next-steps).
 ### Google Compute Engine (GCE)
 Atlantis can also be run on Google Compute Engine using a Terraform module that deploys it as a Docker container on a managed Compute Engine instance. 
 
-This Terraform module features the creation of a Cloud load balancer, a Container-Optimized OS-based VM, a persistent data disk, and a managed instance group.[https://registry.terraform.io/modules/bschaatsbergen/atlantis/gce/latest](https://registry.terraform.io/modules/bschaatsbergen/atlantis/gce/latest).
+This Terraform module features the creation of a Cloud load balancer, a Container-Optimized OS-based VM, a persistent data disk, and a managed instance group. [https://registry.terraform.io/modules/bschaatsbergen/atlantis/gce/latest](https://registry.terraform.io/modules/bschaatsbergen/atlantis/gce/latest).
 
 When you're finished, see [Next Steps](#next-steps).
 

--- a/runatlantis.io/docs/deployment.md
+++ b/runatlantis.io/docs/deployment.md
@@ -536,6 +536,15 @@ Cloud Storage Backend and TLS certs: [https://github.com/sethvargo/atlantis-on-g
 
 Once you're done, see [Next Steps](#next-steps).
 
+### Google Compute Engine (CCE)
+It's also possible to run Atlantis on Google Compute Engine.
+
+There's a Terraform module available that runs Atlantis as a Docker container on a Compute Engine VM.
+
+The Terraform module features creation of a Cloud load balancer, Container-Optimized OS based VM, a persistent data disk and a managed instance group: [https://github.com/bschaatsbergen/terraform-gce-atlantis](https://github.com/bschaatsbergen/terraform-gce-atlantis).
+
+When you're finished, see [Next Steps](#next-steps).
+
 ### Docker
 Atlantis has an [official](https://ghcr.io/runatlantis/atlantis) Docker image: `ghcr.io/runatlantis/atlantis`.
 

--- a/runatlantis.io/docs/deployment.md
+++ b/runatlantis.io/docs/deployment.md
@@ -536,7 +536,7 @@ Cloud Storage Backend and TLS certs: [https://github.com/sethvargo/atlantis-on-g
 
 Once you're done, see [Next Steps](#next-steps).
 
-### Google Compute Engine (CCE)
+### Google Compute Engine (GCE)
 Atlantis can also be run on Google Compute Engine using a Terraform module that deploys it as a Docker container on a managed Compute Engine instance. 
 
 This Terraform module features the creation of a Cloud load balancer, a Container-Optimized OS-based VM, a persistent data disk, and a managed instance group.[https://github.com/bschaatsbergen/terraform-gce-atlantis](https://github.com/bschaatsbergen/terraform-gce-atlantis).

--- a/runatlantis.io/docs/deployment.md
+++ b/runatlantis.io/docs/deployment.md
@@ -537,11 +537,9 @@ Cloud Storage Backend and TLS certs: [https://github.com/sethvargo/atlantis-on-g
 Once you're done, see [Next Steps](#next-steps).
 
 ### Google Compute Engine (CCE)
-It's also possible to run Atlantis on Google Compute Engine.
+Atlantis can also be run on Google Compute Engine using a Terraform module that deploys it as a Docker container on a managed Compute Engine instance. 
 
-There's a Terraform module available that deploys Atlantis as a Docker container on a managed Compute Engine instance.
-
-The Terraform module features creation of a Cloud load balancer, Container-Optimized OS based VM, a persistent data disk and a managed instance group: [https://github.com/bschaatsbergen/terraform-gce-atlantis](https://github.com/bschaatsbergen/terraform-gce-atlantis).
+This Terraform module features the creation of a Cloud load balancer, a Container-Optimized OS-based VM, a persistent data disk, and a managed instance group.[https://github.com/bschaatsbergen/terraform-gce-atlantis](https://github.com/bschaatsbergen/terraform-gce-atlantis).
 
 When you're finished, see [Next Steps](#next-steps).
 

--- a/runatlantis.io/docs/deployment.md
+++ b/runatlantis.io/docs/deployment.md
@@ -539,7 +539,7 @@ Once you're done, see [Next Steps](#next-steps).
 ### Google Compute Engine (GCE)
 Atlantis can also be run on Google Compute Engine using a Terraform module that deploys it as a Docker container on a managed Compute Engine instance. 
 
-This Terraform module features the creation of a Cloud load balancer, a Container-Optimized OS-based VM, a persistent data disk, and a managed instance group.[https://github.com/bschaatsbergen/terraform-gce-atlantis](https://github.com/bschaatsbergen/terraform-gce-atlantis).
+This Terraform module features the creation of a Cloud load balancer, a Container-Optimized OS-based VM, a persistent data disk, and a managed instance group.[https://registry.terraform.io/modules/bschaatsbergen/atlantis/gce/latest](https://registry.terraform.io/modules/bschaatsbergen/atlantis/gce/latest).
 
 When you're finished, see [Next Steps](#next-steps).
 


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

- This pull request proposes adding a new way to deploy Atlantis on Google Cloud using Compute Engine

- The Terraform module features the creation of a Container-Optimized VM running Atlantis in a Docker container. The VM is managed by a Managed Instance Group and a stateful GCE Persistent Disk is attached to the VM. In addition to this, an External HTTPS Load Balancer is created that services the traffic destined for Atlantis to handle.

- As we're actively maintaining this production-ready Google Cloud Atlantis Compute Engine module it seemed logical to use to propose this deployment option to the Atlantis documentation.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

- When proposing the use of Atlantis to many clients, we often receive feedback that a Google Kubernetes Engine (GKE) cluster, which is the only featured way to run Atlantis on Google Cloud, may be too complex for their needs, particularly if they lack the knowledge or capacity to maintain the cluster after we are no longer working on the project or with the client.

- The Terraform module is production-ready and has a rich feature set that continues to expand. 

- Using the Terraform module, you can have Atlantis up and running in a couple of minutes.

## tests

<!--
- [ ] I have tested my changes by ...
-->

The module has been extensively tested by me, a set of colleagues that were involved in the development of the module and various users.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- https://github.com/bschaatsbergen/terraform-gce-atlantis
- https://registry.terraform.io/modules/bschaatsbergen/atlantis/gce/latest

