### PR TITLE
chore(test): fix `atlantis import` test

### DIFF
--- a/server/controllers/events/testfixtures/test-repos/import-workspace/exp-output-import-dir1-ops-dummy1.txt
+++ b/server/controllers/events/testfixtures/test-repos/import-workspace/exp-output-import-dir1-ops-dummy1.txt
@@ -14,5 +14,3 @@ your Terraform state and will henceforth be managed by Terraform.
 
 * :repeat: To **plan** this project again, comment:
   * `atlantis plan -p dir1-ops`
-
-

--- a/server/controllers/events/testfixtures/test-repos/import-workspace/exp-output-import-dir1-ops-dummy1.txt
+++ b/server/controllers/events/testfixtures/test-repos/import-workspace/exp-output-import-dir1-ops-dummy1.txt
@@ -10,8 +10,6 @@ Import successful!
 
 The resources that were imported are shown above. These resources are now in
 your Terraform state and will henceforth be managed by Terraform.
-
-
 ```
 
 * :repeat: To **plan** this project again, comment:

--- a/server/controllers/events/testfixtures/test-repos/import-workspace/exp-output-import-dir1-ops-dummy2.txt
+++ b/server/controllers/events/testfixtures/test-repos/import-workspace/exp-output-import-dir1-ops-dummy2.txt
@@ -10,11 +10,7 @@ Import successful!
 
 The resources that were imported are shown above. These resources are now in
 your Terraform state and will henceforth be managed by Terraform.
-
-
 ```
 
 * :repeat: To **plan** this project again, comment:
   * `atlantis plan -p dir1-ops`
-
-

--- a/server/controllers/events/testfixtures/test-repos/import-workspace/exp-output-plan.txt
+++ b/server/controllers/events/testfixtures/test-repos/import-workspace/exp-output-plan.txt
@@ -1,12 +1,10 @@
 Ran Plan for project: `dir1-ops` dir: `dir1` workspace: `ops`
 
 ```diff
-
 No changes. Your infrastructure matches the configuration.
 
 Terraform has compared your real infrastructure against your configuration
 and found no differences, so no changes are needed.
-
 ```
 
 * :arrow_forward: To **apply** this plan, comment:


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- fix `atlantis import` test

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- Previous PR ran tests but not e2e tests. The e2e tests failed after the PR merge.

https://github.com/runatlantis/atlantis/blob/c77149396ac94c9836cbbdc07196d6dac3585530/server/controllers/events/events_controller_e2e_test.go#L449-L463

## tests

- [x] I have tested my changes by running e2e tests in this PR

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Previous PR https://github.com/runatlantis/atlantis/pull/2937
- Bad run https://github.com/runatlantis/atlantis/actions/runs/3897759236/jobs/6655758097
- https://github.com/runatlantis/atlantis/tree/main/server/controllers/events/testfixtures/test-repos/import-workspace
