### PR TITLE
chore(buildkit): pin to v0.10.6

### DIFF
--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -39,7 +39,7 @@ jobs:
 
     # Lint the Dockerfile first before setting anything up
     - name: Lint Dockerfile
-      uses: hadolint/hadolint-action@v3
+      uses: hadolint/hadolint-action@v3.1.0
       with:
         dockerfile: "Dockerfile"
 

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -39,7 +39,7 @@ jobs:
 
     # Lint the Dockerfile first before setting anything up
     - name: Lint Dockerfile
-      uses: hadolint/hadolint-action@master
+      uses: hadolint/hadolint-action@v3
       with:
         dockerfile: "Dockerfile"
 
@@ -51,9 +51,10 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
+      # https://github.com/docker/build-push-action/issues/761#issuecomment-1575006515
       with:
         driver-opts: |
-          image=moby/buildkit:v0.11.2
+          image=moby/buildkit:v0.10.6
 
     # release version is the name of the tag i.e. v0.10.0
     # release version also has the image type appended i.e. v0.10.0-alpine


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- chore(buildkit): pin to v0.10.6

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- Reduce the number of failures when pushing images

## tests

- [ ] I have tested my changes by running tests

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Previous PR https://github.com/runatlantis/atlantis/pull/3481
- Broken run using v0.11.2 https://github.com/runatlantis/atlantis/actions/runs/5250852852/jobs/9485217740
- https://github.com/docker/build-push-action/issues/761#issuecomment-1575006515