### PR TITLE
docs: Update Docs for the Server Config Flag to Enable Failure on Pre Workflow Hook Errors

### DIFF
--- a/runatlantis.io/docs/pre-workflow-hooks.md
+++ b/runatlantis.io/docs/pre-workflow-hooks.md
@@ -15,9 +15,12 @@ workflows](custom-workflows.html#custom-run-command) in several ways.
 
 Pre workflow hooks can only be specified in the Server-Side Repo Config under the
 `repos` key.
+
 ::: tip Note
-`pre-workflow-hooks` do not prevent Atlantis from executing its
-workflows(`plan`, `apply`) even if a `run` command exits with an error.
+By default, `pre-workflow-hooks` do not prevent Atlantis from executing its
+workflows(`plan`, `apply`) even if a `run` command exits with an error. This
+behavior can be changed by setting the [fail-on-pre-workflow-hook-error](server-configuration.html#fail-on-pre-workflow-hook-error)
+flag in the Atlantis server configuration.
 ::: 
 
 ## Use Cases


### PR DESCRIPTION
## What

Update the Pre Workflow Hooks documentation with details of the new `fail-on-pre-workflow-hook-error` server configuration flag. This was missed from PR #3729. 
