### PR TITLE
chore: Fix Go Static Check Errors

### DIFF
--- a/server/events/github_app_working_dir_test.go
+++ b/server/events/github_app_working_dir_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	. "github.com/petergtz/pegomock/v4"
-	pegomock "github.com/petergtz/pegomock/v4"
 	"github.com/runatlantis/atlantis/server/events"
 	eventMocks "github.com/runatlantis/atlantis/server/events/mocks"
 	"github.com/runatlantis/atlantis/server/events/models"
@@ -58,7 +57,7 @@ func TestClone_GithubAppNoneExisting(t *testing.T) {
 }
 
 func TestClone_GithubAppSetsCorrectUrl(t *testing.T) {
-	pegomock.RegisterMockTestingT(t)
+	RegisterMockTestingT(t)
 
 	workingDir := eventMocks.NewMockWorkingDir()
 

--- a/server/events/plan_command_runner_test.go
+++ b/server/events/plan_command_runner_test.go
@@ -496,7 +496,6 @@ func TestPlanCommandRunner_ExecutionOrder(t *testing.T) {
 			}
 
 			planCommandRunner.Run(ctx, cmd)
-			type RepoModel interface{ models.Repo }
 
 			for i := range c.ProjectContexts {
 				projectCommandRunner.VerifyWasCalled(c.RunnerInvokeMatch[i]).Plan(c.ProjectContexts[i])

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -734,7 +734,7 @@ func (p *DefaultProjectCommandBuilder) buildProjectCommandCtx(ctx *command.Conte
 		if repoCfgPtr.ParallelPlan != nil {
 			parallelPlan = *repoCfgPtr.ParallelPlan
 		}
-		abortOnExcecutionOrderFail = *&repoCfgPtr.AbortOnExcecutionOrderFail
+		abortOnExcecutionOrderFail = repoCfgPtr.AbortOnExcecutionOrderFail
 	}
 
 	if len(matchingProjects) > 0 {

--- a/server/events/project_command_context_builder.go
+++ b/server/events/project_command_context_builder.go
@@ -194,7 +194,7 @@ func (cb *PolicyCheckProjectCommandContextBuilder) BuildProjectContext(
 		terraformClient,
 	)
 
-	if cmdName == command.Plan && prjCfg.PolicyCheck != false {
+	if cmdName == command.Plan && prjCfg.PolicyCheck {
 		ctx.Log.Debug("Building project command context for %s", command.PolicyCheck)
 		steps := prjCfg.Workflow.PolicyCheck.Steps
 

--- a/server/events/project_finder.go
+++ b/server/events/project_finder.go
@@ -224,7 +224,7 @@ func (p *DefaultProjectFinder) DetermineProjectsViaConfig(log logging.SimpleLogg
 		// If any of the modified files matches the pattern then this project is
 		// considered modified.
 		for _, file := range modifiedFiles {
-			match, err := pm.Matches(file)
+			match, err := pm.MatchesOrParentMatches(file)
 			if err != nil {
 				log.Debug("match err for file %q: %s", file, err)
 				continue
@@ -266,7 +266,7 @@ func (p *DefaultProjectFinder) filterToFileList(log logging.SimpleLogging, files
 		if p.shouldIgnore(fileName) {
 			continue
 		}
-		match, err := patternMatcher.Matches(fileName)
+		match, err := patternMatcher.MatchesOrParentMatches(fileName)
 		if err != nil {
 			log.Debug("filter err for file %q: %s", fileName, err)
 			continue

--- a/server/events/working_dir_locker.go
+++ b/server/events/working_dir_locker.go
@@ -63,9 +63,9 @@ func (d *DefaultWorkingDirLocker) TryLockPull(repoFullName string, pullNum int) 
 	pullKey := d.pullKey(repoFullName, pullNum)
 	for _, l := range d.locks {
 		if l == pullKey || strings.HasPrefix(l, pullKey+"/") {
-			return func() {}, fmt.Errorf("The Atlantis working dir is currently locked by another" +
+			return func() {}, fmt.Errorf("the Atlantis working dir is currently locked by another" +
 				" command that is running for this pull request.\n" +
-				"Wait until the previous command is complete and try again.")
+				"Wait until the previous command is complete and try again")
 		}
 	}
 	d.locks = append(d.locks, pullKey)
@@ -82,9 +82,9 @@ func (d *DefaultWorkingDirLocker) TryLock(repoFullName string, pullNum int, work
 	workspaceKey := d.workspaceKey(repoFullName, pullNum, workspace, path)
 	for _, l := range d.locks {
 		if l == pullKey || l == workspaceKey {
-			return func() {}, fmt.Errorf("The %s workspace at path %s is currently locked by another"+
+			return func() {}, fmt.Errorf("the %s workspace at path %s is currently locked by another"+
 				" command that is running for this pull request.\n"+
-				"Wait until the previous command is complete and try again.", workspace, path)
+				"Wait until the previous command is complete and try again", workspace, path)
 		}
 	}
 	d.locks = append(d.locks, workspaceKey)

--- a/server/events/working_dir_locker_test.go
+++ b/server/events/working_dir_locker_test.go
@@ -33,9 +33,9 @@ func TestTryLock(t *testing.T) {
 
 	// Now another lock for the same repo, workspace, and pull should fail
 	_, err = locker.TryLock(repo, 1, workspace, path)
-	ErrEquals(t, "The default workspace at path . is currently locked by another"+
+	ErrEquals(t, "the default workspace at path . is currently locked by another"+
 		" command that is running for this pull request.\n"+
-		"Wait until the previous command is complete and try again.", err)
+		"Wait until the previous command is complete and try again", err)
 
 	// Unlock should work.
 	unlockFn()


### PR DESCRIPTION
## what

Fix the following Go static check errors:

```json
{
	"resource": "server/events/github_app_working_dir_test.go",
	"message": "package \"github.com/petergtz/pegomock/v4\" is being imported more than once (ST1019)\n\tgithub_app_working_dir_test.go:8:2: other import of \"github.com/petergtz/pegomock/v4\"",
	"startLineNumber": 7,
},{
	"resource": "server/events/plan_command_runner_test.go",
	"message": "type RepoModel is unused (U1000)",
	"startLineNumber": 499,
},{
	"resource": "server/events/project_command_builder.go",
	"message": "*&x will be simplified to x. It will not copy x. (SA4001)",
	"startLineNumber": 737,
},{
	"resource": "server/events/project_command_context_builder.go",
	"message": "should omit comparison to bool constant, can be simplified to prjCfg.PolicyCheck (S1002)",
	"startLineNumber": 197,
},{
	"resource": "server/events/project_finder.go",
	"message": "pm.Matches is deprecated: This implementation is buggy (it only checks a single parent dir against the pattern) and will be removed soon. Use either MatchesOrParentMatches or MatchesUsingParentResults instead.  (SA1019)",
	"startLineNumber": 227,
	"startColumn": 18,
},{
	"resource": "server/events/project_finder.go",
	"message": "patternMatcher.Matches is deprecated: This implementation is buggy (it only checks a single parent dir against the pattern) and will be removed soon. Use either MatchesOrParentMatches or MatchesUsingParentResults instead.  (SA1019)",
	"startLineNumber": 269,
},{
	"resource": "server/events/working_dir_locker.go",
	"message": "error strings should not be capitalized (ST1005)",
	"startLineNumber": 66,
},{
	"resource": "server/events/working_dir_locker.go",
	"message": "error strings should not end with punctuation or newlines (ST1005)",
	"startLineNumber": 66,
},{
	"resource": "server/events/working_dir_locker.go",
	"severity": 4,
	"message": "error strings should not be capitalized (ST1005)",
	"startLineNumber": 85,
},{
	"resource": "server/events/working_dir_locker.go",
	"message": "error strings should not end with punctuation or newlines (ST1005)",
	"startLineNumber": 85,
}

```

Also fixed the working dir locker tests after the error string change.

## why

Improve code quality

## references

- https://staticcheck.dev/

