### PR TITLE
fix: broken automerge logic

### DIFF
--- a/server/events/automerger.go
+++ b/server/events/automerger.go
@@ -46,14 +46,10 @@ func (c *AutoMerger) automerge(ctx *command.Context, pullStatus models.PullStatu
 
 // automergeEnabled returns true if automerging is enabled in this context.
 func (c *AutoMerger) automergeEnabled(projectCmds []command.ProjectContext) bool {
-	// only automerge if all projects have automerge set; or if global automerge is set and there are no projects.
+	// Use project automerge settings if projects exist; otherwise, use global automerge settings.
 	automerge := c.GlobalAutomerge
 	if len(projectCmds) > 0 {
-		for _, prjCmd := range projectCmds {
-			if !prjCmd.AutomergeEnabled {
-				automerge = false
-			}
-		}
+		automerge = projectCmds[0].AutomergeEnabled
 	}
 	return automerge
 }

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -695,16 +695,17 @@ func TestRunAutoplanCommandWithError_DeletePlans(t *testing.T) {
 	Ok(t, err)
 	dbUpdater.Backend = boltDB
 	applyCommandRunner.Backend = boltDB
-	autoMerger.GlobalAutomerge = true
 	defer func() { autoMerger.GlobalAutomerge = false }()
 
 	When(projectCommandBuilder.BuildAutoplanCommands(Any[*command.Context]())).
 		ThenReturn([]command.ProjectContext{
 			{
-				CommandName: command.Plan,
+				CommandName:      command.Plan,
+				AutomergeEnabled: true, // Setting this manually, since this tests bypasses automerge param reconciliation logic and otherwise defaults to false.
 			},
 			{
-				CommandName: command.Plan,
+				CommandName:      command.Plan,
+				AutomergeEnabled: true, // Setting this manually, since this tests bypasses automerge param reconciliation logic and otherwise defaults to false.
 			},
 		}, nil)
 	callCount := 0


### PR DESCRIPTION
## what

Tests were broken after merging #3379 ; the logic for reconciling automerge between project and global levels was incorrect, as global settings were being used when project-level automerge was configured true. This change addresses the issue by passing project-level settings in whole if a project is being used.


## why

To fix broken tests and broken automerge logic.

## tests

* previously failing e2e tests are now passing.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

