### PR TITLE
fix: Include required checks while evaluating the mergeable state if apply is bypassed

### DIFF
--- a/server/events/vcs/testdata/github-branch-protection-required-checks.json
+++ b/server/events/vcs/testdata/github-branch-protection-required-checks.json
@@ -4,12 +4,17 @@
         "url": "https://api.github.com/repos/octocat/Hello-World/branches/master/protection/required_status_checks",
         "strict": true,
         "contexts": [
-            "atlantis/apply"
+            "atlantis/apply",
+            "atlantis/plan"
         ],
         "contexts_url": "https://api.github.com/repos/octocat/Hello-World/branches/master/protection/required_status_checks/contexts",
         "checks": [
             {
                 "context": "atlantis/apply",
+                "app_id": 123456
+            },
+            {
+                "context": "atlantis/plan",
                 "app_id": 123456
             }
         ]

--- a/server/events/vcs/testdata/github-commit-status-full.json
+++ b/server/events/vcs/testdata/github-commit-status-full.json
@@ -72,6 +72,18 @@
         "context": "atlantis/apply",
         "created_at": "2022-02-10T15:26:28Z",
         "updated_at": "2022-02-10T15:26:28Z"
+      },
+      {
+        "url": "https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+        "avatar_url": "https://avatars.githubusercontent.com/u/583231?v=4",
+        "id": 16230308153,
+        "node_id": "SC_kwDOFRFvL88AAAADx2bAWS",
+        "state": "failure",
+        "description": "Failed to report metrics.",
+        "target_url": "https://localhost/jobs/octocat/Hello-World/1/project2",
+        "context": "report-metrics",
+        "created_at": "2022-02-10T15:26:27Z",
+        "updated_at": "2022-02-10T15:26:27Z"
       }
     ],
     "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",


### PR DESCRIPTION
## what

Currently when the apply condition is set to mergeable along with `--gh-allow-mergeable-bypass-apply` flag, Atlantis considers non required status checks as well to decide whether the PR is mergeable or not (to allow apply or not). This is a deviation from standard github mergeable status.

This PR changes that and includes only required status checks while evaluating mergeable status.

## why

Atlantis uses mergeable status from github API to check if a PR is mergeable if `--gh-allow-mergeable-bypass-apply` is not set.  That is if the status is `unstable`, the PR is considered mergeable.

```
unstable: Failing/pending commit status that is not part of the required
	//           status checks. Merging is allowed (yellow box).
```

If `--gh-allow-mergeable-bypass-apply` enabled, github uses some additional checks to see if the PR is mergeable without considering `atlantis apply`. But in these additional checks, Atlantis looks at all statuses irrespective of if they are required or not.  So, if there is a status check that is failing Atlantis will consider it non mergeable even if its not a required status check and thus will block Apply.

In this change, while checking if the state is `success`, it will also check if the particular status is one of the required checks.  Hence Atlantis will report non mergeable only if the failing status check is a required one.

## tests

- [x] I have adjusted the test data to include scenarios where there could be failing non required checks
- [x] I have tested this by running atlantis locally against a terraform repository with a few valid scenarios