### PR TITLE
docs: fix table formating for multienv

### DIFF
--- a/runatlantis.io/docs/custom-workflows.md
+++ b/runatlantis.io/docs/custom-workflows.md
@@ -509,10 +509,10 @@ to all steps defined **below** the `multienv` step.
 ```yaml
 - multienv: custom-command
 ```
-| Key      | Type   | Default | Required | Description                                   |
-|----------|--------|---------|----------|-----------------------------------------------|
-| multienv | string | none    | no       | Run a custom command and add set              |
-|          |        |         |          | environment variables according to the result |
+| Key      | Type   | Default | Required | Description                                                                    |
+|----------|--------|---------|----------|--------------------------------------------------------------------------------|
+| multienv | string | none    | no       | Run a custom command and add set environment variables according to the result |
+
 The result of the executed command must have a fixed format:
 EnvVar1Name=value1,EnvVar2Name=value2,EnvVar3Name=value3
 


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

Fixes a misformatted table in the docs under `docs/custom-workflows.html#multiple-environment-variables-multienv-command`. 


## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

- The text in the description column was broken over two rows, while the rest of the docs accepts long lines in one cell that wrap when displayed.
- The information on the fixed format expected appears to have been put into the table by mistake.

## tests

<!--
- [ ] I have tested my changes by ...
-->

I have tested the changes by running `yarn run website:dev` locally. Screenshots of before/after:

Before:

<img width="763" alt="ScreenShot 2023-01-23 at 13 25 57@2x" src="https://user-images.githubusercontent.com/1413264/214042474-374b2ac7-aad8-4cb9-b335-904155750e33.png">

After: 
<img width="767" alt="ScreenShot 2023-01-23 at 13 26 13@2x" src="https://user-images.githubusercontent.com/1413264/214042531-ec54c70e-1712-4886-a232-7ba5d6e1615e.png">

This is my first PR for this repo, so please let me know if there are any issues, or if I have misunderstood anything. 