### PR TITLE
feat(build): add new sha ghrc docker tags using docker/metadata-action

### DIFF
--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -63,7 +63,8 @@ jobs:
           type=ref,event=pr,suffix=${{ env.SUFFIX }}
           type=sha,suffix=${{ env.SUFFIX }}
         flavor: |
-          latest=false
+          latest=${{ contains(fromJson('["push", "pull_request"]'), github.event_name) && startsWith(github.ref, 'refs/tags/') }}
+          suffix=${{ format('-{0}', matrix.image_type) }}
 
     - name: Login to Packages Container registry
       uses: docker/login-action@v2

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -83,6 +83,7 @@ jobs:
       run: |
         echo "RELEASE_VERSION=${{ startsWith(github.ref, 'refs/tags/') && '${GITHUB_REF#refs/*/}' || 'dev' }}" >> $GITHUB_ENV
         echo "${{ github.event.pull_request.head.repo.full_name }}"
+        echo "${{ github.repository }}"
 
     - name: "Build ${{ env.PUSH && 'and push' || '' }} ${{ env.DOCKER_REPO }} image"
       if: contains(fromJson('["push", "pull_request"]'), github.event_name)

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -80,7 +80,7 @@ jobs:
       if: contains(fromJson('["push", "pull_request"]'), github.event_name)
       run: echo "RELEASE_VERSION=${{ startsWith(github.ref, 'refs/tags/') && '${GITHUB_REF#refs/*/}' || 'dev' }}" >> $GITHUB_ENV
 
-    - name: "Build ${{ env.PUSH == true && 'and push' }} atlantis:${{ env.RELEASE_VERSION }} image for ${{ env.RELEASE_TYPE }} release"
+    - name: "Build ${{ env.PUSH == true && 'and push' || '' }} atlantis:${{ env.RELEASE_VERSION }} image for ${{ env.RELEASE_TYPE }} release"
       if: contains(fromJson('["push", "pull_request"]'), github.event_name)
       uses: docker/build-push-action@v4
       with:

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -57,10 +57,18 @@ jobs:
         labels: |
           org.opencontainers.image.licenses=Apache-2.0
         tags: |
-          type=ref,event=branch
-          type=ref,event=pr
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
+          type=ref,event=pr,suffix=${{ format('-{0}', matrix.image_type) }}
+          type=semver,pattern={{version}},suffix=${{ format('-{0}', matrix.image_type) }}
+          type=semver,pattern={{major}}.{{minor}},suffix=${{ format('-{0}', matrix.image_type) }}
+          type=sha,suffix=${{ format('-{0}', matrix.image_type) }}
+          type=raw,event=push,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') && matrix.image_type == 'alpine' }}
+          type=raw,event=push,value=dev,enable={{is_default_branch}},suffix=${{ format('-{0}', matrix.image_type) }}
+          type=raw,event=tag,value=prerelease-latest,enable=${{ startsWith(github.ref, 'refs/tags/') && contains(github.ref, 'pre') && matrix.image_type == 'alpine' }}
+          type=raw,event=tag,value=prerelease-latest,enable=${{ startsWith(github.ref, 'refs/tags/') && contains(github.ref, 'pre') }},suffix=${{ format('-{0}', matrix.image_type) }}
+          type=raw,event=tag,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'pre') && matrix.image_type == 'alpine' }}
+          type=raw,event=tag,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'pre') }},suffix=${{ format('-{0}', matrix.image_type) }}
+        flavor: |
+          latest=false
 
     - name: Login to Packages Container registry
       uses: docker/login-action@v2
@@ -68,26 +76,6 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-
-    # Publish dev image to container registry
-    - name: Build and push atlantis:dev${{ env.IMAGE_SUFFIX }} image
-      if: ${{ contains(fromJson('["push", "pull_request"]'), github.event_name) }}
-      uses: docker/build-push-action@v4
-      with:
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
-        context: .
-        build-args: |
-          ATLANTIS_BASE_TAG_TYPE=${{ matrix.image_type }}
-          ATLANTIS_VERSION=dev
-          ATLANTIS_COMMIT=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
-          ATLANTIS_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
-        platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: |
-          ghcr.io/${{ github.repository_owner }}/atlantis:dev${{ env.IMAGE_SUFFIX }}
-          ghcr.io/${{ github.repository_owner }}/atlantis:dev-${{ matrix.image_type }}
-        labels: ${{ steps.meta.outputs.labels }}
 
     # Publish release to container registry
     - name: Populate release version
@@ -118,9 +106,5 @@ jobs:
         # release tag also has the image type appended i.e. latest-alpine
         # if it's v0.10.0 and alpine, it will do v0.10.0, v0.10.0-alpine, latest, latest-alpine
         # if it's v0.10.0 and debian, it will do v0.10.0-debian, latest-debian
-        tags: |
-          ${{ env.IMAGE_BASE }}:${{ env.RELEASE_VERSION }}${{ env.IMAGE_SUFFIX }}
-          ${{ env.IMAGE_BASE }}:${{ env.RELEASE_VERSION }}-${{ matrix.image_type }}
-          ${{ env.IMAGE_BASE }}:${{ env.RELEASE_TAG }}${{ env.IMAGE_SUFFIX }}
-          ${{ env.IMAGE_BASE }}:${{ env.RELEASE_TAG }}-${{ matrix.image_type }}
+        tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -80,7 +80,7 @@ jobs:
       if: contains(fromJson('["push", "pull_request"]'), github.event_name)
       run: echo "RELEASE_VERSION=${{ startsWith(github.ref, 'refs/tags/') && '${GITHUB_REF#refs/*/}' || 'dev' }}" >> $GITHUB_ENV
 
-    - name: "Build ${{ env.PUSH == true && 'and push' || '' }} atlantis:${{ env.RELEASE_VERSION }} image for ${{ env.RELEASE_TYPE }} release"
+    - name: "Build ${{ env.PUSH && 'and push' || '' }} atlantis:${{ env.RELEASE_VERSION }} image for ${{ env.RELEASE_TYPE }} release"
       if: contains(fromJson('["push", "pull_request"]'), github.event_name)
       uses: docker/build-push-action@v4
       with:

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -26,8 +26,8 @@ jobs:
     env:
       # Set docker repo to either the fork or the main repo where the branch exists
       DOCKER_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-      # Push if not (pull request or push) or this is a fork
-      PUSH: ${{ !contains(fromJson('["push", "pull_request"]'), github.event_name) || github.event.pull_request.head.repo.full_name != github.repository }}
+      # Push if not a pull request or this is a fork
+      PUSH: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository }}
 
     steps:
     - uses: actions/checkout@v3
@@ -40,33 +40,28 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
-      # related issues for pinning buildkit
-      # https://github.com/docker/build-push-action/issues/761
-      # https://github.com/containerd/containerd/issues/7972
-      # https://github.com/containerd/containerd/pull/6995
-      with:
-        driver-opts: |
-          image=moby/buildkit:v0.10.6
 
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@v4
+      env:
+        SUFFIX: ${{ format('-{0}', matrix.image_type) }}
       with:
         images: |
           ${{ env.DOCKER_REPO }}
         labels: |
           org.opencontainers.image.licenses=Apache-2.0
         tags: |
-          type=ref,event=pr,suffix=${{ format('-{0}', matrix.image_type) }}
-          type=semver,pattern={{version}},suffix=${{ format('-{0}', matrix.image_type) }}
-          type=semver,pattern={{major}}.{{minor}},suffix=${{ format('-{0}', matrix.image_type) }}
-          type=sha,suffix=${{ format('-{0}', matrix.image_type) }}
-          type=raw,event=push,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') && matrix.image_type == 'alpine' }}
-          type=raw,event=push,value=dev,enable={{is_default_branch}},suffix=${{ format('-{0}', matrix.image_type) }}
-          type=raw,event=tag,value=prerelease-latest,enable=${{ startsWith(github.ref, 'refs/tags/') && contains(github.ref, 'pre') && matrix.image_type == 'alpine' }}
-          type=raw,event=tag,value=prerelease-latest,enable=${{ startsWith(github.ref, 'refs/tags/') && contains(github.ref, 'pre') }},suffix=${{ format('-{0}', matrix.image_type) }}
-          type=raw,event=tag,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'pre') && matrix.image_type == 'alpine' }}
-          type=raw,event=tag,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'pre') }},suffix=${{ format('-{0}', matrix.image_type) }}
+          type=semver,pattern={{version}},suffix=${{ env.SUFFIX }}
+          type=semver,pattern={{major}}.{{minor}},suffix=${{ env.SUFFIX }}
+          type=raw,event=push,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') && matrix.image_type == 'alpine' }},suffix=
+          type=raw,event=push,value=dev,enable={{is_default_branch}},suffix=${{ env.SUFFIX }}
+          type=raw,event=tag,value=prerelease-latest,enable=${{ startsWith(github.ref, 'refs/tags/') && contains(github.ref, 'pre') && matrix.image_type == 'alpine' }},suffix=
+          type=raw,event=tag,value=prerelease-latest,enable=${{ startsWith(github.ref, 'refs/tags/') && contains(github.ref, 'pre') }},suffix=${{ env.SUFFIX }}
+          type=raw,event=tag,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'pre') && matrix.image_type == 'alpine' }},suffix=
+          type=raw,event=tag,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'pre') }},suffix=${{ env.SUFFIX }}
+          type=ref,event=pr,suffix=${{ env.SUFFIX }}
+          type=sha,suffix=${{ env.SUFFIX }}
         flavor: |
           latest=false
 
@@ -80,17 +75,7 @@ jobs:
     # Publish release to container registry
     - name: Populate release version
       if: contains(fromJson('["push", "pull_request"]'), github.event_name)
-      run: |
-        echo "RELEASE_VERSION=${{ startsWith(github.ref, 'refs/tags/') && '${GITHUB_REF#refs/*/}' || 'dev' }}" >> $GITHUB_ENV
-        echo "head.repo: ${{ github.event.pull_request.head.repo.full_name }}"
-        echo "github.repository: ${{ github.repository }}"
-        echo "PUSH: ${{ env.PUSH }}"
-        echo "event_name: ${{ github.event_name }}"
-        echo "IsPushOrPullRequest: ${{ contains(fromJson('["push", "pull_request"]'), github.event_name) }}"
-        echo "IsNotPushOrPullRequest: ${{ !contains(fromJson('["push", "pull_request"]'), github.event_name) }}"
-        echo "head.repo == github.repo: ${{ github.event.pull_request.head.repo.full_name == github.repository }}"
-        echo "head.repo != github.repo: ${{ github.event.pull_request.head.repo.full_name != github.repository }}"
-        
+      run: echo "RELEASE_VERSION=${{ startsWith(github.ref, 'refs/tags/') && '${GITHUB_REF#refs/*/}' || 'dev' }}" >> $GITHUB_ENV
 
     - name: "Build ${{ env.PUSH == 'true' && 'and push' || '' }} ${{ env.DOCKER_REPO }} image"
       if: contains(fromJson('["push", "pull_request"]'), github.event_name)

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -27,7 +27,7 @@ jobs:
       # Set docker repo to either the fork or the main repo where the branch exists
       DOCKER_REPO: ${{ github.event.pull_request.head.repo.full_name }}
       # Push if not (pull request or push) or this is a fork
-      PUSH: ${{ !contains(fromJson('["push", "pull_request"]') || github.event.pull_request.head.repo.full_name != github.repository }}
+      PUSH: ${{ !contains(fromJson('["push", "pull_request"]'), github.event_name) || github.event.pull_request.head.repo.full_name != github.repository }}
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -24,8 +24,10 @@ jobs:
         image_type: [alpine, debian]
     runs-on: ubuntu-22.04
     env:
-      RELEASE_TYPE: ${{ contains(github.ref, 'pre') && 'pre' || 'stable' }}
-      PUSH: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'push-image-from-pr') }}
+      # Set docker repo to either the fork or the main repo where the branch exists
+      DOCKER_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+      # Push if not a pull request or this is a fork
+      PUSH: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != 'runatlantis/atlantis' }}
 
     steps:
     - uses: actions/checkout@v3
@@ -51,7 +53,7 @@ jobs:
       uses: docker/metadata-action@v4
       with:
         images: |
-          atlantis
+          ${{ env.DOCKER_REPO }}
         labels: |
           org.opencontainers.image.licenses=Apache-2.0
         tags: |
@@ -80,7 +82,7 @@ jobs:
       if: contains(fromJson('["push", "pull_request"]'), github.event_name)
       run: echo "RELEASE_VERSION=${{ startsWith(github.ref, 'refs/tags/') && '${GITHUB_REF#refs/*/}' || 'dev' }}" >> $GITHUB_ENV
 
-    - name: "Build ${{ env.PUSH && 'and push' || '' }} atlantis:${{ env.RELEASE_VERSION }} image for ${{ env.RELEASE_TYPE }} release"
+    - name: "Build ${{ env.PUSH && 'and push' || '' }} ${{ env.DOCKER_REPO }} image"
       if: contains(fromJson('["push", "pull_request"]'), github.event_name)
       uses: docker/build-push-action@v4
       with:

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -77,7 +77,7 @@ jobs:
     # Publish release to container registry
     - name: Populate release version
       if: contains(fromJson('["push", "pull_request"]'), github.event_name)
-      run: echo "RELEASE_VERSION=${{ startsWith(github.ref, 'refs/tags/') && '${GITHUB_REF#refs/*/}' || "dev" }}" >> $GITHUB_ENV
+      run: echo "RELEASE_VERSION=${{ startsWith(github.ref, 'refs/tags/') && '${GITHUB_REF#refs/*/}' || 'dev' }}" >> $GITHUB_ENV
 
     - name: "Build and push atlantis:${{ env.RELEASE_VERSION }} image for ${{ env.RELEASE_TYPE }} release"
       if: contains(fromJson('["push", "pull_request"]'), github.event_name)

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -92,7 +92,7 @@ jobs:
         echo "head.repo != github.repo: ${{ github.event.pull_request.head.repo.full_name != github.repository }}"
         
 
-    - name: "Build ${{ env.PUSH && 'and push' || '' }} ${{ env.DOCKER_REPO }} image"
+    - name: "Build ${{ env.PUSH == 'true' && 'and push' || '' }} ${{ env.DOCKER_REPO }} image"
       if: contains(fromJson('["push", "pull_request"]'), github.event_name)
       uses: docker/build-push-action@v4
       with:

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -27,7 +27,7 @@ jobs:
       # Set docker repo to either the fork or the main repo where the branch exists
       DOCKER_REPO: ${{ github.event.pull_request.head.repo.full_name }}
       # Push if not a pull request or this is a fork
-      PUSH: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != 'runatlantis/atlantis' }}
+      PUSH: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository }}
 
     steps:
     - uses: actions/checkout@v3
@@ -80,7 +80,9 @@ jobs:
     # Publish release to container registry
     - name: Populate release version
       if: contains(fromJson('["push", "pull_request"]'), github.event_name)
-      run: echo "RELEASE_VERSION=${{ startsWith(github.ref, 'refs/tags/') && '${GITHUB_REF#refs/*/}' || 'dev' }}" >> $GITHUB_ENV
+      run: |
+        echo "RELEASE_VERSION=${{ startsWith(github.ref, 'refs/tags/') && '${GITHUB_REF#refs/*/}' || 'dev' }}" >> $GITHUB_ENV
+        echo "${{ github.event.pull_request.head.repo.full_name }}"
 
     - name: "Build ${{ env.PUSH && 'and push' || '' }} ${{ env.DOCKER_REPO }} image"
       if: contains(fromJson('["push", "pull_request"]'), github.event_name)

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -26,8 +26,8 @@ jobs:
     env:
       # Set docker repo to either the fork or the main repo where the branch exists
       DOCKER_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-      # Push if not a pull request or this is a fork
-      PUSH: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository }}
+      # Push if not (pull request or push) or this is a fork
+      PUSH: ${{ !contains(fromJson('["push", "pull_request"]') || github.event.pull_request.head.repo.full_name != github.repository }}
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'main'
     tags:
-      - v*.*.*       # stable release like, v0.19.2
+      - v*.*.* # stable release like, v0.19.2
       - v*.*.*-pre.* # pre release like, v0.19.0-pre.calendardate
   pull_request:
     paths:
@@ -92,7 +92,7 @@ jobs:
           ATLANTIS_COMMIT=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
           ATLANTIS_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
         platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
-        push: ${{ github.event_name != 'pull_request' }}
+        push: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'push-image-from-pr') }}
         # release version is the name of the tag i.e. v0.10.0
         # release version also has the image type appended i.e. v0.10.0-alpine
         # release tag is either pre-release or latest i.e. latest

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -25,9 +25,6 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       RELEASE_TYPE: ${{ contains(github.ref, 'pre') && 'pre' || 'stable' }}
-      RELEASE_TAG: ${{ contains(github.ref, 'pre') && 'prerelease-latest' || 'latest' }}
-      IMAGE_BASE: ghcr.io/${{ github.repository_owner }}/atlantis
-      IMAGE_SUFFIX: ${{ matrix.image_type != 'alpine' && format('-{0}', matrix.image_type) || '' }}
 
     steps:
     - uses: actions/checkout@v3
@@ -79,15 +76,11 @@ jobs:
 
     # Publish release to container registry
     - name: Populate release version
-      if: |
-        contains(fromJson('["push", "pull_request"]'), github.event_name) &&
-        startsWith(github.ref, 'refs/tags/')
-      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      if: contains(fromJson('["push", "pull_request"]'), github.event_name)
+      run: echo "RELEASE_VERSION=${{ startsWith(github.ref, 'refs/tags/') && '${GITHUB_REF#refs/*/}' || "dev" }}" >> $GITHUB_ENV
 
     - name: "Build and push atlantis:${{ env.RELEASE_VERSION }} image for ${{ env.RELEASE_TYPE }} release"
-      if: |
-        contains(fromJson('["push", "pull_request"]'), github.event_name) &&
-        startsWith(github.ref, 'refs/tags/')
+      if: contains(fromJson('["push", "pull_request"]'), github.event_name)
       uses: docker/build-push-action@v4
       with:
         cache-from: type=gha

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -82,8 +82,15 @@ jobs:
       if: contains(fromJson('["push", "pull_request"]'), github.event_name)
       run: |
         echo "RELEASE_VERSION=${{ startsWith(github.ref, 'refs/tags/') && '${GITHUB_REF#refs/*/}' || 'dev' }}" >> $GITHUB_ENV
-        echo "${{ github.event.pull_request.head.repo.full_name }}"
-        echo "${{ github.repository }}"
+        echo "head.repo: ${{ github.event.pull_request.head.repo.full_name }}"
+        echo "github.repository: ${{ github.repository }}"
+        echo "PUSH: ${{ env.PUSH }}"
+        echo "event_name: ${{ github.event_name }}"
+        echo "IsPushOrPullRequest: ${{ contains(fromJson('["push", "pull_request"]'), github.event_name) }}"
+        echo "IsNotPushOrPullRequest: ${{ !contains(fromJson('["push", "pull_request"]'), github.event_name) }}"
+        echo "head.repo == github.repo: ${{ github.event.pull_request.head.repo.full_name == github.repository }}"
+        echo "head.repo != github.repo: ${{ github.event.pull_request.head.repo.full_name != github.repository }}"
+        
 
     - name: "Build ${{ env.PUSH && 'and push' || '' }} ${{ env.DOCKER_REPO }} image"
       if: contains(fromJson('["push", "pull_request"]'), github.event_name)

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       RELEASE_TYPE: ${{ contains(github.ref, 'pre') && 'pre' || 'stable' }}
+      PUSH: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'push-image-from-pr') }}
 
     steps:
     - uses: actions/checkout@v3
@@ -79,7 +80,7 @@ jobs:
       if: contains(fromJson('["push", "pull_request"]'), github.event_name)
       run: echo "RELEASE_VERSION=${{ startsWith(github.ref, 'refs/tags/') && '${GITHUB_REF#refs/*/}' || 'dev' }}" >> $GITHUB_ENV
 
-    - name: "Build and push atlantis:${{ env.RELEASE_VERSION }} image for ${{ env.RELEASE_TYPE }} release"
+    - name: "Build ${{ env.PUSH == true && 'and push' }} atlantis:${{ env.RELEASE_VERSION }} image for ${{ env.RELEASE_TYPE }} release"
       if: contains(fromJson('["push", "pull_request"]'), github.event_name)
       uses: docker/build-push-action@v4
       with:
@@ -92,7 +93,7 @@ jobs:
           ATLANTIS_COMMIT=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
           ATLANTIS_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
         platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
-        push: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'push-image-from-pr') }}
+        push: ${{ env.PUSH }}
         # release version is the name of the tag i.e. v0.10.0
         # release version also has the image type appended i.e. v0.10.0-alpine
         # release tag is either pre-release or latest i.e. latest

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'main'
     tags:
-      - v*.*.* # stable release like, v0.19.2
+      - v*.*.*       # stable release like, v0.19.2
       - v*.*.*-pre.* # pre release like, v0.19.0-pre.calendardate
   pull_request:
     paths:

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -1,5 +1,6 @@
 name: atlantis-image
 
+
 on:
   push:
     branches:
@@ -25,7 +26,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       # Set docker repo to either the fork or the main repo where the branch exists
-      DOCKER_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+      DOCKER_REPO: ${{ github.repository }}
       # Push if not a pull request or this is a fork
       PUSH: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository }}
 
@@ -41,6 +42,12 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 
+    # release version is the name of the tag i.e. v0.10.0
+    # release version also has the image type appended i.e. v0.10.0-alpine
+    # release tag is either pre-release or latest i.e. latest
+    # release tag also has the image type appended i.e. latest-alpine
+    # if it's v0.10.0 and alpine, it will do v0.10.0, v0.10.0-alpine, latest, latest-alpine
+    # if it's v0.10.0 and debian, it will do v0.10.0-debian, latest-debian
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@v4
@@ -52,19 +59,26 @@ jobs:
         labels: |
           org.opencontainers.image.licenses=Apache-2.0
         tags: |
+          # semver
           type=semver,pattern={{version}},suffix=${{ env.SUFFIX }}
+          type=semver,pattern={{version}},enable=${{ matrix.image_type == 'alpine' }}
           type=semver,pattern={{major}}.{{minor}},suffix=${{ env.SUFFIX }}
+          # dev
+          type=raw,value=dev,suffix=${{ env.SUFFIX }}-{{ sha }}
           type=raw,event=push,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') && matrix.image_type == 'alpine' }},suffix=
           type=raw,event=push,value=dev,enable={{is_default_branch}},suffix=${{ env.SUFFIX }}
+          # prerelease
           type=raw,event=tag,value=prerelease-latest,enable=${{ startsWith(github.ref, 'refs/tags/') && contains(github.ref, 'pre') && matrix.image_type == 'alpine' }},suffix=
           type=raw,event=tag,value=prerelease-latest,enable=${{ startsWith(github.ref, 'refs/tags/') && contains(github.ref, 'pre') }},suffix=${{ env.SUFFIX }}
+          # latest
           type=raw,event=tag,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'pre') && matrix.image_type == 'alpine' }},suffix=
           type=raw,event=tag,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'pre') }},suffix=${{ env.SUFFIX }}
+          # pr
           type=ref,event=pr,suffix=${{ env.SUFFIX }}
-          type=sha,suffix=${{ env.SUFFIX }}
         flavor: |
-          latest=${{ contains(fromJson('["push", "pull_request"]'), github.event_name) && startsWith(github.ref, 'refs/tags/') }}
-          suffix=${{ format('-{0}', matrix.image_type) }}
+          # This is disabled here so we can use the raw form above
+          latest=false
+          # Suffix is not used here since there's no way to disable it above
 
     - name: Login to Packages Container registry
       uses: docker/login-action@v2
@@ -92,11 +106,5 @@ jobs:
           ATLANTIS_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
         platforms: linux/arm64/v8,linux/amd64,linux/arm/v7
         push: ${{ env.PUSH }}
-        # release version is the name of the tag i.e. v0.10.0
-        # release version also has the image type appended i.e. v0.10.0-alpine
-        # release tag is either pre-release or latest i.e. latest
-        # release tag also has the image type appended i.e. latest-alpine
-        # if it's v0.10.0 and alpine, it will do v0.10.0, v0.10.0-alpine, latest, latest-alpine
-        # if it's v0.10.0 and debian, it will do v0.10.0-debian, latest-debian
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- [x] use docker meta for tags
- [x] add sha specific dev tags
- [x] account for `latest` tag
- [x] finish testing (see below)
- ~enable build + push on pr on a condition~
    - run condition:
        - currently we only build when atlantis-image workflow is modified by a pr
        - should we always run atlantis-image but only build when necessary?
            - ideal
    - build condition:
        - at the moment, we always build when the run condition is met
        - we could build only when there is a pr label present
    - push condition:
        - specific github pr label? - `push-image-from-pr`
        - always? if we're building anyway, why not just push a specific pr tag up?
        - slash command from maintainer?
        - why build and NOT push ?
            - Maybe only to verify changes to atlantis-image.yml continue to work.
    - push repo:
        - doesn't allow non-admins to push to runatlantis/atlantis ghcr
        - testing if it will push to fork
- [x] logic to show "Build" or "Build and push"
- [x] update moby build to latest again
- [x] Separate PR to show version, commit, and date in version
    - Output after merging PR #3159 
      ```
      # atlantis version
      atlantis dev (commit: 53e9e5880b0c662192d414cc0b455d8188051b99) (build date: 2023-02-25T04:09:47.976Z)
      ```

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- combine the dev and release builds into a single step (less maintenance, faster builds when merging to default branch)
- backwards compatibility of tags (all the same tags as now)
- added an additional tag so users can test out a specific sha. This will help when trying to test specific changes.
- added an additional tag so users can test out prs from images before merging code.
    - This does not push at the moment from a PR
- Now "Build and push" will actually reflect that it will do both. Currently, it will always say that even though pushing is only allowed on pr merge. This bubbles up the push toggle clearly in the build step without having to wait for the whole build to finish to see if it pushed or not... technically if you can catch the build early enough, you can see the initial command which shows `--push`, but if you miss it, gh ui will not let you go backwards until the build is finished UNLESS you hit the API directly.
- moby buildkit has resolved the upstream issue where pushes would intermittently fail so we can now use the latest version again

## tests

<details><summary>creating a PR to my fork w/o changes to atlantis-image.yml</summary>

- [x] I have tested my changes by creating a PR to my fork

    No atlantis-image build since it will only trigger upon atlantis-image changes

</details>

<details><summary>creating a PR to my fork w/ changes to atlantis-image.yml</summary>

- [x] I have tested my changes by creating a PR to my fork

    my proposal results with a build and no push

    https://github.com/nitrocode/github-actions-test/pull/1

    ```diff
    + atlantis:pr-3121-alpine
    + atlantis:dev-alpine-1598318
    + atlantis:pr-3121-debian
    + atlantis:dev-debian-1598318
    ```

</details>

<details><summary>merging a PR to my fork</summary>

- [x] I have tested my changes by merging a PR to my fork

    my proposal results

    merged pr https://github.com/nitrocode/github-actions-test/pull/1

    https://github.com/nitrocode/github-actions-test/actions/runs/4270596616/jobs/7434490993
    https://github.com/nitrocode/github-actions-test/actions/runs/4270596616/jobs/7434491045

    ```diff
    atlantis:dev
    atlantis:dev-alpine
    + atlantis:dev-alpine-7b02250
    atlantis:dev-debian
    + atlantis:dev-debian-7b02250
    ```

</details>

<details><summary>adding a new file to my fork</summary>

- [x] I have tested my changes by adding a new file to my fork

    my proposal results

    ```diff
    atlantis:dev
    atlantis:dev-alpine
    + atlantis:dev-alpine-45cc678
    atlantis:dev-debian
    + atlantis:dev-debian-45cc678
    ```

</details>

<details><summary>creating a pre-release in my fork</summary>

- [x] I have tested my changes by creating a pre-release in my fork

    my proposal results

    https://github.com/nitrocode/github-actions-test/actions/runs/4270524770/jobs/7434375615
    https://github.com/nitrocode/github-actions-test/actions/runs/4270524770/jobs/7434375643

    ```diff
    # alpine
    atlantis:v0.23.0-pre.20230209
    atlantis:v0.23.0-pre.20230209-alpine
    atlantis:prerelease-latest
    atlantis:prerelease-latest-alpine
    + atlantis:dev-alpine-f2b9705
    # debian
    atlantis:v0.23.0-pre.20230209-debian
    atlantis:prerelease-latest-debian
    + atlantis:dev-debian-f2b9705
    ```

</details>

<details><summary>creating a release in my fork</summary>

- [x] I have tested my changes by creating a release in my fork

    image results

    https://github.com/nitrocode/github-actions-test/actions/runs/4270533710/jobs/7434390942
    https://github.com/nitrocode/github-actions-test/actions/runs/4270533710/jobs/7434390979

    ```diff
    # alpine
    atlantis:0.23.0-alpine
    atlantis:0.23.0
    + atlantis:0.23-alpine
    atlantis:latest
    atlantis:latest-alpine
    + atlantis:dev-alpine-893f0a5
    # debian
    atlantis:0.23.0-debian
    + atlantis:0.23-debian
    atlantis:latest-debian
    + atlantis:dev-debian-893f0a5
    ```

</details>

<details><summary>creating a workflow dispatch in my fork</summary>

- [x] I have tested my changes by kicking off a workflow dispatch on branch test

    image results

    https://github.com/nitrocode/github-actions-test/actions/runs/4270576426/jobs/7434459882

    ```diff
    + atlantis:dev-alpine-c1855f0
    + atlantis:dev-debian-c1855f0
    ```

</details>

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- https://github.com/nitrocode/atlantis
- https://github.com/nitrocode/github-actions-test
- https://github.com/docker/metadata-action
- Closes https://github.com/runatlantis/atlantis/issues/2972
