### PR TITLE
build(docker): fix intermittent ghcr push failures

### DIFF
--- a/.github/workflows/atlantis-base.yml
+++ b/.github/workflows/atlantis-base.yml
@@ -42,6 +42,13 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
+      # related issues for pinning buildkit
+      # https://github.com/docker/build-push-action/issues/761
+      # https://github.com/containerd/containerd/issues/7972
+      # https://github.com/containerd/containerd/pull/6995
+      with:
+        driver-opts: |
+          image=moby/buildkit:v0.10.6
 
     - name: Docker meta
       id: meta

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -39,6 +39,13 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
+      # related issues for pinning buildkit
+      # https://github.com/docker/build-push-action/issues/761
+      # https://github.com/containerd/containerd/issues/7972
+      # https://github.com/containerd/containerd/pull/6995
+      with:
+        driver-opts: |
+          image=moby/buildkit:v0.10.6
 
     - name: Docker meta
       id: meta


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- pin buildkit to v0.10.6

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- fix intermittent ghcr push failures

## tests

- I have not tested my changes
- I used the workaround provided by maintainers and hoping for the best

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- closes https://github.com/runatlantis/atlantis/issues/3017
- implements https://github.com/docker/build-push-action/issues/761#issuecomment-1383822381
