### PR TITLE
fix: properly render :put_litter_in_its_place: in default templates

### DIFF
--- a/server/controllers/events/testdata/test-repos/automerge/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/automerge/exp-output-autoplan.txt
@@ -51,5 +51,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/import-multiple-project/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/import-multiple-project/exp-output-autoplan.txt
@@ -71,5 +71,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/import-multiple-project/exp-output-plan-again.txt
+++ b/server/controllers/events/testdata/test-repos/import-multiple-project/exp-output-plan-again.txt
@@ -55,5 +55,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/import-single-project-var/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/import-single-project-var/exp-output-autoplan.txt
@@ -45,5 +45,5 @@ Plan: 2 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/import-single-project-var/exp-output-plan-again.txt
+++ b/server/controllers/events/testdata/test-repos/import-single-project-var/exp-output-plan-again.txt
@@ -16,5 +16,5 @@ and found no differences, so no changes are needed.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/import-single-project/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/import-single-project/exp-output-autoplan.txt
@@ -45,5 +45,5 @@ Plan: 2 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/import-single-project/exp-output-plan-again.txt
+++ b/server/controllers/events/testdata/test-repos/import-single-project/exp-output-plan-again.txt
@@ -16,5 +16,5 @@ and found no differences, so no changes are needed.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/import-workspace/exp-output-plan.txt
+++ b/server/controllers/events/testdata/test-repos/import-workspace/exp-output-plan.txt
@@ -16,5 +16,5 @@ and found no differences, so no changes are needed.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/modules-yaml/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/modules-yaml/exp-output-autoplan.txt
@@ -65,5 +65,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/modules/exp-output-autoplan-only-staging.txt
+++ b/server/controllers/events/testdata/test-repos/modules/exp-output-autoplan-only-staging.txt
@@ -31,5 +31,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/modules/exp-output-plan-production.txt
+++ b/server/controllers/events/testdata/test-repos/modules/exp-output-plan-production.txt
@@ -31,5 +31,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/modules/exp-output-plan-staging.txt
+++ b/server/controllers/events/testdata/test-repos/modules/exp-output-plan-staging.txt
@@ -31,5 +31,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/policy-checks-apply-reqs/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-apply-reqs/exp-output-auto-policy-check.txt
@@ -23,7 +23,7 @@ policy set: test_policy: requires: 1 approval(s), have: 0.
 ---
 * :heavy_check_mark: To **approve** all unapplied plans from this pull request, comment:
     * `atlantis approve_policies`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`
 * :repeat: To re-run policies **plan** this project again by commenting:
     * `atlantis plan`

--- a/server/controllers/events/testdata/test-repos/policy-checks-apply-reqs/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-apply-reqs/exp-output-autoplan.txt
@@ -31,5 +31,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/policy-checks-clear-approval/exp-output-approve-policies-clear.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-clear-approval/exp-output-approve-policies-clear.txt
@@ -17,7 +17,7 @@ policy set: test_policy: requires: 1 approval(s), have: 0.
 ---
 * :heavy_check_mark: To **approve** all unapplied plans from this pull request, comment:
     * `atlantis approve_policies`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`
 * :repeat: To re-run policies **plan** this project again by commenting:
     * `atlantis plan`

--- a/server/controllers/events/testdata/test-repos/policy-checks-clear-approval/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-clear-approval/exp-output-auto-policy-check.txt
@@ -23,7 +23,7 @@ policy set: test_policy: requires: 1 approval(s), have: 0.
 ---
 * :heavy_check_mark: To **approve** all unapplied plans from this pull request, comment:
     * `atlantis approve_policies`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`
 * :repeat: To re-run policies **plan** this project again by commenting:
     * `atlantis plan`

--- a/server/controllers/events/testdata/test-repos/policy-checks-clear-approval/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-clear-approval/exp-output-autoplan.txt
@@ -31,5 +31,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/policy-checks-custom-run-steps/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-custom-run-steps/exp-output-auto-policy-check.txt
@@ -33,7 +33,7 @@ policy set: test_policy: requires: 1 approval(s), have: 0.
 ---
 * :heavy_check_mark: To **approve** all unapplied plans from this pull request, comment:
     * `atlantis approve_policies`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`
 * :repeat: To re-run policies **plan** this project again by commenting:
     * `atlantis plan`

--- a/server/controllers/events/testdata/test-repos/policy-checks-custom-run-steps/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-custom-run-steps/exp-output-autoplan.txt
@@ -31,5 +31,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/policy-checks-diff-owner/exp-output-approve-policies.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-diff-owner/exp-output-approve-policies.txt
@@ -23,7 +23,7 @@ policy set: test_policy: requires: 1 approval(s), have: 0.
 ---
 * :heavy_check_mark: To **approve** all unapplied plans from this pull request, comment:
     * `atlantis approve_policies`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`
 * :repeat: To re-run policies **plan** this project again by commenting:
     * `atlantis plan`

--- a/server/controllers/events/testdata/test-repos/policy-checks-diff-owner/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-diff-owner/exp-output-auto-policy-check.txt
@@ -23,7 +23,7 @@ policy set: test_policy: requires: 1 approval(s), have: 0.
 ---
 * :heavy_check_mark: To **approve** all unapplied plans from this pull request, comment:
     * `atlantis approve_policies`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`
 * :repeat: To re-run policies **plan** this project again by commenting:
     * `atlantis plan`

--- a/server/controllers/events/testdata/test-repos/policy-checks-diff-owner/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-diff-owner/exp-output-autoplan.txt
@@ -31,5 +31,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/policy-checks-disabled-previous-match/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-disabled-previous-match/exp-output-auto-policy-check.txt
@@ -23,7 +23,7 @@ policy set: test_policy: requires: 1 approval(s), have: 0.
 ---
 * :heavy_check_mark: To **approve** all unapplied plans from this pull request, comment:
     * `atlantis approve_policies`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`
 * :repeat: To re-run policies **plan** this project again by commenting:
     * `atlantis plan`

--- a/server/controllers/events/testdata/test-repos/policy-checks-disabled-previous-match/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-disabled-previous-match/exp-output-autoplan.txt
@@ -31,5 +31,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/policy-checks-disabled-repo-server-side/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-disabled-repo-server-side/exp-output-auto-policy-check.txt
@@ -23,7 +23,7 @@ policy set: test_policy: requires: 1 approval(s), have: 0.
 ---
 * :heavy_check_mark: To **approve** all unapplied plans from this pull request, comment:
     * `atlantis approve_policies`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`
 * :repeat: To re-run policies **plan** this project again by commenting:
     * `atlantis plan`

--- a/server/controllers/events/testdata/test-repos/policy-checks-disabled-repo-server-side/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-disabled-repo-server-side/exp-output-autoplan.txt
@@ -31,5 +31,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/policy-checks-disabled-repo/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-disabled-repo/exp-output-auto-policy-check.txt
@@ -23,7 +23,7 @@ policy set: test_policy: requires: 1 approval(s), have: 0.
 ---
 * :heavy_check_mark: To **approve** all unapplied plans from this pull request, comment:
     * `atlantis approve_policies`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`
 * :repeat: To re-run policies **plan** this project again by commenting:
     * `atlantis plan`

--- a/server/controllers/events/testdata/test-repos/policy-checks-disabled-repo/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-disabled-repo/exp-output-autoplan.txt
@@ -31,5 +31,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/policy-checks-enabled-repo-server-side/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-enabled-repo-server-side/exp-output-auto-policy-check.txt
@@ -23,7 +23,7 @@ policy set: test_policy: requires: 1 approval(s), have: 0.
 ---
 * :heavy_check_mark: To **approve** all unapplied plans from this pull request, comment:
     * `atlantis approve_policies`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`
 * :repeat: To re-run policies **plan** this project again by commenting:
     * `atlantis plan`

--- a/server/controllers/events/testdata/test-repos/policy-checks-enabled-repo-server-side/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-enabled-repo-server-side/exp-output-autoplan.txt
@@ -31,5 +31,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/policy-checks-enabled-repo/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-enabled-repo/exp-output-auto-policy-check.txt
@@ -23,7 +23,7 @@ policy set: test_policy: requires: 1 approval(s), have: 0.
 ---
 * :heavy_check_mark: To **approve** all unapplied plans from this pull request, comment:
     * `atlantis approve_policies`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`
 * :repeat: To re-run policies **plan** this project again by commenting:
     * `atlantis plan`

--- a/server/controllers/events/testdata/test-repos/policy-checks-enabled-repo/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-enabled-repo/exp-output-autoplan.txt
@@ -31,5 +31,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/policy-checks-extra-args/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-extra-args/exp-output-auto-policy-check.txt
@@ -23,7 +23,7 @@ policy set: test_policy: requires: 1 approval(s), have: 0.
 ---
 * :heavy_check_mark: To **approve** all unapplied plans from this pull request, comment:
     * `atlantis approve_policies`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`
 * :repeat: To re-run policies **plan** this project again by commenting:
     * `atlantis plan`

--- a/server/controllers/events/testdata/test-repos/policy-checks-extra-args/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-extra-args/exp-output-autoplan.txt
@@ -31,5 +31,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/policy-checks-multi-projects/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-multi-projects/exp-output-auto-policy-check.txt
@@ -43,7 +43,7 @@ policy set: test_policy: requires: 1 approval(s), have: 0.
 ---
 * :heavy_check_mark: To **approve** all unapplied plans from this pull request, comment:
     * `atlantis approve_policies`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`
 * :repeat: To re-run policies **plan** this project again by commenting:
     * `atlantis plan`

--- a/server/controllers/events/testdata/test-repos/policy-checks-multi-projects/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-multi-projects/exp-output-autoplan.txt
@@ -65,5 +65,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/policy-checks-success-silent/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks-success-silent/exp-output-autoplan.txt
@@ -17,5 +17,5 @@ state, without changing any real infrastructure.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/policy-checks/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks/exp-output-auto-policy-check.txt
@@ -23,7 +23,7 @@ policy set: test_policy: requires: 1 approval(s), have: 0.
 ---
 * :heavy_check_mark: To **approve** all unapplied plans from this pull request, comment:
     * `atlantis approve_policies`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`
 * :repeat: To re-run policies **plan** this project again by commenting:
     * `atlantis plan`

--- a/server/controllers/events/testdata/test-repos/policy-checks/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/policy-checks/exp-output-autoplan.txt
@@ -31,5 +31,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/repo-config-file/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/repo-config-file/exp-output-autoplan.txt
@@ -51,5 +51,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/server-side-cfg/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/server-side-cfg/exp-output-autoplan.txt
@@ -73,5 +73,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/simple-with-lockfile/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/simple-with-lockfile/exp-output-autoplan.txt
@@ -42,5 +42,5 @@ Plan: 3 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/simple-with-lockfile/exp-output-plan.txt
+++ b/server/controllers/events/testdata/test-repos/simple-with-lockfile/exp-output-plan.txt
@@ -42,5 +42,5 @@ Plan: 3 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/simple-yaml/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/simple-yaml/exp-output-autoplan.txt
@@ -72,5 +72,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/simple-yaml/exp-output-plan-default.txt
+++ b/server/controllers/events/testdata/test-repos/simple-yaml/exp-output-plan-default.txt
@@ -37,5 +37,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/simple-yaml/exp-output-plan-staging.txt
+++ b/server/controllers/events/testdata/test-repos/simple-yaml/exp-output-plan-staging.txt
@@ -32,5 +32,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/simple/exp-output-atlantis-plan-new-workspace.txt
+++ b/server/controllers/events/testdata/test-repos/simple/exp-output-atlantis-plan-new-workspace.txt
@@ -42,5 +42,5 @@ Plan: 3 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/simple/exp-output-atlantis-plan-var-overridden.txt
+++ b/server/controllers/events/testdata/test-repos/simple/exp-output-atlantis-plan-var-overridden.txt
@@ -42,5 +42,5 @@ Plan: 3 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/simple/exp-output-atlantis-plan.txt
+++ b/server/controllers/events/testdata/test-repos/simple/exp-output-atlantis-plan.txt
@@ -42,5 +42,5 @@ Plan: 3 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/simple/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testdata/test-repos/simple/exp-output-auto-policy-check.txt
@@ -13,5 +13,5 @@ Ran Policy Check for dir: `.` workspace: `default`
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/simple/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/simple/exp-output-autoplan.txt
@@ -42,5 +42,5 @@ Plan: 3 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/state-rm-multiple-project/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/state-rm-multiple-project/exp-output-autoplan.txt
@@ -71,5 +71,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/state-rm-multiple-project/exp-output-plan-again.txt
+++ b/server/controllers/events/testdata/test-repos/state-rm-multiple-project/exp-output-plan-again.txt
@@ -71,5 +71,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/state-rm-multiple-project/exp-output-plan.txt
+++ b/server/controllers/events/testdata/test-repos/state-rm-multiple-project/exp-output-plan.txt
@@ -39,5 +39,5 @@ and found no differences, so no changes are needed.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/state-rm-single-project/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/state-rm-single-project/exp-output-autoplan.txt
@@ -56,5 +56,5 @@ Plan: 3 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/state-rm-single-project/exp-output-plan-again.txt
+++ b/server/controllers/events/testdata/test-repos/state-rm-single-project/exp-output-plan-again.txt
@@ -56,5 +56,5 @@ Plan: 3 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/state-rm-single-project/exp-output-plan.txt
+++ b/server/controllers/events/testdata/test-repos/state-rm-single-project/exp-output-plan.txt
@@ -16,5 +16,5 @@ and found no differences, so no changes are needed.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/state-rm-workspace/exp-output-plan-again.txt
+++ b/server/controllers/events/testdata/test-repos/state-rm-workspace/exp-output-plan-again.txt
@@ -34,5 +34,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/state-rm-workspace/exp-output-plan.txt
+++ b/server/controllers/events/testdata/test-repos/state-rm-workspace/exp-output-plan.txt
@@ -18,5 +18,5 @@ and found no differences, so no changes are needed.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-default.txt
+++ b/server/controllers/events/testdata/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-default.txt
@@ -32,5 +32,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-staging.txt
+++ b/server/controllers/events/testdata/test-repos/tfvars-yaml-no-autoplan/exp-output-plan-staging.txt
@@ -32,5 +32,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/tfvars-yaml/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/tfvars-yaml/exp-output-autoplan.txt
@@ -69,5 +69,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/workspace-parallel-yaml/exp-output-autoplan-production.txt
+++ b/server/controllers/events/testdata/test-repos/workspace-parallel-yaml/exp-output-autoplan-production.txt
@@ -65,5 +65,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/workspace-parallel-yaml/exp-output-autoplan-staging.txt
+++ b/server/controllers/events/testdata/test-repos/workspace-parallel-yaml/exp-output-autoplan-staging.txt
@@ -65,5 +65,5 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `atlantis unlock`

--- a/server/events/templates/multi_project_plan.tmpl
+++ b/server/events/templates/multi_project_plan.tmpl
@@ -15,7 +15,7 @@
 {{ if and (gt (len .Results) 0) (not .PlansDeleted) -}}
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `{{ .ExecutableName }} apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `{{ .ExecutableName }} unlock`
 {{ end -}}
 {{ end -}}

--- a/server/events/templates/multi_project_policy_unsuccessful.tmpl
+++ b/server/events/templates/multi_project_policy_unsuccessful.tmpl
@@ -13,7 +13,7 @@
 {{ if and (gt (len .Results) 0) (not .PlansDeleted) -}}
 * :heavy_check_mark: To **approve** all unapplied plans from this pull request, comment:
     * `{{ .ExecutableName }} approve_policies`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `{{ .ExecutableName }} unlock`
 * :repeat: To re-run policies **plan** this project again by commenting:
     * `{{ .ExecutableName }} plan`

--- a/server/events/templates/single_project_plan_success.tmpl
+++ b/server/events/templates/single_project_plan_success.tmpl
@@ -7,7 +7,7 @@ Ran {{ .Command }} for {{ if $result.ProjectName }}project: `{{ $result.ProjectN
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `{{ .ExecutableName }} apply`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `{{ .ExecutableName }} unlock`
 {{ end -}}
 {{- template "log" . -}}

--- a/server/events/templates/single_project_policy_unsuccessful.tmpl
+++ b/server/events/templates/single_project_policy_unsuccessful.tmpl
@@ -7,7 +7,7 @@ Ran {{ .Command }} for {{ if $result.ProjectName }}project: `{{ $result.ProjectN
 ---
 * :heavy_check_mark: To **approve** all unapplied plans from this pull request, comment:
     * `{{ .ExecutableName }} approve_policies`
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * `{{ .ExecutableName }} unlock`
 * :repeat: To re-run policies **plan** this project again by commenting:
     * `{{ .ExecutableName }} plan`


### PR DESCRIPTION
## what

It seems that GitHub has changed its Markdown renderer such that an emoji followed by a string of plain text (with no other formatting) followed by a colon at the end of the line renders as plain text instead of as the emoji. Compare the following three lines:

* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:

* :put_litter_in_its_place: To delete all plans and locks for the PR, comment

* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:

While this seems like it is probably a GitHub bug, we can work around it by adding some formatting between the emoji and the end of the line, which matches the bullet point above it anyway.

## why

It's ugly to see spelled-out emoji instead of the emoji.

## tests

Just look a few lines up in this message to see the impact.
