### PR TITLE
feat: Support team owners for conftest policies

### DIFF
--- a/runatlantis.io/docs/access-credentials.md
+++ b/runatlantis.io/docs/access-credentials.md
@@ -57,6 +57,8 @@ GitHub App needs these permissions. These are automatically set when a GitHub ap
 
 ::: tip NOTE
 Since v0.19.7, a new permission for `Administration` has been added. If you have already created a GitHub app, updating Atlantis to v0.19.7 will not automatically add this permission, so you will need to set it manually.
+
+Since v0.22.3, a new permission for `Members` has been added, which is required for features that apply permissions to an organizations team members rather than individual users. Like the `Administration` permission above, updating Atlantis will not automatically add this permission, so if you wish to use features that rely on checking team membership you will need to add this manually.
 :::
 
 | Type            | Access              | 
@@ -69,6 +71,7 @@ Since v0.19.7, a new permission for `Administration` has been added. If you have
 | Metadata        | Read-only (default) | 
 | Pull requests   | Read and write      | 
 | Webhooks        | Read and write      | 
+| Members         | Read-only           | 
 
 ### GitLab
 - Follow: [https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html#create-a-personal-access-token](https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html#create-a-personal-access-token)

--- a/runatlantis.io/docs/server-side-repo-config.md
+++ b/runatlantis.io/docs/server-side-repo-config.md
@@ -521,7 +521,8 @@ If you set a workflow with the key `default`, it will override this.
 ### Owners
 | Key         | Type              | Default | Required   | Description                                             |
 |-------------|-------------------|---------|------------|---------------------------------------------------------|
-| users       | []string          | none    | yes        | list of github users that can approve failing policies  |
+| users       | []string          | none    | no         | list of github users that can approve failing policies  |
+| teams       | []string          | none    | no         | list of github teams that can approve failing policies  |
 
 ### PolicySet
 

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1222,6 +1222,7 @@ func setupE2E(t *testing.T, repoDir string, opt setupOption) (events_controllers
 		dbUpdater,
 		silenceNoProjects,
 		false,
+		e2eVCSClient,
 	)
 
 	unlockCommandRunner := events.NewUnlockCommandRunner(

--- a/server/controllers/github_app_controller.go
+++ b/server/controllers/github_app_controller.go
@@ -121,6 +121,7 @@ func (g *GithubAppController) New(w http.ResponseWriter, r *http.Request) {
 			"repository_hooks": "write",
 			"statuses":         "write",
 			"administration":   "read",
+			"members":          "read",
 		},
 	}
 

--- a/server/core/config/raw/policies.go
+++ b/server/core/config/raw/policies.go
@@ -40,6 +40,7 @@ func (p PolicySets) ToValid() valid.PolicySets {
 
 type PolicyOwners struct {
 	Users []string `yaml:"users,omitempty" json:"users,omitempty"`
+	Teams []string `yaml:"teams,omitempty" json:"teams,omitempty"`
 }
 
 func (o PolicyOwners) ToValid() valid.PolicyOwners {
@@ -47,6 +48,10 @@ func (o PolicyOwners) ToValid() valid.PolicyOwners {
 
 	if len(o.Users) > 0 {
 		policyOwners.Users = o.Users
+	}
+
+	if len(o.Teams) > 0 {
+		policyOwners.Teams = o.Teams
 	}
 	return policyOwners
 }

--- a/server/core/config/raw/policies_test.go
+++ b/server/core/config/raw/policies_test.go
@@ -180,6 +180,9 @@ func TestPolicySets_ToValid(t *testing.T) {
 					Users: []string{
 						"test",
 					},
+					Teams: []string{
+						"testteam",
+					},
 				},
 				PolicySets: []raw.PolicySet{
 					{
@@ -199,6 +202,7 @@ func TestPolicySets_ToValid(t *testing.T) {
 				Version: version,
 				Owners: valid.PolicyOwners{
 					Users: []string{"test"},
+					Teams: []string{"testteam"},
 				},
 				PolicySets: []valid.PolicySet{
 					{

--- a/server/core/config/valid/policies.go
+++ b/server/core/config/valid/policies.go
@@ -22,6 +22,7 @@ type PolicySets struct {
 
 type PolicyOwners struct {
 	Users []string
+	Teams []string
 }
 
 type PolicySet struct {
@@ -35,10 +36,22 @@ func (p *PolicySets) HasPolicies() bool {
 	return len(p.PolicySets) > 0
 }
 
-func (p *PolicySets) IsOwner(username string) bool {
+func (p *PolicySets) HasTeamOwners() bool {
+	return len(p.Owners.Teams) > 0
+}
+
+func (p *PolicySets) IsOwner(username string, userTeams []string) bool {
 	for _, uname := range p.Owners.Users {
 		if strings.EqualFold(uname, username) {
 			return true
+		}
+	}
+
+	for _, orgTeamName := range p.Owners.Teams {
+		for _, userTeamName := range userTeams {
+			if strings.EqualFold(orgTeamName, userTeamName) {
+				return true
+			}
 		}
 	}
 

--- a/server/events/approve_policies_command_runner_test.go
+++ b/server/events/approve_policies_command_runner_test.go
@@ -20,16 +20,41 @@ func TestApproveCommandRunner_IsOwner(t *testing.T) {
 	cases := []struct {
 		Description string
 		OwnerUsers  []string
+		OwnerTeams  []string // Teams configured as owners
+		UserTeams   []string // Teams the user is a member of
 		ExpComment  string
 	}{
 		{
 			Description: "When user is not an owner, approval fails",
 			OwnerUsers:  []string{},
+			OwnerTeams:  []string{},
 			ExpComment:  "**Approve Policies Error**\n```\ncontact policy owners to approve failing policies\n```\n",
 		},
 		{
 			Description: "When user is an owner, approval succeeds",
 			OwnerUsers:  []string{fixtures.User.Username},
+			OwnerTeams:  []string{},
+			ExpComment:  "Approved Policies for 1 projects:\n\n1. dir: `` workspace: ``\n\n\n",
+		},
+		{
+			Description: "When user is an owner via team membership, approval succeeds",
+			OwnerUsers:  []string{},
+			OwnerTeams:  []string{"SomeTeam"},
+			UserTeams:   []string{"SomeTeam"},
+			ExpComment:  "Approved Policies for 1 projects:\n\n1. dir: `` workspace: ``\n\n\n",
+		},
+		{
+			Description: "When user belongs to a team not configured as a owner, approval fails",
+			OwnerUsers:  []string{},
+			OwnerTeams:  []string{"SomeTeam"},
+			UserTeams:   []string{"SomeOtherTeam}"},
+			ExpComment:  "**Approve Policies Error**\n```\ncontact policy owners to approve failing policies\n```\n",
+		},
+		{
+			Description: "When user is an owner but not a team member, approval succeeds",
+			OwnerUsers:  []string{fixtures.User.Username},
+			OwnerTeams:  []string{"SomeTeam"},
+			UserTeams:   []string{"SomeOtherTeam"},
 			ExpComment:  "Approved Policies for 1 projects:\n\n1. dir: `` workspace: ``\n\n\n",
 		},
 	}
@@ -57,10 +82,12 @@ func TestApproveCommandRunner_IsOwner(t *testing.T) {
 					PolicySets: valid.PolicySets{
 						Owners: valid.PolicyOwners{
 							Users: c.OwnerUsers,
+							Teams: c.OwnerTeams,
 						},
 					},
 				},
 			}, nil)
+			When(vcsClient.GetTeamNamesForUser(fixtures.GithubRepo, fixtures.User)).ThenReturn(c.UserTeams, nil)
 
 			approvePoliciesCommandRunner.Run(ctx, &events.CommentCommand{Name: command.ApprovePolicies})
 

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -182,6 +182,7 @@ func setup(t *testing.T, options ...func(testConfig *TestConfig)) *vcsmocks.Mock
 		dbUpdater,
 		testConfig.SilenceNoProjects,
 		false,
+		vcsClient,
 	)
 
 	unlockCommandRunner = events.NewUnlockCommandRunner(

--- a/server/server.go
+++ b/server/server.go
@@ -714,6 +714,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		dbUpdater,
 		userConfig.SilenceNoProjects,
 		userConfig.SilenceVCSStatusNoPlans,
+		vcsClient,
 	)
 
 	unlockCommandRunner := events.NewUnlockCommandRunner(


### PR DESCRIPTION
## what

In addition to a list of usernames, support checking team membership when validating a particular user can approve policy violations. The new code path is only executed if team membership is configured, so it's a low impact change for existing installations.

This also documents a missing GitHub app permission - `GetTeamNamesForUser` was added in #1694 and requires the `members:read` scope, I had to add that to my GitHub app to test this feature.

~I need to make some doc updates for this, but wanted to get some feedback on the code first.~ docs updated

## why

Maintaining a list of users by hand is a lot of toil for larger orgs.

## tests

- Tested against Github using a real GitHub app, org, and repo. ([gif](https://user-images.githubusercontent.com/398706/211519646-aaae07d1-7adb-4e26-a4ea-57b4012fe15a.gif))
- Unit tests

## references

- Closes #1476
- Depends on: #2955