### PR TITLE
fix: make go-generate now creates working mocks out of the box

### DIFF
--- a/server/core/runtime/mocks/mock_status_updater.go
+++ b/server/core/runtime/mocks/mock_status_updater.go
@@ -26,16 +26,16 @@ func NewMockStatusUpdater(options ...pegomock.Option) *MockStatusUpdater {
 func (mock *MockStatusUpdater) SetFailHandler(fh pegomock.FailHandler) { mock.fail = fh }
 func (mock *MockStatusUpdater) FailHandler() pegomock.FailHandler      { return mock.fail }
 
-func (mock *MockStatusUpdater) UpdateProject(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus, url string, result *command.ProjectResult) error {
+func (mock *MockStatusUpdater) UpdateProject(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus, url string, res *command.ProjectResult) error {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockStatusUpdater().")
 	}
-	params := []pegomock.Param{ctx, cmdName, status, url, result}
-	pegomockResult := pegomock.GetGenericMockFrom(mock).Invoke("UpdateProject", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
+	params := []pegomock.Param{ctx, cmdName, status, url, res}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("UpdateProject", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 error
-	if len(pegomockResult) != 0 {
-		if pegomockResult[0] != nil {
-			ret0 = pegomockResult[0].(error)
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(error)
 		}
 	}
 	return ret0
@@ -78,8 +78,8 @@ type VerifierMockStatusUpdater struct {
 	timeout                time.Duration
 }
 
-func (verifier *VerifierMockStatusUpdater) UpdateProject(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus, url string, result *command.ProjectResult) *MockStatusUpdater_UpdateProject_OngoingVerification {
-	params := []pegomock.Param{ctx, cmdName, status, url, result}
+func (verifier *VerifierMockStatusUpdater) UpdateProject(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus, url string, res *command.ProjectResult) *MockStatusUpdater_UpdateProject_OngoingVerification {
+	params := []pegomock.Param{ctx, cmdName, status, url, res}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "UpdateProject", params, verifier.timeout)
 	return &MockStatusUpdater_UpdateProject_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -90,8 +90,8 @@ type MockStatusUpdater_UpdateProject_OngoingVerification struct {
 }
 
 func (c *MockStatusUpdater_UpdateProject_OngoingVerification) GetCapturedArguments() (command.ProjectContext, command.Name, models.CommitStatus, string, *command.ProjectResult) {
-	ctx, cmdName, status, url, result := c.GetAllCapturedArguments()
-	return ctx[len(ctx)-1], cmdName[len(cmdName)-1], status[len(status)-1], url[len(url)-1], result[len(result)-1]
+	ctx, cmdName, status, url, res := c.GetAllCapturedArguments()
+	return ctx[len(ctx)-1], cmdName[len(cmdName)-1], status[len(status)-1], url[len(url)-1], res[len(res)-1]
 }
 
 func (c *MockStatusUpdater_UpdateProject_OngoingVerification) GetAllCapturedArguments() (_param0 []command.ProjectContext, _param1 []command.Name, _param2 []models.CommitStatus, _param3 []string, _param4 []*command.ProjectResult) {

--- a/server/core/runtime/runtime.go
+++ b/server/core/runtime/runtime.go
@@ -51,7 +51,7 @@ type AsyncTFExec interface {
 //
 //go:generate pegomock generate --package mocks -o mocks/mock_status_updater.go StatusUpdater
 type StatusUpdater interface {
-	UpdateProject(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus, url string, result *command.ProjectResult) error
+	UpdateProject(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus, url string, res *command.ProjectResult) error
 }
 
 // Runner mirrors events.StepRunner as a way to bring it into this package

--- a/server/events/mocks/mock_event_parsing.go
+++ b/server/events/mocks/mock_event_parsing.go
@@ -531,8 +531,8 @@ type VerifierMockEventParsing struct {
 	timeout                time.Duration
 }
 
-func (verifier *VerifierMockEventParsing) GetBitbucketCloudPullEventType(eventTypeHeader string) *MockEventParsing_GetBitbucketCloudPullEventType_OngoingVerification {
-	params := []pegomock.Param{eventTypeHeader}
+func (verifier *VerifierMockEventParsing) GetBitbucketCloudPullEventType(eventTypeHeader string, sha string, pr string) *MockEventParsing_GetBitbucketCloudPullEventType_OngoingVerification {
+	params := []pegomock.Param{eventTypeHeader, sha, pr}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "GetBitbucketCloudPullEventType", params, verifier.timeout)
 	return &MockEventParsing_GetBitbucketCloudPullEventType_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -542,17 +542,25 @@ type MockEventParsing_GetBitbucketCloudPullEventType_OngoingVerification struct 
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockEventParsing_GetBitbucketCloudPullEventType_OngoingVerification) GetCapturedArguments() string {
-	eventTypeHeader := c.GetAllCapturedArguments()
-	return eventTypeHeader[len(eventTypeHeader)-1]
+func (c *MockEventParsing_GetBitbucketCloudPullEventType_OngoingVerification) GetCapturedArguments() (string, string, string) {
+	eventTypeHeader, sha, pr := c.GetAllCapturedArguments()
+	return eventTypeHeader[len(eventTypeHeader)-1], sha[len(sha)-1], pr[len(pr)-1]
 }
 
-func (c *MockEventParsing_GetBitbucketCloudPullEventType_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
+func (c *MockEventParsing_GetBitbucketCloudPullEventType_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string, _param2 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
+		}
+		_param1 = make([]string, len(c.methodInvocations))
+		for u, param := range params[1] {
+			_param1[u] = param.(string)
+		}
+		_param2 = make([]string, len(c.methodInvocations))
+		for u, param := range params[2] {
+			_param2[u] = param.(string)
 		}
 	}
 	return

--- a/server/events/mocks/mock_job_url_setter.go
+++ b/server/events/mocks/mock_job_url_setter.go
@@ -26,16 +26,16 @@ func NewMockJobURLSetter(options ...pegomock.Option) *MockJobURLSetter {
 func (mock *MockJobURLSetter) SetFailHandler(fh pegomock.FailHandler) { mock.fail = fh }
 func (mock *MockJobURLSetter) FailHandler() pegomock.FailHandler      { return mock.fail }
 
-func (mock *MockJobURLSetter) SetJobURLWithStatus(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus, result *command.ProjectResult) error {
+func (mock *MockJobURLSetter) SetJobURLWithStatus(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus, res *command.ProjectResult) error {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockJobURLSetter().")
 	}
-	params := []pegomock.Param{ctx, cmdName, status, result}
-	pegomockResult := pegomock.GetGenericMockFrom(mock).Invoke("SetJobURLWithStatus", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
+	params := []pegomock.Param{ctx, cmdName, status, res}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("SetJobURLWithStatus", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 error
-	if len(pegomockResult) != 0 {
-		if pegomockResult[0] != nil {
-			ret0 = pegomockResult[0].(error)
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(error)
 		}
 	}
 	return ret0
@@ -78,8 +78,8 @@ type VerifierMockJobURLSetter struct {
 	timeout                time.Duration
 }
 
-func (verifier *VerifierMockJobURLSetter) SetJobURLWithStatus(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus, result *command.ProjectResult) *MockJobURLSetter_SetJobURLWithStatus_OngoingVerification {
-	params := []pegomock.Param{ctx, cmdName, status, result}
+func (verifier *VerifierMockJobURLSetter) SetJobURLWithStatus(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus, res *command.ProjectResult) *MockJobURLSetter_SetJobURLWithStatus_OngoingVerification {
+	params := []pegomock.Param{ctx, cmdName, status, res}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "SetJobURLWithStatus", params, verifier.timeout)
 	return &MockJobURLSetter_SetJobURLWithStatus_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -90,8 +90,8 @@ type MockJobURLSetter_SetJobURLWithStatus_OngoingVerification struct {
 }
 
 func (c *MockJobURLSetter_SetJobURLWithStatus_OngoingVerification) GetCapturedArguments() (command.ProjectContext, command.Name, models.CommitStatus, *command.ProjectResult) {
-	ctx, cmdName, status, result := c.GetAllCapturedArguments()
-	return ctx[len(ctx)-1], cmdName[len(cmdName)-1], status[len(status)-1], result[len(result)-1]
+	ctx, cmdName, status, res := c.GetAllCapturedArguments()
+	return ctx[len(ctx)-1], cmdName[len(cmdName)-1], status[len(status)-1], res[len(res)-1]
 }
 
 func (c *MockJobURLSetter_SetJobURLWithStatus_OngoingVerification) GetAllCapturedArguments() (_param0 []command.ProjectContext, _param1 []command.Name, _param2 []models.CommitStatus, _param3 []*command.ProjectResult) {

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -143,7 +143,7 @@ type ProjectCommandRunner interface {
 type JobURLSetter interface {
 	// SetJobURLWithStatus sets the commit status for the project represented by
 	// ctx and updates the status with and url to a job.
-	SetJobURLWithStatus(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus, result *command.ProjectResult) error
+	SetJobURLWithStatus(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus, res *command.ProjectResult) error
 }
 
 //go:generate pegomock generate --package mocks -o mocks/mock_job_message_sender.go JobMessageSender

--- a/server/jobs/job_url_setter.go
+++ b/server/jobs/job_url_setter.go
@@ -17,7 +17,7 @@ type ProjectJobURLGenerator interface {
 type ProjectStatusUpdater interface {
 	// UpdateProject sets the commit status for the project represented by
 	// ctx.
-	UpdateProject(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus, url string, result *command.ProjectResult) error
+	UpdateProject(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus, url string, res *command.ProjectResult) error
 }
 
 type JobURLSetter struct {

--- a/server/jobs/mocks/mock_project_status_updater.go
+++ b/server/jobs/mocks/mock_project_status_updater.go
@@ -26,16 +26,16 @@ func NewMockProjectStatusUpdater(options ...pegomock.Option) *MockProjectStatusU
 func (mock *MockProjectStatusUpdater) SetFailHandler(fh pegomock.FailHandler) { mock.fail = fh }
 func (mock *MockProjectStatusUpdater) FailHandler() pegomock.FailHandler      { return mock.fail }
 
-func (mock *MockProjectStatusUpdater) UpdateProject(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus, url string, result *command.ProjectResult) error {
+func (mock *MockProjectStatusUpdater) UpdateProject(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus, url string, res *command.ProjectResult) error {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockProjectStatusUpdater().")
 	}
-	params := []pegomock.Param{ctx, cmdName, status, url, result}
-	pegomockResult := pegomock.GetGenericMockFrom(mock).Invoke("UpdateProject", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
+	params := []pegomock.Param{ctx, cmdName, status, url, res}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("UpdateProject", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 error
-	if len(pegomockResult) != 0 {
-		if pegomockResult[0] != nil {
-			ret0 = pegomockResult[0].(error)
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(error)
 		}
 	}
 	return ret0
@@ -78,8 +78,8 @@ type VerifierMockProjectStatusUpdater struct {
 	timeout                time.Duration
 }
 
-func (verifier *VerifierMockProjectStatusUpdater) UpdateProject(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus, url string, result *command.ProjectResult) *MockProjectStatusUpdater_UpdateProject_OngoingVerification {
-	params := []pegomock.Param{ctx, cmdName, status, url, result}
+func (verifier *VerifierMockProjectStatusUpdater) UpdateProject(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus, url string, res *command.ProjectResult) *MockProjectStatusUpdater_UpdateProject_OngoingVerification {
+	params := []pegomock.Param{ctx, cmdName, status, url, res}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "UpdateProject", params, verifier.timeout)
 	return &MockProjectStatusUpdater_UpdateProject_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -90,8 +90,8 @@ type MockProjectStatusUpdater_UpdateProject_OngoingVerification struct {
 }
 
 func (c *MockProjectStatusUpdater_UpdateProject_OngoingVerification) GetCapturedArguments() (command.ProjectContext, command.Name, models.CommitStatus, string, *command.ProjectResult) {
-	ctx, cmdName, status, url, result := c.GetAllCapturedArguments()
-	return ctx[len(ctx)-1], cmdName[len(cmdName)-1], status[len(status)-1], url[len(url)-1], result[len(result)-1]
+	ctx, cmdName, status, url, res := c.GetAllCapturedArguments()
+	return ctx[len(ctx)-1], cmdName[len(cmdName)-1], status[len(status)-1], url[len(url)-1], res[len(res)-1]
 }
 
 func (c *MockProjectStatusUpdater_UpdateProject_OngoingVerification) GetAllCapturedArguments() (_param0 []command.ProjectContext, _param1 []command.Name, _param2 []models.CommitStatus, _param3 []string, _param4 []*command.ProjectResult) {


### PR DESCRIPTION
## what

Change some function parameter names from "result" to "res" so `pegomock` creates valid go code automatically.

## why

pegomock generates code that among other things contains `result := ...`, which breaks if result exists as a function parameter.  I don't know how this was handled before, I suspect manual editing after running make go-generate?

## tests

- [X] I have tested my changes by make test-all

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

