### PR TITLE
chore(Dockerfile): re-add terraform 1.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,7 +126,8 @@ RUN case ${TARGETPLATFORM} in \
 ENV DEFAULT_TERRAFORM_VERSION=1.5.0
 
 # In the official Atlantis image, we only have the latest of each Terraform version.
-RUN AVAILABLE_TERRAFORM_VERSIONS="1.1.9 1.2.9 1.3.9 ${DEFAULT_TERRAFORM_VERSION}" && \
+# Each binary is about 80 MB so we limit it to the 4 latest minor releases or fewer
+RUN AVAILABLE_TERRAFORM_VERSIONS="1.2.9 1.3.9 1.4.6 ${DEFAULT_TERRAFORM_VERSION}" && \
     case "${TARGETPLATFORM}" in \
         "linux/amd64") TERRAFORM_ARCH=amd64 ;; \
         "linux/arm64") TERRAFORM_ARCH=arm64 ;; \


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- re-add terraform 1.4
- maintain 4 releases as we previously had

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- Add 1.4 again since renovate updated to 1.5 and removed 1.4 by accident. Difficult to prevent this.
- We previously had 4 releases so this maintains 4 releases cached in the container since each release is 80 MB making it expensive in bandwidth.

## tests

- [x] I have tested my changes by creating the image

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Previous PR https://github.com/runatlantis/atlantis/pull/3514
- https://releases.hashicorp.com/terraform/
