### PR TITLE
fix: add exempt labels to stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,13 +4,15 @@ on:
     - cron: '30 1 * * *'
 jobs:
   stale:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v8
         with:
           stale-pr-message: 'This issue is stale because it has been open for 1 month with no activity. Remove stale label or comment or this will be closed in 1 month.'
           stale-issue-message: This issue is stale because it has been open for 1 month with no activity. Remove stale label or comment or this will be closed in 1 month.'
           remove-stale-when-updated: true
+          exempt-pr-labels: "never-stale"
+          exempt-issue-labels: "never-stale"
           # 1 month
           days-before-stale: 31
           # 1 month


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- add exempt labels to stale action

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- for some issues and prs that should never be stale

## tests

- I have not tested my changes. I did follow the referenced docs so I assume this works as expected. If this doesn't work as expected, nothing should break.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- https://github.com/actions/stale

