### PR TITLE
fix import/state rm success wrapped template

### DIFF
--- a/server/events/templates/import_success_wrapped.tmpl
+++ b/server/events/templates/import_success_wrapped.tmpl
@@ -1,5 +1,6 @@
 {{ define "importSuccessWrapped" -}}
 <details><summary>Show Output</summary>
+
 ```diff
 {{ .Output }}
 ```

--- a/server/events/templates/state_rm_success_wrapped.tmpl
+++ b/server/events/templates/state_rm_success_wrapped.tmpl
@@ -1,5 +1,6 @@
 {{ define "stateRmSuccessWrapped" -}}
 <details><summary>Show Output</summary>
+
 ```diff
 {{ .Output }}
 ```


### PR DESCRIPTION
## what

`server/events/templates/import_success_wrapped.tmpl` and `server/events/templates/state_rm_success_wrapped.tmpl` wrap templates are not processed correctly (others are correct like followings).


```
✘╹◡╹✘☆  ag -A1 '<details><summary>Show Output</summary>' server/events/templates/
server/events/templates/import_success_wrapped.tmpl
2:<details><summary>Show Output</summary>
3-```diff

server/events/templates/policy_check_success_wrapped.tmpl
2:<details><summary>Show Output</summary>
3-

server/events/templates/wrapped_err.tmpl
3:<details><summary>Show Output</summary>
4-

server/events/templates/plan_success_wrapped.tmpl
2:<details><summary>Show Output</summary>
3-

server/events/templates/state_rm_success_wrapped.tmpl
2:<details><summary>Show Output</summary>
3-```diff

server/events/templates/version_wrapped_success.tmpl
2:<details><summary>Show Output</summary>
3-

server/events/templates/apply_wrapped_success.tmpl
2:<details><summary>Show Output</summary>
3-
```

## why

When import/state rm result are too log, the comments are not wrapped correctly.

https://github.com/krrrr38/atlantis-debug/pull/11#issuecomment-1409868595

## tests

<details><summary>before</summary>
```diff
not wrapped correctly without empty line
```
</details>

<details><summary>after</summary>

```diff
wrapped correctly with empty line
```
</details>


## references

- https://github.com/krrrr38/atlantis-debug/pull/11#issuecomment-1409868595
