### PR TITLE
feat: Slack notifications matched on base branch name

### DIFF
--- a/runatlantis.io/docs/using-slack-hooks.md
+++ b/runatlantis.io/docs/using-slack-hooks.md
@@ -41,6 +41,7 @@ In your Atlantis configuration you can now add the following:
 webhooks:
 - event: apply
   workspace-regex: .*
+  branch-regex: .*
   kind: slack
   channel: my-channel
 ```
@@ -56,6 +57,7 @@ config: |
    webhooks:
      - event: apply
        workspace-regex: .*
+       branch-regex: .*
        kind: slack
        channel: my-channel
 ```

--- a/server/events/webhooks/slack_client.go
+++ b/server/events/webhooks/slack_client.go
@@ -103,6 +103,11 @@ func (d *DefaultSlackClient) createAttachments(applyResult ApplyResult) []slack.
 				Short: true,
 			},
 			{
+				Title: "Branch",
+				Value: applyResult.Pull.BaseBranch,
+				Short: true,
+			},
+			{
 				Title: "User",
 				Value: applyResult.User.Username,
 				Short: true,

--- a/server/events/webhooks/slack_client_test.go
+++ b/server/events/webhooks/slack_client_test.go
@@ -163,8 +163,9 @@ func setup(t *testing.T) {
 			FullName: "runatlantis/atlantis",
 		},
 		Pull: models.PullRequest{
-			Num: 1,
-			URL: "url",
+			Num:        1,
+			URL:        "url",
+			BaseBranch: "main",
 		},
 		User: models.User{
 			Username: "lkysow",

--- a/server/events/webhooks/slack_test.go
+++ b/server/events/webhooks/slack_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	. "github.com/petergtz/pegomock/v4"
+	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/events/webhooks"
 	"github.com/runatlantis/atlantis/server/events/webhooks/mocks"
 	"github.com/runatlantis/atlantis/server/logging"
@@ -35,10 +36,14 @@ func TestSend_PostMessage(t *testing.T) {
 	hook := webhooks.SlackWebhook{
 		Client:         client,
 		WorkspaceRegex: regex,
+		BranchRegex:    regex,
 		Channel:        channel,
 	}
 	result := webhooks.ApplyResult{
 		Workspace: "production",
+		Pull: models.PullRequest{
+			BaseBranch: "main",
+		},
 	}
 
 	t.Log("PostMessage should be called, doesn't matter if it errors or not")
@@ -57,10 +62,14 @@ func TestSend_NoopSuccess(t *testing.T) {
 	hook := webhooks.SlackWebhook{
 		Client:         client,
 		WorkspaceRegex: regex,
+		BranchRegex:    regex,
 		Channel:        channel,
 	}
 	result := webhooks.ApplyResult{
 		Workspace: "production",
+		Pull: models.PullRequest{
+			BaseBranch: "main",
+		},
 	}
 	err = hook.Send(logging.NewNoopLogger(t), result)
 	Ok(t, err)

--- a/server/events/webhooks/webhooks.go
+++ b/server/events/webhooks/webhooks.go
@@ -52,6 +52,7 @@ type MultiWebhookSender struct {
 type Config struct {
 	Event          string
 	WorkspaceRegex string
+	BranchRegex    string
 	Kind           string
 	Channel        string
 }
@@ -59,7 +60,11 @@ type Config struct {
 func NewMultiWebhookSender(configs []Config, client SlackClient) (*MultiWebhookSender, error) {
 	var webhooks []Sender
 	for _, c := range configs {
-		r, err := regexp.Compile(c.WorkspaceRegex)
+		wr, err := regexp.Compile(c.WorkspaceRegex)
+		if err != nil {
+			return nil, err
+		}
+		br, err := regexp.Compile(c.BranchRegex)
 		if err != nil {
 			return nil, err
 		}
@@ -77,7 +82,7 @@ func NewMultiWebhookSender(configs []Config, client SlackClient) (*MultiWebhookS
 			if c.Channel == "" {
 				return nil, errors.New("must specify \"channel\" if using a webhook of \"kind: slack\"")
 			}
-			slack, err := NewSlack(r, c.Channel, client)
+			slack, err := NewSlack(wr, br, c.Channel, client)
 			if err != nil {
 				return nil, err
 			}

--- a/server/events/webhooks/webhooks_test.go
+++ b/server/events/webhooks/webhooks_test.go
@@ -34,6 +34,7 @@ const (
 var validConfig = webhooks.Config{
 	Event:          validEvent,
 	WorkspaceRegex: validRegex,
+	BranchRegex:    validRegex,
 	Kind:           validKind,
 	Channel:        validChannel,
 }
@@ -42,14 +43,27 @@ func validConfigs() []webhooks.Config {
 	return []webhooks.Config{validConfig}
 }
 
-func TestNewWebhooksManager_InvalidRegex(t *testing.T) {
-	t.Log("When given an invalid regex in a config, an error is returned")
+func TestNewWebhooksManager_InvalidWorkspaceRegex(t *testing.T) {
+	t.Log("When given an invalid workspace regex in a config, an error is returned")
 	RegisterMockTestingT(t)
 	client := mocks.NewMockSlackClient()
 
 	invalidRegex := "("
 	configs := validConfigs()
 	configs[0].WorkspaceRegex = invalidRegex
+	_, err := webhooks.NewMultiWebhookSender(configs, client)
+	Assert(t, err != nil, "expected error")
+	Assert(t, strings.Contains(err.Error(), "error parsing regexp"), "expected regex error")
+}
+
+func TestNewWebhooksManager_InvalidBranchRegex(t *testing.T) {
+	t.Log("When given an invalid branch regex in a config, an error is returned")
+	RegisterMockTestingT(t)
+	client := mocks.NewMockSlackClient()
+
+	invalidRegex := "("
+	configs := validConfigs()
+	configs[0].BranchRegex = invalidRegex
 	_, err := webhooks.NewMultiWebhookSender(configs, client)
 	Assert(t, err != nil, "expected error")
 	Assert(t, strings.Contains(err.Error(), "error parsing regexp"), "expected regex error")

--- a/server/server.go
+++ b/server/server.go
@@ -141,6 +141,10 @@ type WebhookConfig struct {
 	// that is being modified for this event. If the regex matches, we'll
 	// send the webhook, ex. "production.*".
 	WorkspaceRegex string `mapstructure:"workspace-regex"`
+	// BranchRegex is a regex that is used to match against the branch
+	// that is being modified for this event. If the regex matches, we'll
+	// send the webhook, ex. "production.*".
+	BranchRegex string `mapstructure:"branch-regex"`
 	// Kind is the type of webhook we should send, ex. slack.
 	Kind string `mapstructure:"kind"`
 	// Channel is the channel to send this webhook to. It only applies to
@@ -344,6 +348,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	for _, c := range userConfig.Webhooks {
 		config := webhooks.Config{
 			Channel:        c.Channel,
+			BranchRegex:    c.BranchRegex,
 			Event:          c.Event,
 			Kind:           c.Kind,
 			WorkspaceRegex: c.WorkspaceRegex,

--- a/server/server.go
+++ b/server/server.go
@@ -141,9 +141,9 @@ type WebhookConfig struct {
 	// that is being modified for this event. If the regex matches, we'll
 	// send the webhook, ex. "production.*".
 	WorkspaceRegex string `mapstructure:"workspace-regex"`
-	// BranchRegex is a regex that is used to match against the branch
+	// BranchRegex is a regex that is used to match against the base branch
 	// that is being modified for this event. If the regex matches, we'll
-	// send the webhook, ex. "production.*".
+	// send the webhook, ex. "main.*".
 	BranchRegex string `mapstructure:"branch-regex"`
 	// Kind is the type of webhook we should send, ex. slack.
 	Kind string `mapstructure:"kind"`


### PR DESCRIPTION
## what

Add ability to send Slack notifications matched on base branch name

## why

We currently use the[ `default` workspace](https://www.runatlantis.io/docs/repo-level-atlantis-yaml.html#project) for a given Atlantis project but with separate branches per environment (`production`, `staging`, etc). We cannot filter the Slack notifications since they all match on the `default` workspace.

## tests

- [x] I have tested my changes by running `make test` and `make test-all`
- [x] Ran this branch of Atlantis [locally with ngrok](https://github.com/runatlantis/atlantis/blob/d218686830adc8a888bd77e9d80449d7e6c9ac81/CONTRIBUTING.md#calling-your-local-atlantis-from-github) with slack webhooks enabled on a [test terraform repo](https://github.com/smstone/terraform-module-test/pull/4) with the following `config.yaml`:
```
webhooks:
- event: apply
  workspace-regex: .*
  branch-regex: test-atlantis-slack
  kind: slack
  channel: auto-cicd-test
```

Produced the following slack notification:
<img width="485" alt="slack-test-1" src="https://github.com/runatlantis/atlantis/assets/515671/01ee22e8-613c-4a91-99a5-242bfc27457f">


