### PR TITLE
fix: Change message for when request is not approved to be more accurate

### DIFF
--- a/server/events/command_requirement_handler.go
+++ b/server/events/command_requirement_handler.go
@@ -22,7 +22,7 @@ func (a *DefaultCommandRequirementHandler) ValidatePlanProject(repoDir string, c
 		switch req {
 		case raw.ApprovedRequirement:
 			if !ctx.PullReqStatus.ApprovalStatus.IsApproved {
-				return "Pull request must be approved by at least one person other than the author before running plan.", nil
+				return "Pull request must be approved according to the project's approval rules before running plan.", nil
 			}
 		case raw.MergeableRequirement:
 			if !ctx.PullReqStatus.Mergeable {

--- a/server/events/command_requirement_handler.go
+++ b/server/events/command_requirement_handler.go
@@ -70,7 +70,7 @@ func (a *DefaultCommandRequirementHandler) ValidateImportProject(repoDir string,
 		switch req {
 		case raw.ApprovedRequirement:
 			if !ctx.PullReqStatus.ApprovalStatus.IsApproved {
-				return "Pull request must be approved by at least one person other than the author before running import.", nil
+				return "Pull request must be approved according to the project's approval rules before running import.", nil
 			}
 		case raw.MergeableRequirement:
 			if !ctx.PullReqStatus.Mergeable {

--- a/server/events/command_requirement_handler.go
+++ b/server/events/command_requirement_handler.go
@@ -43,7 +43,7 @@ func (a *DefaultCommandRequirementHandler) ValidateApplyProject(repoDir string, 
 		switch req {
 		case raw.ApprovedRequirement:
 			if !ctx.PullReqStatus.ApprovalStatus.IsApproved {
-				return "Pull request must be approved by at least one person other than the author before running apply.", nil
+				return "Pull request must be approved according to the project's approval rules before running apply.", nil
 			}
 		// this should come before mergeability check since mergeability is a superset of this check.
 		case valid.PoliciesPassedCommandReq:

--- a/server/events/command_requirement_handler_test.go
+++ b/server/events/command_requirement_handler_test.go
@@ -58,7 +58,7 @@ func TestAggregateApplyRequirements_ValidatePlanProject(t *testing.T) {
 					ApprovalStatus: models.ApprovalStatus{IsApproved: false},
 				},
 			},
-			wantFailure: "Pull request must be approved by at least one person other than the author before running plan.",
+			wantFailure: "Pull request must be approved according to the project's approval rules before running plan.",
 			wantErr:     assert.NoError,
 		},
 		{
@@ -142,7 +142,7 @@ func TestAggregateApplyRequirements_ValidateApplyProject(t *testing.T) {
 					ApprovalStatus: models.ApprovalStatus{IsApproved: false},
 				},
 			},
-			wantFailure: "Pull request must be approved by at least one person other than the author before running apply.",
+			wantFailure: "Pull request must be approved according to the project's approval rules before running plan.",
 			wantErr:     assert.NoError,
 		},
 		{
@@ -249,7 +249,7 @@ func TestAggregateApplyRequirements_ValidateImportProject(t *testing.T) {
 					ApprovalStatus: models.ApprovalStatus{IsApproved: false},
 				},
 			},
-			wantFailure: "Pull request must be approved by at least one person other than the author before running import.",
+			wantFailure: "Pull request must be approved according to the project's approval rules before running plan.",
 			wantErr:     assert.NoError,
 		},
 		{

--- a/server/events/command_requirement_handler_test.go
+++ b/server/events/command_requirement_handler_test.go
@@ -142,7 +142,7 @@ func TestAggregateApplyRequirements_ValidateApplyProject(t *testing.T) {
 					ApprovalStatus: models.ApprovalStatus{IsApproved: false},
 				},
 			},
-			wantFailure: "Pull request must be approved according to the project's approval rules before running plan.",
+			wantFailure: "Pull request must be approved according to the project's approval rules before running apply.",
 			wantErr:     assert.NoError,
 		},
 		{
@@ -249,7 +249,7 @@ func TestAggregateApplyRequirements_ValidateImportProject(t *testing.T) {
 					ApprovalStatus: models.ApprovalStatus{IsApproved: false},
 				},
 			},
-			wantFailure: "Pull request must be approved according to the project's approval rules before running apply.",
+			wantFailure: "Pull request must be approved according to the project's approval rules before running import.",
 			wantErr:     assert.NoError,
 		},
 		{

--- a/server/events/command_requirement_handler_test.go
+++ b/server/events/command_requirement_handler_test.go
@@ -249,7 +249,7 @@ func TestAggregateApplyRequirements_ValidateImportProject(t *testing.T) {
 					ApprovalStatus: models.ApprovalStatus{IsApproved: false},
 				},
 			},
-			wantFailure: "Pull request must be approved according to the project's approval rules before running plan.",
+			wantFailure: "Pull request must be approved according to the project's approval rules before running apply.",
 			wantErr:     assert.NoError,
 		},
 		{

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -272,7 +272,7 @@ func TestDefaultProjectCommandRunner_ApplyNotApproved(t *testing.T) {
 	When(mockWorkingDir.GetWorkingDir(ctx.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(tmp, nil)
 
 	res := runner.Apply(ctx)
-	Equals(t, "Pull request must be approved by at least one person other than the author before running apply.", res.Failure)
+	Equals(t, "Pull request must be approved according to the project's approval rules before running apply.", res.Failure)
 }
 
 // Test that if mergeable is required and the PR isn't mergeable we give an error.
@@ -676,7 +676,7 @@ func TestDefaultProjectCommandRunner_Import(t *testing.T) {
 					IsApproved: false,
 				},
 			},
-			expFailure: "Pull request must be approved by at least one person other than the author before running import.",
+			expFailure: "Pull request must be approved according to the project's approval rules before running import.",
 		},
 	}
 


### PR DESCRIPTION
## what

Changed verbiage on comment that is posted on a PR when the approval is required and not given.


## why

The comment currently says "Pull request must be approved by at least one person other than the author before running apply". However that's not always true. What the code is actually looking for is for whether the relevant VCS calls this request "approved". In my case of gitlab, but presumably in other VCSs as well, there are a lot of things that could go into determining whether an approval is "sufficient" or not, which may or may not include a person other than the other approving. This causes confusion for users who, understandably, think they need to find someone else to approve their MR, when they might not.

Additionally, I don't see any code in https://github.com/runatlantis/atlantis/tree/master/server/events/vcs that would indicate that atlantis has logic that expects an approval by "at least one person other than the author".

It would potentially be better (but a lot more work) to have the VCSs expose a description of what it meant for a specific PR to be approved, and relay that to the end user. That's a possible followup from this, but this change at least makes the statement more accurate.

## tests

I ran unit tests, should be sufficient since it's just changing a string.

## references

closes #2290 (which was already closed by virtue of being stale).