### PR TITLE
feat(azure-devops): Add token header to git for on premise support

### DIFF
--- a/server/core/runtime/post_workflow_hook_runner_test.go
+++ b/server/core/runtime/post_workflow_hook_runner_test.go
@@ -88,7 +88,7 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 				},
 				HeadRepo: models.Repo{
 					Name:  "headname",
-					Owner: "headowner",
+					Owner: "headowner",					
 				},
 				Pull: models.PullRequest{
 					Num:        2,

--- a/server/core/runtime/post_workflow_hook_runner_test.go
+++ b/server/core/runtime/post_workflow_hook_runner_test.go
@@ -88,7 +88,7 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 				},
 				HeadRepo: models.Repo{
 					Name:  "headname",
-					Owner: "headowner",					
+					Owner: "headowner",
 				},
 				Pull: models.PullRequest{
 					Num:        2,

--- a/server/events/event_parser_test.go
+++ b/server/events/event_parser_test.go
@@ -1215,6 +1215,7 @@ func TestParseAzureDevopsRepo(t *testing.T) {
 		VCSHost: models.VCSHost{
 			Hostname: "dev.azure.com",
 			Type:     models.AzureDevops,
+			VcsToken: "azuredevops-token",
 		},
 	}, r)
 
@@ -1232,6 +1233,7 @@ func TestParseAzureDevopsRepo(t *testing.T) {
 		VCSHost: models.VCSHost{
 			Hostname: "dev.azure.com",
 			Type:     models.AzureDevops,
+			VcsToken: "azuredevops-token",
 		},
 	}, r)
 
@@ -1249,6 +1251,7 @@ func TestParseAzureDevopsRepo(t *testing.T) {
 		VCSHost: models.VCSHost{
 			Hostname: "owner.visualstudio.com",
 			Type:     models.AzureDevops,
+			VcsToken: "azuredevops-token",
 		},
 	}, r)
 
@@ -1266,6 +1269,7 @@ func TestParseAzureDevopsRepo(t *testing.T) {
 		VCSHost: models.VCSHost{
 			Hostname: "dev.azure.com",
 			Type:     models.AzureDevops,
+			VcsToken: "azuredevops-token",
 		},
 	}, r)
 }
@@ -1308,6 +1312,7 @@ func TestParseAzureDevopsPullEvent(t *testing.T) {
 		VCSHost: models.VCSHost{
 			Hostname: "dev.azure.com",
 			Type:     models.AzureDevops,
+			VcsToken: "azuredevops-token",
 		},
 	}
 	Equals(t, expBaseRepo, actBaseRepo)
@@ -1410,6 +1415,7 @@ func TestParseAzureDevopsPull(t *testing.T) {
 		VCSHost: models.VCSHost{
 			Hostname: "dev.azure.com",
 			Type:     models.AzureDevops,
+			VcsToken: "azuredevops-token",
 		},
 	}
 	Equals(t, models.PullRequest{
@@ -1441,6 +1447,7 @@ func TestParseAzureDevopsSelfHostedRepo(t *testing.T) {
 		VCSHost: models.VCSHost{
 			Hostname: "devops.abc.com",
 			Type:     models.AzureDevops,
+			VcsToken: "azuredevops-token",
 		},
 	}, r)
 
@@ -1484,6 +1491,7 @@ func TestParseAzureDevopsSelfHostedPullEvent(t *testing.T) {
 		VCSHost: models.VCSHost{
 			Hostname: "devops.abc.com",
 			Type:     models.AzureDevops,
+			VcsToken: "azuredevops-token",
 		},
 	}
 	Equals(t, expBaseRepo, actBaseRepo)
@@ -1586,6 +1594,7 @@ func TestParseAzureSelfHostedDevopsPull(t *testing.T) {
 		VCSHost: models.VCSHost{
 			Hostname: "devops.abc.com",
 			Type:     models.AzureDevops,
+			VcsToken: "azuredevops-token",
 		},
 	}
 	Equals(t, models.PullRequest{

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -131,6 +131,11 @@ func NewRepo(vcsHostType VCSHostType, repoFullName string, cloneURL string, vcsU
 		return Repo{}, fmt.Errorf("invalid repo format %q, repo %q should not contain any /'s", repoFullName, owner)
 	}
 
+	azuredevopsVcsToken := ""
+	if vcsHostType == AzureDevops {
+		azuredevopsVcsToken = vcsToken
+	}
+
 	return Repo{
 		FullName:          repoFullName,
 		Owner:             owner,
@@ -140,7 +145,7 @@ func NewRepo(vcsHostType VCSHostType, repoFullName string, cloneURL string, vcsU
 		VCSHost: VCSHost{
 			Type:     vcsHostType,
 			Hostname: cloneURLParsed.Hostname(),
-			VcsToken: vcsToken,
+			VcsToken: azuredevopsVcsToken,
 		},
 	}, nil
 }

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -140,6 +140,7 @@ func NewRepo(vcsHostType VCSHostType, repoFullName string, cloneURL string, vcsU
 		VCSHost: VCSHost{
 			Type:     vcsHostType,
 			Hostname: cloneURLParsed.Hostname(),
+			VcsToken: vcsToken,
 		},
 	}, nil
 }
@@ -289,6 +290,9 @@ type VCSHost struct {
 
 	// Type is which type of VCS host this is, ex. GitHub or GitLab.
 	Type VCSHostType
+
+	// Pat token for DevOps as can't be included in repo URL
+	VcsToken string
 }
 
 type VCSHostType int

--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -232,10 +232,16 @@ func (w *FileWorkspace) forceClone(log logging.SimpleLogging,
 	if w.TestingOverrideBaseCloneURL != "" {
 		baseCloneURL = w.TestingOverrideBaseCloneURL
 	}
-	
-	auth := fmt.Sprintf(":%s", headRepo.VCSHost.VcsToken)
-	authBase64Token := base64.StdEncoding.EncodeToString([]byte(auth))
-	headerCmd := []string{"-c", fmt.Sprintf(`http.extraHeader=Authorization: Basic %s`,authBase64Token)}
+
+	var headerCmd []string
+
+	if headRepo.VCSHost.VcsToken != "" {
+		auth := fmt.Sprintf(":%s", headRepo.VCSHost.VcsToken)
+		authBase64Token := base64.StdEncoding.EncodeToString([]byte(auth))
+		headerCmd = []string{"-c", fmt.Sprintf(`http.extraHeader=Authorization: Basic %s`, authBase64Token)}
+	} else {
+		headerCmd = []string{}
+	}
 
 	var cmds [][]string
 	if w.CheckoutMerge {


### PR DESCRIPTION
## what

- The PR allows Atlantis to work with the on-premise installation of DevOps by adding the PAT token as an HTTP Header to GIT operations.

## why

- To be able to use Atlantis with the on-premise installation of DevOps.

## tests

- The testing implementation is now. Further discussion is needed on the optionality of distinguishing between cloud and hosted Azure DevOps.

## references

- Closes #2637



