### PR TITLE
fix (workflow-hook): Make Unique Output IDs for Separate Pre and Post Workflow Hooks

### DIFF
--- a/server/events/post_workflow_hooks_command_runner.go
+++ b/server/events/post_workflow_hooks_command_runner.go
@@ -85,7 +85,6 @@ func (w *DefaultPostWorkflowHooksCommandRunner) RunPostHooks(
 			User:               user,
 			Verbose:            false,
 			EscapedCommentArgs: escapedArgs,
-			HookID:             uuid.NewString(),
 		},
 		postWorkflowHooks, repoDir)
 
@@ -108,6 +107,7 @@ func (w *DefaultPostWorkflowHooksCommandRunner) runHooks(
 			hookDescription = fmt.Sprintf("Post workflow hook #%d", i)
 		}
 
+		ctx.HookID = uuid.NewString()
 		url, err := w.Router.GenerateProjectWorkflowHookURL(ctx.HookID)
 		if err != nil {
 			return err

--- a/server/events/pre_workflow_hooks_command_runner.go
+++ b/server/events/pre_workflow_hooks_command_runner.go
@@ -83,7 +83,6 @@ func (w *DefaultPreWorkflowHooksCommandRunner) RunPreHooks(ctx *command.Context,
 			User:               user,
 			Verbose:            false,
 			EscapedCommentArgs: escapedArgs,
-			HookID:             uuid.NewString(),
 		},
 		preWorkflowHooks, repoDir)
 
@@ -105,6 +104,7 @@ func (w *DefaultPreWorkflowHooksCommandRunner) runHooks(
 			hookDescription = fmt.Sprintf("Pre workflow hook #%d", i)
 		}
 
+		ctx.HookID = uuid.NewString()
 		url, err := w.Router.GenerateProjectWorkflowHookURL(ctx.HookID)
 		if err != nil {
 			return err


### PR DESCRIPTION
## what

Moved the generation of the `HookID` from outside the workflow hook processing loop to inside, so a unique id gets created for each hook.

## why

- Fixes #3453 

## tests

### repos.yaml

```yaml
repos:
- id: /.*/
  pre_workflow_hooks:
    - description: pre workflow test 1
      run: echo "pre workflow test 1"
    - description: pre workflow test 2
      run: echo "pre workflow test 2"
  post_workflow_hooks:
    - description: post workflow test 1
      run: echo "post workflow test 1"
    - description: post workflow test 2
      run: echo "post workflow test 2"
```

### GitHub Checks

<img width="627" alt="image" src="https://github.com/runatlantis/atlantis/assets/32168619/619880e0-d24f-40d1-b8d4-0e78b040f608">

### Pre Workflow Test 1 Output

<img width="407" alt="image" src="https://github.com/runatlantis/atlantis/assets/32168619/c9d8ad07-6cf7-4007-9f78-b0a749e57403">

### Pre Workflow Test 2 Output

<img width="406" alt="image" src="https://github.com/runatlantis/atlantis/assets/32168619/50a1f099-5687-49ea-8fce-384d326e9114">

### Post Workflow Test 1 Output

<img width="416" alt="image" src="https://github.com/runatlantis/atlantis/assets/32168619/e0a40598-ed7f-4f09-ad86-608403e18b5b">

### Post Workflow Test 2 Output

<img width="413" alt="image" src="https://github.com/runatlantis/atlantis/assets/32168619/5219dd89-aad9-4a2c-b7e1-a6f4f9c2981e">
