### PR TITLE
chore(docs): Add notes to atlantis-url in server-configuration

### DIFF
--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -103,7 +103,8 @@ Values are chosen in this order:
   where `$port` is from the [`--port`](#port) flag. Supports a basepath if you're hosting Atlantis under a path.
 
   Notes:
-  * If you're using a load balancer with a different port, remember to update the URL with the correct one, not the one defined in the `--port` flag.
+  * If a load balancer with a non http/https port (not the one defined in the `--port` flag) is used, update the URL to include the port like in the example above.
+   * This URL is used as the `details` link next to each atlantis job to view the job's logs.
 
 ### `--automerge`
   ```bash

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -102,6 +102,9 @@ Values are chosen in this order:
   and in links from pull request comments. Defaults to `http://$(hostname):$port`
   where `$port` is from the [`--port`](#port) flag. Supports a basepath if you're hosting Atlantis under a path.
 
+  Notes:
+  * If you're using a load balancer with a different port, remember to update the URL with the correct one, not the one defined in the `--port` flag.
+
 ### `--automerge`
   ```bash
   atlantis server --automerge


### PR DESCRIPTION
## what

Add more context to the `atlantis-url` parameter in the server-configuration documentation.

## why

Some users had similar issues with this part and have commented on it in the #community slack channel.

## tests

- [x] I have tested my changes in local:
![image](https://user-images.githubusercontent.com/994837/236663812-1a448173-c0e1-453f-9364-106a632967d7.png)


## references

- [Slack channel link to have more context ](https://atlantis-community.slack.com/archives/C5MGGAV0C/p1683277236911529)

