### PR TITLE
fix(tests): Pin ngrok to v2 and use https

### DIFF
--- a/scripts/e2e-deps.sh
+++ b/scripts/e2e-deps.sh
@@ -18,7 +18,7 @@ unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 chmod +x terraform
 cp terraform /home/circleci/go/bin
 # Download ngrok to create a tunnel to expose atlantis server
-wget https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip
+wget https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v2-stable-linux-amd64.tgz
 unzip ngrok-stable-linux-amd64.zip 
 chmod +x ngrok 
 wget https://stedolan.github.io/jq/download/linux64/jq

--- a/scripts/e2e-deps.sh
+++ b/scripts/e2e-deps.sh
@@ -18,7 +18,7 @@ unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 chmod +x terraform
 cp terraform /home/circleci/go/bin
 # Download ngrok to create a tunnel to expose atlantis server
-wget https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v2-stable-linux-amd64.tgz
+wget https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v2-stable-linux-amd64.zip
 unzip ngrok-stable-linux-amd64.zip 
 chmod +x ngrok 
 wget https://stedolan.github.io/jq/download/linux64/jq

--- a/scripts/e2e-deps.sh
+++ b/scripts/e2e-deps.sh
@@ -18,7 +18,7 @@ unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 chmod +x terraform
 cp terraform /home/circleci/go/bin
 # Download ngrok to create a tunnel to expose atlantis server
-wget https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v2-stable-linux-amd64.zip
+wget https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v2-stable-linux-amd64.zip -O ngrok-stable-linux-amd64.zip 
 unzip ngrok-stable-linux-amd64.zip 
 chmod +x ngrok 
 wget https://stedolan.github.io/jq/download/linux64/jq

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -24,7 +24,7 @@ sleep 2
 sleep 2
 
 # find out what URL ngrok has given us
-export ATLANTIS_URL=$(curl -s 'http://localhost:4040/api/tunnels' | jq -r '.tunnels[] | select(.proto=="http") | .public_url')
+export ATLANTIS_URL=$(curl -s 'http://localhost:4040/api/tunnels' | jq -r '.tunnels[] | select(.proto=="https") | .public_url')
 
 # Now we can start the e2e tests
 echo "Running 'make build'"


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- [x] Pin ngrok to v2 e2e-deps.sh
- [x] Use https proto

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- v3 became the stable version recently and we haven't updated our scripts yet. This is a temporary change until we upgrade to ngrok v3.
- `http` proto was deprecated so it returned an empty string

Error with localhost

```
2023/05/22 14:05:38 cleaning workspace /tmp/atlantis-tests
2023/05/22 14:05:38 creating atlantis webhook with http://localhost:4141/events url
2023/05/22 14:05:39 error creating atlantis webhook: POST https://api.github.com/repos/runatlantis/atlantis-tests/hooks: 422 Validation Failed [{Resource:Hook Field: Code:custom Message:Sorry, the URL host localhost is not supported because it isn't reachable over the public Internet}]
```

What we should see

```
2023/05/13 02:51:56 cleaning workspace /tmp/atlantis-tests
2023/05/13 02:51:56 creating atlantis webhook with http://c0e6-3-237-188-8.ngrok.io/events url
2023/05/13 02:51:56 https://api.github.com/repos/runatlantis/atlantis-tests/hooks/414310601
```


## tests

- [x] I have tested my changes by branch tests for this pr

```
$ curl -s 'http://localhost:4040/api/tunnels' | jq -r '.tunnels[] | select(.proto=="http") | .public_url'
<empty>
$ curl -s 'http://localhost:4040/api/tunnels' | jq -r '.tunnels[] | select(.proto=="https") | .public_url'
https://snip.ngrok.io
```

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- https://github.com/runatlantis/atlantis/blob/96cf38835e15cd2822739076bb3c9e540fa76f09/scripts/e2e.sh#L27
