### PR TITLE
chore: use actions/checkout@v3

### DIFF
--- a/.github/workflows/renovate-config.yml
+++ b/.github/workflows/renovate-config.yml
@@ -15,6 +15,6 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
       - run: npx --package renovate -c 'renovate-config-validator'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,5 +29,5 @@ jobs:
     runs-on: ubuntu-22.04
     container: ghcr.io/runatlantis/testing-env:2023.01.04
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3
       - run: make test-all


### PR DESCRIPTION
## what

use actions/checkout@v3 instead actions/checkout@v3.3.0.

## why

Both `actions/checkout@v3` and `actions/checkout@v3.3.0` are existed in this repo.

minor version update is redundant like https://github.com/runatlantis/atlantis/pull/2943.

```
✘╹◡╹✘☆  ag uses: .github | perl -pe 's/.*uses: (.*)/$1/' | sort -u
actions/checkout@v3
actions/checkout@v3.3.0
actions/setup-go@v3
actions/setup-node@v3
actions/stale@v7
docker/build-push-action@v3
docker/login-action@v2
docker/metadata-action@v4
docker/setup-buildx-action@v2
docker/setup-qemu-action@v2
goreleaser/goreleaser-action@v4
mislav/bump-homebrew-formula-action@v2
reviewdog/action-golangci-lint@v2
```

## tests
after 

```
✘╹◡╹✘☆  ag uses: .github | perl -pe 's/.*uses: (.*)/$1/' | sort -u | grep checkout
actions/checkout@v3
```

## references
- https://github.com/runatlantis/atlantis/pull/2943