### PR TITLE
fix: removing mr.Headpipeline.Source log when mr.HeadPipeline is missing

### DIFF
--- a/server/events/vcs/gitlab_client.go
+++ b/server/events/vcs/gitlab_client.go
@@ -391,8 +391,8 @@ func (g *GitlabClient) UpdateStatus(repo models.Repo, pull models.PullRequest, s
 				pull.Num, delay)
 			time.Sleep(delay)
 		} else {
-			g.logger.Debug("Head pipeline not found for merge request %d, source '%s'.",
-				pull.Num, mr.HeadPipeline.Source)
+			g.logger.Debug("Head pipeline not found for merge request %d.",
+				pull.Num)
 		}
 	}
 

--- a/server/events/vcs/gitlab_client.go
+++ b/server/events/vcs/gitlab_client.go
@@ -387,8 +387,8 @@ func (g *GitlabClient) UpdateStatus(repo models.Repo, pull models.PullRequest, s
 			break
 		}
 		if i != retries {
-			g.logger.Debug("Head pipeline not found for merge request %d, source '%s'. Retrying in %s",
-				pull.Num, mr.HeadPipeline.Source, delay)
+			g.logger.Debug("Head pipeline not found for merge request %d. Retrying in %s",
+				pull.Num, delay)
 			time.Sleep(delay)
 		} else {
 			g.logger.Debug("Head pipeline not found for merge request %d, source '%s'.",


### PR DESCRIPTION
## what

when mr.HeadPipeline is missing and the gitlab client retries, it logs mr.HeadPipeline.Source which causes a panic:
```
runtime error: invalid memory address or nil pointer dereference
runtime/panic.go:261 (0x4507d7)
runtime/signal_unix.go:861 (0x4507a5)
github.com/runatlantis/atlantis/server/events/vcs/gitlab_client.go:391 (0xdebc50)
github.com/runatlantis/atlantis/server/events/vcs/proxy.go:84 (0xdf1ecc)
github.com/runatlantis/atlantis/server/events/commit_status_updater.go:135 (0x1005e77)
github.com/runatlantis/atlantis/server/events/commit_status_updater.go:111 (0x1005a5a)
github.com/runatlantis/atlantis/server/events/pre_workflow_hooks_command_runner.go:146 (0x101b995)
github.com/runatlantis/atlantis/server/events/pre_workflow_hooks_command_runner.go:90 (0x101afbd)
github.com/runatlantis/atlantis/server/events/command_runner.go:183 (0xffa913)
runtime/asm_amd64.s:1650 (0x46cba0)
```

## why

Should fix the panic


