### PR TITLE
chore(test): remove redundant test job from circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,5 @@
 version: 2
 jobs:
-  test:
-    docker:
-    - image: ghcr.io/runatlantis/testing-env:latest
-    steps:
-    - checkout
-    - run: make check-fmt
-    - run: make check-lint
   e2e:
     docker:
     - image: cimg/go:1.19 # If you update this, update it in the Makefile too
@@ -60,10 +53,6 @@ workflows:
   version: 2
   branch:
     jobs:
-    - test:
-        filters:
-          branches:
-            ignore: /docs\/./
     - e2e:
         context:
           - atlantis-e2e-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,3 +31,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: make test-all
+      - run: make check-fmt


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- rm test job from circleci
- add `make check-fmt` to existing gha test job

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- Reduce reliance on circleci
- `make check-lint` is already done by reviewdog so no need to do that in both gha and circleci. This is why `make check-lint` wasn't added to the PR.

## tests

- [x] I have tested my changes by running action in this PR

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Similar to PR https://github.com/runatlantis/atlantis/pull/1781
