### PR TITLE
docs(adr): setup ADR process 0001

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+docs/adr

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,20 @@
+# 1. Record architecture decisions
+
+Date: 2023-05-09
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made for Atlantis. The project is a very decentralized project. It suffers from frequent one-timer contributors and ever changing team of maintainers.
+By utilizing the ADR process, we can improve who decisions are made and bring transparency to past decisions to avoid future contributors and maintainers to confidently steer the project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools) before submitting a new ADR.

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -8,8 +8,8 @@ Accepted
 
 ## Context
 
-We need to record the architectural decisions made for Atlantis. The project is a very decentralized project. It suffers from frequent one-timer contributors and ever changing team of maintainers.
-By utilizing the ADR process, we can improve who decisions are made and bring transparency to past decisions to avoid future contributors and maintainers to confidently steer the project.
+We need to record the architectural decisions made for Atlantis. The project is a very decentralized project. It suffers from frequent one-timer contributors and an ever-changing team of maintainers.
+By utilizing the ADR process, we can improve who decisions are made and bring transparency to past decisions to assist future contributors and maintainers to confidently steer the project.
 
 ## Decision
 


### PR DESCRIPTION
## what & why

We need to record the architectural decisions made for Atlantis. The project is a very decentralized project. It suffers from frequent one-timer contributors and an ever-changing team of maintainers.
By utilizing the ADR process, we can improve who decisions are made and bring transparency to past decisions to assist future contributors and maintainers to confidently steer the project.

## references

https://github.com/runatlantis/atlantis/pull/3345
