### PR TITLE
chore(deps): bump pegomock v3.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/patternmatcher v0.5.0
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
-	github.com/petergtz/pegomock v2.9.0+incompatible
+	github.com/petergtz/pegomock/v3 v3.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/redis/go-redis/v9 v9.0.5
 	github.com/remeh/sizedwaitgroup v1.0.0
@@ -104,8 +104,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/onsi/ginkgo v1.16.5 // indirect
-	github.com/onsi/gomega v1.24.1 // indirect
+	github.com/onsi/gomega v1.27.6 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,6 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
-github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=
@@ -144,7 +142,7 @@ github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91
 github.com/go-playground/validator/v10 v10.14.1 h1:9c50NUPC30zyuKprjL3vNZ0m5oG+jU0zvx4AqHGnv4k=
 github.com/go-playground/validator/v10 v10.14.1/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
 github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
@@ -219,6 +217,7 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
@@ -261,7 +260,6 @@ github.com/hashicorp/hcl/v2 v2.17.0 h1:z1XvSUyXd1HP10U4lrLg5e0JMVz6CPaJvAgxM0KNZ
 github.com/hashicorp/hcl/v2 v2.17.0/go.mod h1:gJyW2PTShkJqQBKpAmPO3yxMxIuoXkOF2TpqXzrQyx4=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20230522202058-dbe9bfcbfe7a h1:zKVsrHhIOWiXHYqFrOXfHacOOVDMYv+v/Wx8DUeyySs=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20230522202058-dbe9bfcbfe7a/go.mod h1:l8HcFPm9cQh6Q0KSWoYPiePqMvRFenybP1CH2MjKdlg=
-github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
@@ -340,22 +338,13 @@ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
-github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
-github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
-github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
-github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
-github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
-github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
-github.com/onsi/ginkgo/v2 v2.5.0 h1:TRtrvv2vdQqzkwrQ1ke6vtXf7IK34RBUJafIy1wMwls=
-github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
-github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
-github.com/onsi/gomega v1.24.1 h1:KORJXNNTzJXzu4ScJWssJfJMnJ+2QJqhoQSRwNlze9E=
-github.com/onsi/gomega v1.24.1/go.mod h1:3AOiACssS3/MajrniINInwbfOOtfZvplPzuRSmvt1jM=
+github.com/onsi/ginkgo/v2 v2.9.2 h1:BA2GMJOtfGAfagzYtrAlufIP0lq6QERkFmHLMLPwFSU=
+github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
+github.com/onsi/gomega v1.27.6/go.mod h1:PIQNjfQwkP3aQAH7lf7j87O/5FiNr+ZR8+ipb+qQlhg=
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=
 github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNcZljzZR9VXg+4=
-github.com/petergtz/pegomock v2.9.0+incompatible h1:BKfb5XfkJfehe5T+O1xD4Zm26Sb9dnRj7tHxLYwUPiI=
-github.com/petergtz/pegomock v2.9.0+incompatible/go.mod h1:nuBLWZpVyv/fLo56qTwt/AUau7jgouO1h7bEvZCq82o=
+github.com/petergtz/pegomock/v3 v3.1.0 h1:Pkn9DXS0DXb7CsUhvDutX7JNj0NIyjvZ5qWqnDTMAAE=
+github.com/petergtz/pegomock/v3 v3.1.0/go.mod h1:1+YY4LlCpraeTFFYDY6JI6g6zoWKFGny0LpgPXk6YZw=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -396,6 +385,7 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/samber/lo v1.38.1 h1:j2XEAqXKb09Am4ebOg31SpvzUTTs6EN3VfgeLUhPdXM=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
@@ -503,6 +493,7 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 h1:3MTrJm4PyNL9NBqvYDSj3DHl46qQakyfqfWo4jgfaEM=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -530,7 +521,6 @@ golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -553,7 +543,6 @@ golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200501053045-e0ff5e5a1de5/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200506145744-7e3656a0809f/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
-golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
@@ -603,7 +592,6 @@ golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190204203706-41f3e6584952/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -615,10 +603,7 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -642,7 +627,6 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -734,12 +718,12 @@ golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82u
 golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
+golang.org/x/tools v0.8.0 h1:vSDcovVPld282ceKgDimkRSC8kpaH1dgyc9UMzlt84Y=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -844,11 +828,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
-gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
-gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/validator.v2 v2.0.0-20200605151824-2b28d334fa05/go.mod h1:o4V0GXN9/CAmCsvJ0oXYZvrZOe7syiDZSN1GWGZTGzc=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/server/controllers/api_controller_test.go
+++ b/server/controllers/api_controller_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/controllers"
 	. "github.com/runatlantis/atlantis/server/core/locking/mocks"
 	"github.com/runatlantis/atlantis/server/events"

--- a/server/controllers/events/azuredevops_request_validator_test.go
+++ b/server/controllers/events/azuredevops_request_validator_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/controllers/events"
 	. "github.com/runatlantis/atlantis/testing"
 )

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/google/go-github/v53/github"
 	"github.com/hashicorp/go-version"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 
 	"github.com/runatlantis/atlantis/server"
 	events_controllers "github.com/runatlantis/atlantis/server/controllers/events"

--- a/server/controllers/events/events_controller_test.go
+++ b/server/controllers/events/events_controller_test.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	events_controllers "github.com/runatlantis/atlantis/server/controllers/events"
 	"github.com/runatlantis/atlantis/server/controllers/events/mocks"
 	"github.com/runatlantis/atlantis/server/events"

--- a/server/controllers/events/github_request_validator_test.go
+++ b/server/controllers/events/github_request_validator_test.go
@@ -19,7 +19,7 @@ import (
 	"net/url"
 	"testing"
 
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/controllers/events"
 	. "github.com/runatlantis/atlantis/testing"
 )

--- a/server/controllers/events/gitlab_request_parser_validator_test.go
+++ b/server/controllers/events/gitlab_request_parser_validator_test.go
@@ -19,7 +19,7 @@ import (
 	"reflect"
 	"testing"
 
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/controllers/events"
 	. "github.com/runatlantis/atlantis/testing"
 	gitlab "github.com/xanzy/go-gitlab"

--- a/server/controllers/events/mocks/matchers/ptr_to_http_request.go
+++ b/server/controllers/events/mocks/matchers/ptr_to_http_request.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	http "net/http"

--- a/server/controllers/events/mocks/matchers/slice_of_byte.go
+++ b/server/controllers/events/mocks/matchers/slice_of_byte.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 )
 

--- a/server/controllers/events/mocks/mock_azuredevops_request_validator.go
+++ b/server/controllers/events/mocks/mock_azuredevops_request_validator.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	http "net/http"
 	"reflect"
 	"time"

--- a/server/controllers/events/mocks/mock_github_request_validator.go
+++ b/server/controllers/events/mocks/mock_github_request_validator.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	http "net/http"
 	"reflect"
 	"time"

--- a/server/controllers/events/mocks/mock_gitlab_request_parser_validator.go
+++ b/server/controllers/events/mocks/mock_gitlab_request_parser_validator.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	http "net/http"
 	"reflect"
 	"time"

--- a/server/controllers/locks_controller_test.go
+++ b/server/controllers/locks_controller_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/locking"
 
 	"github.com/gorilla/mux"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/events"
 
 	"github.com/runatlantis/atlantis/server/core/locking/mocks"

--- a/server/controllers/templates/mocks/matchers/io_writer.go
+++ b/server/controllers/templates/mocks/matchers/io_writer.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	io "io"

--- a/server/controllers/templates/mocks/mock_template_writer.go
+++ b/server/controllers/templates/mocks/mock_template_writer.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	io "io"
 	"reflect"
 	"time"

--- a/server/core/locking/locking_test.go
+++ b/server/core/locking/locking_test.go
@@ -20,7 +20,7 @@ import (
 
 	"strings"
 
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/core/locking"
 	"github.com/runatlantis/atlantis/server/core/locking/mocks"
 	"github.com/runatlantis/atlantis/server/core/locking/mocks/matchers"

--- a/server/core/locking/mocks/matchers/command_name.go
+++ b/server/core/locking/mocks/matchers/command_name.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	command "github.com/runatlantis/atlantis/server/events/command"

--- a/server/core/locking/mocks/matchers/locking_applycommandlock.go
+++ b/server/core/locking/mocks/matchers/locking_applycommandlock.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	locking "github.com/runatlantis/atlantis/server/core/locking"

--- a/server/core/locking/mocks/matchers/locking_trylockresponse.go
+++ b/server/core/locking/mocks/matchers/locking_trylockresponse.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	locking "github.com/runatlantis/atlantis/server/core/locking"

--- a/server/core/locking/mocks/matchers/map_of_string_to_models_projectlock.go
+++ b/server/core/locking/mocks/matchers/map_of_string_to_models_projectlock.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/core/locking/mocks/matchers/models_project.go
+++ b/server/core/locking/mocks/matchers/models_project.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/core/locking/mocks/matchers/models_projectlock.go
+++ b/server/core/locking/mocks/matchers/models_projectlock.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/core/locking/mocks/matchers/models_projectplanstatus.go
+++ b/server/core/locking/mocks/matchers/models_projectplanstatus.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/core/locking/mocks/matchers/models_pullrequest.go
+++ b/server/core/locking/mocks/matchers/models_pullrequest.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/core/locking/mocks/matchers/models_pullstatus.go
+++ b/server/core/locking/mocks/matchers/models_pullstatus.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/core/locking/mocks/matchers/models_user.go
+++ b/server/core/locking/mocks/matchers/models_user.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/core/locking/mocks/matchers/ptr_to_command_lock.go
+++ b/server/core/locking/mocks/matchers/ptr_to_command_lock.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	command "github.com/runatlantis/atlantis/server/events/command"

--- a/server/core/locking/mocks/matchers/ptr_to_models_projectlock.go
+++ b/server/core/locking/mocks/matchers/ptr_to_models_projectlock.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/core/locking/mocks/matchers/ptr_to_models_pullstatus.go
+++ b/server/core/locking/mocks/matchers/ptr_to_models_pullstatus.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/core/locking/mocks/matchers/slice_of_command_projectresult.go
+++ b/server/core/locking/mocks/matchers/slice_of_command_projectresult.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	command "github.com/runatlantis/atlantis/server/events/command"

--- a/server/core/locking/mocks/matchers/slice_of_models_projectlock.go
+++ b/server/core/locking/mocks/matchers/slice_of_models_projectlock.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/core/locking/mocks/matchers/time_time.go
+++ b/server/core/locking/mocks/matchers/time_time.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	time "time"

--- a/server/core/locking/mocks/mock_apply_lock_checker.go
+++ b/server/core/locking/mocks/mock_apply_lock_checker.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	locking "github.com/runatlantis/atlantis/server/core/locking"
 	"reflect"
 	"time"

--- a/server/core/locking/mocks/mock_apply_locker.go
+++ b/server/core/locking/mocks/mock_apply_locker.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	locking "github.com/runatlantis/atlantis/server/core/locking"
 	"reflect"
 	"time"

--- a/server/core/locking/mocks/mock_backend.go
+++ b/server/core/locking/mocks/mock_backend.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	command "github.com/runatlantis/atlantis/server/events/command"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	"reflect"

--- a/server/core/locking/mocks/mock_locker.go
+++ b/server/core/locking/mocks/mock_locker.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	locking "github.com/runatlantis/atlantis/server/core/locking"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	"reflect"

--- a/server/core/runtime/apply_step_runner_test.go
+++ b/server/core/runtime/apply_step_runner_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	version "github.com/hashicorp/go-version"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/core/runtime"
 	runtimemocks "github.com/runatlantis/atlantis/server/core/runtime/mocks"

--- a/server/core/runtime/cache/mocks/matchers/ptr_to_go_version_version.go
+++ b/server/core/runtime/cache/mocks/matchers/ptr_to_go_version_version.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	go_version "github.com/hashicorp/go-version"

--- a/server/core/runtime/cache/mocks/mock_key_serializer.go
+++ b/server/core/runtime/cache/mocks/mock_key_serializer.go
@@ -5,7 +5,7 @@ package mocks
 
 import (
 	go_version "github.com/hashicorp/go-version"
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 	"time"
 )

--- a/server/core/runtime/cache/mocks/mock_version_path.go
+++ b/server/core/runtime/cache/mocks/mock_version_path.go
@@ -5,7 +5,7 @@ package mocks
 
 import (
 	go_version "github.com/hashicorp/go-version"
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 	"time"
 )

--- a/server/core/runtime/cache/version_path_test.go
+++ b/server/core/runtime/cache/version_path_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-version"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	cache_mocks "github.com/runatlantis/atlantis/server/core/runtime/cache/mocks"
 	"github.com/runatlantis/atlantis/server/core/runtime/models"
 	models_mocks "github.com/runatlantis/atlantis/server/core/runtime/models/mocks"

--- a/server/core/runtime/env_step_runner_test.go
+++ b/server/core/runtime/env_step_runner_test.go
@@ -11,7 +11,7 @@ import (
 	jobmocks "github.com/runatlantis/atlantis/server/jobs/mocks"
 	"github.com/runatlantis/atlantis/server/logging"
 
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	. "github.com/runatlantis/atlantis/testing"
 )
 

--- a/server/core/runtime/import_step_runner_test.go
+++ b/server/core/runtime/import_step_runner_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-version"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	runtimematchers "github.com/runatlantis/atlantis/server/core/runtime/mocks/matchers"
 	"github.com/runatlantis/atlantis/server/core/terraform/mocks"
 	tfmatchers "github.com/runatlantis/atlantis/server/core/terraform/mocks/matchers"

--- a/server/core/runtime/init_step_runner_test.go
+++ b/server/core/runtime/init_step_runner_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	version "github.com/hashicorp/go-version"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/pkg/errors"
 
 	"github.com/runatlantis/atlantis/server/core/runtime"

--- a/server/core/runtime/minimum_version_step_runner_delegate_test.go
+++ b/server/core/runtime/minimum_version_step_runner_delegate_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-version"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/core/runtime/mocks"
 	"github.com/runatlantis/atlantis/server/events/command"
 	. "github.com/runatlantis/atlantis/testing"

--- a/server/core/runtime/mocks/matchers/command_name.go
+++ b/server/core/runtime/mocks/matchers/command_name.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	command "github.com/runatlantis/atlantis/server/events/command"

--- a/server/core/runtime/mocks/matchers/command_projectcontext.go
+++ b/server/core/runtime/mocks/matchers/command_projectcontext.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	command "github.com/runatlantis/atlantis/server/events/command"

--- a/server/core/runtime/mocks/matchers/logging_simplelogging.go
+++ b/server/core/runtime/mocks/matchers/logging_simplelogging.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	logging "github.com/runatlantis/atlantis/server/logging"

--- a/server/core/runtime/mocks/matchers/map_of_string_to_string.go
+++ b/server/core/runtime/mocks/matchers/map_of_string_to_string.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 )
 

--- a/server/core/runtime/mocks/matchers/models_approvalstatus.go
+++ b/server/core/runtime/mocks/matchers/models_approvalstatus.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/core/runtime/mocks/matchers/models_commitstatus.go
+++ b/server/core/runtime/mocks/matchers/models_commitstatus.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/core/runtime/mocks/matchers/models_pullrequest.go
+++ b/server/core/runtime/mocks/matchers/models_pullrequest.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/core/runtime/mocks/matchers/models_repo.go
+++ b/server/core/runtime/mocks/matchers/models_repo.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/core/runtime/mocks/matchers/models_workflowhookcommandcontext.go
+++ b/server/core/runtime/mocks/matchers/models_workflowhookcommandcontext.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/core/runtime/mocks/matchers/ptr_to_command_projectresult.go
+++ b/server/core/runtime/mocks/matchers/ptr_to_command_projectresult.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	command "github.com/runatlantis/atlantis/server/events/command"

--- a/server/core/runtime/mocks/matchers/ptr_to_go_version_version.go
+++ b/server/core/runtime/mocks/matchers/ptr_to_go_version_version.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	go_version "github.com/hashicorp/go-version"

--- a/server/core/runtime/mocks/matchers/recv_chan_of_models_line.go
+++ b/server/core/runtime/mocks/matchers/recv_chan_of_models_line.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/core/runtime/models"

--- a/server/core/runtime/mocks/matchers/send_chan_of_string.go
+++ b/server/core/runtime/mocks/matchers/send_chan_of_string.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 )
 

--- a/server/core/runtime/mocks/matchers/slice_of_string.go
+++ b/server/core/runtime/mocks/matchers/slice_of_string.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 )
 

--- a/server/core/runtime/mocks/mock_async_tfexec.go
+++ b/server/core/runtime/mocks/mock_async_tfexec.go
@@ -5,7 +5,7 @@ package mocks
 
 import (
 	go_version "github.com/hashicorp/go-version"
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	models "github.com/runatlantis/atlantis/server/core/runtime/models"
 	command "github.com/runatlantis/atlantis/server/events/command"
 	"reflect"

--- a/server/core/runtime/mocks/mock_post_workflows_hook_runner.go
+++ b/server/core/runtime/mocks/mock_post_workflows_hook_runner.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	"reflect"
 	"time"

--- a/server/core/runtime/mocks/mock_pre_workflows_hook_runner.go
+++ b/server/core/runtime/mocks/mock_pre_workflows_hook_runner.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	"reflect"
 	"time"

--- a/server/core/runtime/mocks/mock_pull_approved_checker.go
+++ b/server/core/runtime/mocks/mock_pull_approved_checker.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	"reflect"
 	"time"

--- a/server/core/runtime/mocks/mock_runner.go
+++ b/server/core/runtime/mocks/mock_runner.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	command "github.com/runatlantis/atlantis/server/events/command"
 	"reflect"
 	"time"

--- a/server/core/runtime/mocks/mock_status_updater.go
+++ b/server/core/runtime/mocks/mock_status_updater.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	command "github.com/runatlantis/atlantis/server/events/command"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	"reflect"

--- a/server/core/runtime/mocks/mock_versionedexecutorworkflow.go
+++ b/server/core/runtime/mocks/mock_versionedexecutorworkflow.go
@@ -5,7 +5,7 @@ package mocks
 
 import (
 	go_version "github.com/hashicorp/go-version"
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	command "github.com/runatlantis/atlantis/server/events/command"
 	logging "github.com/runatlantis/atlantis/server/logging"
 	"reflect"

--- a/server/core/runtime/models/mocks/matchers/map_of_string_to_string.go
+++ b/server/core/runtime/models/mocks/matchers/map_of_string_to_string.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 )
 

--- a/server/core/runtime/models/mocks/matchers/models_filepath.go
+++ b/server/core/runtime/models/mocks/matchers/models_filepath.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/core/runtime/models"

--- a/server/core/runtime/models/mocks/matchers/slice_of_string.go
+++ b/server/core/runtime/models/mocks/matchers/slice_of_string.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 )
 

--- a/server/core/runtime/models/mocks/mock_exec.go
+++ b/server/core/runtime/models/mocks/mock_exec.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 	"time"
 )

--- a/server/core/runtime/models/mocks/mock_filepath.go
+++ b/server/core/runtime/models/mocks/mock_filepath.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	models "github.com/runatlantis/atlantis/server/core/runtime/models"
 	"reflect"
 	"time"

--- a/server/core/runtime/models/shell_command_runner_test.go
+++ b/server/core/runtime/models/shell_command_runner_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/core/runtime/mocks/matchers"
 	"github.com/runatlantis/atlantis/server/core/runtime/models"
 	"github.com/runatlantis/atlantis/server/events/command"

--- a/server/core/runtime/multienv_step_runner_test.go
+++ b/server/core/runtime/multienv_step_runner_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	version "github.com/hashicorp/go-version"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/core/runtime"
 	"github.com/runatlantis/atlantis/server/core/terraform/mocks"
 	"github.com/runatlantis/atlantis/server/events/command"

--- a/server/core/runtime/plan_step_runner_test.go
+++ b/server/core/runtime/plan_step_runner_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-version"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/core/runtime"
 	runtimemocks "github.com/runatlantis/atlantis/server/core/runtime/mocks"

--- a/server/core/runtime/plan_type_step_runner_delegate_test.go
+++ b/server/core/runtime/plan_type_step_runner_delegate_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-version"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	. "github.com/runatlantis/atlantis/testing"
 
 	"github.com/runatlantis/atlantis/server/core/runtime/mocks"

--- a/server/core/runtime/policy/conftest_client_test.go
+++ b/server/core/runtime/policy/conftest_client_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-version"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/core/runtime/cache/mocks"
 	models_mocks "github.com/runatlantis/atlantis/server/core/runtime/models/mocks"

--- a/server/core/runtime/policy/mocks/matchers/valid_policyset.go
+++ b/server/core/runtime/policy/mocks/matchers/valid_policyset.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	valid "github.com/runatlantis/atlantis/server/core/config/valid"

--- a/server/core/runtime/policy/mocks/mock_conftest_client.go
+++ b/server/core/runtime/policy/mocks/mock_conftest_client.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	valid "github.com/runatlantis/atlantis/server/core/config/valid"
 	"reflect"
 	"time"

--- a/server/core/runtime/policy_check_step_runner_test.go
+++ b/server/core/runtime/policy_check_step_runner_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-version"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/core/runtime/mocks"
 	"github.com/runatlantis/atlantis/server/events/command"

--- a/server/core/runtime/post_workflow_hook_runner_test.go
+++ b/server/core/runtime/post_workflow_hook_runner_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/core/runtime"
 	runtimematchers "github.com/runatlantis/atlantis/server/core/runtime/mocks/matchers"
 	"github.com/runatlantis/atlantis/server/core/terraform/mocks"

--- a/server/core/runtime/pre_workflow_hook_runner_test.go
+++ b/server/core/runtime/pre_workflow_hook_runner_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/core/runtime"
 	runtimematchers "github.com/runatlantis/atlantis/server/core/runtime/mocks/matchers"
 	"github.com/runatlantis/atlantis/server/core/terraform/mocks"

--- a/server/core/runtime/run_step_runner_test.go
+++ b/server/core/runtime/run_step_runner_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	version "github.com/hashicorp/go-version"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/core/runtime"
 	"github.com/runatlantis/atlantis/server/core/terraform/mocks"
 	matchers2 "github.com/runatlantis/atlantis/server/core/terraform/mocks/matchers"

--- a/server/core/runtime/show_step_runner_test.go
+++ b/server/core/runtime/show_step_runner_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-version"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/core/terraform/mocks"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/logging"

--- a/server/core/runtime/state_rm_step_runner_test.go
+++ b/server/core/runtime/state_rm_step_runner_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-version"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	runtimematchers "github.com/runatlantis/atlantis/server/core/runtime/mocks/matchers"
 	"github.com/runatlantis/atlantis/server/core/terraform/mocks"
 	tfmatchers "github.com/runatlantis/atlantis/server/core/terraform/mocks/matchers"

--- a/server/core/runtime/version_step_runner_test.go
+++ b/server/core/runtime/version_step_runner_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-version"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/core/terraform/mocks"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"

--- a/server/core/runtime/workspace_step_runner_delegate_test.go
+++ b/server/core/runtime/workspace_step_runner_delegate_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-version"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/core/terraform/mocks"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"

--- a/server/core/terraform/mocks/matchers/command_projectcontext.go
+++ b/server/core/terraform/mocks/matchers/command_projectcontext.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	command "github.com/runatlantis/atlantis/server/events/command"

--- a/server/core/terraform/mocks/matchers/logging_simplelogging.go
+++ b/server/core/terraform/mocks/matchers/logging_simplelogging.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	logging "github.com/runatlantis/atlantis/server/logging"

--- a/server/core/terraform/mocks/matchers/map_of_string_to_string.go
+++ b/server/core/terraform/mocks/matchers/map_of_string_to_string.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 )
 

--- a/server/core/terraform/mocks/matchers/ptr_to_go_version_version.go
+++ b/server/core/terraform/mocks/matchers/ptr_to_go_version_version.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	go_version "github.com/hashicorp/go-version"

--- a/server/core/terraform/mocks/matchers/slice_of_string.go
+++ b/server/core/terraform/mocks/matchers/slice_of_string.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 )
 

--- a/server/core/terraform/mocks/mock_downloader.go
+++ b/server/core/terraform/mocks/mock_downloader.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 	"time"
 )

--- a/server/core/terraform/mocks/mock_terraform_client.go
+++ b/server/core/terraform/mocks/mock_terraform_client.go
@@ -5,7 +5,7 @@ package mocks
 
 import (
 	go_version "github.com/hashicorp/go-version"
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	command "github.com/runatlantis/atlantis/server/events/command"
 	logging "github.com/runatlantis/atlantis/server/logging"
 	"reflect"

--- a/server/core/terraform/terraform_client_internal_test.go
+++ b/server/core/terraform/terraform_client_internal_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	version "github.com/hashicorp/go-version"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	runtimemodels "github.com/runatlantis/atlantis/server/core/runtime/models"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"

--- a/server/core/terraform/terraform_client_test.go
+++ b/server/core/terraform/terraform_client_test.go
@@ -23,8 +23,8 @@ import (
 	"time"
 
 	version "github.com/hashicorp/go-version"
-	"github.com/petergtz/pegomock"
-	. "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/cmd"
 	"github.com/runatlantis/atlantis/server/core/terraform"
 	"github.com/runatlantis/atlantis/server/core/terraform/mocks"

--- a/server/events/apply_command_runner_test.go
+++ b/server/events/apply_command_runner_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v53/github"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/core/db"
 	"github.com/runatlantis/atlantis/server/core/locking"
 	"github.com/runatlantis/atlantis/server/events"

--- a/server/events/command_requirement_handler_test.go
+++ b/server/events/command_requirement_handler_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/logging/mocks/matchers"
 
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/mocks"

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/runatlantis/atlantis/server/metrics"
 
 	"github.com/google/go-github/v53/github"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	lockingmocks "github.com/runatlantis/atlantis/server/core/locking/mocks"
 	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/events/mocks"

--- a/server/events/commit_status_updater_test.go
+++ b/server/events/commit_status_updater_test.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"

--- a/server/events/delete_lock_command_test.go
+++ b/server/events/delete_lock_command_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/core/db"
 	lockmocks "github.com/runatlantis/atlantis/server/core/locking/mocks"
 	"github.com/runatlantis/atlantis/server/events"

--- a/server/events/github_app_working_dir_test.go
+++ b/server/events/github_app_working_dir_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/petergtz/pegomock"
-	pegomock "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/events"
 	eventMocks "github.com/runatlantis/atlantis/server/events/mocks"
 	"github.com/runatlantis/atlantis/server/events/models"

--- a/server/events/import_command_runner_test.go
+++ b/server/events/import_command_runner_test.go
@@ -3,7 +3,7 @@ package events_test
 import (
 	"testing"
 
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"

--- a/server/events/matchers/logging_simplelogging.go
+++ b/server/events/matchers/logging_simplelogging.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	logging "github.com/runatlantis/atlantis/server/logging"

--- a/server/events/matchers/models_pullrequest.go
+++ b/server/events/matchers/models_pullrequest.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/events/matchers/models_repo.go
+++ b/server/events/matchers/models_repo.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/events/matchers/ptr_to_logging_simplelogger.go
+++ b/server/events/matchers/ptr_to_logging_simplelogger.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	logging "github.com/runatlantis/atlantis/server/logging"
 )
 

--- a/server/events/mock_workingdir_test.go
+++ b/server/events/mock_workingdir_test.go
@@ -4,7 +4,7 @@
 package events
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	logging "github.com/runatlantis/atlantis/server/logging"
 	"reflect"

--- a/server/events/mocks/matchers/azuredevops_event.go
+++ b/server/events/mocks/matchers/azuredevops_event.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	azuredevops "github.com/mcdafydd/go-azuredevops/azuredevops"

--- a/server/events/mocks/matchers/command_name.go
+++ b/server/events/mocks/matchers/command_name.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	command "github.com/runatlantis/atlantis/server/events/command"

--- a/server/events/mocks/matchers/command_projectcontext.go
+++ b/server/events/mocks/matchers/command_projectcontext.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	command "github.com/runatlantis/atlantis/server/events/command"

--- a/server/events/mocks/matchers/command_projectresult.go
+++ b/server/events/mocks/matchers/command_projectresult.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	command "github.com/runatlantis/atlantis/server/events/command"

--- a/server/events/mocks/matchers/events_commentparseresult.go
+++ b/server/events/mocks/matchers/events_commentparseresult.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	events "github.com/runatlantis/atlantis/server/events"

--- a/server/events/mocks/matchers/go_gitlab_mergecommentevent.go
+++ b/server/events/mocks/matchers/go_gitlab_mergecommentevent.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	go_gitlab "github.com/xanzy/go-gitlab"

--- a/server/events/mocks/matchers/go_gitlab_mergeevent.go
+++ b/server/events/mocks/matchers/go_gitlab_mergeevent.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	go_gitlab "github.com/xanzy/go-gitlab"

--- a/server/events/mocks/matchers/jobs_pullinfo.go
+++ b/server/events/mocks/matchers/jobs_pullinfo.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	jobs "github.com/runatlantis/atlantis/server/jobs"

--- a/server/events/mocks/matchers/logging_simplelogging.go
+++ b/server/events/mocks/matchers/logging_simplelogging.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	logging "github.com/runatlantis/atlantis/server/logging"

--- a/server/events/mocks/matchers/map_of_string_to_string.go
+++ b/server/events/mocks/matchers/map_of_string_to_string.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 )
 

--- a/server/events/mocks/matchers/models_commitstatus.go
+++ b/server/events/mocks/matchers/models_commitstatus.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/events/mocks/matchers/models_project.go
+++ b/server/events/mocks/matchers/models_project.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/events/mocks/matchers/models_pullrequest.go
+++ b/server/events/mocks/matchers/models_pullrequest.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/events/mocks/matchers/models_pullrequesteventtype.go
+++ b/server/events/mocks/matchers/models_pullrequesteventtype.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/events/mocks/matchers/models_repo.go
+++ b/server/events/mocks/matchers/models_repo.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/events/mocks/matchers/models_user.go
+++ b/server/events/mocks/matchers/models_user.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/events/mocks/matchers/models_vcshosttype.go
+++ b/server/events/mocks/matchers/models_vcshosttype.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/events/mocks/matchers/ptr_to_azuredevops_gitpullrequest.go
+++ b/server/events/mocks/matchers/ptr_to_azuredevops_gitpullrequest.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	azuredevops "github.com/mcdafydd/go-azuredevops/azuredevops"

--- a/server/events/mocks/matchers/ptr_to_azuredevops_gitrepository.go
+++ b/server/events/mocks/matchers/ptr_to_azuredevops_gitrepository.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	azuredevops "github.com/mcdafydd/go-azuredevops/azuredevops"

--- a/server/events/mocks/matchers/ptr_to_command_context.go
+++ b/server/events/mocks/matchers/ptr_to_command_context.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	command "github.com/runatlantis/atlantis/server/events/command"

--- a/server/events/mocks/matchers/ptr_to_command_projectresult.go
+++ b/server/events/mocks/matchers/ptr_to_command_projectresult.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	command "github.com/runatlantis/atlantis/server/events/command"

--- a/server/events/mocks/matchers/ptr_to_events_commentcommand.go
+++ b/server/events/mocks/matchers/ptr_to_events_commentcommand.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	events "github.com/runatlantis/atlantis/server/events"

--- a/server/events/mocks/matchers/ptr_to_events_trylockresponse.go
+++ b/server/events/mocks/matchers/ptr_to_events_trylockresponse.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	events "github.com/runatlantis/atlantis/server/events"

--- a/server/events/mocks/matchers/ptr_to_github_issuecommentevent.go
+++ b/server/events/mocks/matchers/ptr_to_github_issuecommentevent.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	github "github.com/google/go-github/v53/github"

--- a/server/events/mocks/matchers/ptr_to_github_pullrequest.go
+++ b/server/events/mocks/matchers/ptr_to_github_pullrequest.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	github "github.com/google/go-github/v53/github"

--- a/server/events/mocks/matchers/ptr_to_github_pullrequestevent.go
+++ b/server/events/mocks/matchers/ptr_to_github_pullrequestevent.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	github "github.com/google/go-github/v53/github"

--- a/server/events/mocks/matchers/ptr_to_github_repository.go
+++ b/server/events/mocks/matchers/ptr_to_github_repository.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	github "github.com/google/go-github/v53/github"

--- a/server/events/mocks/matchers/ptr_to_go_gitlab_mergerequest.go
+++ b/server/events/mocks/matchers/ptr_to_go_gitlab_mergerequest.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	go_gitlab "github.com/xanzy/go-gitlab"

--- a/server/events/mocks/matchers/ptr_to_models_projectlock.go
+++ b/server/events/mocks/matchers/ptr_to_models_projectlock.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/events/mocks/matchers/ptr_to_models_pullrequest.go
+++ b/server/events/mocks/matchers/ptr_to_models_pullrequest.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/events/mocks/matchers/ptr_to_models_repo.go
+++ b/server/events/mocks/matchers/ptr_to_models_repo.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/events/mocks/matchers/slice_of_byte.go
+++ b/server/events/mocks/matchers/slice_of_byte.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 )
 

--- a/server/events/mocks/matchers/slice_of_command_projectcontext.go
+++ b/server/events/mocks/matchers/slice_of_command_projectcontext.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	command "github.com/runatlantis/atlantis/server/events/command"

--- a/server/events/mocks/matchers/slice_of_events_pendingplan.go
+++ b/server/events/mocks/matchers/slice_of_events_pendingplan.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	events "github.com/runatlantis/atlantis/server/events"

--- a/server/events/mocks/matchers/slice_of_string.go
+++ b/server/events/mocks/matchers/slice_of_string.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 )
 

--- a/server/events/mocks/matchers/webhooks_applyresult.go
+++ b/server/events/mocks/matchers/webhooks_applyresult.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	webhooks "github.com/runatlantis/atlantis/server/events/webhooks"

--- a/server/events/mocks/mock_azuredevops_pull_getter.go
+++ b/server/events/mocks/mock_azuredevops_pull_getter.go
@@ -5,7 +5,7 @@ package mocks
 
 import (
 	azuredevops "github.com/mcdafydd/go-azuredevops/azuredevops"
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	"reflect"
 	"time"

--- a/server/events/mocks/mock_command_requirement_handler.go
+++ b/server/events/mocks/mock_command_requirement_handler.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	command "github.com/runatlantis/atlantis/server/events/command"
 	"reflect"
 	"time"

--- a/server/events/mocks/mock_command_runner.go
+++ b/server/events/mocks/mock_command_runner.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	events "github.com/runatlantis/atlantis/server/events"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	"reflect"

--- a/server/events/mocks/mock_comment_building.go
+++ b/server/events/mocks/mock_comment_building.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 	"time"
 )

--- a/server/events/mocks/mock_comment_parsing.go
+++ b/server/events/mocks/mock_comment_parsing.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	events "github.com/runatlantis/atlantis/server/events"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	"reflect"

--- a/server/events/mocks/mock_commit_status_updater.go
+++ b/server/events/mocks/mock_commit_status_updater.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	command "github.com/runatlantis/atlantis/server/events/command"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	"reflect"

--- a/server/events/mocks/mock_custom_step_runner.go
+++ b/server/events/mocks/mock_custom_step_runner.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	command "github.com/runatlantis/atlantis/server/events/command"
 	"reflect"
 	"time"

--- a/server/events/mocks/mock_delete_lock_command.go
+++ b/server/events/mocks/mock_delete_lock_command.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	"reflect"
 	"time"

--- a/server/events/mocks/mock_env_step_runner.go
+++ b/server/events/mocks/mock_env_step_runner.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	command "github.com/runatlantis/atlantis/server/events/command"
 	"reflect"
 	"time"

--- a/server/events/mocks/mock_event_parsing.go
+++ b/server/events/mocks/mock_event_parsing.go
@@ -6,7 +6,7 @@ package mocks
 import (
 	github "github.com/google/go-github/v53/github"
 	azuredevops "github.com/mcdafydd/go-azuredevops/azuredevops"
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	go_gitlab "github.com/xanzy/go-gitlab"
 	"reflect"

--- a/server/events/mocks/mock_github_pull_getter.go
+++ b/server/events/mocks/mock_github_pull_getter.go
@@ -5,7 +5,7 @@ package mocks
 
 import (
 	github "github.com/google/go-github/v53/github"
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	"reflect"
 	"time"

--- a/server/events/mocks/mock_gitlab_merge_request_getter.go
+++ b/server/events/mocks/mock_gitlab_merge_request_getter.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	go_gitlab "github.com/xanzy/go-gitlab"
 	"reflect"
 	"time"

--- a/server/events/mocks/mock_job_message_sender.go
+++ b/server/events/mocks/mock_job_message_sender.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	command "github.com/runatlantis/atlantis/server/events/command"
 	"reflect"
 	"time"

--- a/server/events/mocks/mock_job_url_setter.go
+++ b/server/events/mocks/mock_job_url_setter.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	command "github.com/runatlantis/atlantis/server/events/command"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	"reflect"

--- a/server/events/mocks/mock_lock_url_generator.go
+++ b/server/events/mocks/mock_lock_url_generator.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 	"time"
 )

--- a/server/events/mocks/mock_pending_plan_finder.go
+++ b/server/events/mocks/mock_pending_plan_finder.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	events "github.com/runatlantis/atlantis/server/events"
 	"reflect"
 	"time"

--- a/server/events/mocks/mock_post_workflow_hook_url_generator.go
+++ b/server/events/mocks/mock_post_workflow_hook_url_generator.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 	"time"
 )

--- a/server/events/mocks/mock_post_workflows_hooks_command_runner.go
+++ b/server/events/mocks/mock_post_workflows_hooks_command_runner.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	events "github.com/runatlantis/atlantis/server/events"
 	command "github.com/runatlantis/atlantis/server/events/command"
 	"reflect"

--- a/server/events/mocks/mock_pre_workflow_hook_url_generator.go
+++ b/server/events/mocks/mock_pre_workflow_hook_url_generator.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 	"time"
 )

--- a/server/events/mocks/mock_pre_workflows_hooks_command_runner.go
+++ b/server/events/mocks/mock_pre_workflows_hooks_command_runner.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	events "github.com/runatlantis/atlantis/server/events"
 	command "github.com/runatlantis/atlantis/server/events/command"
 	"reflect"

--- a/server/events/mocks/mock_project_command_builder.go
+++ b/server/events/mocks/mock_project_command_builder.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	events "github.com/runatlantis/atlantis/server/events"
 	command "github.com/runatlantis/atlantis/server/events/command"
 	"reflect"

--- a/server/events/mocks/mock_project_command_runner.go
+++ b/server/events/mocks/mock_project_command_runner.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	command "github.com/runatlantis/atlantis/server/events/command"
 	"reflect"
 	"time"

--- a/server/events/mocks/mock_project_lock.go
+++ b/server/events/mocks/mock_project_lock.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	events "github.com/runatlantis/atlantis/server/events"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	logging "github.com/runatlantis/atlantis/server/logging"

--- a/server/events/mocks/mock_pull_cleaner.go
+++ b/server/events/mocks/mock_pull_cleaner.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	"reflect"
 	"time"

--- a/server/events/mocks/mock_resource_cleaner.go
+++ b/server/events/mocks/mock_resource_cleaner.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	jobs "github.com/runatlantis/atlantis/server/jobs"
 	"reflect"
 	"time"

--- a/server/events/mocks/mock_step_runner.go
+++ b/server/events/mocks/mock_step_runner.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	command "github.com/runatlantis/atlantis/server/events/command"
 	"reflect"
 	"time"

--- a/server/events/mocks/mock_webhooks_sender.go
+++ b/server/events/mocks/mock_webhooks_sender.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	webhooks "github.com/runatlantis/atlantis/server/events/webhooks"
 	logging "github.com/runatlantis/atlantis/server/logging"
 	"reflect"

--- a/server/events/mocks/mock_working_dir.go
+++ b/server/events/mocks/mock_working_dir.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	logging "github.com/runatlantis/atlantis/server/logging"
 	"reflect"

--- a/server/events/mocks/mock_working_dir_locker.go
+++ b/server/events/mocks/mock_working_dir_locker.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 	"time"
 )

--- a/server/events/plan_command_runner_test.go
+++ b/server/events/plan_command_runner_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v53/github"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/core/db"
 	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/events/command"

--- a/server/events/post_workflow_hooks_command_runner_test.go
+++ b/server/events/post_workflow_hooks_command_runner_test.go
@@ -8,7 +8,7 @@ import (
 	runtime_mocks "github.com/runatlantis/atlantis/server/core/runtime/mocks"
 	runtimematchers "github.com/runatlantis/atlantis/server/core/runtime/mocks/matchers"
 
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/events/command"

--- a/server/events/pre_workflow_hooks_command_runner_test.go
+++ b/server/events/pre_workflow_hooks_command_runner_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	runtime_mocks "github.com/runatlantis/atlantis/server/core/runtime/mocks"
 	runtimematchers "github.com/runatlantis/atlantis/server/core/runtime/mocks/matchers"

--- a/server/events/project_command_builder_internal_test.go
+++ b/server/events/project_command_builder_internal_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	version "github.com/hashicorp/go-version"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/core/config"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/core/terraform/mocks"

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-version"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	terraform_mocks "github.com/runatlantis/atlantis/server/core/terraform/mocks"
 
 	"github.com/runatlantis/atlantis/server/core/config"

--- a/server/events/project_command_context_builder_test.go
+++ b/server/events/project_command_context_builder_test.go
@@ -3,7 +3,7 @@ package events_test
 import (
 	"testing"
 
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	terraform_mocks "github.com/runatlantis/atlantis/server/core/terraform/mocks"
 	"github.com/runatlantis/atlantis/server/events"

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-version"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/core/runtime"
 	tmocks "github.com/runatlantis/atlantis/server/core/terraform/mocks"

--- a/server/events/project_locker_test.go
+++ b/server/events/project_locker_test.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/core/locking"
 	"github.com/runatlantis/atlantis/server/core/locking/mocks"
 	"github.com/runatlantis/atlantis/server/events"

--- a/server/events/pull_closed_executor_test.go
+++ b/server/events/pull_closed_executor_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	bolt "go.etcd.io/bbolt"
 
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	lockmocks "github.com/runatlantis/atlantis/server/core/locking/mocks"
 	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/events/command"

--- a/server/events/vcs/mocks/matchers/models_approvalstatus.go
+++ b/server/events/vcs/mocks/matchers/models_approvalstatus.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/events/vcs/mocks/matchers/models_commitstatus.go
+++ b/server/events/vcs/mocks/matchers/models_commitstatus.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/events/vcs/mocks/matchers/models_pullreqstatus.go
+++ b/server/events/vcs/mocks/matchers/models_pullreqstatus.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/events/vcs/mocks/matchers/models_pullrequest.go
+++ b/server/events/vcs/mocks/matchers/models_pullrequest.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/events/vcs/mocks/matchers/models_pullrequestoptions.go
+++ b/server/events/vcs/mocks/matchers/models_pullrequestoptions.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/events/vcs/mocks/matchers/models_repo.go
+++ b/server/events/vcs/mocks/matchers/models_repo.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/events/vcs/mocks/matchers/models_user.go
+++ b/server/events/vcs/mocks/matchers/models_user.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/events/vcs/mocks/matchers/models_vcshosttype.go
+++ b/server/events/vcs/mocks/matchers/models_vcshosttype.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/events/vcs/mocks/matchers/ptr_to_github_pullrequest.go
+++ b/server/events/vcs/mocks/matchers/ptr_to_github_pullrequest.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	github "github.com/google/go-github/v53/github"

--- a/server/events/vcs/mocks/matchers/ptr_to_http_client.go
+++ b/server/events/vcs/mocks/matchers/ptr_to_http_client.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	http "net/http"

--- a/server/events/vcs/mocks/matchers/slice_of_byte.go
+++ b/server/events/vcs/mocks/matchers/slice_of_byte.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 )
 

--- a/server/events/vcs/mocks/matchers/slice_of_string.go
+++ b/server/events/vcs/mocks/matchers/slice_of_string.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 )
 

--- a/server/events/vcs/mocks/mock_client.go
+++ b/server/events/vcs/mocks/mock_client.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	"reflect"
 	"time"

--- a/server/events/vcs/mocks/mock_github_credentials.go
+++ b/server/events/vcs/mocks/mock_github_credentials.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	http "net/http"
 	"reflect"
 	"time"

--- a/server/events/vcs/mocks/mock_github_pull_request_getter.go
+++ b/server/events/vcs/mocks/mock_github_pull_request_getter.go
@@ -5,7 +5,7 @@ package mocks
 
 import (
 	github "github.com/google/go-github/v53/github"
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	"reflect"
 	"time"

--- a/server/events/vcs/mocks/mock_pull_req_status_fetcher.go
+++ b/server/events/vcs/mocks/mock_pull_req_status_fetcher.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	"reflect"
 	"time"

--- a/server/events/webhooks/mocks/matchers/logging_simplelogging.go
+++ b/server/events/webhooks/mocks/matchers/logging_simplelogging.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	logging "github.com/runatlantis/atlantis/server/logging"

--- a/server/events/webhooks/mocks/matchers/ptr_to_slack_authtestresponse.go
+++ b/server/events/webhooks/mocks/matchers/ptr_to_slack_authtestresponse.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	slack "github.com/slack-go/slack"

--- a/server/events/webhooks/mocks/matchers/ptr_to_slack_getconversationsparameters.go
+++ b/server/events/webhooks/mocks/matchers/ptr_to_slack_getconversationsparameters.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	slack "github.com/slack-go/slack"

--- a/server/events/webhooks/mocks/matchers/slack_msgoption.go
+++ b/server/events/webhooks/mocks/matchers/slack_msgoption.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	slack "github.com/slack-go/slack"

--- a/server/events/webhooks/mocks/matchers/slice_of_slack_channel.go
+++ b/server/events/webhooks/mocks/matchers/slice_of_slack_channel.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	slack "github.com/slack-go/slack"

--- a/server/events/webhooks/mocks/matchers/webhooks_applyresult.go
+++ b/server/events/webhooks/mocks/matchers/webhooks_applyresult.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	webhooks "github.com/runatlantis/atlantis/server/events/webhooks"

--- a/server/events/webhooks/mocks/mock_sender.go
+++ b/server/events/webhooks/mocks/mock_sender.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	webhooks "github.com/runatlantis/atlantis/server/events/webhooks"
 	logging "github.com/runatlantis/atlantis/server/logging"
 	"reflect"

--- a/server/events/webhooks/mocks/mock_slack_client.go
+++ b/server/events/webhooks/mocks/mock_slack_client.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	webhooks "github.com/runatlantis/atlantis/server/events/webhooks"
 	"reflect"
 	"time"

--- a/server/events/webhooks/mocks/mock_underlying_slack_client.go
+++ b/server/events/webhooks/mocks/mock_underlying_slack_client.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	slack "github.com/slack-go/slack"
 	"reflect"
 	"time"

--- a/server/events/webhooks/slack_client_test.go
+++ b/server/events/webhooks/slack_client_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/runatlantis/atlantis/server/events/webhooks"
 	"github.com/runatlantis/atlantis/server/events/webhooks/mocks"
 
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	. "github.com/runatlantis/atlantis/testing"
 )
 

--- a/server/events/webhooks/slack_test.go
+++ b/server/events/webhooks/slack_test.go
@@ -17,7 +17,7 @@ import (
 	"regexp"
 	"testing"
 
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/events/webhooks"
 	"github.com/runatlantis/atlantis/server/events/webhooks/mocks"
 	"github.com/runatlantis/atlantis/server/logging"

--- a/server/events/webhooks/webhooks_test.go
+++ b/server/events/webhooks/webhooks_test.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/events/webhooks"
 	"github.com/runatlantis/atlantis/server/events/webhooks/mocks"
 	"github.com/runatlantis/atlantis/server/logging"

--- a/server/jobs/job_url_setter_test.go
+++ b/server/jobs/job_url_setter_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/jobs"

--- a/server/jobs/mocks/matchers/chan_of_string.go
+++ b/server/jobs/mocks/matchers/chan_of_string.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 )
 

--- a/server/jobs/mocks/matchers/command_name.go
+++ b/server/jobs/mocks/matchers/command_name.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	command "github.com/runatlantis/atlantis/server/events/command"

--- a/server/jobs/mocks/matchers/command_projectcontext.go
+++ b/server/jobs/mocks/matchers/command_projectcontext.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	command "github.com/runatlantis/atlantis/server/events/command"

--- a/server/jobs/mocks/matchers/jobs_pullinfo.go
+++ b/server/jobs/mocks/matchers/jobs_pullinfo.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	jobs "github.com/runatlantis/atlantis/server/jobs"

--- a/server/jobs/mocks/matchers/models_commitstatus.go
+++ b/server/jobs/mocks/matchers/models_commitstatus.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/jobs/mocks/matchers/models_workflowhookcommandcontext.go
+++ b/server/jobs/mocks/matchers/models_workflowhookcommandcontext.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	models "github.com/runatlantis/atlantis/server/events/models"

--- a/server/jobs/mocks/matchers/ptr_to_command_projectresult.go
+++ b/server/jobs/mocks/matchers/ptr_to_command_projectresult.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	command "github.com/runatlantis/atlantis/server/events/command"

--- a/server/jobs/mocks/mock_project_command_output_handler.go
+++ b/server/jobs/mocks/mock_project_command_output_handler.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	command "github.com/runatlantis/atlantis/server/events/command"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	jobs "github.com/runatlantis/atlantis/server/jobs"

--- a/server/jobs/mocks/mock_project_job_url_generator.go
+++ b/server/jobs/mocks/mock_project_job_url_generator.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	command "github.com/runatlantis/atlantis/server/events/command"
 	"reflect"
 	"time"

--- a/server/jobs/mocks/mock_project_status_updater.go
+++ b/server/jobs/mocks/mock_project_status_updater.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	command "github.com/runatlantis/atlantis/server/events/command"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	"reflect"

--- a/server/logging/mocks/matchers/logging_loglevel.go
+++ b/server/logging/mocks/matchers/logging_loglevel.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	logging "github.com/runatlantis/atlantis/server/logging"

--- a/server/logging/mocks/matchers/logging_simplelogging.go
+++ b/server/logging/mocks/matchers/logging_simplelogging.go
@@ -2,7 +2,7 @@
 package matchers
 
 import (
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 
 	logging "github.com/runatlantis/atlantis/server/logging"

--- a/server/logging/mocks/mock_simple_logging.go
+++ b/server/logging/mocks/mock_simple_logging.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	logging "github.com/runatlantis/atlantis/server/logging"
 	"reflect"
 	"time"

--- a/server/scheduled/executor_service_test.go
+++ b/server/scheduled/executor_service_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/scheduled/mocks"
 )

--- a/server/scheduled/mocks/mock_executor_service_job.go
+++ b/server/scheduled/mocks/mock_executor_service_job.go
@@ -4,7 +4,7 @@
 package mocks
 
 import (
-	pegomock "github.com/petergtz/pegomock"
+	pegomock "github.com/petergtz/pegomock/v3"
 	"reflect"
 	"time"
 )

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	. "github.com/petergtz/pegomock"
+	. "github.com/petergtz/pegomock/v3"
 	"github.com/runatlantis/atlantis/server"
 	"github.com/runatlantis/atlantis/server/controllers/templates"
 	tMocks "github.com/runatlantis/atlantis/server/controllers/templates/mocks"


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- bump pegomock v3.0.1

```
go get github.com/petergtz/pegomock/v3
sed 's,\. "github.com/petergtz/pegomock",\. "github.com/petergtz/pegomock/v3",g' -i **/*.go
sed 's,"github.com/petergtz/pegomock",pegomock "github.com/petergtz/pegomock/v3",g' -i **/*.go
go mod tidy
```

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- latest v3.0.1 (May 4 2023)
    - v4.0.0 was released (May 11 2023) recently but I'm more hesitant to adopting the latest major version without at least a couple patches.

## tests

- [x] I have tested my changes by running tests

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Relates to https://github.com/runatlantis/atlantis/issues/2795
- https://github.com/petergtz/pegomock/releases/tag/v3.0.1