### PR TITLE
fix(docs): Update access-credentials.md

### DIFF
--- a/runatlantis.io/docs/access-credentials.md
+++ b/runatlantis.io/docs/access-credentials.md
@@ -52,7 +52,7 @@ Only a single installation per GitHub App is supported at the moment.
 :::
 
 ::: tip NOTE
-GitHub App handles the webhook calls by itself, hence there is no need to create wehbooks separately. If you have created webhooks manually, you need to remove them when using GitHub App. Otherwise, there would be 2 calls to Atlantis which causes locking errors on path/workspace.
+GitHub App handles the webhook calls by itself, hence there is no need to create wehbooks separately. If webhooks were created manually, those should be removed when using GitHub App. Otherwise, there would be 2 calls to Atlantis resulting in locking errors on path/workspace.
 :::
 
 #### Permissions

--- a/runatlantis.io/docs/access-credentials.md
+++ b/runatlantis.io/docs/access-credentials.md
@@ -49,6 +49,8 @@ Available in Atlantis versions **newer** than 0.13.0.
 
 ::: warning
 Only a single installation per GitHub App is supported at the moment.
+
+GitHub App handles the webhook calls by itself, hence there is no need to create wehbooks separately. If you have created webhooks manually, you need to remove them when using GitHub App. Otherwise, there would be 2 calls to Atlantis which causes locking errors on path/workspace.
 :::
 
 #### Permissions

--- a/runatlantis.io/docs/access-credentials.md
+++ b/runatlantis.io/docs/access-credentials.md
@@ -49,7 +49,9 @@ Available in Atlantis versions **newer** than 0.13.0.
 
 ::: warning
 Only a single installation per GitHub App is supported at the moment.
+:::
 
+::: tip NOTE
 GitHub App handles the webhook calls by itself, hence there is no need to create wehbooks separately. If you have created webhooks manually, you need to remove them when using GitHub App. Otherwise, there would be 2 calls to Atlantis which causes locking errors on path/workspace.
 :::
 


### PR DESCRIPTION
## what

This PR updates the documentation to clarify there is no need to have manual webhooks created when using GitHub App method.

## why

It is not clear that you don't need a webook with GitHub App and users might create that when setting up Atlantis. This leads to locking errors on Atlantis server.

## tests

<!--
- [n/a] I have tested my changes by ...
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- documents https://github.com/runatlantis/atlantis/issues/2346
