### PR TITLE
fix: push to full ghcr repo name

### DIFF
--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       # Set docker repo to either the fork or the main repo where the branch exists
-      DOCKER_REPO: atlantis
+      DOCKER_REPO: ghcr.io/${{ github.repository }}
       # Push if not a pull request or this is a fork
       PUSH: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository }}
 


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- push to full ghcr repo name

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- The tag requires the full ghcr path

Previously when working

https://github.com/runatlantis/atlantis/actions/runs/4268268678/jobs/7430636285

```
--tag ghcr.io/runatlantis/atlantis:dev
--tag ghcr.io/runatlantis/atlantis:dev-alpine
```

Currently broken

https://github.com/runatlantis/atlantis/actions/runs/4271736874/jobs/7436413322

```
--tag atlantis:dev
--tag atlantis:dev-alpine
```

This PR will bring back the previously working route

## tests

<!--
- [ ] I have tested my changes by ...
-->
N/A

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Previous PR #3164 
- Previous PR #3121 
