### PR TITLE
fix: allow `Require Linear History` when selecting merge method

### DIFF
--- a/server/events/vcs/github_client_test.go
+++ b/server/events/vcs/github_client_test.go
@@ -789,7 +789,7 @@ func TestGithubClient_MergePullHandlesError(t *testing.T) {
 						w.Write([]byte(resp)) // nolint: errcheck
 					case "/api/v3/repos/runatlantis/atlantis/branches/master/protection":
 						w.WriteHeader(404)
-						w.Write([]byte("{\"message\":\"Branch not protected\"}"))
+						w.Write([]byte("{\"message\":\"Branch not protected\"}")) // nolint: errcheck
 						return
 					default:
 						t.Errorf("got unexpected request at %q", r.RequestURI)
@@ -1000,10 +1000,10 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 						return
 					case "/api/v3/repos/runatlantis/atlantis/branches/master/protection":
 						if c.protectedBranch {
-							w.Write([]byte(protected))
+							w.Write([]byte(protected)) // nolint: errcheck
 						} else {
 							w.WriteHeader(404)
-							w.Write([]byte("{\"message\":\"Branch not protected\"}"))
+							w.Write([]byte("{\"message\":\"Branch not protected\"}")) // nolint: errcheck
 						}
 						return
 					case "/api/v3/repos/runatlantis/atlantis/pulls/1/merge":

--- a/server/events/vcs/github_client_test.go
+++ b/server/events/vcs/github_client_test.go
@@ -787,6 +787,10 @@ func TestGithubClient_MergePullHandlesError(t *testing.T) {
 						defer r.Body.Close() // nolint: errcheck
 						w.WriteHeader(c.code)
 						w.Write([]byte(resp)) // nolint: errcheck
+					case "/api/v3/repos/runatlantis/atlantis/branches/master/protection":
+						w.WriteHeader(404)
+						w.Write([]byte("{\"message\":\"Branch not protected\"}"))
+						return
 					default:
 						t.Errorf("got unexpected request at %q", r.RequestURI)
 						http.Error(w, "not found", http.StatusNotFound)
@@ -813,7 +817,8 @@ func TestGithubClient_MergePullHandlesError(t *testing.T) {
 							Hostname: "github.com",
 						},
 					},
-					Num: 1,
+					Num:        1,
+					BaseBranch: "master",
 				}, models.PullRequestOptions{
 					DeleteSourceBranchOnMerge: false,
 				})
@@ -831,40 +836,132 @@ func TestGithubClient_MergePullHandlesError(t *testing.T) {
 // use that method
 func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 	cases := map[string]struct {
-		allowMerge  bool
-		allowRebase bool
-		allowSquash bool
-		expMethod   string
+		allowMerge           bool
+		allowRebase          bool
+		allowSquash          bool
+		requireLinearHistory bool
+		protectedBranch      bool
+		expMethod            string
 	}{
 		"all true": {
-			allowMerge:  true,
-			allowRebase: true,
-			allowSquash: true,
-			expMethod:   "merge",
+			allowMerge:           true,
+			allowRebase:          true,
+			allowSquash:          true,
+			requireLinearHistory: false,
+			protectedBranch:      false,
+			expMethod:            "merge",
 		},
 		"all false (edge case)": {
-			allowMerge:  false,
-			allowRebase: false,
-			allowSquash: false,
-			expMethod:   "merge",
+			allowMerge:           false,
+			allowRebase:          false,
+			allowSquash:          false,
+			requireLinearHistory: false,
+			protectedBranch:      false,
+			expMethod:            "merge",
 		},
 		"merge: false rebase: true squash: true": {
-			allowMerge:  false,
-			allowRebase: true,
-			allowSquash: true,
-			expMethod:   "rebase",
+			allowMerge:           false,
+			allowRebase:          true,
+			allowSquash:          true,
+			requireLinearHistory: false,
+			protectedBranch:      false,
+			expMethod:            "rebase",
 		},
 		"merge: false rebase: false squash: true": {
-			allowMerge:  false,
-			allowRebase: false,
-			allowSquash: true,
-			expMethod:   "squash",
+			allowMerge:           false,
+			allowRebase:          false,
+			allowSquash:          true,
+			requireLinearHistory: false,
+			protectedBranch:      false,
+			expMethod:            "squash",
 		},
 		"merge: false rebase: true squash: false": {
-			allowMerge:  false,
-			allowRebase: true,
-			allowSquash: false,
-			expMethod:   "rebase",
+			allowMerge:           false,
+			allowRebase:          true,
+			allowSquash:          false,
+			requireLinearHistory: false,
+			protectedBranch:      false,
+			expMethod:            "rebase",
+		},
+		"protected, all true, rlh: false": {
+			allowMerge:           true,
+			allowRebase:          true,
+			allowSquash:          true,
+			requireLinearHistory: false,
+			protectedBranch:      true,
+			expMethod:            "merge",
+		},
+		"protected, all false (edge case), rlh: false": {
+			allowMerge:           false,
+			allowRebase:          false,
+			allowSquash:          false,
+			requireLinearHistory: false,
+			protectedBranch:      true,
+			expMethod:            "merge",
+		},
+		"protected, merge: false rebase: true squash: true, rlh: false": {
+			allowMerge:           false,
+			allowRebase:          true,
+			allowSquash:          true,
+			requireLinearHistory: false,
+			protectedBranch:      true,
+			expMethod:            "rebase",
+		},
+		"protected, merge: false rebase: false squash: true, rlh: false": {
+			allowMerge:           false,
+			allowRebase:          false,
+			allowSquash:          true,
+			requireLinearHistory: false,
+			protectedBranch:      true,
+			expMethod:            "squash",
+		},
+		"protected, merge: false rebase: true squash: false, rlh: false": {
+			allowMerge:           false,
+			allowRebase:          true,
+			allowSquash:          false,
+			requireLinearHistory: false,
+			protectedBranch:      true,
+			expMethod:            "rebase",
+		},
+		"protected, all true, rlh: true": {
+			allowMerge:           true,
+			allowRebase:          true,
+			allowSquash:          true,
+			requireLinearHistory: true,
+			protectedBranch:      true,
+			expMethod:            "rebase",
+		},
+		"protected, all false (edge case), rlh: true": {
+			allowMerge:           false,
+			allowRebase:          false,
+			allowSquash:          false,
+			requireLinearHistory: true,
+			protectedBranch:      true,
+			expMethod:            "merge",
+		},
+		"protected, merge: false rebase: true squash: true, rlh: true": {
+			allowMerge:           false,
+			allowRebase:          true,
+			allowSquash:          true,
+			requireLinearHistory: true,
+			protectedBranch:      true,
+			expMethod:            "rebase",
+		},
+		"protected, merge: false rebase: false squash: true, rlh: true": {
+			allowMerge:           false,
+			allowRebase:          false,
+			allowSquash:          true,
+			requireLinearHistory: true,
+			protectedBranch:      true,
+			expMethod:            "squash",
+		},
+		"protected, merge: false rebase: true squash: false, rlh: true": {
+			allowMerge:           false,
+			allowRebase:          true,
+			allowSquash:          false,
+			requireLinearHistory: true,
+			protectedBranch:      true,
+			expMethod:            "rebase",
 		},
 	}
 
@@ -874,7 +971,10 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 			// Modify response.
 			jsBytes, err := os.ReadFile("testdata/github-repo.json")
 			Ok(t, err)
+			rlhBytes, err := os.ReadFile("testdata/github-branch-protection-require-linear-history.json")
+			Ok(t, err)
 			resp := string(jsBytes)
+			protected := string(rlhBytes)
 			resp = strings.Replace(resp,
 				`"allow_squash_merge": true`,
 				fmt.Sprintf(`"allow_squash_merge": %t`, c.allowSquash),
@@ -887,12 +987,24 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 				`"allow_rebase_merge": true`,
 				fmt.Sprintf(`"allow_rebase_merge": %t`, c.allowRebase),
 				-1)
+			protected = strings.Replace(protected,
+				`"enabled": true`,
+				fmt.Sprintf(`"enabled": %t`, c.requireLinearHistory),
+				-1)
 
 			testServer := httptest.NewTLSServer(
 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.RequestURI {
 					case "/api/v3/repos/runatlantis/atlantis":
 						w.Write([]byte(resp)) // nolint: errcheck
+						return
+					case "/api/v3/repos/runatlantis/atlantis/branches/master/protection":
+						if c.protectedBranch {
+							w.Write([]byte(protected))
+						} else {
+							w.WriteHeader(404)
+							w.Write([]byte("{\"message\":\"Branch not protected\"}"))
+						}
 						return
 					case "/api/v3/repos/runatlantis/atlantis/pulls/1/merge":
 						body, err := io.ReadAll(r.Body)
@@ -936,7 +1048,8 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 							Hostname: "github.com",
 						},
 					},
-					Num: 1,
+					Num:        1,
+					BaseBranch: "master",
 				}, models.PullRequestOptions{
 					DeleteSourceBranchOnMerge: false,
 				})

--- a/server/events/vcs/testdata/github-branch-protection-require-linear-history.json
+++ b/server/events/vcs/testdata/github-branch-protection-require-linear-history.json
@@ -1,0 +1,6 @@
+{
+    "url": "https://api.github.com/repos/octocat/Hello-World/branches/master/protection",
+    "required_linear_history": {
+        "enabled": true
+    }
+}


### PR DESCRIPTION
## what
Account for branch protection rule "Require Linear History" when choosing merge method
<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->


## why
When repo config allows merge commits:
<img width="797" alt="Screenshot 2023-03-18 at 13 40 13" src="https://user-images.githubusercontent.com/10550832/226106700-06a35e14-497c-482f-94c4-3fe13bca3f8d.png">

But branch protection rules requires linear history (aka banning merge commits):
<img width="506" alt="Screenshot 2023-03-18 at 13 40 36" src="https://user-images.githubusercontent.com/10550832/226106733-0b6a99b0-e3de-404e-9389-ffd86fdaaabe.png">

Current logic will always pick `merge` method by default. This PR fixes that.

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## tests
- [x] I have updated [TestGithubClient_MergePullCorrectMethod](https://github.com/runatlantis/atlantis/blob/main/server/events/vcs/github_client_test.go#L832) test
- [x] I have tested my changes by running tests from VSCode
- [x] I have tested my changes by running `make test`
- [x] I have tested my changes on test environment

<!--
- [ ] I have tested my changes by ...
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Closes #1176
