### PR TITLE
feat: Relax constraints for alpine utilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -158,13 +158,13 @@ COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 # We place this last as it will bust less docker layer caches when packages update
 RUN apk add --no-cache \
         ca-certificates~=20230506 \
-        curl~=8.4 \
-        git~=2.40 \
-        unzip~=6.0 \
-        bash~=5.2 \
-        openssh~=9.3_p2 \
-        dumb-init~=1.2 \
-        gcompat~=1.1
+        curl~=8 \
+        git~=2 \
+        unzip~=6 \
+        bash~=5 \
+        openssh~=9 \
+        dumb-init~=1 \
+        gcompat~=1
 
 
 # Set the entry point to the atlantis user and run the atlantis command


### PR DESCRIPTION
## what

Relax constraints for utility packages installed in the alpine-based docker image

## why

Right now, these packages require specific major and minor version but take the newest patch at build time. However, since we use a slim alpine version and no cache, that means as soon as a new minor version is released, build (and thus CI) will immediately fail. See for example: https://github.com/runatlantis/atlantis/pull/4019

I understand the benefit of pinning versions (reproducible builds, etc.), but in this case I think relaxing the constraints is a net positive for two reasons:
1. Since apk is so "slim", as soon as a new release appears and because we're not using a frozen version of the package manager, the build will break, so the builds aren't actually "reproducible"
2. We're not actually pinning now, since we allow patch to automatically update, so this change is a matter of degree

curl for example, has an expected cadence for minor releases of about 8 weeks (https://curl.se/docs/releases.html), which will then block a completely unrelated PR, as well as any new PRs. At that point maintainers must make a manual but mechanical update before any subsequent changes can be made.

My argument for 2) is that the packages this affects (git, curl, bash, ...) are very stable projects and are (I believe) used in relatively vanilla ways throughout atlantis, such that minor releases are very unlikely to break anything. Of course any dependency can have bugs, so this is definitely a tradeoff, but again since we're already accepting any patch updates we already accept that risk, so we're just moving the needle slightly more towards the "get me fixes quickly" end of the spectrum.

For debian the pinning was removed entirely (https://github.com/runatlantis/atlantis/pull/3528) due to an issue with the semantics of `apt-get`. If maintainers would prefer we go that route with alpine for consistency and to remove this problem entirely, I'd be happy to make that change instead.

Another direction would be to figure out how to pull down specific versions of packages (maybe apk has some kind of "archive" repo?) and actually pin all the versions, then periodically do a dedicated update.

## tests

`docker buildx build --target alpine .` builds fine

## references

