### PR TITLE
docs: fix policy-checking command example

### DIFF
--- a/runatlantis.io/docs/policy-checking.md
+++ b/runatlantis.io/docs/policy-checking.md
@@ -23,7 +23,7 @@ Any failures need to either be addressed in a successive commit, or approved by 
 
 Policy approvals may be cleared either by re-planing, or by issuing the following command:
 ```
-atlantis approve_policies --clear-policy-approvals
+atlantis approve_policies --clear-policy-approval
 ```
 
 ::: warning


### PR DESCRIPTION


## what

Fix the documentation of the policy approval command introduced by #3351


## why

There's a typo, the command in the doc before this patch does not exist

## tests


## references

#3351 