### PR TITLE
fix: remove unused packages after gosu cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,6 @@ RUN apt-get update && \
         git \
         unzip \
         openssh-server \
-        libcap2 \
         dumb-init \
         gnupg \
         openssl && \
@@ -164,7 +163,6 @@ RUN apk add --no-cache \
         unzip~=6.0 \
         bash~=5.2 \
         openssh~=9.3_p2 \
-        libcap~=2.69 \
         dumb-init~=1.2 \
         gcompat~=1.1
 


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- remove unused packages after setcap removal

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- unneded packages
- smaller image size

## tests

<!--
- [ ] I have tested my changes by ...
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

- https://github.com/runatlantis/atlantis/pull/3964#issuecomment-1804608527