### PR TITLE
fix: Update Conftest 'Failed to get default conftest version' Log entry to Info

### DIFF
--- a/server/core/runtime/policy/conftest_client.go
+++ b/server/core/runtime/policy/conftest_client.go
@@ -148,7 +148,7 @@ func NewConfTestExecutorWorkflow(log logging.SimpleLogging, versionRootDir strin
 
 	if err != nil {
 		// conftest default versions are not essential to service startup so let's not block on it.
-		log.Warn("failed to get default conftest version. Will attempt request scoped lazy loads %s", err.Error())
+		log.Info("failed to get default conftest version. Will attempt request scoped lazy loads %s", err.Error())
 	}
 
 	versionCache := cache.NewExecutionVersionLayeredLoadingCache(


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

Update the ConfTest log message if the default conftest version is not found from `warning` to `info`, as this message complete with a Go stack trace is logged even if conftest is not configured. 

## why

Remove an irrelevant Go stack trace log entry which is logged on every Atlantis service start. 

## tests

Log entry before the change:

```
{"level":"warn","ts":"2023-07-28T14:13:14.405+0100","caller":"policy/conftest_client.go:151","msg":"failed to get default conftest version. Will attempt request scoped lazy loads DEFAULT_CONFTEST_VERSION not set"
,"json":{},"stacktrace":"github.com/runatlantis/atlantis/server/core/runtime/policy.NewConfTestExecutorWorkflow\n\t/mnt/c/Users/Simon/Documents/GitHub/X-Guardian/atlantis/server/core/runtime/policy/conftest_client.go:151\n
github.com/runatlantis/atlantis/server.NewServer\n\t/mnt/c/Users/Simon/Documents/GitHub/X-Guardian/atlantis/server/server.go:607\ngithub.com/runatlantis/atlantis/cmd.
(*DefaultServerCreator).NewServer\n\t/mnt/c/Users/Simon/Documents/GitHub/X-Guardian/atlantis/cmd/server.go:647\ngithub.com/runatlantis/atlantis/cmd.
(*ServerCmd).run\n\t/mnt/c/Users/Simon/Documents/GitHub/X-Guardian/atlantis/cmd/server.go:774\ngithub.com/runatlantis/atlantis/cmd.
(*ServerCmd).Init.func2\n\t/mnt/c/Users/Simon/Documents/GitHub/X-Guardian/atlantis/cmd/server.go:662\ngithub.com/runatlantis/atlantis/cmd.
(*ServerCmd).withErrPrint.func1\n\t/mnt/c/Users/Simon/Documents/GitHub/X-Guardian/atlantis/cmd/server.go:1134\ngithub.com/spf13/cobra.
(*Command).execute\n\t/root/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:940\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\t/root/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068\ngithub.com/spf13/cobra.
(*Command).Execute\n\t/root/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992\ngithub.com/runatlantis/atlantis/cmd.
Execute\n\t/mnt/c/Users/Simon/Documents/GitHub/X-Guardian/atlantis/cmd/root.go:30\nmain.main\n\t/mnt/c/Users/Simon/Documents/GitHub/X-Guardian/atlantis/main.go:66\nruntime.main\n\t/usr/lib/go-1.20/src/runtime/proc.go:250"}
```

Log entry after the change:

```
{"level":"info","ts":"2023-07-28T14:23:05.058+0100","caller":"policy/conftest_client.go:151","msg":"failed to get default conftest version. Will attempt request scoped lazy loads DEFAULT_CONFTEST_VERSION not set","json":{}}
```

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

