### PR TITLE
feat: Include commit and date in version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,24 +5,41 @@ PKG_COMMAS := $(shell go list ./... | grep -v e2e | grep -v static | grep -v moc
 IMAGE_NAME := runatlantis/atlantis
 
 .DEFAULT_GOAL := help
-help: ## List targets & descriptions
-	@cat Makefile* | grep -E '^[a-zA-Z_-]+:.*?## .*$$' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+.PHONY: help
+help: ## List targets & descriptions
+	@cat Makefile* | grep -E '^[a-zA-Z\/_-]+:.*?## .*$$' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: id
 id: ## Output BUILD_ID being used
 	@echo $(BUILD_ID)
 
+.PHONY: debug
 debug: ## Output internal make variables
 	@echo BUILD_ID = $(BUILD_ID)
 	@echo IMAGE_NAME = $(IMAGE_NAME)
 	@echo WORKSPACE = $(WORKSPACE)
 	@echo PKG = $(PKG)
 
+.PHONY: build-service
 build-service: ## Build the main Go service
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o atlantis .
 
+.PHONY: build
+build: build-service ## Runs make build-service
+
+.PHONY: all
+all: build-service ## Runs make build-service
+
+.PHONY: clean
+clean: ## Cleans compiled binary
+	@rm -f atlantis
+
+.PHONY: go-generate
 go-generate: ## Run go generate in all packages
 	./scripts/go-generate.sh
 
+.PHONY: regen-mocks
 regen-mocks: ## Delete and regenerate all mocks
 	find . -type f | grep mocks/mock_ | xargs rm
 	find . -type f | grep mocks/matchers | xargs rm
@@ -38,6 +55,7 @@ test: ## Run tests
 docker/test: ## Run tests in docker
 	docker run -it -v $(PWD):/atlantis ghcr.io/runatlantis/testing-env:latest sh -c "cd /atlantis && make test"
 
+.PHONY: test-all
 test-all: ## Run tests including integration
 	@go test  $(PKG)
 
@@ -45,43 +63,55 @@ test-all: ## Run tests including integration
 docker/test-all: ## Run all tests in docker
 	docker run -it -v $(pwd):/atlantis ghcr.io/runatlantis/testing-env:latest sh -c "cd /atlantis && make test-all"
 
-test-coverage:
+.PHONY: test-coverage
+test-coverage: ## Show test coverage
 	@mkdir -p .cover
 	@go test -covermode atomic -coverprofile .cover/cover.out $(PKG)
 
-test-coverage-html:
+.PHONY: test-coverage-html
+test-coverage-html: ## Show test coverage and output html
 	@mkdir -p .cover
 	@go test -covermode atomic -coverpkg $(PKG_COMMAS) -coverprofile .cover/cover.out $(PKG)
 	go tool cover -html .cover/cover.out
 
-dev-docker:
+.PHONY: docker/dev
+docker/dev: ## Build dev Dockerfile as atlantis-dev
 	GOOS=linux GOARCH=amd64 go build -o atlantis .
 	docker build -f Dockerfile.dev -t atlantis-dev .
 
+.PHONY: dist
 dist: ## Package static/ using go-bindata-assetfs into a single binary
 	rm -f server/static/bindata_assetfs.go && go-bindata-assetfs -o bindata_assetfs.go -pkg static -prefix server server/static/... && mv bindata_assetfs.go server/static
 
+.PHONY: release
 release: ## Create packages for a release
 	docker run -v $$(pwd):/go/src/github.com/runatlantis/atlantis cimg/go:1.20 sh -c 'cd /go/src/github.com/runatlantis/atlantis && scripts/binary-release.sh'
 
+.PHONY: fmt
 fmt: ## Run goimports (which also formats)
 	goimports -w $$(find . -type f -name '*.go' ! -path "./vendor/*" ! -path "./server/static/bindata_assetfs.go" ! -path "**/mocks/*")
 
+.PHONY: lint
 lint: ## Run linter locally
 	golangci-lint run
 
+.PHONY: check-lint
 check-lint: ## Run linter in CI/CD. If running locally use 'lint'
 	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin v1.49.0
 	./bin/golangci-lint run -j 4 --timeout 5m
 
+.PHONY: check-fmt
 check-fmt: ## Fail if not formatted
 	if [[ $$(goimports -l $$(find . -type f -name '*.go' ! -path "./vendor/*" ! -path "./server/static/bindata_assetfs.go" ! -path "**/mocks/*")) ]]; then exit 1; fi
 
+.PHONY: end-to-end-deps
 end-to-end-deps: ## Install e2e dependencies
 	./scripts/e2e-deps.sh
 
+.PHONY: end-to-end-tests
 end-to-end-tests: ## Run e2e tests
 	./scripts/e2e.sh
 
-website-dev: ## Run runatlantis.io on localhost:8080
+.PHONY: website-dev
+website-dev: ## Run runatlantic.io on localhost:8080
 	yarn website:dev

--- a/main.go
+++ b/main.go
@@ -43,15 +43,17 @@ func main() {
 		panic(fmt.Sprintf("unable to initialize logger. %s", err.Error()))
 	}
 
+	atlantisVersion := fmt.Sprintf("%s (commit: %s) (build date: %s)", version, commit, date)
+
 	// We're creating commands manually here rather than using init() functions
 	// (as recommended by cobra) because it makes testing easier.
 	server := &cmd.ServerCmd{
 		ServerCreator:   &cmd.DefaultServerCreator{},
 		Viper:           v,
-		AtlantisVersion: version,
+		AtlantisVersion: atlantisVersion,
 		Logger:          logger,
 	}
-	version := &cmd.VersionCmd{AtlantisVersion: version}
+	version := &cmd.VersionCmd{AtlantisVersion: atlantisVersion}
 	testdrive := &cmd.TestdriveCmd{}
 	cmd.RootCmd.AddCommand(server.Init())
 	cmd.RootCmd.AddCommand(version.Init())


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- [x] Include commit and date in version
- [x] Allow forward slash make targets in `make help`

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- When new versions are built, we will be able to see the exact commit hash on the pod/ec2 where atlantis is deployed as well as its user interface
- This will help a lot if people use the `dev` image tag which currently does not show its short git sha in the tag itself (except in the image labels)

## tests

- [x] I have tested my changes by running `atlantis version` locally

```bash
✗ go build -v -o atlantis .
✗ ./atlantis version
atlantis dev (commit: none) (build date: unknown)
```

With appropriate inputs that will come from goreleaser and in the Dockerfile

```
✗ go build -trimpath -ldflags "-s -w -X 'main.version=v0.99.0' -X 'main.commit=db70ffe' -X 'main.date=2022-02-24'" -v -o atlantis
✗ ./atlantis version
atlantis v0.99.0 (commit: db70ffe) (build date: 2022-02-24)
```

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Previous PR https://github.com/runatlantis/atlantis/pull/3051
