### PR TITLE
fix(workflow-hook): pre/post hook not sending output due to invalid key

### DIFF
--- a/server/core/runtime/post_workflow_hook_runner.go
+++ b/server/core/runtime/post_workflow_hook_runner.go
@@ -70,7 +70,8 @@ func (wh DefaultPostWorkflowHookRunner) Run(ctx models.WorkflowHookCommandContex
 		}
 	}
 
-	wh.OutputHandler.SendWorkflowHook(ctx, fmt.Sprintf("%s\n", string(out)), true)
+	wh.OutputHandler.SendWorkflowHook(ctx, string(out), false)
+	wh.OutputHandler.SendWorkflowHook(ctx, "\n", true)
 
 	ctx.Log.Info("successfully ran %q in %q", command, path)
 	return string(out), strings.Trim(string(customStatusOut), "\n"), nil

--- a/server/core/runtime/pre_workflow_hook_runner.go
+++ b/server/core/runtime/pre_workflow_hook_runner.go
@@ -70,7 +70,8 @@ func (wh DefaultPreWorkflowHookRunner) Run(ctx models.WorkflowHookCommandContext
 		}
 	}
 
-	wh.OutputHandler.SendWorkflowHook(ctx, fmt.Sprintf("%s\n", string(out)), true)
+	wh.OutputHandler.SendWorkflowHook(ctx, string(out), false)
+	wh.OutputHandler.SendWorkflowHook(ctx, "\n", true)
 
 	ctx.Log.Info("successfully ran %q in %q", command, path)
 	return string(out), strings.Trim(string(customStatusOut), "\n"), nil


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

- Fixes workflow output not sending output for ws channel.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

- Turns out if we set the first message as closed the Handle will close the channel before we send any message as can be seem [here](https://github.com/runatlantis/atlantis/blob/main/server/jobs/project_command_output_handler.go#L134), we need to have at least 2 messages one with our output and another one to close the channel.

## tests

- [ ] I have tested my changes by ...

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

- closes #3008
