### PR TITLE
fix(docker): Set version based on release tag, revert gorelease signing

### DIFF
--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -28,20 +28,18 @@ jobs:
       RELEASE_TAG: ${{ contains(github.ref, 'pre') && 'prerelease-latest' || 'latest' }}
       IMAGE_BASE: ghcr.io/${{ github.repository_owner }}/atlantis
       IMAGE_SUFFIX: ${{ matrix.image_type != 'alpine' && format('-{0}', matrix.image_type) || '' }}
+
     steps:
     - uses: actions/checkout@v3
-      if: false
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
-      if: false
       with:
         image: tonistiigi/binfmt:latest
         platforms: arm64,arm
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
-      if: false
       # related issues for pinning buildkit
       # https://github.com/docker/build-push-action/issues/761
       # https://github.com/containerd/containerd/issues/7972
@@ -68,7 +66,6 @@ jobs:
 
     - name: Login to Packages Container registry
       uses: docker/login-action@v2
-      if: false
       with:
         registry: ghcr.io
         username: ${{ github.actor }}

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -62,7 +62,6 @@ jobs:
           type=ref,event=pr
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
-          type=schedule,pattern={{date 'YYYYMMDD'}}
 
     - name: Login to Packages Container registry
       uses: docker/login-action@v2
@@ -93,17 +92,16 @@ jobs:
 
     # Publish release to container registry
     - name: Populate release version
-      if: false
-      # if: |
-      #   contains(fromJson('["push", "pull_request"]'), github.event_name) &&
-      #   startsWith(github.ref, 'refs/tags/')
+      if: |
+        contains(fromJson('["push", "pull_request"]'), github.event_name) &&
+        startsWith(github.ref, 'refs/tags/')
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
     - name: "Build and push atlantis:${{ env.RELEASE_VERSION }} image for ${{ env.RELEASE_TYPE }} release"
       if: false
-      # if: |
-      #   contains(fromJson('["push", "pull_request"]'), github.event_name) &&
-      #   startsWith(github.ref, 'refs/tags/')
+      if: |
+        contains(fromJson('["push", "pull_request"]'), github.event_name) &&
+        startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
         cache-from: type=gha

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     strategy:
       matrix:
-        image_type: [alpine, debian]
+        image_type: [alpine] # , debian]
     runs-on: ubuntu-22.04
     env:
       RELEASE_TYPE: ${{ contains(github.ref, 'pre') && 'pre' || 'stable' }}
@@ -30,15 +30,18 @@ jobs:
       IMAGE_SUFFIX: ${{ matrix.image_type != 'alpine' && format('-{0}', matrix.image_type) || '' }}
     steps:
     - uses: actions/checkout@v3
+      if: false
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
+      if: false
       with:
         image: tonistiigi/binfmt:latest
         platforms: arm64,arm
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
+      if: false
       # related issues for pinning buildkit
       # https://github.com/docker/build-push-action/issues/761
       # https://github.com/containerd/containerd/issues/7972
@@ -56,10 +59,12 @@ jobs:
         labels: |
           org.opencontainers.image.licenses=Apache-2.0
         tags: |
+          type=raw,value=dev
           type=ref,event=branch
           type=ref,event=pr
-          type=semver,pattern={{version}},value=dev
+          type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
+          type=schedule,pattern={{date 'YYYYMMDD'}}
 
     - name: Login to Packages Container registry
       uses: docker/login-action@v2

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -98,7 +98,6 @@ jobs:
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
     - name: "Build and push atlantis:${{ env.RELEASE_VERSION }} image for ${{ env.RELEASE_TYPE }} release"
-      if: false
       if: |
         contains(fromJson('["push", "pull_request"]'), github.event_name) &&
         startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -58,11 +58,12 @@ jobs:
         tags: |
           type=ref,event=branch
           type=ref,event=pr
-          type=semver,pattern={{version}}
+          type=semver,pattern={{version}},value=dev
           type=semver,pattern={{major}}.{{minor}}
 
     - name: Login to Packages Container registry
       uses: docker/login-action@v2
+      if: false
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -70,13 +71,18 @@ jobs:
 
     # Publish dev image to container registry
     - name: Build and push atlantis:dev${{ env.IMAGE_SUFFIX }} image
-      if: ${{ contains(fromJson('["push", "pull_request"]'), github.event_name) }}
+      if: false
+      # if: ${{ contains(fromJson('["push", "pull_request"]'), github.event_name) }}
       uses: docker/build-push-action@v3
       with:
         cache-from: type=gha
         cache-to: type=gha,mode=max
         context: .
-        build-args: ATLANTIS_BASE_TAG_TYPE=${{ matrix.image_type }}
+        build-args: |
+          ATLANTIS_BASE_TAG_TYPE=${{ matrix.image_type }}
+          ATLANTIS_VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+          ATLANTIS_COMMIT=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+          ATLANTIS_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
         platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
         push: ${{ github.event_name != 'pull_request' }}
         tags: |
@@ -86,15 +92,17 @@ jobs:
 
     # Publish release to container registry
     - name: Populate release version
-      if: |
-        contains(fromJson('["push", "pull_request"]'), github.event_name) &&
-        startsWith(github.ref, 'refs/tags/')
+      if: false
+      # if: |
+      #   contains(fromJson('["push", "pull_request"]'), github.event_name) &&
+      #   startsWith(github.ref, 'refs/tags/')
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
     - name: "Build and push atlantis:${{ env.RELEASE_VERSION }} image for ${{ env.RELEASE_TYPE }} release"
-      if: |
-        contains(fromJson('["push", "pull_request"]'), github.event_name) &&
-        startsWith(github.ref, 'refs/tags/')
+      if: false
+      # if: |
+      #   contains(fromJson('["push", "pull_request"]'), github.event_name) &&
+      #   startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
         cache-from: type=gha

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -76,8 +76,7 @@ jobs:
 
     # Publish dev image to container registry
     - name: Build and push atlantis:dev${{ env.IMAGE_SUFFIX }} image
-      if: false
-      # if: ${{ contains(fromJson('["push", "pull_request"]'), github.event_name) }}
+      if: ${{ contains(fromJson('["push", "pull_request"]'), github.event_name) }}
       uses: docker/build-push-action@v3
       with:
         cache-from: type=gha
@@ -85,7 +84,7 @@ jobs:
         context: .
         build-args: |
           ATLANTIS_BASE_TAG_TYPE=${{ matrix.image_type }}
-          ATLANTIS_VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+          ATLANTIS_VERSION=dev
           ATLANTIS_COMMIT=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
           ATLANTIS_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
         platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
@@ -113,7 +112,11 @@ jobs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
         context: .
-        build-args: ATLANTIS_BASE_TAG_TYPE=${{ matrix.image_type }}
+        build-args: |
+          ATLANTIS_BASE_TAG_TYPE=${{ matrix.image_type }}
+          ATLANTIS_VERSION=dev
+          ATLANTIS_COMMIT=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+          ATLANTIS_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
         platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
         push: ${{ github.event_name != 'pull_request' }}
         # release version is the name of the tag i.e. v0.10.0

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     strategy:
       matrix:
-        image_type: [alpine] # , debian]
+        image_type: [alpine, debian]
     runs-on: ubuntu-22.04
     env:
       RELEASE_TYPE: ${{ contains(github.ref, 'pre') && 'pre' || 'stable' }}
@@ -57,7 +57,6 @@ jobs:
         labels: |
           org.opencontainers.image.licenses=Apache-2.0
         tags: |
-          type=raw,value=dev
           type=ref,event=branch
           type=ref,event=pr
           type=semver,pattern={{version}}
@@ -108,7 +107,7 @@ jobs:
         context: .
         build-args: |
           ATLANTIS_BASE_TAG_TYPE=${{ matrix.image_type }}
-          ATLANTIS_VERSION=dev
+          ATLANTIS_VERSION=${{ env.RELEASE_VERSION }}
           ATLANTIS_COMMIT=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
           ATLANTIS_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
         platforms: linux/arm64/v8,linux/amd64,linux/arm/v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     tags:
       - v*.*.* # stable release like, v0.19.2
       - v*.*.*-pre.* # pre release like, v0.19.0-pre.calendardate
+  workflow_dispatch:
 
 jobs:
   goreleaser:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,7 @@ archives:
     format: zip
     files:
       - none*
+    rlcp: true
 
 checksum:
   name_template: 'checksums.txt'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,10 +25,6 @@ changelog:
   skip: true
 
 release:
-  github:
-    owner: runatlantis
-    name: atlantis
-
   # If set to true, will not auto-publish the release.
   # Default is false.
   draft: false

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,7 +17,6 @@ archives:
     format: zip
     files:
       - none*
-    rlcp: true
 
 checksum:
   name_template: 'checksums.txt'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,10 +48,12 @@ release:
   # Default is false.
   prerelease: auto
 
-signs:
-  # https://goreleaser.com/customization/sign/
-  -
-    artifacts: all
+# TODO: This requires a gpg_private_key
+#       https://github.com/marketplace/actions/goreleaser-action#signing
+# signs:
+#   # https://goreleaser.com/customization/sign/
+#   -
+#     artifacts: all
 
 snapshot:
   name_template: "{{ incpatch .Version }}-next"

--- a/main.go
+++ b/main.go
@@ -33,12 +33,12 @@ var (
 )
 
 func main() {
-	fmt.Printf("atlantis %s, commit %s, built at %s", version, commit, date)
 
 	v := viper.New()
 
 	logger, err := logging.NewStructuredLogger()
 
+	logger.Debug("atlantis %s, commit %s, built at %s\n", version, commit, date)
 	if err != nil {
 		panic(fmt.Sprintf("unable to initialize logger. %s", err.Error()))
 	}


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- Set version based on github release tag in docker
- Missing commit from previous pr to disable signing
- Used logger instead of fmt
- Quoted strings in Dockerfile
- add `workflow_dispatch` to `release` action
- goreleaser's `github` config is omitted

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- Set version in docker container otherwise it will default to `dev` instead of the tag passed to it
- Disable signing since there is a missing GPG key (added TODO)
- Using logger so log entry only shows up as a debug message
- Dockerfile quotes to resolve hadolint issues
- `release` action can now be run manually to correct a broken tag (like the current one) without having to create a brand new release
- goreleaser now implicitly grabs the github info so if a user forks the repo, not only is there image built and uploaded on their fork, but if they created custom releases, goreleaser would upload those successfully to their fork as well

## notes

- Previously added rlcp to calm goreleaser deprecations but we use a very old version of goreleaser so rlcp is not even understood. Filed a separate ticket for this. https://github.com/runatlantis/atlantis/issues/3052
- Tried to use the docker meta action to swap between `dev` and the release tag but it's a bit difficult since not all of the code uses the meta action yet. This will have to be done in another ticket. Filed a separate ticket for this. https://github.com/runatlantis/atlantis/issues/3053

## tests

Testing...

- [x] I have tested my changes on my fork

on pr merge [action run](https://github.com/nitrocode/atlantis/actions/runs/4011923222/jobs/6889941939) and notable expected build-args and tags from `Build and push (for dev)`

```
/usr/bin/docker buildx build \
  --build-arg ATLANTIS_BASE_TAG_TYPE=alpine \
  --build-arg ATLANTIS_VERSION=dev \
  --build-arg ATLANTIS_COMMIT=5dd99934118ec370aaa51ce63bae7ac722177231 \
  --build-arg ATLANTIS_DATE=2023-01-26T03:02:17.318Z \
  --tag ghcr.io/nitrocode/atlantis:dev \
  --tag ghcr.io/nitrocode/atlantis:dev-alpine \
  --push .
```

on pre-release [action run](https://github.com/nitrocode/atlantis/actions/runs/4011958163/jobs/6890009132) and notable expected build-args and tags from `Build and push (for pre-release)`

```
/usr/bin/docker buildx build \
  --build-arg ATLANTIS_BASE_TAG_TYPE=alpine \
  --build-arg ATLANTIS_VERSION=v0.23.0-pre.20230125 \
  --build-arg ATLANTIS_COMMIT=5dd99934118ec370aaa51ce63bae7ac722177231 \
  --build-arg ATLANTIS_DATE=2023-01-26T03:08:27.628Z \
  --tag ghcr.io/nitrocode/atlantis:v0.23.0-pre.20230125 \
  --tag ghcr.io/nitrocode/atlantis:v0.23.0-pre.20230125-alpine \
  --tag ghcr.io/nitrocode/atlantis:prerelease-latest \
  --tag ghcr.io/nitrocode/atlantis:prerelease-latest-alpine \
  --push .
```

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Previous PR https://github.com/runatlantis/atlantis/pull/3049 (mostly worked, touchups needed)
- Previous PR to revert https://github.com/runatlantis/atlantis/pull/3040
    - https://github.com/marketplace/actions/goreleaser-action#signing
- https://github.com/docker/metadata-action
- https://github.com/docker/build-push-action
- meta action kick off
  - [on last PR merge](https://github.com/runatlantis/atlantis/actions/runs/4011350155/jobs/6888835866) resulting in tags `main`
  - [after cutting pre-release](https://github.com/runatlantis/atlantis/actions/runs/4011457722/jobs/6889049144) resulting in tags `0.23.0-pre.20230125`
  - [after cutting previous release](https://github.com/runatlantis/atlantis/actions/runs/3953933740/jobs/6770726756) resulting in tags `0.22.3`
- will need to recreate https://github.com/runatlantis/atlantis/releases/tag/v0.23.0-pre.20230125

![2023-01-25_21-40](https://user-images.githubusercontent.com/7775707/214753977-695893a4-38d3-44a6-a50f-252f209bfa2e.png)
