### PR TITLE
fix(actions): set labeler to use correct `on` event

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,6 +9,12 @@ on:
     branches:
       - main
 
+permissions:
+  # All other permissions are set to none
+  checks: write
+  contents: read
+  pull-requests: write
+
 jobs:
   triage:
     permissions:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,19 +1,13 @@
 name: "Pull Request Labeler"
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize
       - reopened
     branches:
       - main
-
-permissions:
-  # All other permissions are set to none
-  checks: write
-  contents: read
-  pull-requests: write
 
 jobs:
   triage:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   triage:
     permissions:
+      checks: write
       contents: read
       pull-requests: write
     if: github.event.pull_request.draft == false

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,12 +2,6 @@ name: "Pull Request Labeler"
 
 on:
   pull_request_target:
-    types:
-      - opened
-      - synchronize
-      - reopened
-    branches:
-      - main
 
 jobs:
   triage:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,7 +6,6 @@ on:
 jobs:
   triage:
     permissions:
-      checks: write
       contents: read
       pull-requests: write
     if: github.event.pull_request.draft == false


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- change to pull_request_target per docs

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- fix labeler error

```
Error: HttpError: Resource not accessible by integration
Error: Resource not accessible by integration
```

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- mention of missing perm https://github.com/actions/labeler/issues/12#issuecomment-1095272652
- mention of pull_request_target https://github.com/actions/labeler/issues/136#issuecomment-1357839196
- should fix error in https://github.com/runatlantis/atlantis/actions/runs/3986925127/jobs/6837118127
