### PR TITLE
fix(renovate): add release branches to renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,7 @@
   commitMessageSuffix: " in {{packageFile}}",
   dependencyDashboardAutoclose: true,
   automerge: true,
+  baseBranches: ["main", "/^release\-.*/"],
   platformAutomerge: true,
   labels: ["dependencies"],
   postUpdateOptions: [

--- a/.github/workflows/renovate-config.yml
+++ b/.github/workflows/renovate-config.yml
@@ -6,6 +6,7 @@ on:
       - '.github/renovate.json5'
     branches:
       - main
+      - 'releases-**'
   pull_request:
     paths:
       - '.github/renovate.json5'
@@ -13,7 +14,7 @@ on:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## what

This fixes renovate to also autoMerge fixes to our release branches.

## why

This improves automation so we don't have to manually cherry-pick and backport dependency bumps 

## references

https://docs.renovatebot.com/configuration-options/#basebranches

