### PR TITLE
docker: bump base to 2023-01-09

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ATLANTIS_BASE=ghcr.io/runatlantis/atlantis-base
-ARG ATLANTIS_BASE_TAG_DATE=2022.12.29
+ARG ATLANTIS_BASE_TAG_DATE=2023.01.09
 ARG ATLANTIS_BASE_TAG_TYPE=alpine
 
 # Stage 1: build artifact


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- Bump base to 2023-01-09

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- Latest dependency updates

## tests

- [ ] I have tested my changes by confirming tests below

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Relates to https://github.com/runatlantis/atlantis/pull/2896
- Relates to https://github.com/runatlantis/atlantis/pull/2954
- https://github.com/runatlantis/atlantis/pkgs/container/atlantis-base/62508117?tag=2023.01.09