### PR TITLE
fix: Better determine number of expected comments and webhooks in e2e test

### DIFF
--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -645,7 +645,7 @@ func TestGitHubWorkflow(t *testing.T) {
 
 			// If there are locks to delete at the end, that will take a comment
 			if !c.ExpNoLocksToDelete {
-				expNumReplies += 1
+				expNumReplies++
 			}
 
 			if c.ExpAutoplan {

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -111,7 +111,28 @@ func TestGitHubWorkflow(t *testing.T) {
 		ExpAllowResponseCommentBack bool
 		// ExpParseFailedCount represents how many times test sends invalid commands
 		ExpParseFailedCount int
+		// ExpNoLocksToDelete whether we expect that there are no locks at the end to delete
+		ExpNoLocksToDelete bool
 	}{
+		{
+			Description:        "no comment or change",
+			RepoDir:            "simple",
+			ModifiedFiles:      []string{},
+			Comments:           []string{},
+			ExpReplies:         [][]string{},
+			ExpNoLocksToDelete: true,
+		},
+		{
+			Description:   "no comment",
+			RepoDir:       "simple",
+			ModifiedFiles: []string{"main.tf"},
+			Comments:      []string{},
+			ExpReplies: [][]string{
+				{"exp-output-autoplan.txt"},
+				{"exp-output-merge.txt"},
+			},
+			ExpAutoplan: true,
+		},
 		{
 			Description:   "simple",
 			RepoDir:       "simple",
@@ -208,6 +229,7 @@ func TestGitHubWorkflow(t *testing.T) {
 			},
 			ExpAllowResponseCommentBack: true,
 			ExpParseFailedCount:         1,
+			ExpNoLocksToDelete:          true,
 		},
 		{
 			Description:   "simple with atlantis.yaml",
@@ -618,9 +640,13 @@ func TestGitHubWorkflow(t *testing.T) {
 
 			// Now we're ready to verify Atlantis made all the comments back (or
 			// replies) that we expect.  We expect each plan to have 1 comment,
-			// and apply have 1 for each comment plus one for the locks deleted at the
-			// end.
-			expNumReplies := len(c.Comments) + 1 - c.ExpParseFailedCount
+			// and apply have 1 for each comment
+			expNumReplies := len(c.Comments)
+
+			// If there are locks to delete at the end, that will take a comment
+			if !c.ExpNoLocksToDelete {
+				expNumReplies += 1
+			}
 
 			if c.ExpAutoplan {
 				expNumReplies++


### PR DESCRIPTION
## what

Determine how many expected comments and webhooks there are in the events controller e2e test by making use of a variable that tracks whether or not plans need to be discarded.


## why

This was a very subtle bug that I noticed when working on #2992. Right now we use the `ExpParseFailedCount` flag to decrement not only the number of webhooks we expect to have fired, but also the number of comments that are expected. When the controller fails to parse the command, it does not fire a webhook (https://github.com/runatlantis/atlantis/blob/main/server/controllers/events/events_controller.go#L577), however it *does add a comment*. We then unconditionally add `1` to the expected number of comments to handle the comment for the cleanup of locks, but *this does not happen in this case*. Therefore two wrongs made a right, and the tests passed :)

In the process of removing `--disable-apply` for #2992, I had the need to tweak these tests in such a way that we had a parse error, but still had locks to cleanup. In this case there was no right setting to make both number of webhooks and number of comments happy, thus necessitating another parameter, `ExpNoLocksToDelete` that can vary independently from `ExpParseFailedCount`.

## tests

All the changes are in unit tests, so unit tests passing should be sufficient.

The most straightforward test to demonstrate the old code has a bug is to add this simple test in `main` (which I ended up including in my PR)

```
atlantis % git diff
diff --git a/server/controllers/events/events_controller_e2e_test.go b/server/controllers/events/events_controller_e2e_test.go
index 93c63df3..1c6b2b6c 100644
--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -112,6 +112,13 @@ func TestGitHubWorkflow(t *testing.T) {
                // ExpParseFailedCount represents how many times test sends invalid commands
                ExpParseFailedCount int
        }{
+               {
+                       Description:   "no comment or change",
+                       RepoDir:       "simple",
+                       ModifiedFiles: []string{},
+                       Comments:      []string{},
+                       ExpReplies:    [][]string{},
+               },
                {
                        Description:   "simple",
                        RepoDir:       "simple",
```

This fails with this message:
```
            Mock invocation count for CreateComment(Any(models.Repo), Any(int), Any(string), Any(string)) does not match expectation.
            
            	Expected: 1; but got: 0
```

This is because we're unconditionally adding `1` with the expectation that every PR will need a comment to clean up, when it doesn't.


The only Comment that `simple_with_allow_commands` creates is the response about the incorrect command. Adding `1` to handle the cleanup then is not correct.
```
    --- FAIL: TestGitHubWorkflow/simple_with_allow_commands (0.11s)
...
            	CreateComment(models.Repo{FullName:"runatlantis/atlantis-tests", Owner:"runatlantis", Name:"atlantis-tests", CloneURL:"https://github-user:github-token@github.com/runatlantis/atlantis-tests.git", SanitizedCloneURL:"https://github-user:<redacted>@github.com/runatlantis/atlantis-tests.git", VCSHost:models.VCSHost{Hostname:"github.com", Type:0}}, 1, "```\nError: unknown command \"import\".\nRun 'atlantis --help' for usage.\nAvailable commands(--allow-commands): plan, apply\n```", "")
...
```

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

