### PR TITLE
fix(ci): Create atlantis-image-required.yml

### DIFF
--- a/.github/workflows/atlantis-image-required.yml
+++ b/.github/workflows/atlantis-image-required.yml
@@ -1,0 +1,28 @@
+# For required checks when path filtering doesn't trigger the other job
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+
+name: atlantis-image
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'Dockerfile'
+      - 'docker-entrypoint.sh'
+      - '.github/workflows/atlantis-image.yml'
+      - '**.go'
+      - 'go.*'
+      - 'yarn.lock'
+      - 'package.json'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        image_type: [alpine, debian]
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'


### PR DESCRIPTION
There are still some corner cases where atlantis-image doesn't run, thus blocking PRs for passing. This should properly handle all cases by inverting the paths with paths-ignore.

## what & why

There are still some corner cases where atlantis-image doesn't run, thus blocking PRs for passing. This should properly handle all cases by inverting the paths with paths-ignore.

## references

https://github.com/runatlantis/atlantis/pull/3374
https://github.com/runatlantis/atlantis/pull/3330

