### PR TITLE
fix(ci): fix workflows to run when required to avoid empty required c…

### DIFF
--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -12,6 +12,7 @@ on:
       - 'Dockerfile'
       - 'docker-entrypoint.sh'
       - '.github/workflows/atlantis-image.yml'
+      - '**.go'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/codeql-required.yml
+++ b/.github/workflows/codeql-required.yml
@@ -7,7 +7,8 @@ on:
   push:
     branches: [ "main" ]
     paths:
-      - '.github/**'
+      - '!**.go'
+      - '!**.js'
   pull_request:
     # The branches below must be a subset of the branches above
     types:
@@ -17,7 +18,8 @@ on:
       - ready_for_review
     branches: [ "main" ]
     paths:
-      - '.github/**'
+      - '!**.go'
+      - '!**.js'
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-required.yml
+++ b/.github/workflows/codeql-required.yml
@@ -6,9 +6,9 @@ name: "CodeQL"
 on:
   push:
     branches: [ "main" ]
-    paths:
-      - '!**.go'
-      - '!**.js'
+    paths-ignore:
+      - '**.go'
+      - '**.js'
   pull_request:
     # The branches below must be a subset of the branches above
     types:
@@ -17,9 +17,9 @@ on:
       - synchronize
       - ready_for_review
     branches: [ "main" ]
-    paths:
-      - '!**.go'
-      - '!**.js'
+    paths-ignore:
+      - '**.go'
+      - '**.js'
 
 jobs:
   analyze:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ on:
       - synchronize
       - ready_for_review
     branches: [ "main" ]
-    paths-ignore:
+    paths:
       - '**.go'
       - '**.js'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,8 +14,9 @@ name: "CodeQL"
 on:
   push:
     branches: [ "main" ]
-    paths-ignore:
-      - '.github/**'
+    paths:
+      - '**.go'
+      - '**.js'
   pull_request:
     # The branches below must be a subset of the branches above
     types:
@@ -25,7 +26,9 @@ on:
       - ready_for_review
     branches: [ "main" ]
     paths-ignore:
-      - '.github/**'
+      - '**.go'
+      - '**.js'
+
   schedule:
     - cron: '17 9 * * 5'
 

--- a/.github/workflows/lint-required.yml
+++ b/.github/workflows/lint-required.yml
@@ -12,10 +12,10 @@ on:
       - ready_for_review
     branches:
       - "main"
-    paths:
-      - 'runatlantis.io/**'
-      - '.github/**'
-      - '**.md'
+    paths-ignore:
+      - '**.go'
+      - 'go.*'
+      - '.github/workflows/linter.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,10 @@ on:
       - ready_for_review
     branches:
       - "main"
-    paths-ignore:
-      - 'runatlantis.io/**'
-      - '.github/**'
-      - '**.md'
+    paths:
+      - '**.go'
+      - 'go.*'
+      - '.github/workflows/linter.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
…hecks

## what

This adjusts our workflows to run in more cases that are deemed relative to the required check or not. It's a bit more comprehensive and less targeted. 

## why

We have certain GHA workflows that we are required to pass before we allow Pull Requests to merge. However, some workflows are not triggered in certain cases which results in a PR being "stuck" due to a workflow being required without any build getting queued up.

## tests

- [ ] I have tested my changes

## references

Similar to #3267

