### PR TITLE
feat: set default tf & conftest env vars for apline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG DEFAULT_CONFTEST_VERSION=0.46.0
 
 # Stage 1: build artifact and download deps
 
-FROM golang:1.21.1-alpine AS builder
+FROM golang:1.21.2-alpine AS builder
 
 ARG ATLANTIS_VERSION=dev
 ENV ATLANTIS_VERSION=${ATLANTIS_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@
 ARG ALPINE_TAG=3.18.4
 ARG DEBIAN_TAG=12.1-slim
 
+ARG DEFAULT_TERRAFORM_VERSION=1.5.7
+ARG DEFAULT_CONFTEST_VERSION=0.46.0
+
 # Stage 1: build artifact and download deps
 
 FROM golang:1.21.1-alpine AS builder
@@ -13,6 +16,11 @@ ARG ATLANTIS_COMMIT=none
 ENV ATLANTIS_COMMIT=${ATLANTIS_COMMIT}
 ARG ATLANTIS_DATE=unknown
 ENV ATLANTIS_DATE=${ATLANTIS_DATE}
+
+ARG DEFAULT_TERRAFORM_VERSION
+ENV DEFAULT_TERRAFORM_VERSION=${DEFAULT_TERRAFORM_VERSION}
+ARG DEFAULT_CONFTEST_VERSION
+ENV DEFAULT_CONFTEST_VERSION=${DEFAULT_CONFTEST_VERSION}
 
 WORKDIR /app
 
@@ -60,7 +68,8 @@ WORKDIR /tmp/build
 
 # install conftest
 # renovate: datasource=github-releases depName=open-policy-agent/conftest
-ENV DEFAULT_CONFTEST_VERSION=0.46.0
+ARG DEFAULT_CONFTEST_VERSION
+ENV DEFAULT_CONFTEST_VERSION=${DEFAULT_CONFTEST_VERSION}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN AVAILABLE_CONFTEST_VERSIONS=${DEFAULT_CONFTEST_VERSION} && \
     case ${TARGETPLATFORM} in \
@@ -121,7 +130,8 @@ RUN case ${TARGETPLATFORM} in \
 
 # install terraform binaries
 # renovate: datasource=github-releases depName=hashicorp/terraform versioning=hashicorp
-ENV DEFAULT_TERRAFORM_VERSION=1.5.7
+ARG DEFAULT_TERRAFORM_VERSION
+ENV DEFAULT_TERRAFORM_VERSION=${DEFAULT_TERRAFORM_VERSION}
 
 # In the official Atlantis image, we only have the latest of each Terraform version.
 # Each binary is about 80 MB so we limit it to the 4 latest minor releases or fewer


### PR DESCRIPTION

## what
In the Alpine Docker image, those 2 variables are not available, but they are available in the ubuntu version : 
DEFAULT_CONFTEST_VERSION
DEFAULT_TERRAFORM_VERSION



## why

Some have expressed the need to use the DEFAULT_TERRAFORM_VERSION and DEFAULT_CONFTEST_VERSION in the alpine image. Right now, we're rebuilding the image to include this environment variable. 

## tests

I have tested my changes by building locally


