### PR TITLE
fix(ci): link_check required

### DIFF
--- a/.github/workflows/website-required.yml
+++ b/.github/workflows/website-required.yml
@@ -31,7 +31,7 @@ jobs:
   # Check that there's no missing links for the website.
   # This job builds the website, starts a server to serve it, and then uses
   # muffet (https://github.com/raviqqe/muffet) to perform the link check.
-  website_check:
+  link_check:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
## what

- This needs to match up with the website / link_check

## why

If it doesn't, it won't allow non-website related JS files to block PRs

## tests

- [ ] I have tested my changes by ...

## references


