### PR TITLE
feat(renovatebot): automerge enabled

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,7 +6,7 @@
   commitMessageSuffix: " in {{packageFile}}",
   dependencyDashboardAutoclose: true,
   automerge: true,
-  platformAutomerge: false,
+  platformAutomerge: true,
   labels: ["dependencies"],
   postUpdateOptions: [
     "gomodTidy",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,7 +5,7 @@
   ],
   commitMessageSuffix: " in {{packageFile}}",
   dependencyDashboardAutoclose: true,
-  automerge: false,
+  automerge: true,
   platformAutomerge: false,
   labels: ["dependencies"],
   postUpdateOptions: [

--- a/.github/workflows/codeql-required.yml
+++ b/.github/workflows/codeql-required.yml
@@ -1,0 +1,38 @@
+# For required checks when path filtering doesn;'t trigger the other job
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - '.github/**'
+  pull_request:
+    # The branches below must be a subset of the branches above
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+    branches: [ "main" ]
+    paths:
+      - '.github/**'
+
+jobs:
+  analyze:
+    name: Analyze
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'go', 'javascript' ]
+    
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/lint-required.yml
+++ b/.github/workflows/lint-required.yml
@@ -1,0 +1,44 @@
+# For required checks when path filtering doesn;'t trigger the other job
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+
+name: linter
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+    branches:
+      - "main"
+    paths:
+      - 'runatlantis.io/**'
+      - '.github/**'
+      - '**/*.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  golangci-lint:
+    if: github.event.pull_request.draft == false
+    name: runner / golangci-lint
+    runs-on: ubuntu-22.04
+    steps:
+      - run: 'echo "No build required"'
+
+  revive:
+    if: github.event.pull_request.draft == false
+    name: runner / revive
+    runs-on: ubuntu-22.04
+    steps:
+      - run: 'echo "No build required"'
+
+  errcheck:
+    if: github.event.pull_request.draft == false
+    name: runner / errcheck
+    runs-on: ubuntu-22.04
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/test-required.yml
+++ b/.github/workflows/test-required.yml
@@ -1,0 +1,41 @@
+# For required checks when path filtering doesn;'t trigger the other job
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+
+name: tester
+
+on:
+  push:
+    branches:
+      - "main"
+    paths-ignore:
+      - '**/*.go'
+      - '.github/workflows/test.yml'
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+    branches:
+      - "main"
+    paths-ignore:
+      - '**/*.go'
+      - '.github/workflows/test.yml'
+ 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    if: github.event.pull_request.draft == false
+    name: runner / gotest
+    runs-on: ubuntu-22.04
+    steps:
+      - run: 'echo "No build required"'
+
+  website_link_check:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-22.04
+    steps:
+      - run: 'echo "No build required"'


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- [x] automerge enabled
- [x] verify required checks are set by repo owner

    ```
    runner / golangci-lint
    runner / revive
    runner / errcheck
    runner / gotest
    Analyze (go)
    Analyze (javascript)
    ```

- [x] need to create a generic test for each required check if the path filtering causes us to not run the check (see [doc](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks))

Any others?

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- once the repo owner sets required checks, automerge can be enabled for renovatebot pra
- this will save maintainer time and get security/dependency updates in much sooner

## tests

- [x] I have tested my changes by approving and merging many renovate prs. Ive closed all the failing ones so they should not cause issues.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- closes #3112
- https://docs.renovatebot.com/configuration-options/#automerge
- https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
