### PR TITLE
fix: use shorter commit sha in version output

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,7 +43,12 @@ func main() {
 		panic(fmt.Sprintf("unable to initialize logger. %s", err.Error()))
 	}
 
-	atlantisVersion := fmt.Sprintf("%s (commit: %s) (build date: %s)", version, commit, date)
+	var sha = commit
+	if len(commit) >= 7 {
+		sha = commit[:7]
+	}
+
+	atlantisVersion := fmt.Sprintf("%s (commit: %s) (build date: %s)", version, sha, date)
 
 	// We're creating commands manually here rather than using init() functions
 	// (as recommended by cobra) because it makes testing easier.


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- use shorter commit sha in version output

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- The full commit sha is too long. The first 7 chars is unique enough.

## tests

- [x] I have tested my changes by testing locally

```
✗ go build -v -ldflags "-X 'main.commit=53e9e5880b0c662192d414cc0b455d8188051b99'" -o atlantis . && ./atlantis version
atlantis dev (commit: 53e9e58) (build date: unknown)

✗ go build -v -o atlantis . && ./atlantis version
atlantis dev (commit: none) (build date: unknown)
```

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Previous PR #3159
