### PR TITLE
fix(github-actions): pin buildx to v0.11.2

### DIFF
--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -51,6 +51,9 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
+      with:
+        driver-opts: |
+          image=moby/buildkit:v0.11.2
 
     # release version is the name of the tag i.e. v0.10.0
     # release version also has the image type appended i.e. v0.10.0-alpine


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- fix(github-actions): pin buildx to v0.11.2

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- resolve intermittent build failures
- at one point we did not have a pin, which gave us many build failures. Then we pinned to v0.10.6 and experienced no build failures. Then buildkit released a fix in v0.11.2 and instead of pinning, we removed the pin to use the latest again. I think a recent release maybe v0.11.6 or earlier caused a regression, albeit rare.
- if pinning to v0.11.2 doesn't resolve this then we pin to v0.10.6 again

## tests

- [x] I have tested my changes by reading docs and references and testing in this pr

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- https://github.com/docker/build-push-action/issues/761#issuecomment-1406261692
- https://github.com/docker/build-push-action/issues/761#issuecomment-1575006515
- https://github.com/runatlantis/atlantis/actions/runs/5139979174/jobs/9250992369
- previous pr #3018 (pin to v0.10.6) and #3121 (remove pin)
- https://github.com/moby/buildkit/releases/tag/v0.11.6 (latest and assumption is that this release or a recent release causes this error)
- https://github.com/moby/buildkit/releases/tag/v0.11.2 (contains bug fix)
- https://github.com/moby/buildkit/releases/tag/v0.10.6 (last working release before first set if failures)
