### PR TITLE
fix: Remove the 'Plan Discarded' Message from the Enable/Disable Apply Commands

### DIFF
--- a/server/controllers/templates/web_templates.go
+++ b/server/controllers/templates/web_templates.go
@@ -168,7 +168,7 @@ var IndexTemplate = template.Must(template.New("index.html.tmpl").Parse(`
                 url: '{{ .CleanedBasePath }}/apply/lock',
                 type: 'POST',
                 success: function(result) {
-                  window.location.replace("{{ .CleanedBasePath }}/?discard=true");
+                  window.location.replace("{{ .CleanedBasePath }}");
                 }
             });
           });
@@ -185,7 +185,7 @@ var IndexTemplate = template.Must(template.New("index.html.tmpl").Parse(`
                 url: '{{ .CleanedBasePath }}/apply/unlock',
                 type: 'DELETE',
                 success: function(result) {
-                  window.location.replace("{{ .CleanedBasePath }}/?discard=true");
+                  window.location.replace("{{ .CleanedBasePath }}");
                 }
             });
           });

--- a/server/controllers/templates/web_templates.go
+++ b/server/controllers/templates/web_templates.go
@@ -168,7 +168,7 @@ var IndexTemplate = template.Must(template.New("index.html.tmpl").Parse(`
                 url: '{{ .CleanedBasePath }}/apply/lock',
                 type: 'POST',
                 success: function(result) {
-                  window.location.replace("{{ .CleanedBasePath }}");
+                  window.location.replace("{{ .CleanedBasePath }}/");
                 }
             });
           });
@@ -185,7 +185,7 @@ var IndexTemplate = template.Must(template.New("index.html.tmpl").Parse(`
                 url: '{{ .CleanedBasePath }}/apply/unlock',
                 type: 'DELETE',
                 success: function(result) {
-                  window.location.replace("{{ .CleanedBasePath }}");
+                  window.location.replace("{{ .CleanedBasePath }}/");
                 }
             });
           });


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

Remove the incorrect `?discard=true` query string from the `lock` and `unlock` conditions in the `applyLockModalSetup` function.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

- Fixes #3510 

## tests

Tested locally


