### PR TITLE
Increase pod memory to 512Mi

### DIFF
--- a/kustomize/bundle.yaml
+++ b/kustomize/bundle.yaml
@@ -34,12 +34,13 @@ spec:
         ports:
         - name: atlantis
           containerPort: 4141
+        # You may need to increase the memory depends on the state size terraform manages.
         resources:
           requests:
-            memory: 256Mi
+            memory: 512Mi
             cpu: 100m
           limits:
-            memory: 256Mi
+            memory: 1GBi
             cpu: 100m
         livenessProbe:
           # We only need to check every 60s since Atlantis is not a


### PR DESCRIPTION
Problem:

`terraform plan` was hanged and killed without any helpful message. It turned out that the spawned terraform process from Atlantis was killed due to OMM. We manage a few hundred terraform states (I believe the size is small to medium) and Atlantis should work out of the box for most cases.

Solution:

Double request/limit of memory.