### PR TITLE
ci(workflows): actually run GHA workflows on s/releases/release branches

### DIFF
--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -4,14 +4,14 @@ on:
   push:
     branches:
       - 'main'
-      - 'releases-**'
+      - 'release-**'
     tags:
       - v*.*.* # stable release like, v0.19.2
       - v*.*.*-pre.* # pre release like, v0.19.0-pre.calendardate
   pull_request:
     branches:
       - 'main'
-      - 'releases-**'
+      - 'release-**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ on:
   push:
     branches:
       - 'main'
-      - 'releases-**'
+      - 'release-**'
   pull_request:
     # The branches below must be a subset of the branches above
     types:
@@ -25,7 +25,7 @@ on:
       - ready_for_review
     branches:
       - 'main'
-      - 'releases-**'
+      - 'release-**'
 
   schedule:
     - cron: '17 9 * * 5'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ on:
       - ready_for_review
     branches:
       - "main"
-      - 'releases-**'
+      - 'release-**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - 'main'
-      - 'releases-**'
+      - 'release-**'
   pull_request:
     types:
       - opened
@@ -13,7 +13,7 @@ on:
       - ready_for_review
     branches:
       - 'main'
-      - 'releases-**'
+      - 'release-**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
## what

Not all workflows were running the release branches.

## why

extra character. `s/releases/release`

