### PR TITLE
docs: Add `api-secret` flag

### DIFF
--- a/runatlantis.io/docs/server-side-repo-config.md
+++ b/runatlantis.io/docs/server-side-repo-config.md
@@ -78,6 +78,10 @@ repos:
   post_workflow_hooks: 
     - run: my-post-workflow-hook-command arg1
 
+  # api-secret defines the secret used to pass to the /api/plan and /api/apply endpoints
+  # if not present the api endpoints will not be accesible.
+  api-secret: "myapisecret"
+
   # id can also be an exact match.
 - id: github.com/myorg/specific-repo
 
@@ -472,6 +476,7 @@ If you set a workflow with the key `default`, it will override this.
 | allow_custom_workflows        | bool     | false   | no       | Whether or not to allow [Custom Workflows](custom-workflows.html).                                                                                                                                                                                                                                        |
 | delete_source_branch_on_merge | bool     | false   | no       | Whether or not to delete the source branch on merge (only AzureDevOps and GitLab support)                                                                                                                                                                                                                 |
 | repo_locking                  | bool     | false   | no       | Whether or not to get a lock                                                                                                                                                                                                                                                                              |
+| api-secret                    | string   | none    | no       | Api secret key for the /api/plan and /api/apply api endpoints. if not set the /api/* endpoints are disable by default.  |
 
 
 :::tip Notes


### PR DESCRIPTION
## what

Addin `api-secret` key to docs


## why

missing config key for the API

## tests

Tested locally

## references

#997 

