### PR TITLE
ci: auto generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,7 +2,6 @@ changelog:
   exclude:
     labels:
       - ignore-for-release
-      - docs
       - github-actions
     authors:
       - octocat
@@ -22,9 +21,3 @@ changelog:
     - title: Other Changes
       labels:
         - "*"
-    - title: Dependencies
-      labels:
-        - dependencies
-    - title: Build
-      labels:
-        - build


### PR DESCRIPTION
## what

Refactored the release notes a bit to catch-all at the end and surface fixes/features better.


## why

docs were excluded but we auto-tag docs when the docs are touched even in fix/feature PRs. This caused important changes to be excluded from release notes.


## references

fixes #3667 

