### PR TITLE
fix: auto plan when .terraform.lock.hcl changed

### DIFF
--- a/runatlantis.io/docs/repo-level-atlantis-yaml.md
+++ b/runatlantis.io/docs/repo-level-atlantis-yaml.md
@@ -344,7 +344,7 @@ Atlantis supports this but requires the `name` key to be specified. See [Custom 
 ### Autoplan
 ```yaml
 enabled: true
-when_modified: ["*.tf", "terragrunt.hcl"]
+when_modified: ["*.tf", "terragrunt.hcl", ".terraform.lock.hcl"]
 ```
 | Key                   | Type          | Default        | Required | Description                                                                                                                                                                                                                                                       |
 |-----------------------|---------------|----------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/server/core/config/parser_validator_test.go
+++ b/server/core/config/parser_validator_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/runatlantis/atlantis/server/core/config"
+	"github.com/runatlantis/atlantis/server/core/config/raw"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	. "github.com/runatlantis/atlantis/testing"
 )
@@ -217,7 +218,7 @@ projects:
 						WorkflowName:     nil,
 						TerraformVersion: nil,
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      true,
 						},
 						ApplyRequirements: nil,
@@ -240,7 +241,7 @@ projects:
 						Dir:       ".",
 						Workspace: "default",
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      true,
 						},
 					},
@@ -286,7 +287,7 @@ projects:
 						Dir:       ".",
 						Workspace: "default",
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      true,
 						},
 					},
@@ -309,7 +310,7 @@ workflows: ~
 						Dir:       ".",
 						Workspace: "default",
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      true,
 						},
 					},
@@ -337,7 +338,7 @@ workflows:
 						Dir:       ".",
 						Workspace: "default",
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      true,
 						},
 					},
@@ -368,7 +369,7 @@ workflows:
 						WorkflowName:     String("myworkflow"),
 						TerraformVersion: tfVersion,
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      true,
 						},
 						ApplyRequirements: []string{"approved"},
@@ -402,7 +403,7 @@ workflows:
 						WorkflowName:     String("myworkflow"),
 						TerraformVersion: tfVersion,
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      false,
 						},
 						ApplyRequirements: []string{"approved"},
@@ -436,7 +437,7 @@ workflows:
 						WorkflowName:     String("myworkflow"),
 						TerraformVersion: tfVersion,
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      false,
 						},
 						ApplyRequirements: []string{"mergeable"},
@@ -470,7 +471,7 @@ workflows:
 						WorkflowName:     String("myworkflow"),
 						TerraformVersion: tfVersion,
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      false,
 						},
 						ApplyRequirements: []string{"undiverged"},
@@ -504,7 +505,7 @@ workflows:
 						WorkflowName:     String("myworkflow"),
 						TerraformVersion: tfVersion,
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      false,
 						},
 						ApplyRequirements: []string{"mergeable", "approved"},
@@ -538,7 +539,7 @@ workflows:
 						WorkflowName:     String("myworkflow"),
 						TerraformVersion: tfVersion,
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      false,
 						},
 						ApplyRequirements: []string{"undiverged", "approved"},
@@ -572,7 +573,7 @@ workflows:
 						WorkflowName:     String("myworkflow"),
 						TerraformVersion: tfVersion,
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      false,
 						},
 						ApplyRequirements: []string{"undiverged", "mergeable"},
@@ -606,7 +607,7 @@ workflows:
 						WorkflowName:     String("myworkflow"),
 						TerraformVersion: tfVersion,
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      false,
 						},
 						ApplyRequirements: []string{"undiverged", "mergeable", "approved"},
@@ -716,7 +717,7 @@ projects:
 						Dir:       ".",
 						Workspace: "workspace",
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      true,
 						},
 					},
@@ -725,7 +726,7 @@ projects:
 						Dir:       ".",
 						Workspace: "workspace",
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      true,
 						},
 					},
@@ -767,7 +768,7 @@ workflows:
 						Dir:       ".",
 						Workspace: "default",
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      true,
 						},
 					},
@@ -866,7 +867,7 @@ workflows:
 						Dir:       ".",
 						Workspace: "default",
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      true,
 						},
 					},
@@ -957,7 +958,7 @@ workflows:
 						Dir:       ".",
 						Workspace: "default",
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      true,
 						},
 					},
@@ -1050,7 +1051,7 @@ workflows:
 						Dir:       ".",
 						Workspace: "default",
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      true,
 						},
 					},

--- a/server/core/config/raw/autoplan.go
+++ b/server/core/config/raw/autoplan.go
@@ -6,7 +6,11 @@ import (
 
 // DefaultAutoPlanWhenModified is the default element in the when_modified
 // list if none is defined.
-var DefaultAutoPlanWhenModified = []string{"**/*.tf*", "**/terragrunt.hcl"}
+var DefaultAutoPlanWhenModified = []string{
+	"**/*.tf*",
+	"**/terragrunt.hcl",
+	"**/.terraform.lock.hcl",
+}
 
 type Autoplan struct {
 	WhenModified []string `yaml:"when_modified,omitempty"`

--- a/server/core/config/raw/autoplan_test.go
+++ b/server/core/config/raw/autoplan_test.go
@@ -109,7 +109,7 @@ func TestAutoplan_ToValid(t *testing.T) {
 			input:       raw.Autoplan{},
 			exp: valid.Autoplan{
 				Enabled:      true,
-				WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+				WhenModified: raw.DefaultAutoPlanWhenModified,
 			},
 		},
 		{
@@ -129,7 +129,7 @@ func TestAutoplan_ToValid(t *testing.T) {
 			},
 			exp: valid.Autoplan{
 				Enabled:      false,
-				WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+				WhenModified: raw.DefaultAutoPlanWhenModified,
 			},
 		},
 		{
@@ -139,7 +139,7 @@ func TestAutoplan_ToValid(t *testing.T) {
 			},
 			exp: valid.Autoplan{
 				Enabled:      true,
-				WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+				WhenModified: raw.DefaultAutoPlanWhenModified,
 			},
 		},
 	}

--- a/server/core/config/raw/project_test.go
+++ b/server/core/config/raw/project_test.go
@@ -349,7 +349,7 @@ func TestProject_ToValid(t *testing.T) {
 				WorkflowName:     nil,
 				TerraformVersion: nil,
 				Autoplan: valid.Autoplan{
-					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+					WhenModified: raw.DefaultAutoPlanWhenModified,
 					Enabled:      true,
 				},
 				ApplyRequirements: nil,
@@ -396,7 +396,7 @@ func TestProject_ToValid(t *testing.T) {
 				Workspace:        "default",
 				TerraformVersion: tfVersionPointEleven,
 				Autoplan: valid.Autoplan{
-					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+					WhenModified: raw.DefaultAutoPlanWhenModified,
 					Enabled:      true,
 				},
 			},
@@ -411,7 +411,7 @@ func TestProject_ToValid(t *testing.T) {
 				Dir:       ".",
 				Workspace: "default",
 				Autoplan: valid.Autoplan{
-					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+					WhenModified: raw.DefaultAutoPlanWhenModified,
 					Enabled:      true,
 				},
 			},
@@ -425,7 +425,7 @@ func TestProject_ToValid(t *testing.T) {
 				Dir:       "a/b/c",
 				Workspace: "default",
 				Autoplan: valid.Autoplan{
-					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+					WhenModified: raw.DefaultAutoPlanWhenModified,
 					Enabled:      true,
 				},
 			},
@@ -439,7 +439,7 @@ func TestProject_ToValid(t *testing.T) {
 				Dir:       "mydir",
 				Workspace: "default",
 				Autoplan: valid.Autoplan{
-					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+					WhenModified: raw.DefaultAutoPlanWhenModified,
 					Enabled:      true,
 				},
 			},
@@ -454,7 +454,7 @@ func TestProject_ToValid(t *testing.T) {
 				Dir:       "mydir",
 				Workspace: "default",
 				Autoplan: valid.Autoplan{
-					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+					WhenModified: raw.DefaultAutoPlanWhenModified,
 					Enabled:      true,
 				},
 			},
@@ -468,7 +468,7 @@ func TestProject_ToValid(t *testing.T) {
 				Dir:       ".",
 				Workspace: "default",
 				Autoplan: valid.Autoplan{
-					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+					WhenModified: raw.DefaultAutoPlanWhenModified,
 					Enabled:      true,
 				},
 			},
@@ -482,7 +482,7 @@ func TestProject_ToValid(t *testing.T) {
 				Dir:       ".",
 				Workspace: "default",
 				Autoplan: valid.Autoplan{
-					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+					WhenModified: raw.DefaultAutoPlanWhenModified,
 					Enabled:      true,
 				},
 			},
@@ -496,7 +496,7 @@ func TestProject_ToValid(t *testing.T) {
 				Dir:       ".",
 				Workspace: "default",
 				Autoplan: valid.Autoplan{
-					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+					WhenModified: raw.DefaultAutoPlanWhenModified,
 					Enabled:      true,
 				},
 			},
@@ -512,7 +512,7 @@ func TestProject_ToValid(t *testing.T) {
 				Dir:       ".",
 				Workspace: "default",
 				Autoplan: valid.Autoplan{
-					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+					WhenModified: raw.DefaultAutoPlanWhenModified,
 					Enabled:      true,
 				},
 			},

--- a/server/core/config/raw/repo_cfg_test.go
+++ b/server/core/config/raw/repo_cfg_test.go
@@ -433,7 +433,7 @@ func TestConfig_ToValid(t *testing.T) {
 						Dir:       "mydir",
 						Workspace: "default",
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      true,
 						},
 					},

--- a/server/core/config/valid/repo_cfg_test.go
+++ b/server/core/config/valid/repo_cfg_test.go
@@ -5,6 +5,7 @@ import (
 
 	validation "github.com/go-ozzo/ozzo-validation"
 	version "github.com/hashicorp/go-version"
+	"github.com/runatlantis/atlantis/server/core/config/raw"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	. "github.com/runatlantis/atlantis/testing"
 )
@@ -29,7 +30,7 @@ func TestConfig_FindProjectsByDir(t *testing.T) {
 						Workspace:        "myworkspace",
 						TerraformVersion: tfVersion,
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      false,
 						},
 						ApplyRequirements: []string{"approved"},
@@ -52,7 +53,7 @@ func TestConfig_FindProjectsByDir(t *testing.T) {
 					Workspace:        "myworkspace",
 					TerraformVersion: tfVersion,
 					Autoplan: valid.Autoplan{
-						WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+						WhenModified: raw.DefaultAutoPlanWhenModified,
 						Enabled:      false,
 					},
 					ApplyRequirements: []string{"approved"},
@@ -71,7 +72,7 @@ func TestConfig_FindProjectsByDir(t *testing.T) {
 						Workspace:        "myworkspace",
 						TerraformVersion: tfVersion,
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      false,
 						},
 						ApplyRequirements: []string{"approved"},
@@ -82,7 +83,7 @@ func TestConfig_FindProjectsByDir(t *testing.T) {
 						Workspace:        "myworkspace",
 						TerraformVersion: tfVersion,
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      false,
 						},
 						ApplyRequirements: []string{"approved"},
@@ -112,7 +113,7 @@ func TestConfig_FindProjectsByDir(t *testing.T) {
 						Workspace:        "myworkspace",
 						TerraformVersion: tfVersion,
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      false,
 						},
 						ApplyRequirements: []string{"approved"},
@@ -123,7 +124,7 @@ func TestConfig_FindProjectsByDir(t *testing.T) {
 						Workspace:        "myworkspace",
 						TerraformVersion: tfVersion,
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      false,
 						},
 						ApplyRequirements: []string{"approved"},
@@ -146,7 +147,7 @@ func TestConfig_FindProjectsByDir(t *testing.T) {
 					Workspace:        "myworkspace",
 					TerraformVersion: tfVersion,
 					Autoplan: valid.Autoplan{
-						WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+						WhenModified: raw.DefaultAutoPlanWhenModified,
 						Enabled:      false,
 					},
 					ApplyRequirements: []string{"approved"},
@@ -157,7 +158,7 @@ func TestConfig_FindProjectsByDir(t *testing.T) {
 					Workspace:        "myworkspace",
 					TerraformVersion: tfVersion,
 					Autoplan: valid.Autoplan{
-						WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+						WhenModified: raw.DefaultAutoPlanWhenModified,
 						Enabled:      false,
 					},
 					ApplyRequirements: []string{"approved"},
@@ -176,7 +177,7 @@ func TestConfig_FindProjectsByDir(t *testing.T) {
 						Workspace:        "myworkspace",
 						TerraformVersion: tfVersion,
 						Autoplan: valid.Autoplan{
-							WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+							WhenModified: raw.DefaultAutoPlanWhenModified,
 							Enabled:      false,
 						},
 						ApplyRequirements: []string{"approved"},
@@ -199,7 +200,7 @@ func TestConfig_FindProjectsByDir(t *testing.T) {
 					Workspace:        "myworkspace",
 					TerraformVersion: tfVersion,
 					Autoplan: valid.Autoplan{
-						WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
+						WhenModified: raw.DefaultAutoPlanWhenModified,
 						Enabled:      false,
 					},
 					ApplyRequirements: []string{"approved"},

--- a/server/events/project_finder_test.go
+++ b/server/events/project_finder_test.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/runatlantis/atlantis/server/core/config/raw"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/logging"
@@ -483,6 +484,22 @@ func TestDefaultProjectFinder_DetermineProjectsViaConfig(t *testing.T) {
 				},
 			},
 			modified:     []string{"project2/terraform.tfvars"},
+			expProjPaths: []string{"project2"},
+		},
+		{
+			description: ".terraform.lock.hcl file modified",
+			config: valid.RepoCfg{
+				Projects: []valid.Project{
+					{
+						Dir: "project2",
+						Autoplan: valid.Autoplan{
+							Enabled:      true,
+							WhenModified: raw.DefaultAutoPlanWhenModified,
+						},
+					},
+				},
+			},
+			modified:     []string{"project2/.terraform.lock.hcl"},
 			expProjPaths: []string{"project2"},
 		},
 		{


### PR DESCRIPTION
## what

When `projects` are specified and `when_modified` is not specified via
the config file, changing `.terraform.lock.hcl` file won't trigger auto
plan. This is because the default `raw.WhenModified` does not include
`.terraform.lock.hcl`.

Note that when projects are auto detected, changing
`.terraform.lock.hcl` triggers auto plan. This is because the
`cmd.DefaultAutoplanFileList` includes `.terraform.lock.hcl`.

## why

It is desirable to run terraform plan/apply even if only `.terraform.lock.hcl` are updated.

## tests

I added a unit test and also tested this behavior by running atlantis with this change.

## references

See also https://github.com/runatlantis/atlantis/pull/3466.