### PR TITLE
feat: Remove deprecated repo whitelist flag

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -118,33 +118,31 @@ const (
 	RedisInsecureSkipVerify          = "redis-insecure-skip-verify"
 	RepoConfigFlag                   = "repo-config"
 	RepoConfigJSONFlag               = "repo-config-json"
-	// RepoWhitelistFlag is deprecated for RepoAllowlistFlag.
-	RepoWhitelistFlag          = "repo-whitelist"
-	RepoAllowlistFlag          = "repo-allowlist"
-	RequireApprovalFlag        = "require-approval"
-	RequireMergeableFlag       = "require-mergeable"
-	SilenceNoProjectsFlag      = "silence-no-projects"
-	SilenceForkPRErrorsFlag    = "silence-fork-pr-errors"
-	SilenceVCSStatusNoPlans    = "silence-vcs-status-no-plans"
-	SilenceAllowlistErrorsFlag = "silence-allowlist-errors"
-	SkipCloneNoChanges         = "skip-clone-no-changes"
-	SlackTokenFlag             = "slack-token"
-	SSLCertFileFlag            = "ssl-cert-file"
-	SSLKeyFileFlag             = "ssl-key-file"
-	RestrictFileList           = "restrict-file-list"
-	TFDownloadFlag             = "tf-download"
-	TFDownloadURLFlag          = "tf-download-url"
-	UseTFPluginCache           = "use-tf-plugin-cache"
-	VarFileAllowlistFlag       = "var-file-allowlist"
-	VCSStatusName              = "vcs-status-name"
-	TFEHostnameFlag            = "tfe-hostname"
-	TFELocalExecutionModeFlag  = "tfe-local-execution-mode"
-	TFETokenFlag               = "tfe-token"
-	WriteGitCredsFlag          = "write-git-creds" // nolint: gosec
-	WebBasicAuthFlag           = "web-basic-auth"
-	WebUsernameFlag            = "web-username"
-	WebPasswordFlag            = "web-password"
-	WebsocketCheckOrigin       = "websocket-check-origin"
+	RepoAllowlistFlag                = "repo-allowlist"
+	RequireApprovalFlag              = "require-approval"
+	RequireMergeableFlag             = "require-mergeable"
+	SilenceNoProjectsFlag            = "silence-no-projects"
+	SilenceForkPRErrorsFlag          = "silence-fork-pr-errors"
+	SilenceVCSStatusNoPlans          = "silence-vcs-status-no-plans"
+	SilenceAllowlistErrorsFlag       = "silence-allowlist-errors"
+	SkipCloneNoChanges               = "skip-clone-no-changes"
+	SlackTokenFlag                   = "slack-token"
+	SSLCertFileFlag                  = "ssl-cert-file"
+	SSLKeyFileFlag                   = "ssl-key-file"
+	RestrictFileList                 = "restrict-file-list"
+	TFDownloadFlag                   = "tf-download"
+	TFDownloadURLFlag                = "tf-download-url"
+	UseTFPluginCache                 = "use-tf-plugin-cache"
+	VarFileAllowlistFlag             = "var-file-allowlist"
+	VCSStatusName                    = "vcs-status-name"
+	TFEHostnameFlag                  = "tfe-hostname"
+	TFELocalExecutionModeFlag        = "tfe-local-execution-mode"
+	TFETokenFlag                     = "tfe-token"
+	WriteGitCredsFlag                = "write-git-creds" // nolint: gosec
+	WebBasicAuthFlag                 = "web-basic-auth"
+	WebUsernameFlag                  = "web-username"
+	WebPasswordFlag                  = "web-password"
+	WebsocketCheckOrigin             = "websocket-check-origin"
 
 	// NOTE: Must manually set these as defaults in the setDefaults function.
 	DefaultADBasicUser                  = ""
@@ -368,10 +366,6 @@ var stringFlags = map[string]stringFlag{
 			"The format is {hostname}/{owner}/{repo}, ex. github.com/runatlantis/atlantis. '*' matches any characters until the next comma. Examples: " +
 			"all repos: '*' (not secure), an entire hostname: 'internalgithub.com/*' or an organization: 'github.com/runatlantis/*'." +
 			" For Bitbucket Server, {owner} is the name of the project (not the key).",
-	},
-	RepoWhitelistFlag: {
-		description: "[Deprecated for --repo-allowlist].",
-		hidden:      true,
 	},
 	SlackTokenFlag: {
 		description: "API token for Slack notifications.",
@@ -918,15 +912,8 @@ func (s *ServerCmd) validate(userConfig server.UserConfig) error {
 		return vcsErr
 	}
 
-	// Handle deprecation of repo whitelist.
-	if userConfig.RepoWhitelist == "" && userConfig.RepoAllowlist == "" {
+	if userConfig.RepoAllowlist == "" {
 		return fmt.Errorf("--%s must be set for security purposes", RepoAllowlistFlag)
-	}
-	if userConfig.RepoAllowlist != "" && userConfig.RepoWhitelist != "" {
-		return fmt.Errorf("both --%s and --%s cannot be set–use --%s", RepoAllowlistFlag, RepoWhitelistFlag, RepoAllowlistFlag)
-	}
-	if strings.Contains(userConfig.RepoWhitelist, "://") {
-		return fmt.Errorf("--%s cannot contain ://, should be hostnames only", RepoWhitelistFlag)
 	}
 	if strings.Contains(userConfig.RepoAllowlist, "://") {
 		return fmt.Errorf("--%s cannot contain ://, should be hostnames only", RepoAllowlistFlag)
@@ -1130,11 +1117,6 @@ func (s *ServerCmd) deprecationWarnings(userConfig *server.UserConfig) error {
 			jsonCfg,
 		)
 		fmt.Println(warning)
-	}
-
-	// Handle repo whitelist deprecation.
-	if userConfig.RepoWhitelist != "" {
-		userConfig.RepoAllowlist = userConfig.RepoWhitelist
 	}
 
 	return nil

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -84,8 +84,6 @@ type UserConfig struct {
 	RepoConfig                      string `mapstructure:"repo-config"`
 	RepoConfigJSON                  string `mapstructure:"repo-config-json"`
 	RepoAllowlist                   string `mapstructure:"repo-allowlist"`
-	// RepoWhitelist is deprecated in favour of RepoAllowlist.
-	RepoWhitelist string `mapstructure:"repo-whitelist"`
 
 	// RequireApproval is whether to require pull request approval before
 	// allowing terraform apply's to be run.


### PR DESCRIPTION
## what

Remove `--repo-whitelist` flag.

## why

This flag was deprecated in https://github.com/runatlantis/atlantis/commit/8ac19e4017cf69b0afb1d6a58740f97a5e894b0d

## tests

This setting only appeared in configuration, and any behavior changes had been deferred to `--repo-allowlist`, so unit tests passing should be sufficient.

The only functional change of this PR is then:
```
Error: unknown flag: --repo-whitelist
```

## references

- Partially addresses #2992
