### PR TITLE
fix: push image to repo name without org

### DIFF
--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -1,6 +1,5 @@
 name: atlantis-image
 
-
 on:
   push:
     branches:
@@ -26,7 +25,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       # Set docker repo to either the fork or the main repo where the branch exists
-      DOCKER_REPO: ${{ github.repository }}
+      DOCKER_REPO: atlantis
       # Push if not a pull request or this is a fork
       PUSH: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository }}
 


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- push image to repo name without org

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- pushing to the org/repo causes an `insufficient_scope: authorization failed` error
- previously wasn't caught since I was skipping push in my tests...

Current

```
  runatlantis/atlantis:pr-3164-debian
  runatlantis/atlantis:dev-debian-54859c6
```

Before and currently proposed

```
  atlantis:pr-3164-debian
  atlantis:dev-debian-54859c6
```

## tests

- This was previously working without the org so this is reverting that one portion.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Previous PR #3121 
