### PR TITLE
feat(release): version based on github release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,11 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version-file: go.mod
 
     - name: Run GoReleaser for stable release
       uses: goreleaser/goreleaser-action@v4
-      if: (!contains(github.ref, '-pre.'))
+      if: (!contains(github.ref, 'pre'))
       with:
         version: v0.183.0
         args: release --rm-dist
@@ -30,7 +30,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Generate changelog for pre release
-      if: contains(github.ref, '-pre.')
+      if: contains(github.ref, 'pre')
       id: changelog
       run: |
         echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
@@ -43,7 +43,7 @@ jobs:
 
     - name: Run GoReleaser for pre-release
       uses: goreleaser/goreleaser-action@v4
-      if: contains(github.ref, '-pre.')
+      if: contains(github.ref, 'pre')
       with:
         version: v0.183.0
         args: release --rm-dist --release-notes=tmp-CHANGELOG.md
@@ -55,7 +55,7 @@ jobs:
     name: "Bump Homebrew formula"
     runs-on: ubuntu-22.04
     if: false
-    # if: (!contains(github.ref, '-pre.'))
+    # if: (!contains(github.ref, 'pre'))
     steps:
       - uses: mislav/bump-homebrew-formula-action@v2
         with:

--- a/kustomize/bundle.yaml
+++ b/kustomize/bundle.yaml
@@ -22,7 +22,7 @@ spec:
         fsGroup: 1000 # Atlantis group (1000) read/write access to volumes.
       containers:
       - name: atlantis
-        image: ghcr.io/runatlantis/atlantis:v0.22.3
+        image: ghcr.io/runatlantis/atlantis:latest
         env:
         - name: ATLANTIS_DATA_DIR
           value: /atlantis

--- a/main.go
+++ b/main.go
@@ -24,9 +24,17 @@ import (
 	"github.com/spf13/viper"
 )
 
-const atlantisVersion = "0.22.3"
+// All of this is filled in by goreleaser upon release
+// https://goreleaser.com/cookbooks/using-main.version/
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
 
 func main() {
+	fmt.Printf("atlantis %s, commit %s, built at %s", version, commit, date)
+
 	v := viper.New()
 
 	logger, err := logging.NewStructuredLogger()
@@ -40,10 +48,10 @@ func main() {
 	server := &cmd.ServerCmd{
 		ServerCreator:   &cmd.DefaultServerCreator{},
 		Viper:           v,
-		AtlantisVersion: atlantisVersion,
+		AtlantisVersion: version,
 		Logger:          logger,
 	}
-	version := &cmd.VersionCmd{AtlantisVersion: atlantisVersion}
+	version := &cmd.VersionCmd{AtlantisVersion: version}
 	testdrive := &cmd.TestdriveCmd{}
 	cmd.RootCmd.AddCommand(server.Init())
 	cmd.RootCmd.AddCommand(version.Init())


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- Set version based on github release tag
- Set `kustomize` version to latest
- Set `rlcp` explicitly in `.goreleaser.yaml`

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- Prevent having to do manual PRs right before a release by passing in the tag version to goreleaser automatically
- set `kustomize` to our stable version `latest` to avoid manual bumps
- set `rlcp` to avoid deprecation for december 2023

## tests

- [x] I have tested my changes by checking this in a fork

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Closes #2912 
- https://goreleaser.com/cookbooks/using-main.version/
- https://goreleaser.com/deprecations/#archivesrlcp
- [action run](https://github.com/nitrocode/atlantis/actions/runs/4011248679/jobs/6888629922) for my fork version of v0.22.9000 shows it passes the tag to the version as described in goreleaser docs

Validate goreleaser config

```shell
✗ goreleaser check
  • loading config file                              file=.goreleaser.yml
  • checking config...
  • config is valid
```

From the action in fork

```shell
Run goreleaser/goreleaser-action@v4
Downloading https://github.com/goreleaser/goreleaser/releases/download/v0.183.0/goreleaser_Linux_x86_64.tar.gz
Extracting GoReleaser
/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/8577ded7-9a2b-4840-a39e-cfc6d1585df8 -f /home/runner/work/_temp/9c5966e3-718b-4bc4-9fc2-aa6bdf295ff2
GoReleaser v0.183.0 installed successfully
/opt/hostedtoolcache/goreleaser-action/0.183.0/x64/goreleaser release --rm-dist
   • releasing...     
   • loading config file       file=.goreleaser.yml
   • loading environment variables
   • getting and validating git state
      • building...               commit=9f50c6f0c382e516380617bf0f8bb323fba63789 latest tag=v0.22.9000
```

If this is run from the command line using `goreleaser`

```shell
✗ goreleaser build --rm-dist --snapshot --single-target
./dist/atlantis_darwin_amd64_v1/atlantis version
✗ atlantis 0.22.4-next, commit 9b0be50e889f5446394367b953623ea13ee44df5, built at 2023-01-26T00:50:21Zatlantis 0.22.4-next
```

If this is run from the command line using `go build` with the version explicitly added

```shell
✗ go build -v -ldflags "-X 'main.version=whosyourdaddy'" -o atlantis .
✗ ./atlantis version
github.com/runatlantis/atlantis
atlantis whosyourdaddy
```
