### PR TITLE
feat: add workflow-name-delimiter flag

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -135,7 +135,7 @@ const (
 	RestrictFileList           = "restrict-file-list"
 	TFDownloadFlag             = "tf-download"
 	TFDownloadURLFlag          = "tf-download-url"
-	UseTFPluginCache             = "use-tf-plugin-cache"
+	UseTFPluginCache           = "use-tf-plugin-cache"
 	VarFileAllowlistFlag       = "var-file-allowlist"
 	VCSStatusName              = "vcs-status-name"
 	TFEHostnameFlag            = "tfe-hostname"
@@ -146,6 +146,7 @@ const (
 	WebUsernameFlag            = "web-username"
 	WebPasswordFlag            = "web-password"
 	WebsocketCheckOrigin       = "websocket-check-origin"
+	WorkflowNameDelimiterFlag  = "workflow-name-delimiter"
 
 	// NOTE: Must manually set these as defaults in the setDefaults function.
 	DefaultADBasicUser                  = ""
@@ -178,6 +179,7 @@ const (
 	DefaultWebBasicAuth                 = false
 	DefaultWebUsername                  = "atlantis"
 	DefaultWebPassword                  = "atlantis"
+	DefaultWorkflowNameDelimiter        = ":"
 )
 
 var stringFlags = map[string]stringFlag{
@@ -411,6 +413,10 @@ var stringFlags = map[string]stringFlag{
 	WebPasswordFlag: {
 		description:  "Password used for Web Basic Authentication on Atlantis HTTP Middleware",
 		defaultValue: DefaultWebPassword,
+	},
+	WorkflowNameDelimiterFlag: {
+		description:  "delimiter to be used when workflow name generated",
+		defaultValue: DefaultWorkflowNameDelimiter,
 	},
 }
 
@@ -878,6 +884,9 @@ func (s *ServerCmd) setDefaults(c *server.UserConfig) {
 	}
 	if c.WebPassword == "" {
 		c.WebPassword = DefaultWebPassword
+	}
+	if c.WorkflowNameDelimiter == "" {
+		c.WorkflowNameDelimiter = DefaultWorkflowNameDelimiter
 	}
 }
 

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1197,7 +1197,7 @@ func setupE2E(t *testing.T, repoDir string, opt setupOption) (events_controllers
 
 	// Mocks.
 	e2eVCSClient := vcsmocks.NewMockClient()
-	e2eStatusUpdater := &events.DefaultCommitStatusUpdater{Client: e2eVCSClient}
+	e2eStatusUpdater := &events.DefaultCommitStatusUpdater{Client: e2eVCSClient, WorkflowNameDelimiter: ":"}
 	e2eGithubGetter := mocks.NewMockGithubPullGetter()
 	e2eGitlabGetter := mocks.NewMockGitlabMergeRequestGetter()
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()

--- a/server/events/commit_status_updater.go
+++ b/server/events/commit_status_updater.go
@@ -45,6 +45,8 @@ type DefaultCommitStatusUpdater struct {
 	Client vcs.Client
 	// StatusName is the name used to identify Atlantis when creating PR statuses.
 	StatusName string
+	// WorkflowNameDelimiter is a delimiter used in generation of workflow name.
+	WorkflowNameDelimiter string
 }
 
 // ensure DefaultCommitStatusUpdater implements runtime.StatusUpdater interface
@@ -116,7 +118,7 @@ func (d *DefaultCommitStatusUpdater) UpdatePostWorkflowHook(pull models.PullRequ
 }
 
 func (d *DefaultCommitStatusUpdater) updateWorkflowHook(pull models.PullRequest, status models.CommitStatus, hookDescription string, runtimeDescription string, workflowType string, url string) error {
-	src := fmt.Sprintf("%s/%s: %s", d.StatusName, workflowType, hookDescription)
+	src := fmt.Sprintf("%s/%s%s %s", d.StatusName, workflowType, d.WorkflowNameDelimiter, hookDescription)
 
 	var descripWords string
 	if runtimeDescription != "" {

--- a/server/events/commit_status_updater_test.go
+++ b/server/events/commit_status_updater_test.go
@@ -67,7 +67,7 @@ func TestUpdateCombined(t *testing.T) {
 		t.Run(c.expDescrip, func(t *testing.T) {
 			RegisterMockTestingT(t)
 			client := mocks.NewMockClient()
-			s := events.DefaultCommitStatusUpdater{Client: client, StatusName: "atlantis"}
+			s := events.DefaultCommitStatusUpdater{Client: client, StatusName: "atlantis", WorkflowNameDelimiter: ":"}
 			err := s.UpdateCombined(models.Repo{}, models.PullRequest{}, c.status, c.command)
 			Ok(t, err)
 
@@ -133,7 +133,7 @@ func TestUpdateCombinedCount(t *testing.T) {
 		t.Run(c.expDescrip, func(t *testing.T) {
 			RegisterMockTestingT(t)
 			client := mocks.NewMockClient()
-			s := events.DefaultCommitStatusUpdater{Client: client, StatusName: "atlantis-test"}
+			s := events.DefaultCommitStatusUpdater{Client: client, StatusName: "atlantis-test", WorkflowNameDelimiter: ":"}
 			err := s.UpdateCombinedCount(models.Repo{}, models.PullRequest{}, c.status, c.command, c.numSuccess, c.numTotal)
 			Ok(t, err)
 
@@ -170,7 +170,7 @@ func TestDefaultCommitStatusUpdater_UpdateProjectSrc(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.expSrc, func(t *testing.T) {
 			client := mocks.NewMockClient()
-			s := events.DefaultCommitStatusUpdater{Client: client, StatusName: "atlantis"}
+			s := events.DefaultCommitStatusUpdater{Client: client, StatusName: "atlantis", WorkflowNameDelimiter: ":"}
 			err := s.UpdateProject(command.ProjectContext{
 				ProjectName: c.projectName,
 				RepoRelDir:  c.repoRelDir,
@@ -234,7 +234,7 @@ func TestDefaultCommitStatusUpdater_UpdateProject(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.expDescrip, func(t *testing.T) {
 			client := mocks.NewMockClient()
-			s := events.DefaultCommitStatusUpdater{Client: client, StatusName: "atlantis"}
+			s := events.DefaultCommitStatusUpdater{Client: client, StatusName: "atlantis", WorkflowNameDelimiter: ":"}
 			err := s.UpdateProject(command.ProjectContext{
 				RepoRelDir: ".",
 				Workspace:  "default",
@@ -249,7 +249,7 @@ func TestDefaultCommitStatusUpdater_UpdateProject(t *testing.T) {
 func TestDefaultCommitStatusUpdater_UpdateProjectCustomStatusName(t *testing.T) {
 	RegisterMockTestingT(t)
 	client := mocks.NewMockClient()
-	s := events.DefaultCommitStatusUpdater{Client: client, StatusName: "custom"}
+	s := events.DefaultCommitStatusUpdater{Client: client, StatusName: "custom", WorkflowNameDelimiter: ":"}
 	err := s.UpdateProject(command.ProjectContext{
 		RepoRelDir: ".",
 		Workspace:  "default",

--- a/server/server.go
+++ b/server/server.go
@@ -360,7 +360,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		return nil, errors.Wrap(err, "initializing webhooks")
 	}
 	vcsClient := vcs.NewClientProxy(githubClient, gitlabClient, bitbucketCloudClient, bitbucketServerClient, azuredevopsClient)
-	commitStatusUpdater := &events.DefaultCommitStatusUpdater{Client: vcsClient, StatusName: userConfig.VCSStatusName}
+	commitStatusUpdater := &events.DefaultCommitStatusUpdater{Client: vcsClient, StatusName: userConfig.VCSStatusName, WorkflowNameDelimiter: userConfig.WorkflowNameDelimiter}
 
 	binDir, err := mkSubDir(userConfig.DataDir, BinDirName)
 

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -126,7 +126,8 @@ type UserConfig struct {
 	WebPassword            string          `mapstructure:"web-password"`
 	WriteGitCreds          bool            `mapstructure:"write-git-creds"`
 	WebsocketCheckOrigin   bool            `mapstructure:"websocket-check-origin"`
-	UseTFPluginCache         bool            `mapstructure:"use-tf-plugin-cache"`
+	WorkflowNameDelimiter  string          `mapstructure:"workflow-name-delimiter"`
+	UseTFPluginCache       bool            `mapstructure:"use-tf-plugin-cache"`
 }
 
 // ToAllowCommandNames parse AllowCommands into a slice of CommandName


### PR DESCRIPTION
## what

Add `workflow-name-delimiter` flag to allow change delimiter in workflow name from default `:`.
<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->


## why
To use something compatible with  terraform-provider-github and avoid https://github.com/integrations/terraform-provider-github/issues/1531.
<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## tests

<!--
- [ ] I have tested my changes by ...
-->

## references

closes #3814
<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

