### PR TITLE
deps: bump to go1.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   e2e:
     docker:
-    - image: cimg/go:1.19 # If you update this, update it in the Makefile too
+    - image: cimg/go:1.20 # If you update this, update it in the Makefile too
       environment:
         # This version of TF will be downloaded before Atlantis is started.
         # We do this instead of setting --default-tf-version because setting

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG ATLANTIS_BASE_TAG_TYPE=alpine
 
 # Stage 1: build artifact
 
-FROM golang:1.19.5-alpine AS builder
+FROM golang:1.20-alpine AS builder
 
 ARG ATLANTIS_VERSION=dev
 ENV ATLANTIS_VERSION=${ATLANTIS_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG ATLANTIS_BASE_TAG_TYPE=alpine
 
 # Stage 1: build artifact
 
-FROM golang:1.20-alpine AS builder
+FROM golang:1.20.0-alpine AS builder
 
 ARG ATLANTIS_VERSION=dev
 ENV ATLANTIS_VERSION=${ATLANTIS_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ dist: ## Package static/ using go-bindata-assetfs into a single binary
 	rm -f server/static/bindata_assetfs.go && go-bindata-assetfs -o bindata_assetfs.go -pkg static -prefix server server/static/... && mv bindata_assetfs.go server/static
 
 release: ## Create packages for a release
-	docker run -v $$(pwd):/go/src/github.com/runatlantis/atlantis cimg/go:1.19 sh -c 'cd /go/src/github.com/runatlantis/atlantis && scripts/binary-release.sh'
+	docker run -v $$(pwd):/go/src/github.com/runatlantis/atlantis cimg/go:1.20 sh -c 'cd /go/src/github.com/runatlantis/atlantis && scripts/binary-release.sh'
 
 fmt: ## Run goimports (which also formats)
 	goimports -w $$(find . -type f -name '*.go' ! -path "./vendor/*" ! -path "./server/static/bindata_assetfs.go" ! -path "**/mocks/*")

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/runatlantis/atlantis/e2e
 
-go 1.19
+go 1.20
 
 require (
 	github.com/google/go-github/v50 v50.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/runatlantis/atlantis
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20
+FROM golang:1.20.0
 
 RUN apt-get update && apt-get --no-install-recommends -y install unzip \
     && apt-get clean \

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.5
+FROM golang:1.20
 
 RUN apt-get update && apt-get --no-install-recommends -y install unzip \
     && apt-get clean \


### PR DESCRIPTION
## what

- go1.20

## why

- mark as draft PR as the corresponding golang images might not be available yet

## tests

## references

- go1.20 release notes, https://tip.golang.org/doc/go1.20