### PR TITLE
Update Makefile to fix typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,5 +83,5 @@ end-to-end-deps: ## Install e2e dependencies
 end-to-end-tests: ## Run e2e tests
 	./scripts/e2e.sh
 
-website-dev: ## Run runatlantic.io on localhost:8080
+website-dev: ## Run runatlantis.io on localhost:8080
 	yarn website:dev


### PR DESCRIPTION
## what

Fix typo in Makefile

## why

runatlantic vs runatlantis



