### PR TITLE
feat: Add portability to command invocation unit tests

### DIFF
--- a/server/core/runtime/post_workflow_hook_runner_test.go
+++ b/server/core/runtime/post_workflow_hook_runner_test.go
@@ -1,6 +1,7 @@
 package runtime_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -18,6 +19,8 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 
 	defaultShell := "sh"
 	defaultShellArgs := "-c"
+	defautShellCommandNotFoundErrorFormat := commandNotFoundErrorFormat(defaultShell, defaultShellArgs)
+	defaultUnterminatedStringError := unterminatedStringError(defaultShell, defaultShellArgs)
 
 	cases := []struct {
 		Command        string
@@ -63,7 +66,7 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 			Command:        "echo 'a",
 			Shell:          defaultShell,
 			ShellArgs:      defaultShellArgs,
-			ExpOut:         "sh: 1: Syntax error: Unterminated quoted string\r\n",
+			ExpOut:         defaultUnterminatedStringError,
 			ExpErr:         "exit status 2: running \"sh -c echo 'a\" in",
 			ExpDescription: "",
 		},
@@ -79,7 +82,7 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 			Command:        "lkjlkj",
 			Shell:          defaultShell,
 			ShellArgs:      defaultShellArgs,
-			ExpOut:         "sh: 1: lkjlkj: not found\r\n",
+			ExpOut:         fmt.Sprintf(defautShellCommandNotFoundErrorFormat, "lkjlkj"),
 			ExpErr:         "exit status 127: running \"sh -c lkjlkj\" in",
 			ExpDescription: "",
 		},


### PR DESCRIPTION
## what

Add a switch to detect the use of GOOS of darwin, then change the expected output for certain commands that call `exec.Command()`.

## why

Right now on `main` running `make test` causes a bunch of verbose errors (see below). Running `make docker/test` had all tests pass (still the case with this change), it's just that the `/bin/sh` has slightly different output based on operating system.

It's possible (probable) that other OSs (or operating system versions? Maybe even distros for linux?) will have still other outputs that need to be handled. I haven't attempted to address that, and tests will still fail in those cases, but this will give users a hint of how they could add code to fix for their `sh` commands.

## tests

Before:
```
atlantis % make test
?   	github.com/runatlantis/atlantis	[no test files]
ok  	github.com/runatlantis/atlantis/cmd	(cached)
ok  	github.com/runatlantis/atlantis/server	(cached)
ok  	github.com/runatlantis/atlantis/server/controllers	(cached)
ok  	github.com/runatlantis/atlantis/server/controllers/events	(cached)
ok  	github.com/runatlantis/atlantis/server/controllers/templates	(cached)
ok  	github.com/runatlantis/atlantis/server/controllers/websocket	(cached)
ok  	github.com/runatlantis/atlantis/server/core/config	(cached)
ok  	github.com/runatlantis/atlantis/server/core/config/raw	(cached)
ok  	github.com/runatlantis/atlantis/server/core/config/valid	(cached)
ok  	github.com/runatlantis/atlantis/server/core/db	(cached)
ok  	github.com/runatlantis/atlantis/server/core/locking	(cached)
ok  	github.com/runatlantis/atlantis/server/core/redis	(cached)
?   	github.com/runatlantis/atlantis/testdrive	[no test files]
--- FAIL: TestPostWorkflowHookRunner_Run (0.15s)
    logger.go:130: 2023-09-10T17:24:27.187-0400	INFO	successfully ran "sh -c " in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPostWorkflowHookRunner_Run1345747504/001"
    logger.go:130: 2023-09-10T17:24:27.198-0400	INFO	successfully ran "sh -c echo hi" in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPostWorkflowHookRunner_Run1345747504/002"
    logger.go:130: 2023-09-10T17:24:27.209-0400	INFO	successfully ran "sh -c printf \\'your main.tf file does not provide default region.\\\\ncheck\\'" in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPostWorkflowHookRunner_Run1345747504/003"
    logger.go:130: 2023-09-10T17:24:27.220-0400	INFO	successfully ran "sh -c printf 'your main.tf file does not provide default region.\\ncheck'" in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPostWorkflowHookRunner_Run1345747504/004"
    logger.go:130: 2023-09-10T17:24:27.231-0400	DEBUG	error: exit status 2: running "sh -c echo 'a" in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPostWorkflowHookRunner_Run1345747504/005": 
        sh: -c: line 0: unexpected EOF while looking for matching `''
        sh: -c: line 1: syntax error: unexpected end of file
    testing_t_support.go:41: 
        	/Users/lukemassa/go/pkg/mod/github.com/petergtz/pegomock/v4@v4.0.0/testing_t_support.go:40 +0x51
        github.com/petergtz/pegomock/v4.(*GenericMock).Verify(0xc0003d7350, 0x0, {0x1493f20, 0xc00048b860}, {0x13f75fb, 0x10}, {0xc00048b920?, 0x3, 0x3}, {0xc000147878, ...})
        	/Users/lukemassa/go/pkg/mod/github.com/petergtz/pegomock/v4@v4.0.0/dsl.go:153 +0x675
        github.com/runatlantis/atlantis/server/jobs/mocks.(*VerifierMockProjectCommandOutputHandler).SendWorkflowHook(_, {{{0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x0, ...}, ...}, ...}, ...)
        	/Users/lukemassa/atlantis/server/jobs/mocks/mock_project_command_output_handler.go:300 +0x1cb
        github.com/runatlantis/atlantis/server/core/runtime_test.TestPostWorkflowHookRunner_Run.func1(0xc0003ecb60?)
        	/Users/lukemassa/atlantis/server/core/runtime/post_workflow_hook_runner_test.go:188 +0x506
        testing.tRunner(0xc0003ecb60, 0xc0003fa9b0)
        	/usr/local/Cellar/go/1.21.0/libexec/src/testing/testing.go:1595 +0xff
        created by testing.(*T).Run in goroutine 166
        	/usr/local/Cellar/go/1.21.0/libexec/src/testing/testing.go:1648 +0x3ad
        
        Mock invocation count for SendWorkflowHook(Any(models.WorkflowHookCommandContext), Eq("sh: 1: Syntax error: Unterminated quoted string\r\n"), Eq(false)) does not match expectation.
        
        	Expected: 1; but got: 0
        
        	Actual interactions with this mock were:
        	SendWorkflowHook(models.WorkflowHookCommandContext{BaseRepo:models.Repo{FullName:"", Owner:"baseowner", Name:"basename", CloneURL:"", SanitizedCloneURL:"", VCSHost:models.VCSHost{Hostname:"", Type:0}}, HeadRepo:models.Repo{FullName:"", Owner:"headowner", Name:"headname", CloneURL:"", SanitizedCloneURL:"", VCSHost:models.VCSHost{Hostname:"", Type:0}}, Log:(*logging.StructuredLogger)(0xc000317d40), Pull:models.PullRequest{Num:2, HeadCommit:"12345abcdef", URL:"https://github.com/runatlantis/atlantis/pull/2", HeadBranch:"add-feat", BaseBranch:"main", Author:"acme", State:0, BaseRepo:models.Repo{FullName:"", Owner:"", Name:"", CloneURL:"", SanitizedCloneURL:"", VCSHost:models.VCSHost{Hostname:"", Type:0}}}, User:models.User{Username:"acme-user"}, Verbose:false, EscapedCommentArgs:[]string(nil), HookID:"", CommandName:"plan"}, "sh: -c: line 0: unexpected EOF while looking for matching `''\r\nsh: -c: line 1: syntax error: unexpected end of file\r\n", false)
        	SendWorkflowHook(models.WorkflowHookCommandContext{BaseRepo:models.Repo{FullName:"", Owner:"baseowner", Name:"basename", CloneURL:"", SanitizedCloneURL:"", VCSHost:models.VCSHost{Hostname:"", Type:0}}, HeadRepo:models.Repo{FullName:"", Owner:"headowner", Name:"headname", CloneURL:"", SanitizedCloneURL:"", VCSHost:models.VCSHost{Hostname:"", Type:0}}, Log:(*logging.StructuredLogger)(0xc000317d40), Pull:models.PullRequest{Num:2, HeadCommit:"12345abcdef", URL:"https://github.com/runatlantis/atlantis/pull/2", HeadBranch:"add-feat", BaseBranch:"main", Author:"acme", State:0, BaseRepo:models.Repo{FullName:"", Owner:"", Name:"", CloneURL:"", SanitizedCloneURL:"", VCSHost:models.VCSHost{Hostname:"", Type:0}}}, User:models.User{Username:"acme-user"}, Verbose:false, EscapedCommentArgs:[]string(nil), HookID:"", CommandName:"plan"}, "\n", true)
    logger.go:130: 2023-09-10T17:24:27.246-0400	INFO	successfully ran "sh -c echo hi >> file && cat file" in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPostWorkflowHookRunner_Run1345747504/006"
    logger.go:130: 2023-09-10T17:24:27.257-0400	DEBUG	error: exit status 127: running "sh -c lkjlkj" in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPostWorkflowHookRunner_Run1345747504/007": 
        sh: lkjlkj: command not found
    testing_t_support.go:41: 
        	/Users/lukemassa/go/pkg/mod/github.com/petergtz/pegomock/v4@v4.0.0/testing_t_support.go:40 +0x51
        github.com/petergtz/pegomock/v4.(*GenericMock).Verify(0xc0003d76b0, 0x0, {0x1493f20, 0xc0004d0450}, {0x13f75fb, 0x10}, {0xc0004d0510?, 0x3, 0x3}, {0xc000147878, ...})
        	/Users/lukemassa/go/pkg/mod/github.com/petergtz/pegomock/v4@v4.0.0/dsl.go:153 +0x675
        github.com/runatlantis/atlantis/server/jobs/mocks.(*VerifierMockProjectCommandOutputHandler).SendWorkflowHook(_, {{{0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x0, ...}, ...}, ...}, ...)
        	/Users/lukemassa/atlantis/server/jobs/mocks/mock_project_command_output_handler.go:300 +0x1cb
        github.com/runatlantis/atlantis/server/core/runtime_test.TestPostWorkflowHookRunner_Run.func1(0xc0003ecea0?)
        	/Users/lukemassa/atlantis/server/core/runtime/post_workflow_hook_runner_test.go:188 +0x506
        testing.tRunner(0xc0003ecea0, 0xc0003fae60)
        	/usr/local/Cellar/go/1.21.0/libexec/src/testing/testing.go:1595 +0xff
        created by testing.(*T).Run in goroutine 166
        	/usr/local/Cellar/go/1.21.0/libexec/src/testing/testing.go:1648 +0x3ad
        
        Mock invocation count for SendWorkflowHook(Any(models.WorkflowHookCommandContext), Eq("sh: 1: lkjlkj: not found\r\n"), Eq(false)) does not match expectation.
        
        	Expected: 1; but got: 0
        
        	Actual interactions with this mock were:
        	SendWorkflowHook(models.WorkflowHookCommandContext{BaseRepo:models.Repo{FullName:"", Owner:"baseowner", Name:"basename", CloneURL:"", SanitizedCloneURL:"", VCSHost:models.VCSHost{Hostname:"", Type:0}}, HeadRepo:models.Repo{FullName:"", Owner:"headowner", Name:"headname", CloneURL:"", SanitizedCloneURL:"", VCSHost:models.VCSHost{Hostname:"", Type:0}}, Log:(*logging.StructuredLogger)(0xc0004d2080), Pull:models.PullRequest{Num:2, HeadCommit:"12345abcdef", URL:"https://github.com/runatlantis/atlantis/pull/2", HeadBranch:"add-feat", BaseBranch:"main", Author:"acme", State:0, BaseRepo:models.Repo{FullName:"", Owner:"", Name:"", CloneURL:"", SanitizedCloneURL:"", VCSHost:models.VCSHost{Hostname:"", Type:0}}}, User:models.User{Username:"acme-user"}, Verbose:false, EscapedCommentArgs:[]string(nil), HookID:"", CommandName:"plan"}, "sh: lkjlkj: command not found\r\n", false)
        	SendWorkflowHook(models.WorkflowHookCommandContext{BaseRepo:models.Repo{FullName:"", Owner:"baseowner", Name:"basename", CloneURL:"", SanitizedCloneURL:"", VCSHost:models.VCSHost{Hostname:"", Type:0}}, HeadRepo:models.Repo{FullName:"", Owner:"headowner", Name:"headname", CloneURL:"", SanitizedCloneURL:"", VCSHost:models.VCSHost{Hostname:"", Type:0}}, Log:(*logging.StructuredLogger)(0xc0004d2080), Pull:models.PullRequest{Num:2, HeadCommit:"12345abcdef", URL:"https://github.com/runatlantis/atlantis/pull/2", HeadBranch:"add-feat", BaseBranch:"main", Author:"acme", State:0, BaseRepo:models.Repo{FullName:"", Owner:"", Name:"", CloneURL:"", SanitizedCloneURL:"", VCSHost:models.VCSHost{Hostname:"", Type:0}}}, User:models.User{Username:"acme-user"}, Verbose:false, EscapedCommentArgs:[]string(nil), HookID:"", CommandName:"plan"}, "\n", true)
    logger.go:130: 2023-09-10T17:24:27.270-0400	INFO	successfully ran "sh -c echo base_repo_name=$BASE_REPO_NAME base_repo_owner=$BASE_REPO_OWNER head_repo_name=$HEAD_REPO_NAME head_repo_owner=$HEAD_REPO_OWNER head_branch_name=$HEAD_BRANCH_NAME head_commit=$HEAD_COMMIT base_branch_name=$BASE_BRANCH_NAME pull_num=$PULL_NUM pull_url=$PULL_URL pull_author=$PULL_AUTHOR" in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPostWorkflowHookRunner_Run1345747504/008"
    logger.go:130: 2023-09-10T17:24:27.281-0400	INFO	successfully ran "sh -c echo user_name=$USER_NAME" in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPostWorkflowHookRunner_Run1345747504/009"
    logger.go:130: 2023-09-10T17:24:27.293-0400	INFO	successfully ran "sh -c echo something > $OUTPUT_STATUS_FILE" in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPostWorkflowHookRunner_Run1345747504/010"
    logger.go:130: 2023-09-10T17:24:27.300-0400	INFO	successfully ran "bash -c echo shell test 1" in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPostWorkflowHookRunner_Run1345747504/011"
    logger.go:130: 2023-09-10T17:24:27.310-0400	INFO	successfully ran "sh -cx echo shell test 2" in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPostWorkflowHookRunner_Run1345747504/012"
    logger.go:130: 2023-09-10T17:24:27.317-0400	INFO	successfully ran "bash -cv echo shell test 3" in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPostWorkflowHookRunner_Run1345747504/013"
--- FAIL: TestPreWorkflowHookRunner_Run (0.15s)
    logger.go:130: 2023-09-10T17:24:27.332-0400	INFO	successfully ran "sh -c " in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPreWorkflowHookRunner_Run2838667045/001"
    logger.go:130: 2023-09-10T17:24:27.343-0400	INFO	successfully ran "sh -c echo hi" in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPreWorkflowHookRunner_Run2838667045/002"
    logger.go:130: 2023-09-10T17:24:27.354-0400	INFO	successfully ran "sh -c printf \\'your main.tf file does not provide default region.\\\\ncheck\\'" in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPreWorkflowHookRunner_Run2838667045/003"
    logger.go:130: 2023-09-10T17:24:27.366-0400	INFO	successfully ran "sh -c printf 'your main.tf file does not provide default region.\\ncheck'" in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPreWorkflowHookRunner_Run2838667045/004"
    logger.go:130: 2023-09-10T17:24:27.376-0400	DEBUG	error: exit status 2: running "sh -c echo 'a" in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPreWorkflowHookRunner_Run2838667045/005": 
        sh: -c: line 0: unexpected EOF while looking for matching `''
        sh: -c: line 1: syntax error: unexpected end of file
    testing_t_support.go:41: 
        	/Users/lukemassa/go/pkg/mod/github.com/petergtz/pegomock/v4@v4.0.0/testing_t_support.go:40 +0x51
        github.com/petergtz/pegomock/v4.(*GenericMock).Verify(0xc0000a8dc8, 0x0, {0x1493f20, 0xc00042d500}, {0x13f75fb, 0x10}, {0xc00042d5c0?, 0x3, 0x3}, {0xc0000a7878, ...})
        	/Users/lukemassa/go/pkg/mod/github.com/petergtz/pegomock/v4@v4.0.0/dsl.go:153 +0x675
        github.com/runatlantis/atlantis/server/jobs/mocks.(*VerifierMockProjectCommandOutputHandler).SendWorkflowHook(_, {{{0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x0, ...}, ...}, ...}, ...)
        	/Users/lukemassa/atlantis/server/jobs/mocks/mock_project_command_output_handler.go:300 +0x1cb
        github.com/runatlantis/atlantis/server/core/runtime_test.TestPreWorkflowHookRunner_Run.func1(0xc000093520?)
        	/Users/lukemassa/atlantis/server/core/runtime/pre_workflow_hook_runner_test.go:188 +0x506
        testing.tRunner(0xc000093520, 0xc0002b19f0)
        	/usr/local/Cellar/go/1.21.0/libexec/src/testing/testing.go:1595 +0xff
        created by testing.(*T).Run in goroutine 159
        	/usr/local/Cellar/go/1.21.0/libexec/src/testing/testing.go:1648 +0x3ad
        
        Mock invocation count for SendWorkflowHook(Any(models.WorkflowHookCommandContext), Eq("sh: 1: Syntax error: Unterminated quoted string\r\n"), Eq(false)) does not match expectation.
        
        	Expected: 1; but got: 0
        
        	Actual interactions with this mock were:
        	SendWorkflowHook(models.WorkflowHookCommandContext{BaseRepo:models.Repo{FullName:"", Owner:"baseowner", Name:"basename", CloneURL:"", SanitizedCloneURL:"", VCSHost:models.VCSHost{Hostname:"", Type:0}}, HeadRepo:models.Repo{FullName:"", Owner:"headowner", Name:"headname", CloneURL:"", SanitizedCloneURL:"", VCSHost:models.VCSHost{Hostname:"", Type:0}}, Log:(*logging.StructuredLogger)(0xc0001c5980), Pull:models.PullRequest{Num:2, HeadCommit:"12345abcdef", URL:"https://github.com/runatlantis/atlantis/pull/2", HeadBranch:"add-feat", BaseBranch:"main", Author:"acme", State:0, BaseRepo:models.Repo{FullName:"", Owner:"", Name:"", CloneURL:"", SanitizedCloneURL:"", VCSHost:models.VCSHost{Hostname:"", Type:0}}}, User:models.User{Username:"acme-user"}, Verbose:false, EscapedCommentArgs:[]string(nil), HookID:"", CommandName:"plan"}, "sh: -c: line 0: unexpected EOF while looking for matching `''\r\nsh: -c: line 1: syntax error: unexpected end of file\r\n", false)
        	SendWorkflowHook(models.WorkflowHookCommandContext{BaseRepo:models.Repo{FullName:"", Owner:"baseowner", Name:"basename", CloneURL:"", SanitizedCloneURL:"", VCSHost:models.VCSHost{Hostname:"", Type:0}}, HeadRepo:models.Repo{FullName:"", Owner:"headowner", Name:"headname", CloneURL:"", SanitizedCloneURL:"", VCSHost:models.VCSHost{Hostname:"", Type:0}}, Log:(*logging.StructuredLogger)(0xc0001c5980), Pull:models.PullRequest{Num:2, HeadCommit:"12345abcdef", URL:"https://github.com/runatlantis/atlantis/pull/2", HeadBranch:"add-feat", BaseBranch:"main", Author:"acme", State:0, BaseRepo:models.Repo{FullName:"", Owner:"", Name:"", CloneURL:"", SanitizedCloneURL:"", VCSHost:models.VCSHost{Hostname:"", Type:0}}}, User:models.User{Username:"acme-user"}, Verbose:false, EscapedCommentArgs:[]string(nil), HookID:"", CommandName:"plan"}, "\n", true)
    logger.go:130: 2023-09-10T17:24:27.393-0400	INFO	successfully ran "sh -c echo hi >> file && cat file" in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPreWorkflowHookRunner_Run2838667045/006"
    logger.go:130: 2023-09-10T17:24:27.405-0400	DEBUG	error: exit status 127: running "sh -c lkjlkj" in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPreWorkflowHookRunner_Run2838667045/007": 
        sh: lkjlkj: command not found
    testing_t_support.go:41: 
        	/Users/lukemassa/go/pkg/mod/github.com/petergtz/pegomock/v4@v4.0.0/testing_t_support.go:40 +0x51
        github.com/petergtz/pegomock/v4.(*GenericMock).Verify(0xc0002901e0, 0x0, {0x1493f20, 0xc0004d0930}, {0x13f75fb, 0x10}, {0xc0004d09f0?, 0x3, 0x3}, {0xc0000a7878, ...})
        	/Users/lukemassa/go/pkg/mod/github.com/petergtz/pegomock/v4@v4.0.0/dsl.go:153 +0x675
        github.com/runatlantis/atlantis/server/jobs/mocks.(*VerifierMockProjectCommandOutputHandler).SendWorkflowHook(_, {{{0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x0, ...}, ...}, ...}, ...)
        	/Users/lukemassa/atlantis/server/jobs/mocks/mock_project_command_output_handler.go:300 +0x1cb
        github.com/runatlantis/atlantis/server/core/runtime_test.TestPreWorkflowHookRunner_Run.func1(0xc000434820?)
        	/Users/lukemassa/atlantis/server/core/runtime/pre_workflow_hook_runner_test.go:188 +0x506
        testing.tRunner(0xc000434820, 0xc0003fa2d0)
        	/usr/local/Cellar/go/1.21.0/libexec/src/testing/testing.go:1595 +0xff
        created by testing.(*T).Run in goroutine 159
        	/usr/local/Cellar/go/1.21.0/libexec/src/testing/testing.go:1648 +0x3ad
        
        Mock invocation count for SendWorkflowHook(Any(models.WorkflowHookCommandContext), Eq("sh: 1: lkjlkj: not found\r\n"), Eq(false)) does not match expectation.
        
        	Expected: 1; but got: 0
        
        	Actual interactions with this mock were:
        	SendWorkflowHook(models.WorkflowHookCommandContext{BaseRepo:models.Repo{FullName:"", Owner:"baseowner", Name:"basename", CloneURL:"", SanitizedCloneURL:"", VCSHost:models.VCSHost{Hostname:"", Type:0}}, HeadRepo:models.Repo{FullName:"", Owner:"headowner", Name:"headname", CloneURL:"", SanitizedCloneURL:"", VCSHost:models.VCSHost{Hostname:"", Type:0}}, Log:(*logging.StructuredLogger)(0xc000292380), Pull:models.PullRequest{Num:2, HeadCommit:"12345abcdef", URL:"https://github.com/runatlantis/atlantis/pull/2", HeadBranch:"add-feat", BaseBranch:"main", Author:"acme", State:0, BaseRepo:models.Repo{FullName:"", Owner:"", Name:"", CloneURL:"", SanitizedCloneURL:"", VCSHost:models.VCSHost{Hostname:"", Type:0}}}, User:models.User{Username:"acme-user"}, Verbose:false, EscapedCommentArgs:[]string(nil), HookID:"", CommandName:"plan"}, "sh: lkjlkj: command not found\r\n", false)
        	SendWorkflowHook(models.WorkflowHookCommandContext{BaseRepo:models.Repo{FullName:"", Owner:"baseowner", Name:"basename", CloneURL:"", SanitizedCloneURL:"", VCSHost:models.VCSHost{Hostname:"", Type:0}}, HeadRepo:models.Repo{FullName:"", Owner:"headowner", Name:"headname", CloneURL:"", SanitizedCloneURL:"", VCSHost:models.VCSHost{Hostname:"", Type:0}}, Log:(*logging.StructuredLogger)(0xc000292380), Pull:models.PullRequest{Num:2, HeadCommit:"12345abcdef", URL:"https://github.com/runatlantis/atlantis/pull/2", HeadBranch:"add-feat", BaseBranch:"main", Author:"acme", State:0, BaseRepo:models.Repo{FullName:"", Owner:"", Name:"", CloneURL:"", SanitizedCloneURL:"", VCSHost:models.VCSHost{Hostname:"", Type:0}}}, User:models.User{Username:"acme-user"}, Verbose:false, EscapedCommentArgs:[]string(nil), HookID:"", CommandName:"plan"}, "\n", true)
    logger.go:130: 2023-09-10T17:24:27.417-0400	INFO	successfully ran "sh -c echo base_repo_name=$BASE_REPO_NAME base_repo_owner=$BASE_REPO_OWNER head_repo_name=$HEAD_REPO_NAME head_repo_owner=$HEAD_REPO_OWNER head_branch_name=$HEAD_BRANCH_NAME head_commit=$HEAD_COMMIT base_branch_name=$BASE_BRANCH_NAME pull_num=$PULL_NUM pull_url=$PULL_URL pull_author=$PULL_AUTHOR" in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPreWorkflowHookRunner_Run2838667045/008"
    logger.go:130: 2023-09-10T17:24:27.429-0400	INFO	successfully ran "sh -c echo user_name=$USER_NAME" in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPreWorkflowHookRunner_Run2838667045/009"
    logger.go:130: 2023-09-10T17:24:27.442-0400	INFO	successfully ran "sh -c echo something > $OUTPUT_STATUS_FILE" in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPreWorkflowHookRunner_Run2838667045/010"
    logger.go:130: 2023-09-10T17:24:27.450-0400	INFO	successfully ran "bash -c echo shell test 1" in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPreWorkflowHookRunner_Run2838667045/011"
    logger.go:130: 2023-09-10T17:24:27.461-0400	INFO	successfully ran "sh -cx echo shell test 2" in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPreWorkflowHookRunner_Run2838667045/012"
    logger.go:130: 2023-09-10T17:24:27.468-0400	INFO	successfully ran "bash -cv echo shell test 3" in "/var/folders/rd/92z6dwy94ds2kzl28nr1_t0r0000gn/T/TestPreWorkflowHookRunner_Run2838667045/013"
FAIL
FAIL	github.com/runatlantis/atlantis/server/core/runtime	1.756s
```

After:
```
atlantis % make test
?   	github.com/runatlantis/atlantis	[no test files]
ok  	github.com/runatlantis/atlantis/cmd	(cached)
ok  	github.com/runatlantis/atlantis/server	(cached)
ok  	github.com/runatlantis/atlantis/server/controllers	(cached)
ok  	github.com/runatlantis/atlantis/server/controllers/events	(cached)
ok  	github.com/runatlantis/atlantis/server/controllers/templates	(cached)
ok  	github.com/runatlantis/atlantis/server/controllers/websocket	(cached)
ok  	github.com/runatlantis/atlantis/server/core/config	(cached)
ok  	github.com/runatlantis/atlantis/server/core/config/raw	(cached)
ok  	github.com/runatlantis/atlantis/server/core/config/valid	(cached)
ok  	github.com/runatlantis/atlantis/server/core/db	(cached)
ok  	github.com/runatlantis/atlantis/server/core/locking	(cached)
ok  	github.com/runatlantis/atlantis/server/core/redis	(cached)
ok  	github.com/runatlantis/atlantis/server/core/runtime	(cached)
ok  	github.com/runatlantis/atlantis/server/core/runtime/cache	(cached)
ok  	github.com/runatlantis/atlantis/server/core/runtime/common	(cached)
ok  	github.com/runatlantis/atlantis/server/core/runtime/models	(cached)
ok  	github.com/runatlantis/atlantis/server/core/runtime/policy	(cached)
?   	github.com/runatlantis/atlantis/testdrive	[no test files]
ok  	github.com/runatlantis/atlantis/server/core/terraform	(cached)
ok  	github.com/runatlantis/atlantis/server/events	(cached)
ok  	github.com/runatlantis/atlantis/server/events/command	(cached)
ok  	github.com/runatlantis/atlantis/server/events/models	(cached)
ok  	github.com/runatlantis/atlantis/server/events/terraform/ansi	(cached)
ok  	github.com/runatlantis/atlantis/server/events/vcs	(cached)
ok  	github.com/runatlantis/atlantis/server/events/vcs/bitbucketcloud	(cached)
ok  	github.com/runatlantis/atlantis/server/events/vcs/bitbucketserver	(cached)
ok  	github.com/runatlantis/atlantis/server/events/vcs/common	(cached)
ok  	github.com/runatlantis/atlantis/server/events/webhooks	(cached)
ok  	github.com/runatlantis/atlantis/server/jobs	(cached)
ok  	github.com/runatlantis/atlantis/server/logging	(cached)
ok  	github.com/runatlantis/atlantis/server/metrics	(cached)
ok  	github.com/runatlantis/atlantis/server/recovery	(cached)
ok  	github.com/runatlantis/atlantis/server/scheduled	(cached)
ok  	github.com/runatlantis/atlantis/server/utils	(cached)
```

## references