### PR TITLE
fix(atlantis-image): add user in debian image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -180,6 +180,14 @@ CMD ["server"]
 # Stage 2 - Debian
 FROM debian:${DEBIAN_TAG} AS debian
 
+# atlantis user for gosu and OpenShift compatibility
+RUN addgroup atlantis && \
+    adduser --system --ingroup atlantis atlantis && \
+    adduser atlantis root && \
+    chown atlantis:root /home/atlantis/ && \
+    chmod g=u /home/atlantis/ && \
+    chmod g=u /etc/passwd
+
 # copy binary
 COPY --from=builder /app/atlantis /usr/local/bin/atlantis
 # copy terraform


### PR DESCRIPTION
## what

I have added a missing `atlantis` user and group in debian image.

## why

Because `atlantis` user is missing, the container won't start.

## tests

I built an image with this change and confirmed that the container started.

## references

Close https://github.com/runatlantis/atlantis/issues/3318.
See https://github.com/runatlantis/atlantis/commit/310aff835108b527bca6a01298817174be02c838.