### PR TITLE
feat: Add Terraform command duration to log messages

### DIFF
--- a/server/core/terraform/terraform_client.go
+++ b/server/core/terraform/terraform_client.go
@@ -423,7 +423,7 @@ func (c *DefaultClient) RunCommandWithVersion(ctx command.ProjectContext, path s
 		log.Err(err.Error())
 		return ansi.Strip(string(out)), err
 	}
-	log.Info("Successfully ran %q in %q", tfCmd, path)
+	log.Info("successfully ran %q in %q", tfCmd, path)
 
 	return ansi.Strip(string(out)), nil
 }

--- a/server/core/terraform/terraform_client.go
+++ b/server/core/terraform/terraform_client.go
@@ -28,6 +28,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/hashicorp/go-getter/v2"
 	"github.com/hashicorp/go-version"
@@ -413,13 +414,16 @@ func (c *DefaultClient) RunCommandWithVersion(ctx command.ProjectContext, path s
 		envVars = append(envVars, fmt.Sprintf("%s=%s", key, val))
 	}
 	cmd.Env = envVars
+	start := time.Now()
 	out, err := cmd.CombinedOutput()
+	dur := time.Since(start)
+	log := ctx.Log.With("duration", dur)
 	if err != nil {
 		err = errors.Wrapf(err, "running %q in %q", tfCmd, path)
-		ctx.Log.Err(err.Error())
+		log.Err(err.Error())
 		return ansi.Strip(string(out)), err
 	}
-	ctx.Log.Info("Successfully ran %q in %q", tfCmd, path)
+	log.Info("Successfully ran %q in %q", tfCmd, path)
 
 	return ansi.Strip(string(out)), nil
 }

--- a/server/core/terraform/terraform_client_internal_test.go
+++ b/server/core/terraform/terraform_client_internal_test.go
@@ -8,11 +8,13 @@ import (
 	"testing"
 
 	version "github.com/hashicorp/go-version"
+	. "github.com/petergtz/pegomock"
 	runtimemodels "github.com/runatlantis/atlantis/server/core/runtime/models"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
 	jobmocks "github.com/runatlantis/atlantis/server/jobs/mocks"
 	"github.com/runatlantis/atlantis/server/logging"
+	logmocks "github.com/runatlantis/atlantis/server/logging/mocks"
 	. "github.com/runatlantis/atlantis/testing"
 )
 
@@ -168,10 +170,12 @@ func TestDefaultClient_RunCommandWithVersion_Error(t *testing.T) {
 }
 
 func TestDefaultClient_RunCommandAsync_Success(t *testing.T) {
+	RegisterMockTestingT(t)
 	v, err := version.NewVersion("0.11.11")
 	Ok(t, err)
 	tmp := t.TempDir()
-	logger := logging.NewNoopLogger(t)
+	logger := logmocks.NewMockSimpleLogging()
+	When(logger.With(AnyString(), AnyInterface())).ThenReturn(logger)
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 
 	ctx := command.ProjectContext{
@@ -211,13 +215,17 @@ func TestDefaultClient_RunCommandAsync_Success(t *testing.T) {
 	Ok(t, err)
 	exp := fmt.Sprintf("TF_IN_AUTOMATION=true TF_PLUGIN_CACHE_DIR=%s WORKSPACE=workspace ATLANTIS_TERRAFORM_VERSION=0.11.11 DIR=%s", tmp, tmp)
 	Equals(t, exp, out)
+
+	logger.VerifyWasCalledOnce().With(EqString("duration"), AnyInterface())
 }
 
 func TestDefaultClient_RunCommandAsync_BigOutput(t *testing.T) {
+	RegisterMockTestingT(t)
 	v, err := version.NewVersion("0.11.11")
 	Ok(t, err)
 	tmp := t.TempDir()
-	logger := logging.NewNoopLogger(t)
+	logger := logmocks.NewMockSimpleLogging()
+	When(logger.With(AnyString(), AnyInterface())).ThenReturn(logger)
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 
 	ctx := command.ProjectContext{
@@ -258,13 +266,17 @@ func TestDefaultClient_RunCommandAsync_BigOutput(t *testing.T) {
 	out, err := waitCh(outCh)
 	Ok(t, err)
 	Equals(t, strings.TrimRight(exp, "\n"), out)
+
+	logger.VerifyWasCalledOnce().With(EqString("duration"), AnyInterface())
 }
 
 func TestDefaultClient_RunCommandAsync_StderrOutput(t *testing.T) {
+	RegisterMockTestingT(t)
 	v, err := version.NewVersion("0.11.11")
 	Ok(t, err)
 	tmp := t.TempDir()
-	logger := logging.NewNoopLogger(t)
+	logger := logmocks.NewMockSimpleLogging()
+	When(logger.With(AnyString(), AnyInterface())).ThenReturn(logger)
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 
 	ctx := command.ProjectContext{
@@ -294,13 +306,17 @@ func TestDefaultClient_RunCommandAsync_StderrOutput(t *testing.T) {
 	out, err := waitCh(outCh)
 	Ok(t, err)
 	Equals(t, "stderr", out)
+
+	logger.VerifyWasCalledOnce().With(EqString("duration"), AnyInterface())
 }
 
 func TestDefaultClient_RunCommandAsync_ExitOne(t *testing.T) {
+	RegisterMockTestingT(t)
 	v, err := version.NewVersion("0.11.11")
 	Ok(t, err)
 	tmp := t.TempDir()
-	logger := logging.NewNoopLogger(t)
+	logger := logmocks.NewMockSimpleLogging()
+	When(logger.With(AnyString(), AnyInterface())).ThenReturn(logger)
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 
 	ctx := command.ProjectContext{
@@ -331,13 +347,17 @@ func TestDefaultClient_RunCommandAsync_ExitOne(t *testing.T) {
 	ErrEquals(t, fmt.Sprintf(`running "echo dying && exit 1" in %q: exit status 1`, tmp), err)
 	// Test that we still get our output.
 	Equals(t, "dying", out)
+
+	logger.VerifyWasCalledOnce().With(EqString("duration"), AnyInterface())
 }
 
 func TestDefaultClient_RunCommandAsync_Input(t *testing.T) {
+	RegisterMockTestingT(t)
 	v, err := version.NewVersion("0.11.11")
 	Ok(t, err)
 	tmp := t.TempDir()
-	logger := logging.NewNoopLogger(t)
+	logger := logmocks.NewMockSimpleLogging()
+	When(logger.With(AnyString(), AnyInterface())).ThenReturn(logger)
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 
 	ctx := command.ProjectContext{
@@ -369,6 +389,8 @@ func TestDefaultClient_RunCommandAsync_Input(t *testing.T) {
 	out, err := waitCh(outCh)
 	Ok(t, err)
 	Equals(t, "echo me", out)
+
+	logger.VerifyWasCalledOnce().With(EqString("duration"), AnyInterface())
 }
 
 func waitCh(ch <-chan runtimemodels.Line) (string, error) {


### PR DESCRIPTION
## what

This PR adds the wall clock duration of executing any Terraform command to the logs.

## why

This information is useful for observability purposes.

## tests

Tested the changes running Atlantis locally. Because it relies on `time.Now` adding tests that are not flaky is difficult.

## references

- closes #3413.