### PR TITLE
fix: Use Gitlab's pending status when the commit status is pending

### DIFF
--- a/server/events/vcs/gitlab_client.go
+++ b/server/events/vcs/gitlab_client.go
@@ -357,7 +357,7 @@ func (g *GitlabClient) UpdateStatus(repo models.Repo, pull models.PullRequest, s
 	gitlabState := gitlab.Pending
 	switch state {
 	case models.PendingCommitStatus:
-		gitlabState = gitlab.Running
+		gitlabState = gitlab.Pending
 	case models.FailedCommitStatus:
 		gitlabState = gitlab.Failed
 	case models.SuccessCommitStatus:

--- a/server/events/vcs/gitlab_client_test.go
+++ b/server/events/vcs/gitlab_client_test.go
@@ -256,7 +256,7 @@ func TestGitlabClient_UpdateStatus(t *testing.T) {
 	}{
 		{
 			models.PendingCommitStatus,
-			"running",
+			"pending",
 		},
 		{
 			models.SuccessCommitStatus,


### PR DESCRIPTION

## what

Unlike Gitlab, Github's commit statuses do not have a "running" state, so the atlantis flow doesn't have a concept for "running". Instead of adding complexity for the majority use case (Github), I think a clear user experience is to map "pending" to "pending" for Gitlab, and let commit statuses go from pending to either success or failure.

Along with https://github.com/runatlantis/atlantis/pull/3378/, this change should result in a better user experience for Gitlab users.


## why

- See 
- This absolutely is getting in the way of gitlab MR automation, since sometimes you can get a commit status stuck in "running" forever, and never clear the MR status.

## tests

- [x] I ran atlantis locally against my company's gitlab instance, and it updated the commit statuses accurately 

## references

Perhaps closes #2125
