### PR TITLE
fix: checkout before `dorny/paths-filter`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v2
         id: changes
         with:


### PR DESCRIPTION
## what
* Failure to run tests on `main`: https://github.com/runatlantis/atlantis/actions/runs/6112372312/job/16589702601
* Caused by https://github.com/runatlantis/atlantis/pull/3675
* The code must be checked out to run properly on push events (main branch) as mentioned in https://github.com/dorny/paths-filter?tab=readme-ov-file#supported-workflows

