### PR TITLE
fix(clone): omit checkout depth if it is zero

### DIFF
--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -257,13 +257,24 @@ func (w *FileWorkspace) forceClone(log logging.SimpleLogging,
 		return nil
 	}
 
+	// if branch strategy, use depth=1
 	if !w.CheckoutMerge {
 		return runGit("clone", "--depth=1", "--branch", p.HeadBranch, "--single-branch", headCloneURL, cloneDir)
 	}
+	
+	// if merge strategy...
 
-	if err := runGit("clone", "--depth", fmt.Sprint(w.CheckoutDepth), "--branch", p.BaseBranch, "--single-branch", baseCloneURL, cloneDir); err != nil {
-		return err
+	// if no checkout depth, omit depth arg
+	if w.CheckoutDepth == 0 {
+		if err := runGit("clone", "--branch", p.BaseBranch, "--single-branch", baseCloneURL, cloneDir); err != nil {
+			 return err
+		}
+	} else {
+	 	if err := runGit("clone", "--depth", fmt.Sprint(w.CheckoutDepth), "--branch", p.BaseBranch, "--single-branch", baseCloneURL, cloneDir); err != nil {
+			 return err
+		}
 	}
+
 	if err := runGit("remote", "add", "head", headCloneURL); err != nil {
 		return err
 	}


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- omit checkout depth if it is zero

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- git 2.32.0 does not like `--depth=0`, we use git 2.39.1
- in this PR, we omit the depth if the depth is zero which checks out all the commits in the branch

## tests

- [ ] I have tested my changes by

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- closes https://github.com/runatlantis/atlantis/pull/3184
- closes #3183
- previous pr #2758 
- https://github.com/git/git/blob/master/Documentation/RelNotes/2.32.0.txt#L109
