### PR TITLE
fix: set checkout-depth default to 50

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -141,7 +141,7 @@ const (
 	DefaultAutoplanFileList             = "**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl"
 	DefaultAllowCommands                = "version,plan,apply,unlock,approve_policies"
 	DefaultCheckoutStrategy             = "branch"
-	DefaultCheckoutDepth                = 0
+	DefaultCheckoutDepth                = 50
 	DefaultBitbucketBaseURL             = bitbucketcloud.BaseURL
 	DefaultDataDir                      = "~/.atlantis"
 	DefaultExecutableName               = "atlantis"

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -287,12 +287,13 @@ and set `--autoplan-modules` to `false`.
 
 ### `--checkout-depth`
   ```bash
-  atlantis server --checkout-depth=0
+  atlantis server --checkout-depth=50
   # or
-  ATLANTIS_CHECKOUT_DEPTH=0
+  ATLANTIS_CHECKOUT_DEPTH=50
   ```
   The number of commits to fetch from the branch. Used if `--checkout-strategy=merge` since the `--checkout-strategy=branch` (default) checkout strategy always defaults to a shallow clone using a depth of 1.
-  Defaults to `0`. See [Checkout Strategy](checkout-strategy.html) for more details.
+
+  See [Checkout Strategy](checkout-strategy.html) for more details.
 
 ### `--checkout-strategy`
   ```bash


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- fix: set checkout-depth default to 50

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- git 2.32.0 does not like `--depth=0`, we use git 2.39.1

## tests

- [x] I have tested my changes by testing locally

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- closes https://github.com/runatlantis/atlantis/issues/3183
- https://github.com/git/git/blob/master/Documentation/RelNotes/2.32.0.txt#L109
