### PR TITLE
fix: When GitHub/GitLab Auto-Merge Is Used with Atlantis Pre Workflow Hooks, the PR will be Merged Prematurely

### DIFF
--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -15,7 +15,6 @@ package events
 
 import (
 	"fmt"
-	"github.com/runatlantis/atlantis/server/utils"
 	"strconv"
 
 	"github.com/google/go-github/v54/github"
@@ -28,6 +27,7 @@ import (
 	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/metrics"
 	"github.com/runatlantis/atlantis/server/recovery"
+	"github.com/runatlantis/atlantis/server/utils"
 	tally "github.com/uber-go/tally/v4"
 	gitlab "github.com/xanzy/go-gitlab"
 )
@@ -128,6 +128,7 @@ type DefaultCommandRunner struct {
 	PullStatusFetcher              PullStatusFetcher
 	TeamAllowlistChecker           *TeamAllowlistChecker
 	VarFileAllowlistChecker        *VarFileAllowlistChecker
+	CommitStatusUpdater            CommitStatusUpdater
 }
 
 // RunAutoplanCommand runs plan and policy_checks when a pull request is opened or updated.
@@ -186,6 +187,19 @@ func (c *DefaultCommandRunner) RunAutoplanCommand(baseRepo models.Repo, headRepo
 
 		if c.FailOnPreWorkflowHookError {
 			ctx.Log.Err("'fail-on-pre-workflow-hook-error' set, so not running %s command.", command.Plan)
+
+			// Update the plan or apply commit status to pending whilst the pre workflow hook is running so that the PR can't be merged.
+			switch cmd.Name {
+			case command.Plan:
+				if err := c.CommitStatusUpdater.UpdateCombined(ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, command.Plan); err != nil {
+					ctx.Log.Warn("unable to update plan commit status: %s", err)
+				}
+			case command.Apply:
+				if err := c.CommitStatusUpdater.UpdateCombined(ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, command.Apply); err != nil {
+					ctx.Log.Warn("unable to update apply commit status: %s", err)
+				}
+			}
+
 			return
 		}
 
@@ -317,6 +331,19 @@ func (c *DefaultCommandRunner) RunCommentCommand(baseRepo models.Repo, maybeHead
 
 		if c.FailOnPreWorkflowHookError {
 			ctx.Log.Err("'fail-on-pre-workflow-hook-error' set, so not running %s command.", cmd.Name.String())
+
+			// Update the plan or apply commit status to pending whilst the pre workflow hook is running so that the PR can't be merged.
+			switch cmd.Name {
+			case command.Plan:
+				if err := c.CommitStatusUpdater.UpdateCombined(ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, command.Plan); err != nil {
+					ctx.Log.Warn("unable to update plan commit status: %s", err)
+				}
+			case command.Apply:
+				if err := c.CommitStatusUpdater.UpdateCombined(ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, command.Apply); err != nil {
+					ctx.Log.Warn("unable to update apply commit status: %s", err)
+				}
+			}
+
 			return
 		}
 

--- a/server/server.go
+++ b/server/server.go
@@ -813,6 +813,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		PullStatusFetcher:              backend,
 		TeamAllowlistChecker:           githubTeamAllowlistChecker,
 		VarFileAllowlistChecker:        varFileAllowlistChecker,
+		CommitStatusUpdater:            commitStatusUpdater,
 	}
 	repoAllowlist, err := events.NewRepoAllowlistChecker(userConfig.RepoAllowlist)
 	if err != nil {


### PR DESCRIPTION
## what

When a pre-workflow hook is launched for plan and apply commands, set the relevant plan/apply commit status to `pending` at the start of the hook. This prevents a VCS auto-merge feature from prematurely merging the PR when the pre-workflow hook finishes.

Also, if `fail-on-pre-workflow-hook-error` is set, update the relevant plan/apply commit status to 'failed' at the end of the hook.

Also fix the current 'unable to update pre workflow hook status' message text.

## why

- Fixes #3875 

## tests

Tested locally


