### PR TITLE
fix: Initialize VCSClient for commandrunner to remove recent server panics

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -778,6 +778,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	}
 
 	commandRunner := &events.DefaultCommandRunner{
+		VCSClient:                      vcsClient,
 		GithubPullGetter:               githubClient,
 		GitlabMergeRequestGetter:       gitlabClient,
 		AzureDevopsPullGetter:          azuredevopsClient,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -267,3 +267,12 @@ func TestParseAtlantisURL(t *testing.T) {
 		})
 	}
 }
+
+func TestCommandRunnerVCSClientInitialized(t *testing.T) {
+	s, _ := server.NewServer(server.UserConfig{
+		AtlantisURL: "http://example.com",
+	},
+		server.Config{},
+	)
+	Assert(t, s.CommandRunner.VCSClient != nil, "VCSClient must not be nil.")
+}


### PR DESCRIPTION
## what

VCSClient was inadvertently removed from the commandrunner instantiation in #3086.

https://github.com/runatlantis/atlantis/pull/3086/files#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4L780

This has caused server panics during the course of normal operations.

## why

Bugfix.

## tests

Added a unit test to ensure that VCSClient is passed to commandRunner during server initialization.

## references

- Fix #3446

