### PR TITLE
fix(atlantis-image): build atlantis image when all packages update

### DIFF
--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -13,6 +13,9 @@ on:
       - 'docker-entrypoint.sh'
       - '.github/workflows/atlantis-image.yml'
       - '**.go'
+      - 'go.*'
+      - 'yarn.lock'
+      - 'package.json'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## what

Update atlantis-image workflow to build/push the docker image when the following files have updates:
- go.mod
- go.sum
- package.json
- yarn.lock

Automated tools like dependabot and renovate bump these files only and wouldn't normally trigger the workflow.

## why

If there is any version update on any dependency, we should be rebuilding the app and docker image to ensure no conflicts. We were previously only building on go code changes.

## tests

- [x] I have tested my changes by building the image in this PR

## references

https://github.com/runatlantis/atlantis/pull/3352
https://github.com/runatlantis/atlantis/pull/3346
https://github.com/runatlantis/atlantis/pull/3330


