### PR TITLE
feat(api): change the defaults for BaseBranch and HeadCommit

### DIFF
--- a/server/controllers/api_controller.go
+++ b/server/controllers/api_controller.go
@@ -216,9 +216,9 @@ func (a *APIController) apiParseAndValidate(r *http.Request) (*APIRequest, *comm
 		HeadRepo: baseRepo,
 		Pull: models.PullRequest{
 			Num:        request.PR,
-			BaseBranch: request.Ref,
+			BaseBranch: "main",
 			HeadBranch: request.Ref,
-			HeadCommit: request.Ref,
+			HeadCommit: "HEAD",
 			BaseRepo:   baseRepo,
 		},
 		Scope: a.Scope,


### PR DESCRIPTION
As of now, the /api/plan endpoint constructs a PullRequest that uses the provided Ref parameter as the base branch and head commit. This causes issues when running additional steps along with plan (e.g.: policy check, infracost, etc).

Here's an example error:

```
repo was already cloned but is not at correct commit, wanted \"pr-plan-test\" got \"7a19f2011...\"
```

This will then trigger a new clone which will override needed artifacts from the previous steps which will then cause /api/plan to fail.

By properly setting HeadCommit to HEAD this issue is avoided.
