### PR TITLE
chore(docs): add note of autoplan modules limitation

### DIFF
--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -170,6 +170,10 @@ Values are chosen in this order:
 By default, changes to modules will not trigger autoplanning. See the flags below. 
 :::
 
+::: warning NOTE
+If any projects are defined in a repo atlantis.yaml file, the logic for this flag will not execute. See issue [#3122](https://github.com/runatlantis/atlantis/issues/3122).
+:::
+
 ### `--autoplan-modules`
 
 ```bash
@@ -182,6 +186,10 @@ Defaults to `false`. When set to `true`, Atlantis will trace the local modules o
 Included project are projects with files included by `--autoplan-file-list`. 
 After tracing, Atlantis will plan any project that includes a changed module. This is equivalent to setting
 `--autoplan-modules-from-projects` to the value of `--autoplan-file-list`. See below.
+
+::: warning NOTE
+If any projects are defined in a repo atlantis.yaml file, the logic for this flag will not execute. See issue [#3122](https://github.com/runatlantis/atlantis/issues/3122).
+:::
 
 ### `--autoplan-modules-from-projects`
 


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- add note of autoplan modules limitation

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- The original author that contributed does not use a per repo configuration file and the reviewers (like myself) missed it when approving the PR.
- For now, we can document the limitation and remove it once a fix is contributed.

## tests

<!--
- [ ] I have tested my changes by ...
-->
N/A

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Related to issue https://github.com/runatlantis/atlantis/issues/3122
- Related to PR https://github.com/runatlantis/atlantis/pull/2507


