### PR TITLE
fix: close stale issues after 2 months of inactivity

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,11 +8,11 @@ jobs:
     steps:
       - uses: actions/stale@v7
         with:
-          stale-pr-message: 'This issue is stale because it has been open for 6 months with no activity. Remove stale label or comment or this will be closed in 1 month.'
-          stale-issue-message: This issue is stale because it has been open for 6 months with no activity. Remove stale label or comment or this will be closed in 1 month.'
+          stale-pr-message: 'This issue is stale because it has been open for 1 month with no activity. Remove stale label or comment or this will be closed in 1 month.'
+          stale-issue-message: This issue is stale because it has been open for 1 month with no activity. Remove stale label or comment or this will be closed in 1 month.'
           remove-stale-when-updated: true
-          # 6 months
-          days-before-stale: 183
+          # 1 month
+          days-before-stale: 31
           # 1 month
           days-before-close: 31
           only-labels: 'waiting-on-response'


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- close stale issues after 2 months of inactivity by reducing current 180 days after 31 days stale to 31 days after 31 days stale

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- more reasonable setting given the number of abandoned prs and issues

## tests

<!--
- [ ] I have tested my changes by ...
-->
N/A

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- see prs and number of older issues
