### PR TITLE
fix(atlantis-image): add missing atlantis user in Debian image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -180,6 +180,13 @@ CMD ["server"]
 # Stage 2 - Debian
 FROM debian:${DEBIAN_TAG} AS debian
 
+# Add atlantis user to Debian as well
+RUN useradd --create-home --user-group --shell /bin/bash atlantis && \
+    adduser atlantis root && \
+    chown atlantis:root /home/atlantis/ && \
+    chmod g=u /home/atlantis/ && \
+    chmod g=u /etc/passwd
+
 # copy binary
 COPY --from=builder /app/atlantis /usr/local/bin/atlantis
 # copy terraform

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
         ports:
         - '6379:6379'
         command: redis-server --save 20 1 --loglevel warning --requirepass test123
-        volumes: 
+        volumes:
         - redis:/data
     atlantis:
         depends_on:


### PR DESCRIPTION
## what

- add atlantis user to debian image

## why

- It appears that when #3001 combined the Dockerfiles, the bit that adds the `atlantis` user was not added to the Debian build stage
- Also correct some trailing spaces and missing EOL in `docker-compose.yml`

## tests
- [x] I have tested my changes by building Docker locally

```
% docker run --platform linux/amd64 -it ed5edec1285d /bin/bash
root@87731013d732:/# getent passwd atlantis
atlantis:x:1000:1000::/home/atlantis:/bin/bash
```

## references
- #3001 

Closes #3318 
