### PR TITLE
docs(using-atlantis): correct usage of -p for projects

### DIFF
--- a/runatlantis.io/docs/using-atlantis.md
+++ b/runatlantis.io/docs/using-atlantis.md
@@ -53,7 +53,7 @@ atlantis plan
 atlantis plan -d .
 
 # Runs plan in the `project1` directory of the repo with workspace `default`
-atlantis plan -d project1
+atlantis plan -p project1
 
 # Runs plan in the root directory of the repo with workspace `staging`
 atlantis plan -w staging
@@ -101,7 +101,7 @@ atlantis apply
 atlantis apply -d .
 
 # Runs apply in the `project1` directory of the repo with workspace `default`
-atlantis apply -d project1
+atlantis apply -p project1
 
 # Runs apply in the root directory of the repo with workspace `staging`
 atlantis apply -w staging
@@ -144,7 +144,7 @@ atlantis import ADDRESS ID
 atlantis import -d . ADDRESS ID
 
 # Runs import in the `project1` directory of the repo with workspace `default`
-atlantis import -d project1 ADDRESS ID
+atlantis import -p project1 ADDRESS ID
 
 # Runs import in the root directory of the repo with workspace `staging`
 atlantis import -w staging ADDRESS ID
@@ -189,7 +189,7 @@ atlantis state rm ADDRESS1 ADDRESS2
 atlantis state -d . rm ADDRESS
 
 # Runs state rm in the `project1` directory of the repo with workspace `default`
-atlantis state -d project1 rm ADDRESS
+atlantis state -p project1 rm ADDRESS
 
 # Runs state rm in the root directory of the repo with workspace `staging`
 atlantis state -w staging rm ADDRESS


### PR DESCRIPTION
## what

Change `-d project1` to `-p project1` in docs about various atlantis commands.

## why

The docs appear to incorrectly use `-d project1` while consistently documenting the actual option as being `-p`.

## tests

<!--
- [ ] I have tested my changes by ...
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

