### PR TITLE
fix(ci): website tests 403 atlassian links

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -64,6 +64,7 @@ jobs:
             -e 'https://medium.com/runatlantis' \
             -e 'https://github\.com/runatlantis/atlantis/edit/main/.*' \
             -e 'https://github.com/runatlantis/helm-charts#customization' \
+            -e 'https://confluence.atlassian.com/*' \
             --header 'Accept-Encoding:deflate, gzip' \
             --buffer-size 8192 \
             http://localhost:8080/


### PR DESCRIPTION
## what

Website test failure from external sources

## why

Atlassian rate limiting or blocking link checker

## references

https://github.com/runatlantis/atlantis/actions/runs/6401854367/job/17377576143?pr=3810

