### PR TITLE
refactor: regen mocks, use existing VerifyWasCalled(Never())

### DIFF
--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -729,7 +729,7 @@ func TestRunUnlockCommandDoesntRetrieveLabelsIfDisableUnlockLabelNotSet(t *testi
 
 	ch.RunCommentCommand(testdata.GithubRepo, &testdata.GithubRepo, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Unlock})
 
-	vcsClient.VerifyWasNotCalled().GetPullLabels(testdata.GithubRepo, modelPull)
+	vcsClient.VerifyWasCalled(Never()).GetPullLabels(testdata.GithubRepo, modelPull)
 }
 
 func TestRunAutoplanCommand_DeletePlans(t *testing.T) {

--- a/server/events/vcs/mocks/mock_client.go
+++ b/server/events/vcs/mocks/mock_client.go
@@ -286,13 +286,6 @@ func (mock *MockClient) UpdateStatus(repo models.Repo, pull models.PullRequest, 
 	return ret0
 }
 
-func (mock *MockClient) VerifyWasNotCalled() *VerifierMockClient {
-	return &VerifierMockClient{
-		mock:                   mock,
-		invocationCountMatcher: pegomock.Times(0),
-	}
-}
-
 func (mock *MockClient) VerifyWasCalledOnce() *VerifierMockClient {
 	return &VerifierMockClient{
 		mock:                   mock,


### PR DESCRIPTION
## what

Use built in functionality in the mocks that are generated by make go-generate


## why

tests should work after regenerating mocks

## tests

- [X] I have tested my changes by make test-all

