### PR TITLE
fix: Bump curl from 8.4 to 8.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -158,7 +158,7 @@ COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 # We place this last as it will bust less docker layer caches when packages update
 RUN apk add --no-cache \
         ca-certificates~=20230506 \
-        curl~=8 \
+        curl~=8.5 \
         git~=2.40 \
         unzip~=6.0 \
         bash~=5.2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -158,7 +158,7 @@ COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 # We place this last as it will bust less docker layer caches when packages update
 RUN apk add --no-cache \
         ca-certificates~=20230506 \
-        curl~=8.4 \
+        curl~=8 \
         git~=2.40 \
         unzip~=6.0 \
         bash~=5.2 \


### PR DESCRIPTION
## what

Use new version curl 8.5, since 8.4 is now absent from alpine.

## why

https://github.com/runatlantis/atlantis/pull/3911 is failing tests because of:
```
 > [linux/amd64 alpine 8/8] RUN apk add --no-cache         ca-certificates~=20230506         curl~=8.4         git~=2.40         unzip~=6.0         bash~=5.2         openssh~=9.3_p2         dumb-init~=1.2         gcompat~=1.1:
0.175 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/APKINDEX.tar.gz
0.353 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/x86_64/APKINDEX.tar.gz
0.774 ERROR: unable to select packages:
0.776   curl-8.5.0-r0:
0.776     breaks: world[curl~8.4]
```

This seems to be because curl released 8.5.0 a few days ago: https://curl.se/changes.html#8_5_0

Alpine apparently only keeps the newest: https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/
```
[curl-8.5.0-r0.apk](https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/curl-8.5.0-r0.apk)                                  07-Dec-2023 08:40    146K
```

## tests

Before:
```
atlantis % docker buildx build --target alpine .                          
...                                                                                                                          
 > [alpine 8/8] RUN apk add --no-cache         ca-certificates~=20230506         curl~=8.4         git~=2.40         unzip~=6.0         bash~=5.2         openssh~=9.3_p2         dumb-init~=1.2         gcompat~=1.1:                                                                                                                                                        
0.161 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/APKINDEX.tar.gz
1.361 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/x86_64/APKINDEX.tar.gz
2.006 ERROR: unable to select packages:
2.008   curl-8.5.0-r0:
2.008     breaks: world[curl~8.4]
------
Dockerfile:159
```

After:
```
atlantis % docker buildx build --target alpine .
...
 => [alpine 8/8] RUN apk add --no-cache         ca-certificates~=20230506         curl~=8         git~=2.40         unzip~=6.0         bash~=5.2         openssh~=9.3_p2          4.4s
 => exporting to image                                                                                                                                                            1.5s
 => => exporting layers   
```

## references


