### PR TITLE
fix: Use `hashicorp/go-version` to resolve `~> 1.0` to `1.x` instead of `1.0.x`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/runatlantis/atlantis
 go 1.20
 
 require (
-	github.com/Masterminds/semver v1.5.0
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/alicebob/miniredis/v2 v2.30.0
 	github.com/bradleyfalzon/ghinstallation/v2 v2.1.0

--- a/server/core/terraform/terraform_client.go
+++ b/server/core/terraform/terraform_client.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/Masterminds/semver"
 	"github.com/hashicorp/go-getter/v2"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
@@ -337,11 +336,11 @@ func (c *DefaultClient) DetectVersion(log logging.SimpleLogging, projectDirector
 		tfVersions = []string{matched[1]}
 	}
 
-	constraint, _ := semver.NewConstraint(requiredVersionSetting)
-	versions := make([]*semver.Version, len(tfVersions))
+	constraint, _ := version.NewConstraint(requiredVersionSetting)
+	versions := make([]*version.Version, len(tfVersions))
 
 	for i, tfvals := range tfVersions {
-		newVersion, err := semver.NewVersion(tfvals)
+		newVersion, err := version.NewVersion(tfvals)
 		if err == nil {
 			versions[i] = newVersion
 		}
@@ -352,7 +351,7 @@ func (c *DefaultClient) DetectVersion(log logging.SimpleLogging, projectDirector
 		return nil
 	}
 
-	sort.Sort(sort.Reverse(semver.Collection(versions)))
+	sort.Sort(sort.Reverse(version.Collection(versions)))
 
 	for _, element := range versions {
 		if constraint.Check(element) { // Validate a version against a constraint

--- a/server/core/terraform/terraform_client_test.go
+++ b/server/core/terraform/terraform_client_test.go
@@ -369,7 +369,7 @@ func TestDefaultProjectCommandBuilder_TerraformVersion(t *testing.T) {
 
 	baseVersionConfig := `
 terraform {
-  required_version = "%s0.12.8"
+  required_version = "%s"
 }
 `
 
@@ -380,21 +380,48 @@ terraform {
 	// version of 1.3.5.
 	// nonExactSymbols := []string{">", ">=", "<", "<=", "~>"}
 	nonExactSymbols := []string{"<", "<=", "~>"}
-	nonExactVersions := map[string]map[string]string{
-		// ">": {
-		// 	"project1": "1.3.5",
-		// },
-		// ">=": {
-		// 	"project1": "1.3.5",
-		// },
-		"<": {
-			"project1": "0.12.7",
+	expectedVersions := map[string]map[string]map[string]string{
+		"0.12.8": {
+			"=": {
+				"project1": "0.12.8",
+			},
+			"<": {
+				"project1": "0.12.7",
+			},
+			"<=": {
+				"project1": "0.12.8",
+			},
+			"~>": {
+				"project1": "0.12.31",
+			},
 		},
-		"<=": {
-			"project1": "0.12.8",
+		"1.0.0": {
+			"=": {
+				"project1": "1.0.0",
+			},
+			"<": {
+				"project1": "0.15.5",
+			},
+			"<=": {
+				"project1": "1.0.0",
+			},
+			"~>": {
+				"project1": "1.0.11",
+			},
 		},
-		"~>": {
-			"project1": "0.12.31",
+		"1.0": {
+			"=": {
+				"project1": "1.0.0",
+			},
+			"<": {
+				"project1": "0.15.5",
+			},
+			"<=": {
+				"project1": "1.0.0",
+			},
+			"~>": {
+				"project1": "1.3.9",
+			},
 		},
 	}
 
@@ -405,352 +432,56 @@ terraform {
 	}
 
 	testCases := make(map[string]testCase)
+	for version, expected := range expectedVersions {
+		for _, exactSymbol := range exactSymbols {
+			testCases[fmt.Sprintf("exact version using \"%s\"", exactSymbol+version)] = testCase{
+				DirStructure: map[string]interface{}{
+					"project1": map[string]interface{}{
+						"main.tf": fmt.Sprintf(baseVersionConfig, exactSymbol+version),
+					},
+				},
+				Exp:     expected["="],
+				IsExact: true,
+			}
+		}
 
-	for _, exactSymbol := range exactSymbols {
-		testCases[fmt.Sprintf("exact version using \"%s\"", exactSymbol)] = testCase{
+		for _, nonExactSymbol := range nonExactSymbols {
+			testCases[fmt.Sprintf("non-exact version using \"%s\"", nonExactSymbol+version)] = testCase{
+				DirStructure: map[string]interface{}{
+					"project1": map[string]interface{}{
+						"main.tf": fmt.Sprintf(baseVersionConfig, nonExactSymbol+version),
+					},
+				},
+				Exp:     expected[nonExactSymbol],
+				IsExact: false,
+			}
+		}
+
+		testCases["no version specified"] = testCase{
 			DirStructure: map[string]interface{}{
 				"project1": map[string]interface{}{
-					"main.tf": fmt.Sprintf(baseVersionConfig, exactSymbol),
+					"main.tf": nil,
 				},
 			},
 			Exp: map[string]string{
-				"project1": "0.12.8",
+				"project1": "",
 			},
 			IsExact: true,
 		}
 	}
 
-	for _, nonExactSymbol := range nonExactSymbols {
-		testCases[fmt.Sprintf("non-exact version using \"%s\"", nonExactSymbol)] = testCase{
-			DirStructure: map[string]interface{}{
-				"project1": map[string]interface{}{
-					"main.tf": fmt.Sprintf(baseVersionConfig, nonExactSymbol),
-				},
-			},
-			Exp:     nonExactVersions[nonExactSymbol],
-			IsExact: false,
-		}
-	}
-
-	testCases["no version specified"] = testCase{
-		DirStructure: map[string]interface{}{
-			"project1": map[string]interface{}{
-				"main.tf": nil,
-			},
-		},
-		Exp: map[string]string{
-			"project1": "",
-		},
-		IsExact: true,
-	}
-
 	testCases["projects with different terraform versions"] = testCase{
 		DirStructure: map[string]interface{}{
 			"project1": map[string]interface{}{
-				"main.tf": fmt.Sprintf(baseVersionConfig, exactSymbols[0]),
+				"main.tf": fmt.Sprintf(baseVersionConfig, exactSymbols[0]+"0.12.8"),
 			},
 			"project2": map[string]interface{}{
-				"main.tf": strings.Replace(fmt.Sprintf(baseVersionConfig, exactSymbols[0]), "0.12.8", "0.12.9", -1),
+				"main.tf": strings.Replace(fmt.Sprintf(baseVersionConfig, exactSymbols[0]+"0.12.8"), "0.12.8", "0.12.9", -1),
 			},
 		},
 		Exp: map[string]string{
 			"project1": "0.12.8",
 			"project2": "0.12.9",
-		},
-		IsExact: true,
-	}
-
-	runDetectVersionTestCase := func(t *testing.T, name string, testCase testCase, downloadsAllowed bool) bool {
-		return t.Run(name, func(t *testing.T) {
-			RegisterMockTestingT(t)
-
-			logger := logging.NewNoopLogger(t)
-			RegisterMockTestingT(t)
-			_, binDir, cacheDir := mkSubDirs(t)
-			projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
-
-			mockDownloader := mocks.NewMockDownloader()
-			c, err := terraform.NewTestClient(logger,
-				binDir,
-				cacheDir,
-				"",
-				"",
-				"",
-				cmd.DefaultTFVersionFlag,
-				cmd.DefaultTFDownloadURL,
-				mockDownloader,
-				downloadsAllowed,
-				true,
-				projectCmdOutputHandler)
-			Ok(t, err)
-
-			tmpDir := DirStructure(t, testCase.DirStructure)
-
-			for project, expectedVersion := range testCase.Exp {
-				detectedVersion := c.DetectVersion(logger, filepath.Join(tmpDir, project))
-
-				expectNil := expectedVersion == "" || (!testCase.IsExact && !downloadsAllowed)
-				if expectNil {
-					Assert(t, detectedVersion == nil, "TerraformVersion is supposed to be nil.")
-				} else {
-					Assert(t, detectedVersion != nil, "TerraformVersion is nil.")
-					Ok(t, err)
-					Equals(t, expectedVersion, detectedVersion.String())
-				}
-			}
-
-		})
-	}
-
-	for name, testCase := range testCases {
-		runDetectVersionTestCase(t, name+": Downloads Allowed", testCase, true)
-		runDetectVersionTestCase(t, name+": Downloads Disabled", testCase, false)
-	}
-}
-
-func TestDefaultProjectCommandBuilder_TerraformVersionV1_0_0(t *testing.T) {
-	// For the following tests:
-	// If terraform configuration is used, result should be `0.12.8`.
-	// If project configuration is used, result should be `0.12.6`.
-	// If an inexact version is used, the result should be `nil`
-	// If default is to be used, result should be `nil`.
-
-	baseVersionConfig := `
-terraform {
-  required_version = "%s1.0.0"
-}
-`
-
-	exactSymbols := []string{"", "="}
-	// Depending on when the tests are run, the > and >= matching versions will have to be increased.
-	// It's probably not worth testing the terraform-switcher version here so we only test <, <=, and ~>.
-	// One way to test this in the future is to mock tfswitcher.GetTFList() to return the highest
-	// version of 1.3.5.
-	// nonExactSymbols := []string{">", ">=", "<", "<=", "~>"}
-	nonExactSymbols := []string{"<", "<=", "~>"}
-	nonExactVersions := map[string]map[string]string{
-		// ">": {
-		// 	"project1": "1.3.5",
-		// },
-		// ">=": {
-		// 	"project1": "1.3.5",
-		// },
-		"<": {
-			"project1": "0.15.5",
-		},
-		"<=": {
-			"project1": "1.0.0",
-		},
-		"~>": {
-			"project1": "1.0.11",
-		},
-	}
-
-	type testCase struct {
-		DirStructure map[string]interface{}
-		Exp          map[string]string
-		IsExact      bool
-	}
-
-	testCases := make(map[string]testCase)
-
-	for _, exactSymbol := range exactSymbols {
-		testCases[fmt.Sprintf("exact version using \"%s\"", exactSymbol)] = testCase{
-			DirStructure: map[string]interface{}{
-				"project1": map[string]interface{}{
-					"main.tf": fmt.Sprintf(baseVersionConfig, exactSymbol),
-				},
-			},
-			Exp: map[string]string{
-				"project1": "1.0.0",
-			},
-			IsExact: true,
-		}
-	}
-
-	for _, nonExactSymbol := range nonExactSymbols {
-		testCases[fmt.Sprintf("non-exact version using \"%s\"", nonExactSymbol)] = testCase{
-			DirStructure: map[string]interface{}{
-				"project1": map[string]interface{}{
-					"main.tf": fmt.Sprintf(baseVersionConfig, nonExactSymbol),
-				},
-			},
-			Exp:     nonExactVersions[nonExactSymbol],
-			IsExact: false,
-		}
-	}
-
-	testCases["no version specified"] = testCase{
-		DirStructure: map[string]interface{}{
-			"project1": map[string]interface{}{
-				"main.tf": nil,
-			},
-		},
-		Exp: map[string]string{
-			"project1": "",
-		},
-		IsExact: true,
-	}
-
-	testCases["projects with different terraform versions"] = testCase{
-		DirStructure: map[string]interface{}{
-			"project1": map[string]interface{}{
-				"main.tf": fmt.Sprintf(baseVersionConfig, exactSymbols[0]),
-			},
-			"project2": map[string]interface{}{
-				"main.tf": strings.Replace(fmt.Sprintf(baseVersionConfig, exactSymbols[0]), "1.0.0", "1.0.1", -1),
-			},
-		},
-		Exp: map[string]string{
-			"project1": "1.0.0",
-			"project2": "1.0.1",
-		},
-		IsExact: true,
-	}
-
-	runDetectVersionTestCase := func(t *testing.T, name string, testCase testCase, downloadsAllowed bool) bool {
-		return t.Run(name, func(t *testing.T) {
-			RegisterMockTestingT(t)
-
-			logger := logging.NewNoopLogger(t)
-			RegisterMockTestingT(t)
-			_, binDir, cacheDir := mkSubDirs(t)
-			projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
-
-			mockDownloader := mocks.NewMockDownloader()
-			c, err := terraform.NewTestClient(logger,
-				binDir,
-				cacheDir,
-				"",
-				"",
-				"",
-				cmd.DefaultTFVersionFlag,
-				cmd.DefaultTFDownloadURL,
-				mockDownloader,
-				downloadsAllowed,
-				true,
-				projectCmdOutputHandler)
-			Ok(t, err)
-
-			tmpDir := DirStructure(t, testCase.DirStructure)
-
-			for project, expectedVersion := range testCase.Exp {
-				detectedVersion := c.DetectVersion(logger, filepath.Join(tmpDir, project))
-
-				expectNil := expectedVersion == "" || (!testCase.IsExact && !downloadsAllowed)
-				if expectNil {
-					Assert(t, detectedVersion == nil, "TerraformVersion is supposed to be nil.")
-				} else {
-					Assert(t, detectedVersion != nil, "TerraformVersion is nil.")
-					Ok(t, err)
-					Equals(t, expectedVersion, detectedVersion.String())
-				}
-			}
-
-		})
-	}
-
-	for name, testCase := range testCases {
-		runDetectVersionTestCase(t, name+": Downloads Allowed", testCase, true)
-		runDetectVersionTestCase(t, name+": Downloads Disabled", testCase, false)
-	}
-}
-func TestDefaultProjectCommandBuilder_TerraformVersionV1_0(t *testing.T) {
-	// For the following tests:
-	// If terraform configuration is used, result should be `0.12.8`.
-	// If project configuration is used, result should be `0.12.6`.
-	// If an inexact version is used, the result should be `nil`
-	// If default is to be used, result should be `nil`.
-
-	baseVersionConfig := `
-terraform {
-  required_version = "%s1.0"
-}
-`
-
-	exactSymbols := []string{"", "="}
-	// Depending on when the tests are run, the > and >= matching versions will have to be increased.
-	// It's probably not worth testing the terraform-switcher version here so we only test <, <=, and ~>.
-	// One way to test this in the future is to mock tfswitcher.GetTFList() to return the highest
-	// version of 1.3.5.
-	// nonExactSymbols := []string{">", ">=", "<", "<=", "~>"}
-	nonExactSymbols := []string{"<", "<=", "~>"}
-	nonExactVersions := map[string]map[string]string{
-		// ">": {
-		// 	"project1": "1.3.5",
-		// },
-		// ">=": {
-		// 	"project1": "1.3.5",
-		// },
-		"<": {
-			"project1": "0.15.5",
-		},
-		"<=": {
-			"project1": "1.0.0",
-		},
-		"~>": {
-			"project1": "1.3.9",
-		},
-	}
-
-	type testCase struct {
-		DirStructure map[string]interface{}
-		Exp          map[string]string
-		IsExact      bool
-	}
-
-	testCases := make(map[string]testCase)
-
-	for _, exactSymbol := range exactSymbols {
-		testCases[fmt.Sprintf("exact version using \"%s\"", exactSymbol)] = testCase{
-			DirStructure: map[string]interface{}{
-				"project1": map[string]interface{}{
-					"main.tf": fmt.Sprintf(baseVersionConfig, exactSymbol),
-				},
-			},
-			Exp: map[string]string{
-				"project1": "1.0.0",
-			},
-			IsExact: true,
-		}
-	}
-
-	for _, nonExactSymbol := range nonExactSymbols {
-		testCases[fmt.Sprintf("non-exact version using \"%s\"", nonExactSymbol)] = testCase{
-			DirStructure: map[string]interface{}{
-				"project1": map[string]interface{}{
-					"main.tf": fmt.Sprintf(baseVersionConfig, nonExactSymbol),
-				},
-			},
-			Exp:     nonExactVersions[nonExactSymbol],
-			IsExact: false,
-		}
-	}
-
-	testCases["no version specified"] = testCase{
-		DirStructure: map[string]interface{}{
-			"project1": map[string]interface{}{
-				"main.tf": nil,
-			},
-		},
-		Exp: map[string]string{
-			"project1": "",
-		},
-		IsExact: true,
-	}
-
-	testCases["projects with different terraform versions"] = testCase{
-		DirStructure: map[string]interface{}{
-			"project1": map[string]interface{}{
-				"main.tf": fmt.Sprintf(baseVersionConfig, exactSymbols[0]),
-			},
-			"project2": map[string]interface{}{
-				"main.tf": strings.Replace(fmt.Sprintf(baseVersionConfig, exactSymbols[0]), "1.0", "1.0.1", -1),
-			},
-		},
-		Exp: map[string]string{
-			"project1": "1.0.0",
-			"project2": "1.0.1",
 		},
 		IsExact: true,
 	}

--- a/server/core/terraform/terraform_client_test.go
+++ b/server/core/terraform/terraform_client_test.go
@@ -507,3 +507,298 @@ terraform {
 		runDetectVersionTestCase(t, name+": Downloads Disabled", testCase, false)
 	}
 }
+
+func TestDefaultProjectCommandBuilder_TerraformVersionV1_0_0(t *testing.T) {
+	// For the following tests:
+	// If terraform configuration is used, result should be `0.12.8`.
+	// If project configuration is used, result should be `0.12.6`.
+	// If an inexact version is used, the result should be `nil`
+	// If default is to be used, result should be `nil`.
+
+	baseVersionConfig := `
+terraform {
+  required_version = "%s1.0.0"
+}
+`
+
+	exactSymbols := []string{"", "="}
+	// Depending on when the tests are run, the > and >= matching versions will have to be increased.
+	// It's probably not worth testing the terraform-switcher version here so we only test <, <=, and ~>.
+	// One way to test this in the future is to mock tfswitcher.GetTFList() to return the highest
+	// version of 1.3.5.
+	// nonExactSymbols := []string{">", ">=", "<", "<=", "~>"}
+	nonExactSymbols := []string{"<", "<=", "~>"}
+	nonExactVersions := map[string]map[string]string{
+		// ">": {
+		// 	"project1": "1.3.5",
+		// },
+		// ">=": {
+		// 	"project1": "1.3.5",
+		// },
+		"<": {
+			"project1": "0.15.5",
+		},
+		"<=": {
+			"project1": "1.0.0",
+		},
+		"~>": {
+			"project1": "1.0.11",
+		},
+	}
+
+	type testCase struct {
+		DirStructure map[string]interface{}
+		Exp          map[string]string
+		IsExact      bool
+	}
+
+	testCases := make(map[string]testCase)
+
+	for _, exactSymbol := range exactSymbols {
+		testCases[fmt.Sprintf("exact version using \"%s\"", exactSymbol)] = testCase{
+			DirStructure: map[string]interface{}{
+				"project1": map[string]interface{}{
+					"main.tf": fmt.Sprintf(baseVersionConfig, exactSymbol),
+				},
+			},
+			Exp: map[string]string{
+				"project1": "1.0.0",
+			},
+			IsExact: true,
+		}
+	}
+
+	for _, nonExactSymbol := range nonExactSymbols {
+		testCases[fmt.Sprintf("non-exact version using \"%s\"", nonExactSymbol)] = testCase{
+			DirStructure: map[string]interface{}{
+				"project1": map[string]interface{}{
+					"main.tf": fmt.Sprintf(baseVersionConfig, nonExactSymbol),
+				},
+			},
+			Exp:     nonExactVersions[nonExactSymbol],
+			IsExact: false,
+		}
+	}
+
+	testCases["no version specified"] = testCase{
+		DirStructure: map[string]interface{}{
+			"project1": map[string]interface{}{
+				"main.tf": nil,
+			},
+		},
+		Exp: map[string]string{
+			"project1": "",
+		},
+		IsExact: true,
+	}
+
+	testCases["projects with different terraform versions"] = testCase{
+		DirStructure: map[string]interface{}{
+			"project1": map[string]interface{}{
+				"main.tf": fmt.Sprintf(baseVersionConfig, exactSymbols[0]),
+			},
+			"project2": map[string]interface{}{
+				"main.tf": strings.Replace(fmt.Sprintf(baseVersionConfig, exactSymbols[0]), "1.0.0", "1.0.1", -1),
+			},
+		},
+		Exp: map[string]string{
+			"project1": "1.0.0",
+			"project2": "1.0.1",
+		},
+		IsExact: true,
+	}
+
+	runDetectVersionTestCase := func(t *testing.T, name string, testCase testCase, downloadsAllowed bool) bool {
+		return t.Run(name, func(t *testing.T) {
+			RegisterMockTestingT(t)
+
+			logger := logging.NewNoopLogger(t)
+			RegisterMockTestingT(t)
+			_, binDir, cacheDir := mkSubDirs(t)
+			projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
+
+			mockDownloader := mocks.NewMockDownloader()
+			c, err := terraform.NewTestClient(logger,
+				binDir,
+				cacheDir,
+				"",
+				"",
+				"",
+				cmd.DefaultTFVersionFlag,
+				cmd.DefaultTFDownloadURL,
+				mockDownloader,
+				downloadsAllowed,
+				true,
+				projectCmdOutputHandler)
+			Ok(t, err)
+
+			tmpDir := DirStructure(t, testCase.DirStructure)
+
+			for project, expectedVersion := range testCase.Exp {
+				detectedVersion := c.DetectVersion(logger, filepath.Join(tmpDir, project))
+
+				expectNil := expectedVersion == "" || (!testCase.IsExact && !downloadsAllowed)
+				if expectNil {
+					Assert(t, detectedVersion == nil, "TerraformVersion is supposed to be nil.")
+				} else {
+					Assert(t, detectedVersion != nil, "TerraformVersion is nil.")
+					Ok(t, err)
+					Equals(t, expectedVersion, detectedVersion.String())
+				}
+			}
+
+		})
+	}
+
+	for name, testCase := range testCases {
+		runDetectVersionTestCase(t, name+": Downloads Allowed", testCase, true)
+		runDetectVersionTestCase(t, name+": Downloads Disabled", testCase, false)
+	}
+}
+func TestDefaultProjectCommandBuilder_TerraformVersionV1_0(t *testing.T) {
+	// For the following tests:
+	// If terraform configuration is used, result should be `0.12.8`.
+	// If project configuration is used, result should be `0.12.6`.
+	// If an inexact version is used, the result should be `nil`
+	// If default is to be used, result should be `nil`.
+
+	baseVersionConfig := `
+terraform {
+  required_version = "%s1.0"
+}
+`
+
+	exactSymbols := []string{"", "="}
+	// Depending on when the tests are run, the > and >= matching versions will have to be increased.
+	// It's probably not worth testing the terraform-switcher version here so we only test <, <=, and ~>.
+	// One way to test this in the future is to mock tfswitcher.GetTFList() to return the highest
+	// version of 1.3.5.
+	// nonExactSymbols := []string{">", ">=", "<", "<=", "~>"}
+	nonExactSymbols := []string{"<", "<=", "~>"}
+	nonExactVersions := map[string]map[string]string{
+		// ">": {
+		// 	"project1": "1.3.5",
+		// },
+		// ">=": {
+		// 	"project1": "1.3.5",
+		// },
+		"<": {
+			"project1": "0.15.5",
+		},
+		"<=": {
+			"project1": "1.0.0",
+		},
+		"~>": {
+			"project1": "1.3.9",
+		},
+	}
+
+	type testCase struct {
+		DirStructure map[string]interface{}
+		Exp          map[string]string
+		IsExact      bool
+	}
+
+	testCases := make(map[string]testCase)
+
+	for _, exactSymbol := range exactSymbols {
+		testCases[fmt.Sprintf("exact version using \"%s\"", exactSymbol)] = testCase{
+			DirStructure: map[string]interface{}{
+				"project1": map[string]interface{}{
+					"main.tf": fmt.Sprintf(baseVersionConfig, exactSymbol),
+				},
+			},
+			Exp: map[string]string{
+				"project1": "1.0.0",
+			},
+			IsExact: true,
+		}
+	}
+
+	for _, nonExactSymbol := range nonExactSymbols {
+		testCases[fmt.Sprintf("non-exact version using \"%s\"", nonExactSymbol)] = testCase{
+			DirStructure: map[string]interface{}{
+				"project1": map[string]interface{}{
+					"main.tf": fmt.Sprintf(baseVersionConfig, nonExactSymbol),
+				},
+			},
+			Exp:     nonExactVersions[nonExactSymbol],
+			IsExact: false,
+		}
+	}
+
+	testCases["no version specified"] = testCase{
+		DirStructure: map[string]interface{}{
+			"project1": map[string]interface{}{
+				"main.tf": nil,
+			},
+		},
+		Exp: map[string]string{
+			"project1": "",
+		},
+		IsExact: true,
+	}
+
+	testCases["projects with different terraform versions"] = testCase{
+		DirStructure: map[string]interface{}{
+			"project1": map[string]interface{}{
+				"main.tf": fmt.Sprintf(baseVersionConfig, exactSymbols[0]),
+			},
+			"project2": map[string]interface{}{
+				"main.tf": strings.Replace(fmt.Sprintf(baseVersionConfig, exactSymbols[0]), "1.0", "1.0.1", -1),
+			},
+		},
+		Exp: map[string]string{
+			"project1": "1.0.0",
+			"project2": "1.0.1",
+		},
+		IsExact: true,
+	}
+
+	runDetectVersionTestCase := func(t *testing.T, name string, testCase testCase, downloadsAllowed bool) bool {
+		return t.Run(name, func(t *testing.T) {
+			RegisterMockTestingT(t)
+
+			logger := logging.NewNoopLogger(t)
+			RegisterMockTestingT(t)
+			_, binDir, cacheDir := mkSubDirs(t)
+			projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
+
+			mockDownloader := mocks.NewMockDownloader()
+			c, err := terraform.NewTestClient(logger,
+				binDir,
+				cacheDir,
+				"",
+				"",
+				"",
+				cmd.DefaultTFVersionFlag,
+				cmd.DefaultTFDownloadURL,
+				mockDownloader,
+				downloadsAllowed,
+				true,
+				projectCmdOutputHandler)
+			Ok(t, err)
+
+			tmpDir := DirStructure(t, testCase.DirStructure)
+
+			for project, expectedVersion := range testCase.Exp {
+				detectedVersion := c.DetectVersion(logger, filepath.Join(tmpDir, project))
+
+				expectNil := expectedVersion == "" || (!testCase.IsExact && !downloadsAllowed)
+				if expectNil {
+					Assert(t, detectedVersion == nil, "TerraformVersion is supposed to be nil.")
+				} else {
+					Assert(t, detectedVersion != nil, "TerraformVersion is nil.")
+					Ok(t, err)
+					Equals(t, expectedVersion, detectedVersion.String())
+				}
+			}
+
+		})
+	}
+
+	for name, testCase := range testCases {
+		runDetectVersionTestCase(t, name+": Downloads Allowed", testCase, true)
+		runDetectVersionTestCase(t, name+": Downloads Disabled", testCase, false)
+	}
+}


### PR DESCRIPTION
## what

- Use go-version from hashicorp for version checking instead of semver
- add more test cases (I am just duplicating the existing code, feel free to refactor it/ give suggestion)

## why

Currently there is a bug by setting "required_version = "\~> 1.0" " in version.tf, atlantis will choose 1.0.13 instead of 1.3.9
In terraform "\~>" allows only the rightmost version component to increment. (see reference below) 

## tests
 
- [x] I have tested my changes by duplicating the current unit test to include more test cases.
- [x] Tested in a test environment to confirm everything is working as expected

## references
- closes https://github.com/runatlantis/atlantis/issues/2806
- https://developer.hashicorp.com/terraform/language/expressions/version-constraints#-3