### PR TITLE
feat: add PULL_URL to environment variables

### DIFF
--- a/runatlantis.io/docs/custom-workflows.md
+++ b/runatlantis.io/docs/custom-workflows.md
@@ -467,6 +467,7 @@ Or a custom command
   * `BASE_BRANCH_NAME` - Name of the base branch of the pull request (the branch that the pull request is getting merged into)
   * `PROJECT_NAME` - Name of the project configured in `atlantis.yaml`. If no project name is configured this will be an empty string.
   * `PULL_NUM` - Pull request number or ID, ex. `2`.
+  * `PULL_URL` - Pull request URL, ex. `https://github.com/runatlantis/atlantis/pull/2`.
   * `PULL_AUTHOR` - Username of the pull request author, ex. `acme-user`.
   * `REPO_REL_DIR` - The relative path of the project in the repository. For example if your project is in `dir1/dir2/` then this will be set to `"dir1/dir2"`. If your project is at the root this will be `"."`.
   * `USER_NAME` - Username of the VCS user running command, ex. `acme-user`. During an autoplan, the user will be the Atlantis API user, ex. `atlantis`.

--- a/runatlantis.io/docs/post-workflow-hooks.md
+++ b/runatlantis.io/docs/post-workflow-hooks.md
@@ -71,6 +71,7 @@ command](custom-workflows.html#custom-run-command).
   * `HEAD_COMMIT` - The sha256 that points to the head of the branch that is being pull requested into the base. If the pull request is from Bitbucket Cloud the string will only be 12 characters long because Bitbucket Cloud truncates its commit IDs.
   * `BASE_BRANCH_NAME` - Name of the base branch of the pull request (the branch that the pull request is getting merged into)
   * `PULL_NUM` - Pull request number or ID, ex. `2`.
+  * `PULL_URL` - Pull request URL, ex. `https://github.com/runatlantis/atlantis/pull/2`.
   * `PULL_AUTHOR` - Username of the pull request author, ex. `acme-user`.
   * `DIR` - The absolute path to the root of the cloned repository.
   * `USER_NAME` - Username of the VCS user running command, ex. `acme-user`. During an autoplan, the user will be the Atlantis API user, ex. `atlantis`.

--- a/runatlantis.io/docs/pre-workflow-hooks.md
+++ b/runatlantis.io/docs/pre-workflow-hooks.md
@@ -55,6 +55,7 @@ command](custom-workflows.html#custom-run-command).
   * `HEAD_COMMIT` - The sha256 that points to the head of the branch that is being pull requested into the base. If the pull request is from Bitbucket Cloud the string will only be 12 characters long because Bitbucket Cloud truncates its commit IDs.
   * `BASE_BRANCH_NAME` - Name of the base branch of the pull request (the branch that the pull request is getting merged into)
   * `PULL_NUM` - Pull request number or ID, ex. `2`.
+  * `PULL_URL` - Pull request URL, ex. `https://github.com/runatlantis/atlantis/pull/2`.
   * `PULL_AUTHOR` - Username of the pull request author, ex. `acme-user`.
   * `DIR` - The absolute path to the root of the cloned repository. 
   * `USER_NAME` - Username of the VCS user running command, ex. `acme-user`. During an autoplan, the user will be the Atlantis API user, ex. `atlantis`.

--- a/server/core/runtime/post_workflow_hook_runner.go
+++ b/server/core/runtime/post_workflow_hook_runner.go
@@ -39,6 +39,7 @@ func (wh DefaultPostWorkflowHookRunner) Run(ctx models.WorkflowHookCommandContex
 		"HEAD_REPO_OWNER":    ctx.HeadRepo.Owner,
 		"PULL_AUTHOR":        ctx.Pull.Author,
 		"PULL_NUM":           fmt.Sprintf("%d", ctx.Pull.Num),
+		"PULL_URL":           ctx.Pull.URL,
 		"USER_NAME":          ctx.User.Username,
 		"OUTPUT_STATUS_FILE": outputFilePath,
 	}

--- a/server/core/runtime/post_workflow_hook_runner_test.go
+++ b/server/core/runtime/post_workflow_hook_runner_test.go
@@ -51,8 +51,8 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 			ExpErr:  "exit status 127: running \"lkjlkj\" in",
 		},
 		{
-			Command: "echo base_repo_name=$BASE_REPO_NAME base_repo_owner=$BASE_REPO_OWNER head_repo_name=$HEAD_REPO_NAME head_repo_owner=$HEAD_REPO_OWNER head_branch_name=$HEAD_BRANCH_NAME head_commit=$HEAD_COMMIT base_branch_name=$BASE_BRANCH_NAME pull_num=$PULL_NUM pull_author=$PULL_AUTHOR",
-			ExpOut:  "base_repo_name=basename base_repo_owner=baseowner head_repo_name=headname head_repo_owner=headowner head_branch_name=add-feat head_commit=12345abcdef base_branch_name=main pull_num=2 pull_author=acme\n",
+			Command: "echo base_repo_name=$BASE_REPO_NAME base_repo_owner=$BASE_REPO_OWNER head_repo_name=$HEAD_REPO_NAME head_repo_owner=$HEAD_REPO_OWNER head_branch_name=$HEAD_BRANCH_NAME head_commit=$HEAD_COMMIT base_branch_name=$BASE_BRANCH_NAME pull_num=$PULL_NUM pull_url=$PULL_URL pull_author=$PULL_AUTHOR",
+			ExpOut:  "base_repo_name=basename base_repo_owner=baseowner head_repo_name=headname head_repo_owner=headowner head_branch_name=add-feat head_commit=12345abcdef base_branch_name=main pull_num=2 pull_url=https://github.com/runatlantis/atlantis/pull/2 pull_author=acme\n",
 		},
 		{
 			Command: "echo user_name=$USER_NAME",
@@ -92,6 +92,7 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 				},
 				Pull: models.PullRequest{
 					Num:        2,
+					URL:        "https://github.com/runatlantis/atlantis/pull/2",
 					HeadBranch: "add-feat",
 					HeadCommit: "12345abcdef",
 					BaseBranch: "main",

--- a/server/core/runtime/pre_workflow_hook_runner.go
+++ b/server/core/runtime/pre_workflow_hook_runner.go
@@ -39,6 +39,7 @@ func (wh DefaultPreWorkflowHookRunner) Run(ctx models.WorkflowHookCommandContext
 		"HEAD_REPO_OWNER":    ctx.HeadRepo.Owner,
 		"PULL_AUTHOR":        ctx.Pull.Author,
 		"PULL_NUM":           fmt.Sprintf("%d", ctx.Pull.Num),
+		"PULL_URL":           ctx.Pull.URL,
 		"USER_NAME":          ctx.User.Username,
 		"OUTPUT_STATUS_FILE": outputFilePath,
 	}

--- a/server/core/runtime/pre_workflow_hook_runner_test.go
+++ b/server/core/runtime/pre_workflow_hook_runner_test.go
@@ -51,8 +51,8 @@ func TestPreWorkflowHookRunner_Run(t *testing.T) {
 			ExpErr:  "exit status 127: running \"lkjlkj\" in",
 		},
 		{
-			Command: "echo base_repo_name=$BASE_REPO_NAME base_repo_owner=$BASE_REPO_OWNER head_repo_name=$HEAD_REPO_NAME head_repo_owner=$HEAD_REPO_OWNER head_branch_name=$HEAD_BRANCH_NAME head_commit=$HEAD_COMMIT base_branch_name=$BASE_BRANCH_NAME pull_num=$PULL_NUM pull_author=$PULL_AUTHOR",
-			ExpOut:  "base_repo_name=basename base_repo_owner=baseowner head_repo_name=headname head_repo_owner=headowner head_branch_name=add-feat head_commit=12345abcdef base_branch_name=main pull_num=2 pull_author=acme\n",
+			Command: "echo base_repo_name=$BASE_REPO_NAME base_repo_owner=$BASE_REPO_OWNER head_repo_name=$HEAD_REPO_NAME head_repo_owner=$HEAD_REPO_OWNER head_branch_name=$HEAD_BRANCH_NAME head_commit=$HEAD_COMMIT base_branch_name=$BASE_BRANCH_NAME pull_num=$PULL_NUM pull_url=$PULL_URL pull_author=$PULL_AUTHOR",
+			ExpOut:  "base_repo_name=basename base_repo_owner=baseowner head_repo_name=headname head_repo_owner=headowner head_branch_name=add-feat head_commit=12345abcdef base_branch_name=main pull_num=2 pull_url=https://github.com/runatlantis/atlantis/pull/2 pull_author=acme\n",
 		},
 		{
 			Command: "echo user_name=$USER_NAME",
@@ -92,6 +92,7 @@ func TestPreWorkflowHookRunner_Run(t *testing.T) {
 				},
 				Pull: models.PullRequest{
 					Num:        2,
+					URL:        "https://github.com/runatlantis/atlantis/pull/2",
 					HeadBranch: "add-feat",
 					HeadCommit: "12345abcdef",
 					BaseBranch: "main",

--- a/server/core/runtime/run_step_runner.go
+++ b/server/core/runtime/run_step_runner.go
@@ -53,6 +53,7 @@ func (r *RunStepRunner) Run(ctx command.ProjectContext, command string, path str
 		"PROJECT_NAME":               ctx.ProjectName,
 		"PULL_AUTHOR":                ctx.Pull.Author,
 		"PULL_NUM":                   fmt.Sprintf("%d", ctx.Pull.Num),
+		"PULL_URL":                   ctx.Pull.URL,
 		"REPO_REL_DIR":               ctx.RepoRelDir,
 		"USER_NAME":                  ctx.User.Username,
 		"WORKSPACE":                  ctx.Workspace,

--- a/server/core/runtime/run_step_runner_test.go
+++ b/server/core/runtime/run_step_runner_test.go
@@ -71,8 +71,8 @@ func TestRunStepRunner_Run(t *testing.T) {
 			ExpOut:      "workspace=myworkspace version=0.11.0 dir=$DIR planfile=$DIR/my::project::name-myworkspace.tfplan showfile=$DIR/my::project::name-myworkspace.json project=my/project/name\n",
 		},
 		{
-			Command: "echo base_repo_name=$BASE_REPO_NAME base_repo_owner=$BASE_REPO_OWNER head_repo_name=$HEAD_REPO_NAME head_repo_owner=$HEAD_REPO_OWNER head_branch_name=$HEAD_BRANCH_NAME head_commit=$HEAD_COMMIT base_branch_name=$BASE_BRANCH_NAME pull_num=$PULL_NUM pull_author=$PULL_AUTHOR repo_rel_dir=$REPO_REL_DIR",
-			ExpOut:  "base_repo_name=basename base_repo_owner=baseowner head_repo_name=headname head_repo_owner=headowner head_branch_name=add-feat head_commit=12345abcdef base_branch_name=main pull_num=2 pull_author=acme repo_rel_dir=mydir\n",
+			Command: "echo base_repo_name=$BASE_REPO_NAME base_repo_owner=$BASE_REPO_OWNER head_repo_name=$HEAD_REPO_NAME head_repo_owner=$HEAD_REPO_OWNER head_branch_name=$HEAD_BRANCH_NAME head_commit=$HEAD_COMMIT base_branch_name=$BASE_BRANCH_NAME pull_num=$PULL_NUM pull_url=$PULL_URL pull_author=$PULL_AUTHOR repo_rel_dir=$REPO_REL_DIR",
+			ExpOut:  "base_repo_name=basename base_repo_owner=baseowner head_repo_name=headname head_repo_owner=headowner head_branch_name=add-feat head_commit=12345abcdef base_branch_name=main pull_num=2 pull_url=https://github.com/runatlantis/atlantis/pull/2 pull_author=acme repo_rel_dir=mydir\n",
 		},
 		{
 			Command: "echo user_name=$USER_NAME",
@@ -130,6 +130,7 @@ func TestRunStepRunner_Run(t *testing.T) {
 				},
 				Pull: models.PullRequest{
 					Num:        2,
+					URL:        "https://github.com/runatlantis/atlantis/pull/2",
 					HeadBranch: "add-feat",
 					HeadCommit: "12345abcdef",
 					BaseBranch: "main",


### PR DESCRIPTION
## what

This change adds `PULL_URL` to environment variables.

## why

It is convenient to have the PR URL available so that we can link the PR that triggers the infrastructure changes from the audit logging system. For example, the google cloud provider adds user-supplied justification into google cloud audit logging via `CLOUDSDK_CORE_REQUEST_REASON` environment variable.

## tests

Built an image with this PR's change and confirmed that the audit logging system contains the `PULL_URL`. The following workflow was used to export `CLOUDSDK_CORE_REQUEST_REASON` env var.

```
workflows:
  default:
    apply:
      steps:
        - env:
            name: CLOUDSDK_CORE_REQUEST_REASON
            command: echo "$PULL_URL"
        - apply
```

## references

https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#request_reason