### PR TITLE
fix: Update the Simple Logger Log Function to log the Correct Caller

### DIFF
--- a/server/logging/simple_logger.go
+++ b/server/logging/simple_logger.go
@@ -154,13 +154,13 @@ func (l *StructuredLogger) Err(format string, a ...interface{}) {
 func (l *StructuredLogger) Log(level LogLevel, format string, a ...interface{}) {
 	switch level {
 	case Debug:
-		l.Debug(format, a...)
+		l.z.Debugf(format, a...)
 	case Info:
-		l.Info(format, a...)
+		l.z.Infof(format, a...)
 	case Warn:
-		l.Warn(format, a...)
+		l.z.Warnf(format, a...)
 	case Error:
-		l.Err(format, a...)
+		l.z.Errorf(format, a...)
 	}
 }
 


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

Fixes the Simple Logger `Log` function so that the sugared logger is used to log the correct caller, the same as all the other log functions.

## why

The wrong caller is currently logged for this function

## tests

Locks controller 'Apply Lock' log entry before the change:

```
{"level":"info","ts":"2023-07-28T14:13:33.829+0100","caller":"logging/simple_logger.go:159","msg":"Apply Lock is acquired on 2023-07-28 14:13:33","json":{}}
```

after this change:

```
{"level":"info","ts":"2023-07-28T14:08:03.793+0100","caller":"controllers/locks_controller.go:149","msg":"Apply Lock is acquired on 2023-07-28 14:08:03","json":{}}
```