### PR TITLE
fix: use the non-root atlantis user instead of root (cherry-pick #3886)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 FROM debian:${DEBIAN_TAG} as debian-base
 
-# Install packages needed for running Atlantis.
+# Install packages needed to run Atlantis.
 # We place this last as it will bust less docker layer caches when packages update
 # hadolint ignore explanation
 # DL3008 (pin versions using "=") - Ignored to avoid failing the build
@@ -89,30 +89,6 @@ RUN AVAILABLE_CONFTEST_VERSIONS=${DEFAULT_CONFTEST_VERSION} && \
         rm checksums.txt; \
     done
 
-# install gosu
-# We use gosu to step down from root and run as the atlantis user
-# renovate: datasource=github-releases depName=tianon/gosu
-ENV GOSU_VERSION=1.16
-
-RUN case ${TARGETPLATFORM} in \
-        "linux/amd64") GOSU_ARCH=amd64 ;; \
-        "linux/arm64") GOSU_ARCH=arm64 ;; \
-        "linux/arm/v7") GOSU_ARCH=armhf ;; \
-    esac && \
-    curl -L -s --output gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${GOSU_ARCH}" && \
-    curl -L -s --output gosu.asc "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${GOSU_ARCH}.asc" && \
-    for server in $(shuf -e ipv4.pool.sks-keyservers.net \
-                            hkp://p80.pool.sks-keyservers.net:80 \
-                            keyserver.ubuntu.com \
-                            hkp://keyserver.ubuntu.com:80 \
-                            pgp.mit.edu) ; do \
-        gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
-    done && \
-    gpg --batch --verify gosu.asc gosu && \
-    chmod +x gosu && \
-    cp gosu /bin && \
-    gosu --version
-
 # install git-lfs
 # renovate: datasource=github-releases depName=git-lfs/git-lfs
 ENV GIT_LFS_VERSION=3.4.0
@@ -159,26 +135,27 @@ RUN AVAILABLE_TERRAFORM_VERSIONS="1.2.9 1.3.10 1.4.6 ${DEFAULT_TERRAFORM_VERSION
 # Creating the individual distro builds using targets
 FROM alpine:${ALPINE_TAG} AS alpine
 
-# atlantis user for gosu and OpenShift compatibility
+EXPOSE ${ATLANTIS_PORT:-4141}
+
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD curl -f http://localhost:${ATLANTIS_PORT:-4141}/healthz || exit 1
+
+# Set up the 'atlantis' user and adjust permissions
 RUN addgroup atlantis && \
     adduser -S -G atlantis atlantis && \
-    adduser atlantis root && \
     chown atlantis:root /home/atlantis/ && \
-    chmod g=u /home/atlantis/ && \
-    chmod g=u /etc/passwd
+    chmod u+rwx /home/atlantis/
 
-# copy binary
+# copy atlantis binary
 COPY --from=builder /app/atlantis /usr/local/bin/atlantis
-# copy terraform
+# copy terraform binaries
 COPY --from=deps /usr/local/bin/terraform* /usr/local/bin/
-# copy deps
+# copy dependencies
 COPY --from=deps /usr/local/bin/conftest /usr/local/bin/conftest
-COPY --from=deps /bin/gosu /bin/gosu
 COPY --from=deps /usr/bin/git-lfs /usr/bin/git-lfs
-# copy docker entrypoint
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
-# Install packages needed for running Atlantis.
+# Install packages needed to run Atlantis.
 # We place this last as it will bust less docker layer caches when packages update
 RUN apk add --no-cache \
         ca-certificates~=20230506 \
@@ -191,29 +168,36 @@ RUN apk add --no-cache \
         dumb-init~=1.2 \
         gcompat~=1.1
 
+
+# Set the entry point to the atlantis user and run the atlantis command
+USER atlantis
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["server"]
 
 # Stage 2 - Debian
 FROM debian-base AS debian
 
-# Add atlantis user to Debian as well
-RUN useradd --create-home --user-group --shell /bin/bash atlantis && \
-    adduser atlantis root && \
-    chown atlantis:root /home/atlantis/ && \
-    chmod g=u /home/atlantis/ && \
-    chmod g=u /etc/passwd
+EXPOSE ${ATLANTIS_PORT:-4141}
 
-# copy binary
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD curl -f http://localhost:${ATLANTIS_PORT:-4141}/healthz || exit 1
+
+# Set up the 'atlantis' user and adjust permissions
+RUN useradd --create-home --user-group --shell /bin/bash atlantis && \
+    chown atlantis:root /home/atlantis/ && \
+    chmod u+rwx /home/atlantis/
+
+# copy atlantis binary
 COPY --from=builder /app/atlantis /usr/local/bin/atlantis
-# copy terraform
+# copy terraform binaries
 COPY --from=deps /usr/local/bin/terraform* /usr/local/bin/
-# copy deps
+# copy dependencies
 COPY --from=deps /usr/local/bin/conftest /usr/local/bin/conftest
-COPY --from=deps /bin/gosu /bin/gosu
 COPY --from=deps /usr/bin/git-lfs /usr/bin/git-lfs
-# copy docker entrypoint
+# copy docker-entrypoint.sh
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
+# Set the entry point to the atlantis user and run the atlantis command
+USER atlantis
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["server"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,18 +29,4 @@ if ! whoami > /dev/null 2>&1; then
   fi
 fi
 
-# If we're running as root and we're trying to execute atlantis then we use
-# gosu to step down from root and run as the atlantis user.
-# In OpenShift, containers are run as a random users so we don't need to use gosu.
-if [ "$(id -u)" = 0 ] && [ "$1" = 'atlantis' ]; then
-    # If requested, set the capability to bind to privileged ports before
-    # we drop to the non-root user. Note that this doesn't work with all
-    # storage drivers (it won't work with AUFS).
-    if [ -n "${ATLANTIS_ALLOW_PRIVILEGED_PORTS+x}" ]; then
-        setcap "cap_net_bind_service=+ep" /bin/atlantis
-    fi
-
-    set -- gosu atlantis "$@"
-fi
-
 exec "$@"


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

- Make standard use of the `atlantis` user and not root.
- Removed gosu, as we're using the `atlantis` user anyways
- Set `DOCKER_CONTENT_TRUST=1` anywhere we build

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

- gosu has various security issues reported ([see reported issues](https://github.com/tianon/gosu/issues))
- it's not a good practice to use the root user by default

## tests

<!--
- [ ] I have tested my changes by ...
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Original PR #3886
- Closes #3777 
- Partially fixes #3789 
