### PR TITLE
fix(docs): Add missing dir to DRY repo level atlantis.yaml projects key 

### DIFF
--- a/runatlantis.io/docs/repo-level-atlantis-yaml.md
+++ b/runatlantis.io/docs/repo-level-atlantis-yaml.md
@@ -89,6 +89,7 @@ allowed_regexp_prefixes:
 projects:
   - &template
     name: template
+    dir: template
     workflow: custom
     autoplan:
       enabled: true


### PR DESCRIPTION
## what
- add missing required `dir` to projects

## why
- example of [DRYing up the project config](https://www.runatlantis.io/docs/repo-level-atlantis-yaml.html#example-of-drying-up-projects-using-yaml-anchors) is missing the `dir` value
- provided example gave the error `parsing atlantis.yaml: projects: (0: (dir: cannot be blank.).).` , with the extra `dir` value it works

## references
- none
