### PR TITLE
ci: fix pipefail in golang builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ WORKDIR /app
 # This is needed to download transitive dependencies instead of compiling them
 # https://github.com/montanaflynn/golang-docker-cache
 # https://github.com/golang/go/issues/27719
+RUN apk add --no-cache \
+        bash~=5.2
 COPY go.mod go.sum ./
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN go mod graph | awk '{if ($1 !~ "@") print $2}' | xargs go get

--- a/Dockerfile
+++ b/Dockerfile
@@ -166,7 +166,7 @@ RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/ma
         git~=2.40 && \
     apk add --no-cache \
         ca-certificates~=20220614 \
-        curl~=7.87 \
+        curl~=7.88 \
         unzip~=6.0 \
         bash~=5.2 \
         openssh~=9.1_p1 \


### PR DESCRIPTION
The runatlantis/atlantis#3001 PR got auto-merged too quickly leaving out a lingering commit that fixes the new image build process.