### PR TITLE
fix: github branch protection not supported

### DIFF
--- a/server/events/vcs/github_client_test.go
+++ b/server/events/vcs/github_client_test.go
@@ -841,6 +841,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 		allowSquash          bool
 		requireLinearHistory bool
 		protectedBranch      bool
+		protectionAvailabale bool
 		expMethod            string
 	}{
 		"all true": {
@@ -849,6 +850,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 			allowSquash:          true,
 			requireLinearHistory: false,
 			protectedBranch:      false,
+			protectionAvailabale: true,
 			expMethod:            "merge",
 		},
 		"all false (edge case)": {
@@ -857,6 +859,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 			allowSquash:          false,
 			requireLinearHistory: false,
 			protectedBranch:      false,
+			protectionAvailabale: true,
 			expMethod:            "merge",
 		},
 		"merge: false rebase: true squash: true": {
@@ -865,6 +868,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 			allowSquash:          true,
 			requireLinearHistory: false,
 			protectedBranch:      false,
+			protectionAvailabale: true,
 			expMethod:            "rebase",
 		},
 		"merge: false rebase: false squash: true": {
@@ -873,6 +877,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 			allowSquash:          true,
 			requireLinearHistory: false,
 			protectedBranch:      false,
+			protectionAvailabale: true,
 			expMethod:            "squash",
 		},
 		"merge: false rebase: true squash: false": {
@@ -881,6 +886,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 			allowSquash:          false,
 			requireLinearHistory: false,
 			protectedBranch:      false,
+			protectionAvailabale: true,
 			expMethod:            "rebase",
 		},
 		"protected, all true, rlh: false": {
@@ -889,6 +895,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 			allowSquash:          true,
 			requireLinearHistory: false,
 			protectedBranch:      true,
+			protectionAvailabale: true,
 			expMethod:            "merge",
 		},
 		"protected, all false (edge case), rlh: false": {
@@ -897,6 +904,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 			allowSquash:          false,
 			requireLinearHistory: false,
 			protectedBranch:      true,
+			protectionAvailabale: true,
 			expMethod:            "merge",
 		},
 		"protected, merge: false rebase: true squash: true, rlh: false": {
@@ -905,6 +913,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 			allowSquash:          true,
 			requireLinearHistory: false,
 			protectedBranch:      true,
+			protectionAvailabale: true,
 			expMethod:            "rebase",
 		},
 		"protected, merge: false rebase: false squash: true, rlh: false": {
@@ -913,6 +922,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 			allowSquash:          true,
 			requireLinearHistory: false,
 			protectedBranch:      true,
+			protectionAvailabale: true,
 			expMethod:            "squash",
 		},
 		"protected, merge: false rebase: true squash: false, rlh: false": {
@@ -921,6 +931,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 			allowSquash:          false,
 			requireLinearHistory: false,
 			protectedBranch:      true,
+			protectionAvailabale: true,
 			expMethod:            "rebase",
 		},
 		"protected, all true, rlh: true": {
@@ -929,6 +940,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 			allowSquash:          true,
 			requireLinearHistory: true,
 			protectedBranch:      true,
+			protectionAvailabale: true,
 			expMethod:            "rebase",
 		},
 		"protected, all false (edge case), rlh: true": {
@@ -937,6 +949,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 			allowSquash:          false,
 			requireLinearHistory: true,
 			protectedBranch:      true,
+			protectionAvailabale: true,
 			expMethod:            "merge",
 		},
 		"protected, merge: false rebase: true squash: true, rlh: true": {
@@ -945,6 +958,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 			allowSquash:          true,
 			requireLinearHistory: true,
 			protectedBranch:      true,
+			protectionAvailabale: true,
 			expMethod:            "rebase",
 		},
 		"protected, merge: false rebase: false squash: true, rlh: true": {
@@ -953,6 +967,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 			allowSquash:          true,
 			requireLinearHistory: true,
 			protectedBranch:      true,
+			protectionAvailabale: true,
 			expMethod:            "squash",
 		},
 		"protected, merge: false rebase: true squash: false, rlh: true": {
@@ -961,6 +976,43 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 			allowSquash:          false,
 			requireLinearHistory: true,
 			protectedBranch:      true,
+			protectionAvailabale: true,
+			expMethod:            "rebase",
+		},
+		"protection not supported, all true": {
+			allowMerge:           true,
+			allowRebase:          true,
+			allowSquash:          true,
+			requireLinearHistory: false,
+			protectedBranch:      false,
+			protectionAvailabale: false,
+			expMethod:            "merge",
+		},
+		"protection not supported, merge: false, rebase: true, squash: true": {
+			allowMerge:           false,
+			allowRebase:          true,
+			allowSquash:          true,
+			requireLinearHistory: false,
+			protectedBranch:      false,
+			protectionAvailabale: false,
+			expMethod:            "rebase",
+		},
+		"protection not supported, merge: false, rebase: false, squash: true": {
+			allowMerge:           false,
+			allowRebase:          false,
+			allowSquash:          true,
+			requireLinearHistory: false,
+			protectedBranch:      false,
+			protectionAvailabale: false,
+			expMethod:            "squash",
+		},
+		"protection not supported, merge: false, rebase: true, squash: false": {
+			allowMerge:           false,
+			allowRebase:          true,
+			allowSquash:          false,
+			requireLinearHistory: false,
+			protectedBranch:      false,
+			protectionAvailabale: false,
 			expMethod:            "rebase",
 		},
 	}
@@ -999,11 +1051,14 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 						w.Write([]byte(resp)) // nolint: errcheck
 						return
 					case "/api/v3/repos/runatlantis/atlantis/branches/master/protection":
-						if c.protectedBranch {
+						if c.protectedBranch && c.protectionAvailabale {
 							w.Write([]byte(protected)) // nolint: errcheck
-						} else {
+						} else if !c.protectedBranch && c.protectionAvailabale {
 							w.WriteHeader(404)
 							w.Write([]byte("{\"message\":\"Branch not protected\"}")) // nolint: errcheck
+						} else if !c.protectionAvailabale {
+							w.WriteHeader(403)
+							w.Write([]byte("{\"message\":\"Upgrade to GitHub Pro or make this repository public to enable this feature.\"}")) // nolint: errcheck
 						}
 						return
 					case "/api/v3/repos/runatlantis/atlantis/pulls/1/merge":


### PR DESCRIPTION
## what
Correctly handle GitHub API error when branch protection is not available in Free Private repositories
<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->


## why
<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## tests
- [x] I have tested my changes by running tests in VSCode
- [x] I have tested my changes by running `make test`
- [x] I have tested my changes by running `make build`

<!--
- [ ] I have tested my changes by ...
-->

## references
closes #3268
<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

