### PR TITLE
fix(actions): remove unused `test` reference to enable e2e

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,6 @@ workflows:
     - e2e:
         context:
           - atlantis-e2e-tests
-        requires: [test]
         filters:
           branches:
             # Ignore fork PRs since they don't have access to


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- remove unused `test` reference

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- enable e2e again

```
e2e: requires job "test" but "test" is not part of this workflow.
The following jobs are unreachable: e2e
```

## tests

- [x] I have tested my changes by confirming in circleci logs

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Error shown here https://app.circleci.com/pipelines/github/runatlantis/atlantis?branch=labeler
- Previous PR that removed `test` https://github.com/runatlantis/atlantis/pull/3026