### PR TITLE
Bump openssl version to fix CVE-2022-3996

### DIFF
--- a/docker-base/Dockerfile.alpine
+++ b/docker-base/Dockerfile.alpine
@@ -26,7 +26,7 @@ ARG TARGETPLATFORM
 
 # Install packages needed for running Atlantis.
 RUN apk add --no-cache \
-        ca-certificates=20220614-r3 \
+        ca-certificates=20220614-r4 \
         curl=7.87.0-r0 \
         git=2.38.2-r0 \
         unzip=6.0-r13 \
@@ -38,7 +38,7 @@ RUN apk add --no-cache \
     # Install packages needed for building dependencies.
     apk add --no-cache --virtual .build-deps \
         gnupg=2.2.40-r0 \
-        openssl=3.0.7-r0 && \
+        openssl=3.0.7-r2 && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
     # git-lfs


### PR DESCRIPTION
Bump openssl version to fix CVE-2022-3996. Bump ca-certificates to avoid dependency problem.

Signed-off-by: Roberto Montero <roberto.montero@commercetools.com>

## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
CVE-2022-3996 was affecting Docker base alpine version. 
https://www.cve.org/CVERecord?id=CVE-2022-3996

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## tests

<!--
- [ ] I have tested my changes by ...
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

