### PR TITLE
feat(stats): pass plan stats to markdown templates

### DIFF
--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -197,10 +197,18 @@ func (m *MarkdownRenderer) renderProjectResults(results []command.ProjectResult,
 		if result.PlanSuccess != nil {
 			resultData.Stats = result.PlanSuccess.Stats()
 			result.PlanSuccess.TerraformOutput = strings.TrimSpace(result.PlanSuccess.TerraformOutput)
+			data := planSuccessData{
+				PlanSuccess:              *result.PlanSuccess,
+				PlanWasDeleted:           common.PlansDeleted,
+				DisableApply:             common.DisableApply,
+				DisableRepoLocking:       common.DisableRepoLocking,
+				EnableDiffMarkdownFormat: common.EnableDiffMarkdownFormat,
+			}
 			if m.shouldUseWrappedTmpl(vcsHost, result.PlanSuccess.TerraformOutput) {
-				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("planSuccessWrapped"), planSuccessData{PlanSuccess: *result.PlanSuccess, PlanSummary: result.PlanSuccess.Summary(), PlanWasDeleted: common.PlansDeleted, DisableApply: common.DisableApply, DisableRepoLocking: common.DisableRepoLocking, EnableDiffMarkdownFormat: common.EnableDiffMarkdownFormat})
+				data.PlanSummary = result.PlanSuccess.Summary()
+				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("planSuccessWrapped"), data)
 			} else {
-				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("planSuccessUnwrapped"), planSuccessData{PlanSuccess: *result.PlanSuccess, PlanWasDeleted: common.PlansDeleted, DisableApply: common.DisableApply, DisableRepoLocking: common.DisableRepoLocking, EnableDiffMarkdownFormat: common.EnableDiffMarkdownFormat})
+				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("planSuccessUnwrapped"), data)
 			}
 			resultData.NoChanges = result.PlanSuccess.NoChanges()
 			numPlanSuccesses++

--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -116,6 +116,7 @@ type projectResultTmplData struct {
 	ProjectName string
 	Rendered    string
 	NoChanges   bool
+	Stats       models.PlanSuccessStats
 }
 
 // Initialize templates
@@ -194,6 +195,7 @@ func (m *MarkdownRenderer) renderProjectResults(results []command.ProjectResult,
 			ProjectName: result.ProjectName,
 		}
 		if result.PlanSuccess != nil {
+			resultData.Stats = result.PlanSuccess.Stats()
 			result.PlanSuccess.TerraformOutput = strings.TrimSpace(result.PlanSuccess.TerraformOutput)
 			if m.shouldUseWrappedTmpl(vcsHost, result.PlanSuccess.TerraformOutput) {
 				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("planSuccessWrapped"), planSuccessData{PlanSuccess: *result.PlanSuccess, PlanSummary: result.PlanSuccess.Summary(), PlanWasDeleted: common.PlansDeleted, DisableApply: common.DisableApply, DisableRepoLocking: common.DisableRepoLocking, EnableDiffMarkdownFormat: common.EnableDiffMarkdownFormat})

--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -100,6 +100,7 @@ type planSuccessData struct {
 	DisableApply             bool
 	DisableRepoLocking       bool
 	EnableDiffMarkdownFormat bool
+	PlanStats                models.PlanSuccessStats
 }
 
 type policyCheckResultsData struct {
@@ -116,7 +117,6 @@ type projectResultTmplData struct {
 	ProjectName string
 	Rendered    string
 	NoChanges   bool
-	Stats       models.PlanSuccessStats
 }
 
 // Initialize templates
@@ -195,7 +195,6 @@ func (m *MarkdownRenderer) renderProjectResults(results []command.ProjectResult,
 			ProjectName: result.ProjectName,
 		}
 		if result.PlanSuccess != nil {
-			resultData.Stats = result.PlanSuccess.Stats()
 			result.PlanSuccess.TerraformOutput = strings.TrimSpace(result.PlanSuccess.TerraformOutput)
 			data := planSuccessData{
 				PlanSuccess:              *result.PlanSuccess,
@@ -203,6 +202,7 @@ func (m *MarkdownRenderer) renderProjectResults(results []command.ProjectResult,
 				DisableApply:             common.DisableApply,
 				DisableRepoLocking:       common.DisableRepoLocking,
 				EnableDiffMarkdownFormat: common.EnableDiffMarkdownFormat,
+				PlanStats:                result.PlanSuccess.Stats(),
 			}
 			if m.shouldUseWrappedTmpl(vcsHost, result.PlanSuccess.TerraformOutput) {
 				data.PlanSummary = result.PlanSuccess.Summary()

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -427,6 +427,11 @@ func (p PlanSuccess) DiffMarkdownFormattedTerraformOutput() string {
 	return strings.TrimSpace(formattedTerraformOutput)
 }
 
+// Stats returns plan change stats and contextual information.
+func (p PlanSuccess) Stats() PlanSuccessStats {
+	return NewPlanSuccessStats(p.TerraformOutput)
+}
+
 // PolicyCheckResults is the result of a successful policy check run.
 type PolicyCheckResults struct {
 	// PolicySetResults is the output from policy check binary(conftest|opa)

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -384,7 +384,7 @@ type PolicySetStatus struct {
 // Summary regexes
 var (
 	reChangesOutside = regexp.MustCompile(`Note: Objects have changed outside of Terraform`)
-	rePlanChanges    = regexp.MustCompile(`Plan: \d+ to add, \d+ to change, \d+ to destroy.`)
+	rePlanChanges    = regexp.MustCompile(`Plan: (\d+) to add, (\d+) to change, (\d+) to destroy.`)
 	reNoChanges      = regexp.MustCompile(`No changes. (Infrastructure is up-to-date|Your infrastructure matches the configuration).`)
 )
 


### PR DESCRIPTION
## what

- This PR adds an additional struct to the data passed down to the templates in the Markdown renderer with stats about a successful plan: number of resources to add, update, destroy, if it include changes (something that's already covered but I started working on this branch before that change went in) and if there are any resources changed outside of Terraform.

## why

- The benefit of passing down this stats won't probably be notable with the default templates as they are, but it could, however, allow users to render a successful plan like the following:

---

### The following environments have Terraform changes
| environment | add | change | destroy |
|-|-|-|-|
| `staging` | 3 | 1 | 0 |
| `dev` | 0 | 0 | 5 |

### The following environments have changes outside of Terraform
- `prod-01`
- `prod-02`

---

The template code to do something like that could be:

```
{{ $withChangesOutside := false }}
### The following environments have Terraform changes
| environment | add | change | destroy |
|-|-|-|-|
{{ range $i, $result := range .Results }}
{{- if $result.Stats.ChangesOutside }}{{ $withChangesOutside = true }}{{ end -}}
{{- if $result.Stats.Changes }}
| `{{ $result.ProjectName }}` | {{ $result.Stats.Add }} | {{ $result.Stats.Change }} | {{ $result.Stats.Destroy }} |
{{ end -}}
{{ end }}

{{ if $withChangesOutside }}
### The following environments have changes outside of Terraform
{{ range $i, $result := range .Results }}
- `{{ $result.ProjectName }}`
{{ end }}
{{ end }}
```

## tests
- I've been testing these changes locally and if everything goes according to plan it is likely we will test it thoroughly at Grafana Labs, where we manage 300+ environments with Atlantis.

- Adding tests to the test suite implies changing the default templates, which is not probably something we would like to introduce unless this is first approved/merged.

## references

- First mentioned in #2069