### PR TITLE
fix: creating the home directory before attempting to write git creds

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -306,7 +306,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	}
 
 	if userConfig.WriteGitCreds {
-		if err := os.MkdirAll(home, 0700); err != nil {
+		if err := os.MkdirAll(home, 0777); err != nil {
 			return nil, errors.Wrapf(err, "unable to create dir %q", home)
 		}
 

--- a/server/server.go
+++ b/server/server.go
@@ -306,6 +306,10 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	}
 
 	if userConfig.WriteGitCreds {
+		if err := os.MkdirAll(home, 0700); err != nil {
+			return nil, errors.Wrapf(err, "unable to create dir %q", home)
+		}
+
 		if userConfig.GithubUser != "" {
 			if err := vcs.WriteGitCreds(userConfig.GithubUser, userConfig.GithubToken, userConfig.GithubHostname, home, logger, false); err != nil {
 				return nil, err


### PR DESCRIPTION
## what

Adding a step to create the home directory before attempting to write the git credentials.


## why

If you try to start up a completely new instance of Atlantis with the `--write-git-creds` option enabled, it will fail because the `/home/atlantis` directory doesn't exist yet.  The following error will be raised in the logs:

`Error: initializing server: writing generated .git-credentials file with user, token and hostname to /home/atlantis/.git-credentials: open /home/atlantis/.git-credentials: no such file or directory`

The current workaround is to leave `--write-git-creds` false for the first startup, which allows the server to initialize the home directory (likely on [L360 of server.go](https://github.com/runatlantis/atlantis/blob/main/server/server.go#L360)), then change `--write-git-creds` to true (this requires persistent storage).

## tests

### to reproduce the error

```
locals {
    name = "atlantis-unpatched-test"
    location = "east us"
}

resource "azurerm_resource_group" "rg" {
  name     = local.name
  location = local.location
}

resource "azurerm_service_plan" "atlantis" {
  name                = azurerm_resource_group.rg.name
  resource_group_name = azurerm_resource_group.rg.name
  location            = azurerm_resource_group.rg.location
  os_type             = "Linux"
  sku_name            = "B1"
}

resource "azurerm_linux_web_app" "atlantis" {
  name                = "${azurerm_resource_group.rg.name}-app"
  resource_group_name = azurerm_resource_group.rg.name
  location            = azurerm_resource_group.rg.location
  service_plan_id     = azurerm_service_plan.atlantis.id
  https_only          = true
  site_config {
    minimum_tls_version = "1.2"
    application_stack {
      docker_image_name        = "atlantis:latest"
      docker_registry_url      = "https://ghcr.io/runatlantis"
    }
  }

  app_settings = {
    "ATLANTIS_WRITE_GIT_CREDS"      = "true"
    "ATLANTIS_REQUIRE_MERGEABLE"    = "true"
    "ATLANTIS_REQUIRE_APPROVAL"     = "true"
    "ATLANTIS_ENABLE_POLICY_CHECKS" = "true"
    "ATLANTIS_ALLOW_REPO_CONFIG"    = "true"
    "ATLANTIS_GH_USER"              = "fake-user"
    "ATLANTIS_GH_TOKEN"             = "fake-token"
    "ATLANTIS_GH_WEBHOOK_SECRET"    = "fake-secret"
    "ATLANTIS_REPO_WHITELIST"       = "github.com/runatlantis/atlantis"
    "WEBSITES_PORT"                 = "4141"
  }
}
```

### testing the fix

```
locals {
    name = "atlantis-patched-test"
    location = "east us"
}

resource "azurerm_resource_group" "rg" {
  name     = local.name
  location = local.location
}

resource "azurerm_service_plan" "atlantis" {
  name                = azurerm_resource_group.rg.name
  resource_group_name = azurerm_resource_group.rg.name
  location            = azurerm_resource_group.rg.location
  os_type             = "Linux"
  sku_name            = "B1"
}

resource "azurerm_linux_web_app" "atlantis" {
  name                = "${azurerm_resource_group.rg.name}-app"
  resource_group_name = azurerm_resource_group.rg.name
  location            = azurerm_resource_group.rg.location
  service_plan_id     = azurerm_service_plan.atlantis.id
  https_only          = true
  site_config {
    minimum_tls_version = "1.2"
    application_stack {
      docker_image_name        = "atlantis-fix:latest"
      docker_registry_url      = "https://atlantisfix.azurecr.io"
    }
  }

  app_settings = {
    "ATLANTIS_WRITE_GIT_CREDS"      = "true"
    "ATLANTIS_REQUIRE_MERGEABLE"    = "true"
    "ATLANTIS_REQUIRE_APPROVAL"     = "true"
    "ATLANTIS_ENABLE_POLICY_CHECKS" = "true"
    "ATLANTIS_ALLOW_REPO_CONFIG"    = "true"
    "ATLANTIS_GH_USER"              = "fake-user"
    "ATLANTIS_GH_TOKEN"             = "fake-token"
    "ATLANTIS_GH_WEBHOOK_SECRET"    = "fake-secret"
    "ATLANTIS_REPO_WHITELIST"       = "github.com/runatlantis/atlantis"
    "WEBSITES_PORT"                 = "4141"
  }
}
```