### PR TITLE
docs: Add clarification to `enable-regex-cmp` flag

### DIFF
--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -394,6 +394,8 @@ and set `--autoplan-modules` to `false`.
   Enable Atlantis to use regular expressions to run plan/apply commands against defined project names when `-p` flag is passed with it.
   
   This can be used to run all defined projects (with the `name` key) in `atlantis.yaml` using `atlantis plan -p .*`.
+  
+  This flag works in conjunction with [allowed_regexp_prefixes](https://www.runatlantis.io/docs/repo-level-atlantis-yaml.html#reference) in the `atlantis.yaml` file, if defined, will only allow the regexes listed in the `allowed_regexp_prefixes`. By Default if not defined in the `atlantis.yaml` file it will default to `[]` which will allow any regex.
 
   This will not work with `-d` yet and to use `-p` the repo projects must be defined in the repo `atlantis.yaml` file.
 

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -395,7 +395,7 @@ and set `--autoplan-modules` to `false`.
   
   This can be used to run all defined projects (with the `name` key) in `atlantis.yaml` using `atlantis plan -p .*`.
   
-  This flag works in conjunction with [allowed_regexp_prefixes](https://www.runatlantis.io/docs/repo-level-atlantis-yaml.html#reference) in the `atlantis.yaml` file, if defined, will only allow the regexes listed in the `allowed_regexp_prefixes`. By Default if not defined in the `atlantis.yaml` file it will default to `[]` which will allow any regex.
+  The flag will only allow the regexes listed in the [`allowed_regexp_prefixes`](https://www.runatlantis.io/docs/repo-level-atlantis-yaml.html#reference) key defined in the repo `atlantis.yaml` file. If the key is undefined, its value defaults to `[]` which will allow any regex.
 
   This will not work with `-d` yet and to use `-p` the repo projects must be defined in the repo `atlantis.yaml` file.
 


### PR DESCRIPTION
## what

missing doc for flag

## why


The docs did not mention the relationship between `allowed_regexp_prefixes` in the `atlantis.yaml` file and the server config flag `enable-regexp-cmd`


## references
https://www.runatlantis.io/docs/server-configuration.html#enable-regexp-cmd

