### PR TITLE
fix(docker): docker-entrypoint when called with atlantis

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 
 # If the user is trying to run atlantis directly with some arguments, then
 # pass them to atlantis.
-if [ "$(echo "${1}" | cut -c1)" ]; then
+if [ "$(echo "${1}" | cut -c1)" = "-" ]; then
     set -- atlantis "$@"
 fi
 


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
Restore functionality of calling the container with commands starting `atlantis`

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
Prior to v0.22.0 the container could be run with the command `atlantis server`. However this was broken by #2770:
```
Error: unknown command "atlantis" for "atlantis"
```

## tests

- [x] I have tested my changes by running the following commands

This PR reverts to previous functionality and matches the comment. Following calls all work again:

```sh
docker run atlantis server
docker run atlantis --help
docker run atlantis atlantis server
docker run atlantis atlantis --help
```

```sh
hadolint Dockerfile
```
produced no output but I didn't modify that file.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- related to https://github.com/runatlantis/atlantis/pull/2770
