### PR TITLE
ci: fix docker push logic when PR originates from fork

### DIFF
--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -28,7 +28,7 @@ jobs:
       # Set docker repo to either the fork or the main repo where the branch exists
       DOCKER_REPO: ghcr.io/${{ github.repository }}
       # Push if not a pull request or this is a fork
-      PUSH: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository }}
+      PUSH: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## what

The atlantis-image workflow was attempting to push to our ghcr repo on a forked PR when that shouldn't be allowed. It was failing thankfully due to GITHUB_TOKEN permissions properly set to read-only.

## why

The original conditional should have been `github.event.pull_request.head.repo.full_name == github.repository` not `!=` but I found a cleaner way.

## references

https://github.com/runatlantis/atlantis/actions/runs/4671885635/jobs/8273419737?pr=3317

