### PR TITLE
feat: suppress log package logging

### DIFF
--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1063,6 +1063,7 @@ func setupE2E(t *testing.T, repoDir string, opt setupOption) (events_controllers
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 
 	// Real dependencies.
+	logging.SuppressDefaultLogging()
 	logger := logging.NewNoopLogger(t)
 
 	eventParser := &events.EventParser{

--- a/server/logging/log.go
+++ b/server/logging/log.go
@@ -1,0 +1,12 @@
+package logging
+
+import (
+	"io"
+	"log"
+)
+
+// SuppressDefaultLogging suppresses the default logging
+func SuppressDefaultLogging() {
+	// Some packages use the default logger, so we need to suppress it. (such as uber-go/tally)
+	log.SetOutput(io.Discard)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -153,6 +153,7 @@ type WebhookConfig struct {
 // its dependencies an error will be returned. This is like the main() function
 // for the server CLI command because it injects all the dependencies.
 func NewServer(userConfig UserConfig, config Config) (*Server, error) {
+	logging.SuppressDefaultLogging()
 	logger, err := logging.NewStructuredLoggerFromLevel(userConfig.ToLogLevel())
 
 	if err != nil {


### PR DESCRIPTION
To suppress uber-go/tally logs which are not structured logs.

## what

- discard `log` package logging
  - it's enough to logs which are output on atlantis package.

## why

uber-go/tally put non-structured logs using `log` package`.

https://github.com/uber-go/tally/commit/c347bbf48d7998560fa8a821d08ea5b425deda3e#diff-f65e5374d781f61272558959f338307fc0e51e9f59c0c75dc76d03dfd9dd2010R253

Then server output json and non-json logs.

https://github.com/runatlantis/atlantis/actions/runs/4051074308/jobs/6969044735

<img width="500" alt="image" src="https://user-images.githubusercontent.com/915731/215676031-43f13f8a-6771-4be9-a835-2e30daf53593.png">


## tests

- [x] run on local
- begore

```
✘╹◡╹✘☆  go install && atlantis server --log-level info
2023/01/31 14:40:08 counters: 8, gauges: 25, histograms: 0
2023/01/31 14:40:09 counters: 8, gauges: 25, histograms: 0
{"level":"info","ts":"2023-01-31T14:40:09.032+0900","caller":"server/server.go:439","msg":"Utilizing BoltDB","json":{}}
{"level":"info","ts":"2023-01-31T14:40:09.046+0900","caller":"server/server.go:448","msg":"Repo Locking is disabled","json":{}}
...
```

- after

```
✘╹◡╹✘☆  go install && atlantis server --log-level info
{"level":"info","ts":"2023-01-31T14:41:09.032+0900","caller":"server/server.go:439","msg":"Utilizing BoltDB","json":{}}
{"level":"info","ts":"2023-01-31T14:41:09.046+0900","caller":"server/server.go:448","msg":"Repo Locking is disabled","json":{}}
...
```

## references

- https://github.com/uber-go/tally/commit/c347bbf48d7998560fa8a821d08ea5b425deda3e#diff-f65e5374d781f61272558959f338307fc0e51e9f59c0c75dc76d03dfd9dd2010R253
