### PR TITLE
fix(website-test): missing backslash for muffet

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -61,7 +61,7 @@ jobs:
       # medium.com => was being rate limited: HTTP 429
       - run: |
           ./muffet \
-            -e 'https://medium.com/runatlantis'
+            -e 'https://medium.com/runatlantis' \
             -e 'https://github\.com/runatlantis/atlantis/edit/main/.*' \
             -e 'https://github.com/runatlantis/helm-charts#customization' \
             --header 'Accept-Encoding:deflate, gzip' \


### PR DESCRIPTION
## what

- https://github.com/runatlantis/atlantis/actions/runs/5652166425/job/15311381309
missing backslash

## why

- Because I was doing a lot and tests were passing originally 👍 

## tests

- [x] I have tested my changes by adding a backslash

## references

- https://github.com/runatlantis/atlantis/actions/runs/5652166425/job/15311381309

