### PR TITLE
chore: bump muffet from 2.6.3 to 2.9.3

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -58,13 +58,15 @@ jobs:
           MUFFET_VERSION: 2.9.3
         run: |
           npm install -g yarn
-          # http-server is used to serve the website locally as muffet checks it.
-          yarn global add http-server
+
           # install raviqqe/muffet to check for broken links.
           curl -L https://github.com/raviqqe/muffet/releases/download/v${MUFFET_VERSION}/muffet_${MUFFET_VERSION}_Linux_x86_64.tar.gz | tar -xz
-          yarn install
-          yarn website:build
-          http-server runatlantis.io/.vuepress/dist &
+
+          # build the site
+          yarn && yarn website:build
+
+          # run http-server for muffet to check the links
+          npx http-server runatlantis.io/.vuepress/dist &
 
       - name: wait until server listened
         run: curl --retry-delay 1 --retry 30 --retry-all-error http://localhost:8080

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -60,7 +60,7 @@ jobs:
           npm install -g yarn
 
           # install raviqqe/muffet to check for broken links.
-          curl -L https://github.com/raviqqe/muffet/releases/download/v${MUFFET_VERSION}/muffet_${MUFFET_VERSION}_Linux_x86_64.tar.gz | tar -xz
+          curl -Ls https://github.com/raviqqe/muffet/releases/download/v${MUFFET_VERSION}/muffet_linux_amd64.tar.gz | tar -xz
 
           # build the site
           yarn && yarn website:build

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -14,7 +14,7 @@ on:
     branches:
       - 'main'
       - 'release-**'
- 
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -55,7 +55,7 @@ jobs:
       - name: run http-server
         env:
           # renovate: datasource=github-releases depName=raviqqe/muffet
-          MUFFET_VERSION: 2.6.3
+          MUFFET_VERSION: 2.9.3
         run: |
           npm install -g yarn
           # http-server is used to serve the website locally as muffet checks it.
@@ -86,4 +86,4 @@ jobs:
     name: Website Link Check
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"' 
+      - run: 'echo "No build required"'


### PR DESCRIPTION
not quite sure why renovate is not working, but this is the PR to bump the muffet dependency to the latest.