### PR TITLE
fix: revert branch protection feature causing breaking change

### DIFF
--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -34,10 +34,6 @@ import (
 // by GitHub.
 const maxCommentLength = 65536
 
-// Error message GitHub API returns if branch protection is not available
-// in current repository
-const githubBranchProtectionNotAvailable string = "Upgrade to GitHub Pro or make this repository public to enable this feature."
-
 var (
 	clientMutationID            = githubv4.NewString("atlantis")
 	pullRequestDismissalMessage = *githubv4.NewString("Dismissing reviews because of plan changes")
@@ -574,11 +570,6 @@ func (g *GithubClient) UpdateStatus(repo models.Repo, pull models.PullRequest, s
 	return err
 }
 
-func isBranchProtectionNotAvailable(err error) bool {
-	errorResponse, ok := err.(*github.ErrorResponse)
-	return ok && errorResponse.Message == githubBranchProtectionNotAvailable
-}
-
 // MergePull merges the pull request.
 func (g *GithubClient) MergePull(pull models.PullRequest, pullOptions models.PullRequestOptions) error {
 	// Users can set their repo to disallow certain types of merging.
@@ -588,23 +579,13 @@ func (g *GithubClient) MergePull(pull models.PullRequest, pullOptions models.Pul
 	if err != nil {
 		return errors.Wrap(err, "fetching repo info")
 	}
-	protection, _, err := g.client.Repositories.GetBranchProtection(context.Background(), repo.Owner.GetLogin(), *repo.Name, pull.BaseBranch)
-	if err != nil {
-		if !errors.Is(err, github.ErrBranchNotProtected) && !isBranchProtectionNotAvailable(err) {
-			return errors.Wrap(err, "getting branch protection rules")
-		}
-	}
-	requireLinearHistory := false
-	if protection != nil {
-		requireLinearHistory = protection.GetRequireLinearHistory().Enabled
-	}
 	const (
 		defaultMergeMethod = "merge"
 		rebaseMergeMethod  = "rebase"
 		squashMergeMethod  = "squash"
 	)
 	method := defaultMergeMethod
-	if !repo.GetAllowMergeCommit() || requireLinearHistory {
+	if !repo.GetAllowMergeCommit() {
 		if repo.GetAllowRebaseMerge() {
 			method = rebaseMergeMethod
 		} else if repo.GetAllowSquashMerge() {

--- a/server/events/vcs/testdata/github-branch-protection-require-linear-history.json
+++ b/server/events/vcs/testdata/github-branch-protection-require-linear-history.json
@@ -1,6 +1,0 @@
-{
-    "url": "https://api.github.com/repos/octocat/Hello-World/branches/master/protection",
-    "required_linear_history": {
-        "enabled": true
-    }
-}


### PR DESCRIPTION
## what

Currently as it stands in the latest release and since 0.23.2, repositories with branch protections enabled are seeing a breaking change to their workflows.


## why

In summary, the GH user used by Atlantis to interface with GitHub API is unable to access the branch protection endpoint unless their permissions are set to `Admin`. Currently, we only advertise `Write` access` for the user. See [docs](https://www.runatlantis.io/docs/access-credentials.html#github-user)

*Note:* [GH Apps](https://www.runatlantis.io/docs/access-credentials.html#permissions) are unaffected since they are should be giving `Read` permissions on repo "Administration"

## references

Reverts "fix(github): branch protection not supported (#3276)"
Reverts "fix: allow `Require Linear History` when selecting merge method (#3211)"
Closes #3320

