### PR TITLE
fix: markdown renderer use invalid disableApply flag with disableMarkdownFolding

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -415,8 +415,8 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	markdownRenderer := events.NewMarkdownRenderer(
 		gitlabClient.SupportsCommonMark(),
 		userConfig.DisableApplyAll,
-		userConfig.DisableMarkdownFolding,
 		disableApply,
+		userConfig.DisableMarkdownFolding,
 		userConfig.DisableRepoLocking,
 		userConfig.EnableDiffMarkdownFormat,
 		userConfig.MarkdownTemplateOverridesDir,


### PR DESCRIPTION
## what

fix markdown renderer configuration order

## why

- Even if disableApply, comment contains `To apply this plan, comment: atlantis apply -d .`.

## tests

- [x] I have tested my changes by local server and custom repository
  - https://github.com/krrrr38/atlantis-debug/pull/9

## references

- https://github.com/runatlantis/atlantis/discussions/3014#discussioncomment-4728231

