### PR TITLE
fixbug: Update commandName in RunAndEmitStats

### DIFF
--- a/server/events/instrumented_project_command_runner.go
+++ b/server/events/instrumented_project_command_runner.go
@@ -35,30 +35,31 @@ func NewInstrumentedProjectCommandRunner(scope tally.Scope, projectCommandRunner
 }
 
 func (p *InstrumentedProjectCommandRunner) Plan(ctx command.ProjectContext) command.ProjectResult {
-	return RunAndEmitStats("plan", ctx, p.projectCommandRunner.Plan, p.scope)
+	return RunAndEmitStats(ctx, p.projectCommandRunner.Plan, p.scope)
 }
 
 func (p *InstrumentedProjectCommandRunner) PolicyCheck(ctx command.ProjectContext) command.ProjectResult {
-	return RunAndEmitStats("policy check", ctx, p.projectCommandRunner.PolicyCheck, p.scope)
+	return RunAndEmitStats(ctx, p.projectCommandRunner.PolicyCheck, p.scope)
 }
 
 func (p *InstrumentedProjectCommandRunner) Apply(ctx command.ProjectContext) command.ProjectResult {
-	return RunAndEmitStats("apply", ctx, p.projectCommandRunner.Apply, p.scope)
+	return RunAndEmitStats(ctx, p.projectCommandRunner.Apply, p.scope)
 }
 
 func (p *InstrumentedProjectCommandRunner) ApprovePolicies(ctx command.ProjectContext) command.ProjectResult {
-	return RunAndEmitStats("approve policies", ctx, p.projectCommandRunner.ApprovePolicies, p.scope)
+	return RunAndEmitStats(ctx, p.projectCommandRunner.ApprovePolicies, p.scope)
 }
 
 func (p *InstrumentedProjectCommandRunner) Import(ctx command.ProjectContext) command.ProjectResult {
-	return RunAndEmitStats("import", ctx, p.projectCommandRunner.Import, p.scope)
+	return RunAndEmitStats(ctx, p.projectCommandRunner.Import, p.scope)
 }
 
 func (p *InstrumentedProjectCommandRunner) StateRm(ctx command.ProjectContext) command.ProjectResult {
-	return RunAndEmitStats("state rm", ctx, p.projectCommandRunner.StateRm, p.scope)
+	return RunAndEmitStats(ctx, p.projectCommandRunner.StateRm, p.scope)
 }
 
-func RunAndEmitStats(commandName string, ctx command.ProjectContext, execute func(ctx command.ProjectContext) command.ProjectResult, scope tally.Scope) command.ProjectResult {
+func RunAndEmitStats(ctx command.ProjectContext, execute func(ctx command.ProjectContext) command.ProjectResult, scope tally.Scope) command.ProjectResult {
+	commandName := ctx.CommandName.String()
 	// ensures we are differentiating between project level command and overall command
 	scope = ctx.SetProjectScopeTags(scope).SubScope(commandName)
 	logger := ctx.Log


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

- Use the `CommandName.String()` from the `ctx` instead of fixed string.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

- Since the whole metrics implementation was deploy it never used the `commandName` argument from `RunAndEmitStats` function you can see it clearly in the first commit it was only use for `logger.Err()`
  - https://github.com/runatlantis/atlantis/pull/2147/files#diff-161796dd18c10dc19d3513064a1bcc27d4a5e2fc9c2276d82e741aa85f89c79eR24-R58
- All this time the metrics we saw with plan/apply/policy_check those strings came from the actual atlantis commands from the GitHub comments.
- Then this happened: https://github.com/runatlantis/atlantis/issues/3236
- In my previous PR, I start using for the time the `commandName` argument in order to fix the previous mention issue and that when we saw the first panic that was cause by `policy check` string without `_`: https://github.com/runatlantis/atlantis/pull/3416/files#diff-161796dd18c10dc19d3513064a1bcc27d4a5e2fc9c2276d82e741aa85f89c79eR63
```json
{
    "level": "error",
    "ts": "2023-05-23T10:35:45.772Z",
    "caller": "events/command_runner.go:429",
    "msg": "PANIC: descriptor Desc{fqName: \"atlantis_project_policy check_execution_time\", help: \"atlantis_project_policy check_execution_time summary\", constLabels: {}, variableLabels: [terraform_version workspace pr_number base_repo project project_path]} is invalid: \"atlantis_project_policy check_execution_time\" is not a valid metric name\ngithub.com/uber-go/tally@v3.5.3+incompatible/prometheus/reporter.go:306 (0xb02707)\ngithub.com/uber-go/tally@v3.5.3+incompatible/prometheus/reporter.go:554 (0xb02062)\ngithub.com/uber-go/tally@v3.5.3+incompatible/scope.go:363 (0x9e5787)\ngithub.com/runatlantis/atlantis/server/events/instrumented_project_command_runner.go:66 (0xfa8e82)\ngithub.com/runatlantis/atlantis/server/events/instrumented_project_command_runner.go:42 (0xfa86b4)\ngithub.com/runatlantis/atlantis/server/events/project_command_pool_executor.go:48 (0xfbf121)\ngithub.com/runatlantis/atlantis/server/events/policy_check_command_runner.go:65 (0xfb2107)\ngithub.com/runatlantis/atlantis/server/events/plan_command_runner.go:165 (0xfaf930)\ngithub.com/runatlantis/atlantis/server/events/plan_command_runner.go:288 (0xfb1304)\ngithub.com/runatlantis/atlantis/server/events/command_runner.go:174 (0xf94f8d)\nruntime/asm_amd64.s:1598 (0x46b2e0)\n",
    "json": {
        "repo": "foo",
        "pull": "1234"
    },
    "stacktrace": "github.com/runatlantis/atlantis/server/events.(*DefaultCommandRunner).logPanics\n\tgithub.com/runatlantis/atlantis/server/events/command_runner.go:429\nruntime.gopanic\n\truntime/panic.go:884\ngithub.com/uber-go/tally/prometheus.NewReporter.func1\n\tgithub.com/uber-go/tally@v3.5.3+incompatible/prometheus/reporter.go:306\ngithub.com/uber-go/tally/prometheus.(*reporter).AllocateTimer\n\tgithub.com/uber-go/tally@v3.5.3+incompatible/prometheus/reporter.go:554\ngithub.com/uber-go/tally.(*scope).Timer\n\tgithub.com/uber-go/tally@v3.5.3+incompatible/scope.go:363\ngithub.com/runatlantis/atlantis/server/events.RunAndEmitStats\n\tgithub.com/runatlantis/atlantis/server/events/instrumented_project_command_runner.go:66\ngithub.com/runatlantis/atlantis/server/events.(*InstrumentedProjectCommandRunner).PolicyCheck\n\tgithub.com/runatlantis/atlantis/server/events/instrumented_project_command_runner.go:42\ngithub.com/runatlantis/atlantis/server/events.runProjectCmds\n\tgithub.com/runatlantis/atlantis/server/events/project_command_pool_executor.go:48\ngithub.com/runatlantis/atlantis/server/events.(*PolicyCheckCommandRunner).Run\n\tgithub.com/runatlantis/atlantis/server/events/policy_check_command_runner.go:65\ngithub.com/runatlantis/atlantis/server/events.(*PlanCommandRunner).runAutoplan\n\tgithub.com/runatlantis/atlantis/server/events/plan_command_runner.go:165\ngithub.com/runatlantis/atlantis/server/events.(*PlanCommandRunner).Run\n\tgithub.com/runatlantis/atlantis/server/events/plan_command_runner.go:288\ngithub.com/runatlantis/atlantis/server/events.(*DefaultCommandRunner).RunAutoplanCommand\n\tgithub.com/runatlantis/atlantis/server/events/command_runner.go:174"
}
```
- The solution: instead of using a fixed string we re-use the `ctx.CommandName.String()` value that already have the correct command names, https://github.com/runatlantis/atlantis/blob/8e72ab589d901b448737b7ab1bdec1ab7ed861fe/server/events/command/name.go#L59-L79

## tests

<!--
- [ ] I have tested my changes by ...
-->

Debugging:
Before:
policy_check:
![Screenshot 2023-05-23 at 3 44 18 PM](https://github.com/runatlantis/atlantis/assets/8814890/8f36c8d7-3abd-4257-ab07-a477795ba419)

and then panic:
![image](https://github.com/runatlantis/atlantis/assets/8814890/cd416fa9-649c-407b-95fb-fb36d99beb60)


After:
plan:
![Screenshot 2023-05-23 at 3 42 26 PM](https://github.com/runatlantis/atlantis/assets/8814890/349bee9f-76f5-4173-b535-822b504379a6)

policy_check
![Screenshot 2023-05-23 at 3 42 44 PM](https://github.com/runatlantis/atlantis/assets/8814890/9db7e0cd-1db9-42ef-b344-c3e328799d8b)

approve_policies
![Screenshot 2023-05-23 at 3 39 40 PM](https://github.com/runatlantis/atlantis/assets/8814890/e67ee3f7-2477-4592-bcaa-ef02fdd47e30)

apply
![Screenshot 2023-05-23 at 3 40 33 PM](https://github.com/runatlantis/atlantis/assets/8814890/598463d6-78a0-4fd6-b2f6-e8419e575383)

state or state rm
![Screenshot 2023-05-23 at 3 41 06 PM](https://github.com/runatlantis/atlantis/assets/8814890/44e4be56-635a-493e-8368-e7e6d06e45ee)

Metrics:
<details><summary>Show Metrics</summary>

```
# HELP atlantis_api_getprojectjobs_execution_error atlantis_api_getprojectjobs_execution_error counter
# TYPE atlantis_api_getprojectjobs_execution_error counter
atlantis_api_getprojectjobs_execution_error 0
# HELP atlantis_api_getprojectjobs_execution_time atlantis_api_getprojectjobs_execution_time summary
# TYPE atlantis_api_getprojectjobs_execution_time summary
atlantis_api_getprojectjobs_execution_time{quantile="0.5"} 0.001327792
atlantis_api_getprojectjobs_execution_time{quantile="0.75"} 0.001327792
atlantis_api_getprojectjobs_execution_time{quantile="0.95"} 0.001327792
atlantis_api_getprojectjobs_execution_time{quantile="0.99"} 0.001327792
atlantis_api_getprojectjobs_execution_time{quantile="0.999"} 0.001327792
atlantis_api_getprojectjobs_execution_time_sum 0.001327792
atlantis_api_getprojectjobs_execution_time_count 1
# HELP atlantis_builder_execution_error atlantis_builder_execution_error counter
# TYPE atlantis_builder_execution_error counter
atlantis_builder_execution_error 0
# HELP atlantis_builder_execution_success atlantis_builder_execution_success counter
# TYPE atlantis_builder_execution_success counter
atlantis_builder_execution_success 3
# HELP atlantis_builder_execution_time atlantis_builder_execution_time summary
# TYPE atlantis_builder_execution_time summary
atlantis_builder_execution_time{quantile="0.5"} 0.273653083
atlantis_builder_execution_time{quantile="0.75"} 0.29153175
atlantis_builder_execution_time{quantile="0.95"} 0.29153175
atlantis_builder_execution_time{quantile="0.99"} 0.29153175
atlantis_builder_execution_time{quantile="0.999"} 0.29153175
atlantis_builder_execution_time_sum 0.6252524159999999
atlantis_builder_execution_time_count 3
# HELP atlantis_cmd_comment_apply_execution_time atlantis_cmd_comment_apply_execution_time summary
# TYPE atlantis_cmd_comment_apply_execution_time summary
atlantis_cmd_comment_apply_execution_time{quantile="0.5"} 3.660074417
atlantis_cmd_comment_apply_execution_time{quantile="0.75"} 3.660074417
atlantis_cmd_comment_apply_execution_time{quantile="0.95"} 3.660074417
atlantis_cmd_comment_apply_execution_time{quantile="0.99"} 3.660074417
atlantis_cmd_comment_apply_execution_time{quantile="0.999"} 3.660074417
atlantis_cmd_comment_apply_execution_time_sum 3.660074417
atlantis_cmd_comment_apply_execution_time_count 1
# HELP atlantis_cmd_comment_approve_policies_execution_time atlantis_cmd_comment_approve_policies_execution_time summary
# TYPE atlantis_cmd_comment_approve_policies_execution_time summary
atlantis_cmd_comment_approve_policies_execution_time{quantile="0.5"} 2.260303041
atlantis_cmd_comment_approve_policies_execution_time{quantile="0.75"} 2.260303041
atlantis_cmd_comment_approve_policies_execution_time{quantile="0.95"} 2.260303041
atlantis_cmd_comment_approve_policies_execution_time{quantile="0.99"} 2.260303041
atlantis_cmd_comment_approve_policies_execution_time{quantile="0.999"} 2.260303041
atlantis_cmd_comment_approve_policies_execution_time_sum 2.260303041
atlantis_cmd_comment_approve_policies_execution_time_count 1
# HELP atlantis_cmd_comment_plan_execution_time atlantis_cmd_comment_plan_execution_time summary
# TYPE atlantis_cmd_comment_plan_execution_time summary
atlantis_cmd_comment_plan_execution_time{quantile="0.5"} 8.784708625
atlantis_cmd_comment_plan_execution_time{quantile="0.75"} 8.784708625
atlantis_cmd_comment_plan_execution_time{quantile="0.95"} 8.784708625
atlantis_cmd_comment_plan_execution_time{quantile="0.99"} 8.784708625
atlantis_cmd_comment_plan_execution_time{quantile="0.999"} 8.784708625
atlantis_cmd_comment_plan_execution_time_sum 8.784708625
atlantis_cmd_comment_plan_execution_time_count 1
# HELP atlantis_cmd_comment_state_execution_time atlantis_cmd_comment_state_execution_time summary
# TYPE atlantis_cmd_comment_state_execution_time summary
atlantis_cmd_comment_state_execution_time{quantile="0.5"} 2.251546541
atlantis_cmd_comment_state_execution_time{quantile="0.75"} 2.251546541
atlantis_cmd_comment_state_execution_time{quantile="0.95"} 2.251546541
atlantis_cmd_comment_state_execution_time{quantile="0.99"} 2.251546541
atlantis_cmd_comment_state_execution_time{quantile="0.999"} 2.251546541
atlantis_cmd_comment_state_execution_time_sum 2.251546541
atlantis_cmd_comment_state_execution_time_count 1
# HELP atlantis_github_create_comment_execution_error atlantis_github_create_comment_execution_error counter
# TYPE atlantis_github_create_comment_execution_error counter
atlantis_github_create_comment_execution_error{base_repo="foo/repo",pr_number="7"} 0
# HELP atlantis_github_create_comment_execution_success atlantis_github_create_comment_execution_success counter
# TYPE atlantis_github_create_comment_execution_success counter
atlantis_github_create_comment_execution_success{base_repo="foo/repo",pr_number="7"} 5
# HELP atlantis_github_create_comment_execution_time atlantis_github_create_comment_execution_time summary
# TYPE atlantis_github_create_comment_execution_time summary
atlantis_github_create_comment_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.5"} 0.945310875
atlantis_github_create_comment_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.75"} 0.951462833
atlantis_github_create_comment_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.95"} 1.037311916
atlantis_github_create_comment_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.99"} 1.037311916
atlantis_github_create_comment_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.999"} 1.037311916
atlantis_github_create_comment_execution_time_sum{base_repo="foo/repo",pr_number="7"} 4.786881541
atlantis_github_create_comment_execution_time_count{base_repo="foo/repo",pr_number="7"} 5
# HELP atlantis_github_event_comment_created_success_200 atlantis_github_event_comment_created_success_200 counter
# TYPE atlantis_github_event_comment_created_success_200 counter
atlantis_github_event_comment_created_success_200{base_repo="foo/repo",pr_number="7"} 9
# HELP atlantis_github_get_modified_files_execution_error atlantis_github_get_modified_files_execution_error counter
# TYPE atlantis_github_get_modified_files_execution_error counter
atlantis_github_get_modified_files_execution_error{base_repo="foo/repo",pr_number="7"} 0
# HELP atlantis_github_get_modified_files_execution_success atlantis_github_get_modified_files_execution_success counter
# TYPE atlantis_github_get_modified_files_execution_success counter
atlantis_github_get_modified_files_execution_success{base_repo="foo/repo",pr_number="7"} 2
# HELP atlantis_github_get_modified_files_execution_time atlantis_github_get_modified_files_execution_time summary
# TYPE atlantis_github_get_modified_files_execution_time summary
atlantis_github_get_modified_files_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.5"} 0.237940792
atlantis_github_get_modified_files_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.75"} 0.238934292
atlantis_github_get_modified_files_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.95"} 0.238934292
atlantis_github_get_modified_files_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.99"} 0.238934292
atlantis_github_get_modified_files_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.999"} 0.238934292
atlantis_github_get_modified_files_execution_time_sum{base_repo="foo/repo",pr_number="7"} 0.476875084
atlantis_github_get_modified_files_execution_time_count{base_repo="foo/repo",pr_number="7"} 2
# HELP atlantis_github_get_pull_request_execution_error atlantis_github_get_pull_request_execution_error counter
# TYPE atlantis_github_get_pull_request_execution_error counter
atlantis_github_get_pull_request_execution_error{base_repo="foo/repo",pr_number="7"} 0
# HELP atlantis_github_get_pull_request_execution_success atlantis_github_get_pull_request_execution_success counter
# TYPE atlantis_github_get_pull_request_execution_success counter
atlantis_github_get_pull_request_execution_success{base_repo="foo/repo",pr_number="7"} 4
# HELP atlantis_github_get_pull_request_execution_time atlantis_github_get_pull_request_execution_time summary
# TYPE atlantis_github_get_pull_request_execution_time summary
atlantis_github_get_pull_request_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.5"} 0.372129292
atlantis_github_get_pull_request_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.75"} 0.398244209
atlantis_github_get_pull_request_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.95"} 0.495629083
atlantis_github_get_pull_request_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.99"} 0.495629083
atlantis_github_get_pull_request_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.999"} 0.495629083
atlantis_github_get_pull_request_execution_time_sum{base_repo="foo/repo",pr_number="7"} 1.626428251
atlantis_github_get_pull_request_execution_time_count{base_repo="foo/repo",pr_number="7"} 4
# HELP atlantis_github_pull_is_approved_execution_error atlantis_github_pull_is_approved_execution_error counter
# TYPE atlantis_github_pull_is_approved_execution_error counter
atlantis_github_pull_is_approved_execution_error{base_repo="foo/repo",pr_number="7"} 0
# HELP atlantis_github_pull_is_approved_execution_success atlantis_github_pull_is_approved_execution_success counter
# TYPE atlantis_github_pull_is_approved_execution_success counter
atlantis_github_pull_is_approved_execution_success{base_repo="foo/repo",pr_number="7"} 2
# HELP atlantis_github_pull_is_approved_execution_time atlantis_github_pull_is_approved_execution_time summary
# TYPE atlantis_github_pull_is_approved_execution_time summary
atlantis_github_pull_is_approved_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.5"} 0.410166625
atlantis_github_pull_is_approved_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.75"} 0.425089625
atlantis_github_pull_is_approved_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.95"} 0.425089625
atlantis_github_pull_is_approved_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.99"} 0.425089625
atlantis_github_pull_is_approved_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.999"} 0.425089625
atlantis_github_pull_is_approved_execution_time_sum{base_repo="foo/repo",pr_number="7"} 0.83525625
atlantis_github_pull_is_approved_execution_time_count{base_repo="foo/repo",pr_number="7"} 2
# HELP atlantis_github_pull_is_mergeable_execution_error atlantis_github_pull_is_mergeable_execution_error counter
# TYPE atlantis_github_pull_is_mergeable_execution_error counter
atlantis_github_pull_is_mergeable_execution_error{base_repo="foo/repo",pr_number="7"} 0
# HELP atlantis_github_pull_is_mergeable_execution_success atlantis_github_pull_is_mergeable_execution_success counter
# TYPE atlantis_github_pull_is_mergeable_execution_success counter
atlantis_github_pull_is_mergeable_execution_success{base_repo="foo/repo",pr_number="7"} 2
# HELP atlantis_github_pull_is_mergeable_execution_time atlantis_github_pull_is_mergeable_execution_time summary
# TYPE atlantis_github_pull_is_mergeable_execution_time summary
atlantis_github_pull_is_mergeable_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.5"} 0.346136334
atlantis_github_pull_is_mergeable_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.75"} 0.357433667
atlantis_github_pull_is_mergeable_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.95"} 0.357433667
atlantis_github_pull_is_mergeable_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.99"} 0.357433667
atlantis_github_pull_is_mergeable_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.999"} 0.357433667
atlantis_github_pull_is_mergeable_execution_time_sum{base_repo="foo/repo",pr_number="7"} 0.703570001
atlantis_github_pull_is_mergeable_execution_time_count{base_repo="foo/repo",pr_number="7"} 2
# HELP atlantis_github_react_to_comment_execution_error atlantis_github_react_to_comment_execution_error counter
# TYPE atlantis_github_react_to_comment_execution_error counter
atlantis_github_react_to_comment_execution_error 0
# HELP atlantis_github_react_to_comment_execution_success atlantis_github_react_to_comment_execution_success counter
# TYPE atlantis_github_react_to_comment_execution_success counter
atlantis_github_react_to_comment_execution_success 4
# HELP atlantis_github_react_to_comment_execution_time atlantis_github_react_to_comment_execution_time summary
# TYPE atlantis_github_react_to_comment_execution_time summary
atlantis_github_react_to_comment_execution_time{quantile="0.5"} 0.337575875
atlantis_github_react_to_comment_execution_time{quantile="0.75"} 0.340190375
atlantis_github_react_to_comment_execution_time{quantile="0.95"} 0.502541125
atlantis_github_react_to_comment_execution_time{quantile="0.99"} 0.502541125
atlantis_github_react_to_comment_execution_time{quantile="0.999"} 0.502541125
atlantis_github_react_to_comment_execution_time_sum 1.4956419589999999
atlantis_github_react_to_comment_execution_time_count 4
# HELP atlantis_github_update_status_execution_error atlantis_github_update_status_execution_error counter
# TYPE atlantis_github_update_status_execution_error counter
atlantis_github_update_status_execution_error{base_repo="foo/repo",pr_number="7"} 0
# HELP atlantis_github_update_status_execution_success atlantis_github_update_status_execution_success counter
# TYPE atlantis_github_update_status_execution_success counter
atlantis_github_update_status_execution_success{base_repo="foo/repo",pr_number="7"} 12
# HELP atlantis_github_update_status_execution_time atlantis_github_update_status_execution_time summary
# TYPE atlantis_github_update_status_execution_time summary
atlantis_github_update_status_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.5"} 0.3601065
atlantis_github_update_status_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.75"} 0.396579292
atlantis_github_update_status_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.95"} 0.516521125
atlantis_github_update_status_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.99"} 0.516521125
atlantis_github_update_status_execution_time{base_repo="foo/repo",pr_number="7",quantile="0.999"} 0.516521125
atlantis_github_update_status_execution_time_sum{base_repo="foo/repo",pr_number="7"} 4.520204251
atlantis_github_update_status_execution_time_count{base_repo="foo/repo",pr_number="7"} 12
# HELP atlantis_project_apply_execution_error atlantis_project_apply_execution_error counter
# TYPE atlantis_project_apply_execution_error counter
atlantis_project_apply_execution_error{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 0
# HELP atlantis_project_apply_execution_failure atlantis_project_apply_execution_failure counter
# TYPE atlantis_project_apply_execution_failure counter
atlantis_project_apply_execution_failure{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 0
# HELP atlantis_project_apply_execution_success atlantis_project_apply_execution_success counter
# TYPE atlantis_project_apply_execution_success counter
atlantis_project_apply_execution_success{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 1
# HELP atlantis_project_apply_execution_time atlantis_project_apply_execution_time summary
# TYPE atlantis_project_apply_execution_time summary
atlantis_project_apply_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.5"} 0.859556167
atlantis_project_apply_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.75"} 0.859556167
atlantis_project_apply_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.95"} 0.859556167
atlantis_project_apply_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.99"} 0.859556167
atlantis_project_apply_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.999"} 0.859556167
atlantis_project_apply_execution_time_sum{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 0.859556167
atlantis_project_apply_execution_time_count{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 1
# HELP atlantis_project_approve_policies_execution_error atlantis_project_approve_policies_execution_error counter
# TYPE atlantis_project_approve_policies_execution_error counter
atlantis_project_approve_policies_execution_error{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 0
# HELP atlantis_project_approve_policies_execution_failure atlantis_project_approve_policies_execution_failure counter
# TYPE atlantis_project_approve_policies_execution_failure counter
atlantis_project_approve_policies_execution_failure{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 0
# HELP atlantis_project_approve_policies_execution_success atlantis_project_approve_policies_execution_success counter
# TYPE atlantis_project_approve_policies_execution_success counter
atlantis_project_approve_policies_execution_success{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 1
# HELP atlantis_project_approve_policies_execution_time atlantis_project_approve_policies_execution_time summary
# TYPE atlantis_project_approve_policies_execution_time summary
atlantis_project_approve_policies_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.5"} 0.011936
atlantis_project_approve_policies_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.75"} 0.011936
atlantis_project_approve_policies_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.95"} 0.011936
atlantis_project_approve_policies_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.99"} 0.011936
atlantis_project_approve_policies_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.999"} 0.011936
atlantis_project_approve_policies_execution_time_sum{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 0.011936
atlantis_project_approve_policies_execution_time_count{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 1
# HELP atlantis_project_execution_error atlantis_project_execution_error counter
# TYPE atlantis_project_execution_error counter
atlantis_project_execution_error{base_repo="",pr_number="",project="",project_path="",terraform_version="",workspace=""} 0
# HELP atlantis_project_execution_failure atlantis_project_execution_failure counter
# TYPE atlantis_project_execution_failure counter
atlantis_project_execution_failure{base_repo="",pr_number="",project="",project_path="",terraform_version="",workspace=""} 0
# HELP atlantis_project_execution_success atlantis_project_execution_success counter
# TYPE atlantis_project_execution_success counter
atlantis_project_execution_success{base_repo="",pr_number="",project="",project_path="",terraform_version="",workspace=""} 0
# HELP atlantis_project_plan_execution_error atlantis_project_plan_execution_error counter
# TYPE atlantis_project_plan_execution_error counter
atlantis_project_plan_execution_error{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 0
# HELP atlantis_project_plan_execution_failure atlantis_project_plan_execution_failure counter
# TYPE atlantis_project_plan_execution_failure counter
atlantis_project_plan_execution_failure{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 0
# HELP atlantis_project_plan_execution_success atlantis_project_plan_execution_success counter
# TYPE atlantis_project_plan_execution_success counter
atlantis_project_plan_execution_success{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 1
# HELP atlantis_project_plan_execution_time atlantis_project_plan_execution_time summary
# TYPE atlantis_project_plan_execution_time summary
atlantis_project_plan_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.5"} 1.521709416
atlantis_project_plan_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.75"} 1.521709416
atlantis_project_plan_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.95"} 1.521709416
atlantis_project_plan_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.99"} 1.521709416
atlantis_project_plan_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.999"} 1.521709416
atlantis_project_plan_execution_time_sum{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 1.521709416
atlantis_project_plan_execution_time_count{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 1
# HELP atlantis_project_policy_check_execution_error atlantis_project_policy_check_execution_error counter
# TYPE atlantis_project_policy_check_execution_error counter
atlantis_project_policy_check_execution_error{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 1
# HELP atlantis_project_policy_check_execution_failure atlantis_project_policy_check_execution_failure counter
# TYPE atlantis_project_policy_check_execution_failure counter
atlantis_project_policy_check_execution_failure{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 0
# HELP atlantis_project_policy_check_execution_success atlantis_project_policy_check_execution_success counter
# TYPE atlantis_project_policy_check_execution_success counter
atlantis_project_policy_check_execution_success{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 0
# HELP atlantis_project_policy_check_execution_time atlantis_project_policy_check_execution_time summary
# TYPE atlantis_project_policy_check_execution_time summary
atlantis_project_policy_check_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.5"} 0.115006584
atlantis_project_policy_check_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.75"} 0.115006584
atlantis_project_policy_check_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.95"} 0.115006584
atlantis_project_policy_check_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.99"} 0.115006584
atlantis_project_policy_check_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.999"} 0.115006584
atlantis_project_policy_check_execution_time_sum{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 0.115006584
atlantis_project_policy_check_execution_time_count{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 1
# HELP atlantis_project_state_execution_error atlantis_project_state_execution_error counter
# TYPE atlantis_project_state_execution_error counter
atlantis_project_state_execution_error{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 0
# HELP atlantis_project_state_execution_failure atlantis_project_state_execution_failure counter
# TYPE atlantis_project_state_execution_failure counter
atlantis_project_state_execution_failure{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 0
# HELP atlantis_project_state_execution_success atlantis_project_state_execution_success counter
# TYPE atlantis_project_state_execution_success counter
atlantis_project_state_execution_success{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 1
# HELP atlantis_project_state_execution_time atlantis_project_state_execution_time summary
# TYPE atlantis_project_state_execution_time summary
atlantis_project_state_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.5"} 0.622787375
atlantis_project_state_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.75"} 0.622787375
atlantis_project_state_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.95"} 0.622787375
atlantis_project_state_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.99"} 0.622787375
atlantis_project_state_execution_time{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default",quantile="0.999"} 0.622787375
atlantis_project_state_execution_time_sum{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 0.622787375
atlantis_project_state_execution_time_count{base_repo="foo/repo",pr_number="7",project="atlantis-example-live",project_path="example",terraform_version="1.3.4",workspace="default"} 1
# HELP atlantis_pullclosed_cleanup_execution_error atlantis_pullclosed_cleanup_execution_error counter
# TYPE atlantis_pullclosed_cleanup_execution_error counter
atlantis_pullclosed_cleanup_execution_error 0
# HELP atlantis_pullclosed_cleanup_execution_success atlantis_pullclosed_cleanup_execution_success counter
# TYPE atlantis_pullclosed_cleanup_execution_success counter
atlantis_pullclosed_cleanup_execution_success 0
# HELP atlantis_scheduled_runtime_cpu_cgo_calls atlantis_scheduled_runtime_cpu_cgo_calls gauge
# TYPE atlantis_scheduled_runtime_cpu_cgo_calls gauge
atlantis_scheduled_runtime_cpu_cgo_calls 0
# HELP atlantis_scheduled_runtime_cpu_goroutines atlantis_scheduled_runtime_cpu_goroutines gauge
# TYPE atlantis_scheduled_runtime_cpu_goroutines gauge
atlantis_scheduled_runtime_cpu_goroutines 19
# HELP atlantis_scheduled_runtime_memory_alloc atlantis_scheduled_runtime_memory_alloc gauge
# TYPE atlantis_scheduled_runtime_memory_alloc gauge
atlantis_scheduled_runtime_memory_alloc 9.707016e+06
# HELP atlantis_scheduled_runtime_memory_frees atlantis_scheduled_runtime_memory_frees gauge
# TYPE atlantis_scheduled_runtime_memory_frees gauge
atlantis_scheduled_runtime_memory_frees 79581
# HELP atlantis_scheduled_runtime_memory_gc_count atlantis_scheduled_runtime_memory_gc_count gauge
# TYPE atlantis_scheduled_runtime_memory_gc_count gauge
atlantis_scheduled_runtime_memory_gc_count 7
# HELP atlantis_scheduled_runtime_memory_gc_last atlantis_scheduled_runtime_memory_gc_last gauge
# TYPE atlantis_scheduled_runtime_memory_gc_last gauge
atlantis_scheduled_runtime_memory_gc_last 1.684849706485546e+18
# HELP atlantis_scheduled_runtime_memory_gc_next atlantis_scheduled_runtime_memory_gc_next gauge
# TYPE atlantis_scheduled_runtime_memory_gc_next gauge
atlantis_scheduled_runtime_memory_gc_next 1.6133696e+07
# HELP atlantis_scheduled_runtime_memory_gc_pause_total atlantis_scheduled_runtime_memory_gc_pause_total gauge
# TYPE atlantis_scheduled_runtime_memory_gc_pause_total gauge
atlantis_scheduled_runtime_memory_gc_pause_total 1.226333e+06
# HELP atlantis_scheduled_runtime_memory_gc_sys atlantis_scheduled_runtime_memory_gc_sys gauge
# TYPE atlantis_scheduled_runtime_memory_gc_sys gauge
atlantis_scheduled_runtime_memory_gc_sys 4.7154e+06
# HELP atlantis_scheduled_runtime_memory_heap_alloc atlantis_scheduled_runtime_memory_heap_alloc gauge
# TYPE atlantis_scheduled_runtime_memory_heap_alloc gauge
atlantis_scheduled_runtime_memory_heap_alloc 9.707016e+06
# HELP atlantis_scheduled_runtime_memory_heap_idle atlantis_scheduled_runtime_memory_heap_idle gauge
# TYPE atlantis_scheduled_runtime_memory_heap_idle gauge
atlantis_scheduled_runtime_memory_heap_idle 7.028736e+06
# HELP atlantis_scheduled_runtime_memory_heap_inuse atlantis_scheduled_runtime_memory_heap_inuse gauge
# TYPE atlantis_scheduled_runtime_memory_heap_inuse gauge
atlantis_scheduled_runtime_memory_heap_inuse 1.302528e+07
# HELP atlantis_scheduled_runtime_memory_heap_objects atlantis_scheduled_runtime_memory_heap_objects gauge
# TYPE atlantis_scheduled_runtime_memory_heap_objects gauge
atlantis_scheduled_runtime_memory_heap_objects 38741
# HELP atlantis_scheduled_runtime_memory_heap_released atlantis_scheduled_runtime_memory_heap_released gauge
# TYPE atlantis_scheduled_runtime_memory_heap_released gauge
atlantis_scheduled_runtime_memory_heap_released 2.99008e+06
# HELP atlantis_scheduled_runtime_memory_heap_sys atlantis_scheduled_runtime_memory_heap_sys gauge
# TYPE atlantis_scheduled_runtime_memory_heap_sys gauge
atlantis_scheduled_runtime_memory_heap_sys 2.0054016e+07
# HELP atlantis_scheduled_runtime_memory_lookups atlantis_scheduled_runtime_memory_lookups gauge
# TYPE atlantis_scheduled_runtime_memory_lookups gauge
atlantis_scheduled_runtime_memory_lookups 0
# HELP atlantis_scheduled_runtime_memory_malloc atlantis_scheduled_runtime_memory_malloc gauge
# TYPE atlantis_scheduled_runtime_memory_malloc gauge
atlantis_scheduled_runtime_memory_malloc 118322
# HELP atlantis_scheduled_runtime_memory_othersys atlantis_scheduled_runtime_memory_othersys gauge
# TYPE atlantis_scheduled_runtime_memory_othersys gauge
atlantis_scheduled_runtime_memory_othersys 1.689479e+06
# HELP atlantis_scheduled_runtime_memory_stack_inuse atlantis_scheduled_runtime_memory_stack_inuse gauge
# TYPE atlantis_scheduled_runtime_memory_stack_inuse gauge
atlantis_scheduled_runtime_memory_stack_inuse 917504
# HELP atlantis_scheduled_runtime_memory_stack_mcache_inuse atlantis_scheduled_runtime_memory_stack_mcache_inuse gauge
# TYPE atlantis_scheduled_runtime_memory_stack_mcache_inuse gauge
atlantis_scheduled_runtime_memory_stack_mcache_inuse 9600
# HELP atlantis_scheduled_runtime_memory_stack_mcache_sys atlantis_scheduled_runtime_memory_stack_mcache_sys gauge
# TYPE atlantis_scheduled_runtime_memory_stack_mcache_sys gauge
atlantis_scheduled_runtime_memory_stack_mcache_sys 15600
# HELP atlantis_scheduled_runtime_memory_stack_mspan_inuse atlantis_scheduled_runtime_memory_stack_mspan_inuse gauge
# TYPE atlantis_scheduled_runtime_memory_stack_mspan_inuse gauge
atlantis_scheduled_runtime_memory_stack_mspan_inuse 193760
# HELP atlantis_scheduled_runtime_memory_stack_sys atlantis_scheduled_runtime_memory_stack_sys gauge
# TYPE atlantis_scheduled_runtime_memory_stack_sys gauge
atlantis_scheduled_runtime_memory_stack_sys 195840
# HELP atlantis_scheduled_runtime_memory_sys atlantis_scheduled_runtime_memory_sys gauge
# TYPE atlantis_scheduled_runtime_memory_sys gauge
atlantis_scheduled_runtime_memory_sys 2.7593744e+07
# HELP atlantis_scheduled_runtime_memory_total atlantis_scheduled_runtime_memory_total gauge
# TYPE atlantis_scheduled_runtime_memory_total gauge
atlantis_scheduled_runtime_memory_total 2.3479704e+07
```

</details>

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

- https://github.com/runatlantis/atlantis/issues/3236
- previous pr https://github.com/runatlantis/atlantis/pull/3416
