### PR TITLE
docs: Fix server side repo config document typo

### DIFF
--- a/runatlantis.io/docs/server-side-repo-config.md
+++ b/runatlantis.io/docs/server-side-repo-config.md
@@ -550,7 +550,7 @@ If you set a workflow with the key `default`, it will override this.
 | Key                    | Type                      | Default | Required  | Description                              |
 |------------------------|---------------------------|---------|-----------|------------------------------------------|
 | statsd                 | [Statsd](#statsd)         | none    | no        | Statsd metrics provider                  |
-| prometheus             | [Prometheus](#prometheus) | none    | no        | Statsd metrics provider                  |
+| prometheus             | [Prometheus](#prometheus) | none    | no        | Prometheus metrics provider              |
 
 ### Statsd
 


### PR DESCRIPTION
## what
This is a typo in documents. 


