### PR TITLE
chore: using constants for checkout strategies

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -33,6 +33,12 @@ import (
 	"github.com/runatlantis/atlantis/server/logging"
 )
 
+// checkout strategies
+const (
+	CheckoutStrategyBranch = "branch"
+	CheckoutStrategyMerge  = "merge"
+)
+
 // To add a new flag you must:
 // 1. Add a const with the flag name (in alphabetic order).
 // 2. Add a new field to server.UserConfig and set the mapstructure tag equal to the flag name.
@@ -141,7 +147,7 @@ const (
 	DefaultADHostname                   = "dev.azure.com"
 	DefaultAutoplanFileList             = "**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl"
 	DefaultAllowCommands                = "version,plan,apply,unlock,approve_policies"
-	DefaultCheckoutStrategy             = "branch"
+	DefaultCheckoutStrategy             = CheckoutStrategyBranch
 	DefaultCheckoutDepth                = 0
 	DefaultBitbucketBaseURL             = bitbucketcloud.BaseURL
 	DefaultDataDir                      = "~/.atlantis"
@@ -545,7 +551,7 @@ var boolFlags = map[string]boolFlag{
 }
 var intFlags = map[string]intFlag{
 	CheckoutDepthFlag: {
-		description: fmt.Sprintf("Used only if --%s=merge.", CheckoutStrategyFlag) +
+		description: fmt.Sprintf("Used only if --%s=%s.", CheckoutStrategyFlag, CheckoutStrategyMerge) +
 			" How many commits to include in each of base and feature branches when cloning repository." +
 			" If merge base is further behind than this number of commits from any of branches heads, full fetch will be performed.",
 		defaultValue: DefaultCheckoutDepth,
@@ -852,8 +858,9 @@ func (s *ServerCmd) validate(userConfig server.UserConfig) error {
 	}
 
 	checkoutStrategy := userConfig.CheckoutStrategy
-	if checkoutStrategy != "branch" && checkoutStrategy != "merge" {
-		return errors.New("invalid checkout strategy: not one of branch or merge")
+	if checkoutStrategy != CheckoutStrategyBranch && checkoutStrategy != CheckoutStrategyMerge {
+		return fmt.Errorf("invalid checkout strategy: not one of %s or %s",
+			CheckoutStrategyBranch, CheckoutStrategyMerge)
 	}
 
 	if (userConfig.SSLKeyFile == "") != (userConfig.SSLCertFile == "") {

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -66,7 +66,7 @@ var testFlags = map[string]interface{}{
 	BitbucketTokenFlag:               "bitbucket-token",
 	BitbucketUserFlag:                "bitbucket-user",
 	BitbucketWebhookSecretFlag:       "bitbucket-secret",
-	CheckoutStrategyFlag:             "merge",
+	CheckoutStrategyFlag:             CheckoutStrategyMerge,
 	DataDirFlag:                      "/path",
 	DefaultTFVersionFlag:             "v0.11.0",
 	DisableApplyAllFlag:              true,


### PR DESCRIPTION
## what

I couldn't help noticing that the words `branch` and `merge` are scattered throughout the `cmd` package so this is just a proposal to replace them with `const`.

I am not sure how to handle [this](https://github.com/runatlantis/atlantis/blob/main/server/server.go#L461) one however as it creates a cyclic dependency between `cmd` and `server` packages.

We can discard this RP altogether or perhaps use a dedicated package for constants? Open to suggestions / discussion.


## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## tests

<!--
- [ ] I have tested my changes by ...
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

