### PR TITLE
Include link to releases page in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-**NOTE:** We do not plan to update this page anymore. Please see the releases page for the updated changelog.
+**NOTE:** We do not plan to update this page anymore. Please see [the releases page for the updated changelog](https://github.com/runatlantis/atlantis/releases).
 
 ---
 


### PR DESCRIPTION
Minor ease-of-use change to link to the releases page so that when people (like me) google  "atlatnis change log" it's easier to get to releases.
