### PR TITLE
fix: Return error on `InstrumentedClient.MergePull`

### DIFF
--- a/server/events/vcs/instrumented_client.go
+++ b/server/events/vcs/instrumented_client.go
@@ -250,6 +250,7 @@ func (c *InstrumentedClient) MergePull(pull models.PullRequest, pullOptions mode
 	if err := c.Client.MergePull(pull, pullOptions); err != nil {
 		executionError.Inc(1)
 		logger.Err("Unable to merge pull, error: %s", err.Error())
+		return err
 	}
 
 	executionSuccess.Inc(1)


### PR DESCRIPTION
When the underlying GitHub Client returns an error it gets swallowed in this wrapper method. Not only that but also the emitted metrics are wrong, as it counts one error AND success at the same time.

We've found this @grafana when using Atlantis in a massive repository with many changes per minute, and sometimes Atlantis leave a comment saying it's automatically merging but then nothing happens. But checking the logs, we've found the following error message:

    Unable to merge pull, error: merging pull request: PUT     https://api.github.com/repos/grafana/redacted/pulls/XXX/merge: 405 Base branch was modified. Review and try the merge again. []

And because the error is swallowed and `InstrumentedClient.MergePull` returns `nil`, then `Automerger` fails to leave a comment saying merging failed.
