### PR TITLE
Add username to lock screen

### DIFF
--- a/server/controllers/templates/web_templates.go
+++ b/server/controllers/templates/web_templates.go
@@ -36,7 +36,7 @@ type LockIndexData struct {
 	PullNum       int
 	Path          string
 	Workspace     string
-  LockedBy      string
+        LockedBy      string
 	Time          time.Time
 	TimeFormatted string
 }

--- a/server/controllers/templates/web_templates.go
+++ b/server/controllers/templates/web_templates.go
@@ -36,6 +36,7 @@ type LockIndexData struct {
 	PullNum       int
 	Path          string
 	Workspace     string
+  LockedBy      string
 	Time          time.Time
 	TimeFormatted string
 }
@@ -70,15 +71,11 @@ var IndexTemplate = template.Must(template.New("index.html.tmpl").Parse(`
   <script src="{{ .CleanedBasePath }}/static/js/jquery-3.5.1.min.js"></script>
   <script>
     $(document).ready(function () {
-      if (document.URL.indexOf("discard=true") !== -1) {
-        $("p.js-discard-success").show();
-        setTimeout(function() {
-          $("p.js-discard-success").fadeOut('slow',function(){
-            window.location.href = "/";
-          })
-        }, 5000); // <-- time in milliseconds
-      }
+      $("p.js-discard-success").toggle(document.URL.indexOf("discard=true") !== -1);
     });
+    setTimeout(function() {
+        $("p.js-discard-success").fadeOut('slow');
+    }, 5000); // <-- time in milliseconds
   </script>
   <link rel="stylesheet" href="{{ .CleanedBasePath }}/static/css/normalize.css">
   <link rel="stylesheet" href="{{ .CleanedBasePath }}/static/css/skeleton.css">
@@ -119,6 +116,7 @@ var IndexTemplate = template.Must(template.New("index.html.tmpl").Parse(`
       <span>Repository</span>
       <span>Project</span>
       <span>Workspace</span>
+      <span>Locked By</span>
       <span>Date/Time</span>
       <span>Status</span>
     </div>
@@ -134,6 +132,9 @@ var IndexTemplate = template.Must(template.New("index.html.tmpl").Parse(`
           <span><code>{{.Workspace}}</code></span>
         </a>
         <a class="lock-link" tabindex="-1" href="{{ $basePath }}{{.LockPath}}">
+          <span><code>{{.LockedBy}}</code></span>
+        </a>
+        <a class="lock-username" tabindex="-1" href="{{ $basePath }}{{.LockPath}}">
           <span class="lock-datetime">{{.TimeFormatted}}</span>
         </a>
         <a class="lock-link" tabindex="-1" href="{{ $basePath }}{{.LockPath}}">
@@ -263,8 +264,8 @@ type LockDetailData struct {
 	RepoOwner       string
 	RepoName        string
 	PullRequestLink string
-	LockedBy        string
 	Workspace       string
+  LockedBy        string
 	AtlantisVersion string
 	// CleanedBasePath is the path Atlantis is accessible at externally. If
 	// not using a path-based proxy, this will be an empty string. Never ends
@@ -399,6 +400,7 @@ var ProjectJobsTemplate = template.Must(template.New("blank.html.tmpl").Parse(`
         left: 0px;
         bottom: 0px;
         right: 0px;
+        overflow: auto;
         border: 5px solid white;
         }
 
@@ -602,7 +604,7 @@ var GithubAppSetupTemplate = template.Must(template.New("github-app.html.tmpl").
     <a title="atlantis" href="{{ .CleanedBasePath }}"><img class="hero" src="{{ .CleanedBasePath }}/static/images/atlantis-icon_512.png"/></a>
     <p class="title-heading">atlantis</p>
 
-    <p class="github-app-msg"><strong>
+    <p class="js-discard-success"><strong>
     {{ if .Target }}
       Create a github app
     {{ else }}

--- a/server/server.go
+++ b/server/server.go
@@ -463,7 +463,6 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		CheckoutMerge:    userConfig.CheckoutStrategy == "merge",
 		CheckoutDepth:    userConfig.CheckoutDepth,
 		GithubAppEnabled: githubAppEnabled,
-		Logger:           logger,
 	}
 
 	scheduledExecutorService := scheduled.NewExecutorService(
@@ -584,9 +583,6 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		commentParser,
 		userConfig.SkipCloneNoChanges,
 		userConfig.EnableRegExpCmd,
-		userConfig.Automerge,
-		userConfig.ParallelPlan,
-		userConfig.ParallelApply,
 		userConfig.AutoplanModulesFromProjects,
 		userConfig.AutoplanFileList,
 		userConfig.RestrictFileList,
@@ -1040,6 +1036,7 @@ func (s *Server) Index(w http.ResponseWriter, _ *http.Request) {
 			PullNum:       v.Pull.Num,
 			Path:          v.Project.Path,
 			Workspace:     v.Workspace,
+			LockedBy:	   v.Pull.Author,
 			Time:          v.Time,
 			TimeFormatted: v.Time.Format("02-01-2006 15:04:05"),
 		})

--- a/server/server.go
+++ b/server/server.go
@@ -1036,7 +1036,7 @@ func (s *Server) Index(w http.ResponseWriter, _ *http.Request) {
 			PullNum:       v.Pull.Num,
 			Path:          v.Project.Path,
 			Workspace:     v.Workspace,
-			LockedBy:	   v.Pull.Author,
+			LockedBy:      v.Pull.Author,
 			Time:          v.Time,
 			TimeFormatted: v.Time.Format("02-01-2006 15:04:05"),
 		})

--- a/server/static/css/custom.css
+++ b/server/static/css/custom.css
@@ -238,7 +238,7 @@ tbody {
 /* Styles for the lock index */
 .lock-grid{
   display: grid;
-  grid-template-columns: auto auto auto auto auto;
+  grid-template-columns: auto auto auto auto auto auto;
   border: 1px solid #dbeaf4;
   width: 100%;
   font-size: 12px;
@@ -279,6 +279,10 @@ tbody {
 }
 
 .lock-reponame {
+  word-break: break-all;
+}
+
+.lock-username {
   word-break: break-all;
 }
 
@@ -356,10 +360,6 @@ tbody {
 }
 
 .js-discard-success {
-  font-family: monospace, monospace; font-size: 1.1em; text-align: center; display: none;
-}
-
-.github-app-msg {
   font-family: monospace, monospace; font-size: 1.1em; text-align: center;
 }
 


### PR DESCRIPTION
## what

Add the username of the user who owns/created the lock to the main lock screen

## why

In our organisation we have many users and teams who make changes to repos controlled by Atlantis. It will be very useful to be able to see at a glance who created the locks, especially we can have many.

## tests

I've tested the changes locally by running Atlantis in docker and using ngrok to post webhooks into my test instance of Atlantis.

<img width="1209" alt="Atlantis" src="https://github.com/runatlantis/atlantis/assets/92309070/f6c8678e-714a-4a44-a78b-7f4b6118f365">

## references

N/A

