### PR TITLE
chore: enable cherry-pick-bot.yml

### DIFF
--- a/.github/cherry-pick-bot.yml
+++ b/.github/cherry-pick-bot.yml
@@ -1,0 +1,2 @@
+enabled: true
+preservePullRequestTitle: true


### PR DESCRIPTION
## what

Enable cherry-pick-bot to help manage the new release cycle


## why

We are using a new release cycle where minor versions are branched from main to help insulate fixes from features when doing patch releases.

## references

https://github.com/googleapis/repo-automation-bots/tree/main/packages/cherry-pick-bot#configuring

