### PR TITLE
fix(metrics): add missing stat metric scopes

### DIFF
--- a/server/events/instrumented_project_command_runner.go
+++ b/server/events/instrumented_project_command_runner.go
@@ -22,7 +22,7 @@ type InstrumentedProjectCommandRunner struct {
 
 func NewInstrumentedProjectCommandRunner(scope tally.Scope, projectCommandRunner ProjectCommandRunner) *InstrumentedProjectCommandRunner {
 	projectTags := command.ProjectScopeTags{}
-	scope = scope.Tagged(projectTags.Loadtags())
+	scope = scope.SubScope("project").Tagged(projectTags.Loadtags())
 
 	for _, m := range []string{metrics.ExecutionSuccessMetric, metrics.ExecutionErrorMetric, metrics.ExecutionFailureMetric} {
 		metrics.InitCounter(scope, m)
@@ -60,7 +60,7 @@ func (p *InstrumentedProjectCommandRunner) StateRm(ctx command.ProjectContext) c
 
 func RunAndEmitStats(commandName string, ctx command.ProjectContext, execute func(ctx command.ProjectContext) command.ProjectResult, scope tally.Scope) command.ProjectResult {
 	// ensures we are differentiating between project level command and overall command
-	scope = ctx.SetProjectScopeTags(scope)
+	scope = ctx.SetProjectScopeTags(scope).SubScope(commandName)
 	logger := ctx.Log
 
 	executionTime := scope.Timer(metrics.ExecutionTimeMetric).Start()


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

- Add `project` and `commandName` SubScope to CommandRunner scope.
- Metrics:
  - `atlantis_cmd_comment_%COMMAND_project_execution_success` -> `atlantis_project_%COMMAND_execution_success`


## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

- With only `atlantis_project_execution_success` metric there was no way of knowing if it was a `plan`, `apply`, etc.

## tests

<!--
- [ ] I have tested my changes by ...
-->

`atlantis_cmd_comment_%COMMAND_project_execution_success` - > `atlantis_project_%COMMAND_execution_success`

```
# HELP atlantis_cmd_comment_plan_execution_time atlantis_cmd_comment_plan_execution_time summary
# TYPE atlantis_cmd_comment_plan_execution_time summary
atlantis_cmd_comment_plan_execution_time{quantile="0.5"} 4.06519725
atlantis_cmd_comment_plan_execution_time{quantile="0.75"} 4.06519725
atlantis_cmd_comment_plan_execution_time{quantile="0.95"} 4.06519725
atlantis_cmd_comment_plan_execution_time{quantile="0.99"} 4.06519725
atlantis_cmd_comment_plan_execution_time{quantile="0.999"} 4.06519725
atlantis_cmd_comment_plan_execution_time_sum 4.06519725
atlantis_cmd_comment_plan_execution_time_count 1

# HELP atlantis_project_apply_execution_error atlantis_project_apply_execution_error counter
# TYPE atlantis_project_apply_execution_error counter
atlantis_project_apply_execution_error{base_repo="foouser/foo-repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 0

# HELP atlantis_project_apply_execution_failure atlantis_project_apply_execution_failure counter
# TYPE atlantis_project_apply_execution_failure counter
atlantis_project_apply_execution_failure{base_repo="foouser/foo-repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 0

# HELP atlantis_project_apply_execution_success atlantis_project_apply_execution_success counter
# TYPE atlantis_project_apply_execution_success counter
atlantis_project_apply_execution_success{base_repo="foouser/foo-repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 1

# HELP atlantis_project_apply_execution_time atlantis_project_apply_execution_time summary
# TYPE atlantis_project_apply_execution_time summary
atlantis_project_apply_execution_time{base_repo="foouser/foo-repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.5"} 0.936589625
atlantis_project_apply_execution_time{base_repo="foouser/foo-repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.75"} 0.936589625
atlantis_project_apply_execution_time{base_repo="foouser/foo-repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.95"} 0.936589625
atlantis_project_apply_execution_time{base_repo="foouser/foo-repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.99"} 0.936589625
atlantis_project_apply_execution_time{base_repo="foouser/foo-repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.999"} 0.936589625
atlantis_project_apply_execution_time_sum{base_repo="foouser/foo-repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 0.936589625
atlantis_project_apply_execution_time_count{base_repo="foouser/foo-repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 1

# HELP atlantis_project_plan_execution_error atlantis_project_plan_execution_error counter
# TYPE atlantis_project_plan_execution_error counter
atlantis_project_plan_execution_error{base_repo="foouser/foo-repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 0

# HELP atlantis_project_plan_execution_failure atlantis_project_plan_execution_failure counter
# TYPE atlantis_project_plan_execution_failure counter
atlantis_project_plan_execution_failure{base_repo="foouser/foo-repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 0

# HELP atlantis_project_plan_execution_success atlantis_project_plan_execution_success counter
# TYPE atlantis_project_plan_execution_success counter
atlantis_project_plan_execution_success{base_repo="foouser/foo-repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 1

# HELP atlantis_project_plan_execution_time atlantis_project_plan_execution_time summary
# TYPE atlantis_project_plan_execution_time summary
atlantis_project_plan_execution_time{base_repo="foouser/foo-repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.5"} 1.26189025
atlantis_project_plan_execution_time{base_repo="foouser/foo-repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.75"} 1.26189025
atlantis_project_plan_execution_time{base_repo="foouser/foo-repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.95"} 1.26189025
atlantis_project_plan_execution_time{base_repo="foouser/foo-repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.99"} 1.26189025
atlantis_project_plan_execution_time{base_repo="foouser/foo-repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.999"} 1.26189025
atlantis_project_plan_execution_time_sum{base_repo="foouser/foo-repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 1.26189025
atlantis_project_plan_execution_time_count{base_repo="foouser/foo-repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 1
```

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
closes:
- https://github.com/runatlantis/atlantis/issues/3236

relates:
- https://github.com/runatlantis/atlantis/pull/2687
- https://github.com/runatlantis/atlantis/pull/2767
- https://github.com/runatlantis/atlantis/pull/2847

blocked by:
- https://github.com/runatlantis/atlantis/pull/3419
