### PR TITLE
fix(ci): push docker dev tag only on merge to main

### DIFF
--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -31,8 +31,8 @@ jobs:
     env:
       # Set docker repo to either the fork or the main repo where the branch exists
       DOCKER_REPO: ghcr.io/${{ github.repository }}
-      # Push if not a pull request or this is a fork
-      PUSH: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+      # Push if not a pull request and references the main branch
+      PUSH: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
 
     steps:
     - uses: actions/checkout@v3
@@ -75,9 +75,9 @@ jobs:
           type=semver,pattern={{version}},prefix=v,enable=${{ matrix.image_type == 'alpine' }}
           type=semver,pattern={{major}}.{{minor}},prefix=v,suffix=${{ env.SUFFIX }}
           # dev
-          type=raw,value=dev,suffix=${{ env.SUFFIX }}-{{ sha }}
-          type=raw,event=push,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') && matrix.image_type == 'alpine' }},suffix=
           type=raw,event=push,value=dev,enable={{is_default_branch}},suffix=${{ env.SUFFIX }}
+          type=raw,event=push,value=dev,enable={{is_default_branch}},suffix=${{ env.SUFFIX }}-{{ sha }}
+          type=raw,event=push,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') && matrix.image_type == 'alpine' }},suffix=
           # prerelease
           type=raw,event=tag,value=prerelease-latest,enable=${{ startsWith(github.ref, 'refs/tags/') && contains(github.ref, 'pre') && matrix.image_type == 'alpine' }},suffix=
           type=raw,event=tag,value=prerelease-latest,enable=${{ startsWith(github.ref, 'refs/tags/') && contains(github.ref, 'pre') }},suffix=${{ env.SUFFIX }}


### PR DESCRIPTION

## what

- Disables pushing a dev tag within an unmerged pr commit event.
- Also disabled image pushing at all unless the event comes from the main branch

## why

Currently, the workflow updates the dev tag on unmerged pr commit events. This should only happen on the main branch. This is additional logic to prevent such possibilities 

## tests

- [x] I have tested my changes by ...

