### PR TITLE
chore: Remove settings for require approval, mergeable, undiverged

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -1044,20 +1044,13 @@ func (s *ServerCmd) securityWarnings(userConfig *server.UserConfig) {
 }
 
 // deprecationWarnings prints a warning if flags that are deprecated are
-// being used. Right now this only applies to flags that have been made obsolete
-// due to server-side config.
+// being used.
 func (s *ServerCmd) deprecationWarnings(userConfig *server.UserConfig) error {
 	var deprecatedFlags []string
-
-	// Build up strings with what the recommended yaml and json config should
-	// be instead of using the deprecated flags.
-	yamlCfg := "---\nrepos:\n- id: /.*/"
-	jsonCfg := `{"repos":[{"id":"/.*/"}]}`
 
 	// Currently there are no deprecated flags; if flags become deprecated, add them here like so
 	//       if userConfig.SomeDeprecatedFlag {
 	//               deprecatedFlags = append(deprecatedFlags, SomeDeprecatedFlag)
-	//               // Update yamlCfg and jsonCfg to show how to replace them
 	//       }
 	//
 
@@ -1068,12 +1061,6 @@ func (s *ServerCmd) deprecationWarnings(userConfig *server.UserConfig) error {
 		} else {
 			warning += fmt.Sprintf("Flags --%s and --%s have been deprecated.", strings.Join(deprecatedFlags[0:len(deprecatedFlags)-1], ", --"), deprecatedFlags[len(deprecatedFlags)-1:][0])
 		}
-		warning += fmt.Sprintf("\nCreate a --%s file with the following config instead:\n\n%s\n\nor use --%s='%s'\n",
-			RepoConfigFlag,
-			yamlCfg,
-			RepoConfigJSONFlag,
-			jsonCfg,
-		)
 		fmt.Println(warning)
 	}
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -27,7 +27,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/runatlantis/atlantis/server"
-	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events/vcs/bitbucketcloud"
 	"github.com/runatlantis/atlantis/server/logging"
 )
@@ -117,8 +116,6 @@ const (
 	RepoConfigFlag                   = "repo-config"
 	RepoConfigJSONFlag               = "repo-config-json"
 	RepoAllowlistFlag                = "repo-allowlist"
-	RequireApprovalFlag              = "require-approval"
-	RequireMergeableFlag             = "require-mergeable"
 	SilenceNoProjectsFlag            = "silence-no-projects"
 	SilenceForkPRErrorsFlag          = "silence-fork-pr-errors"
 	SilenceVCSStatusNoPlans          = "silence-vcs-status-no-plans"
@@ -496,16 +493,6 @@ var boolFlags = map[string]boolFlag{
 	RedisInsecureSkipVerify: {
 		description:  "Controls whether the Redis client verifies the Redis server's certificate chain and host name. If true, accepts any certificate presented by the server and any host name in that certificate.",
 		defaultValue: DefaultRedisInsecureSkipVerify,
-	},
-	RequireApprovalFlag: {
-		description:  "Require pull requests to be \"Approved\" before allowing the apply command to be run.",
-		defaultValue: false,
-		hidden:       true,
-	},
-	RequireMergeableFlag: {
-		description:  "Require pull requests to be mergeable before allowing the apply command to be run.",
-		defaultValue: false,
-		hidden:       true,
 	},
 	SilenceNoProjectsFlag: {
 		description:  "Silences Atlants from responding to PRs when it finds no projects.",
@@ -1060,30 +1047,19 @@ func (s *ServerCmd) securityWarnings(userConfig *server.UserConfig) {
 // being used. Right now this only applies to flags that have been made obsolete
 // due to server-side config.
 func (s *ServerCmd) deprecationWarnings(userConfig *server.UserConfig) error {
-	var commandReqs []string
 	var deprecatedFlags []string
-	if userConfig.RequireApproval {
-		deprecatedFlags = append(deprecatedFlags, RequireApprovalFlag)
-		commandReqs = append(commandReqs, valid.ApprovedCommandReq)
-	}
-	if userConfig.RequireMergeable {
-		deprecatedFlags = append(deprecatedFlags, RequireMergeableFlag)
-		commandReqs = append(commandReqs, valid.MergeableCommandReq)
-	}
 
 	// Build up strings with what the recommended yaml and json config should
 	// be instead of using the deprecated flags.
 	yamlCfg := "---\nrepos:\n- id: /.*/"
-	jsonCfg := `{"repos":[{"id":"/.*/"`
-	if len(commandReqs) > 0 {
-		yamlCfg += fmt.Sprintf("\n  plan_requirements: [%s]", strings.Join(commandReqs, ", "))
-		yamlCfg += fmt.Sprintf("\n  apply_requirements: [%s]", strings.Join(commandReqs, ", "))
-		yamlCfg += fmt.Sprintf("\n  import_requirements: [%s]", strings.Join(commandReqs, ", "))
-		jsonCfg += fmt.Sprintf(`, "plan_requirements":["%s"]`, strings.Join(commandReqs, "\", \""))
-		jsonCfg += fmt.Sprintf(`, "apply_requirements":["%s"]`, strings.Join(commandReqs, "\", \""))
-		jsonCfg += fmt.Sprintf(`, "import_requirements":["%s"]`, strings.Join(commandReqs, "\", \""))
-	}
-	jsonCfg += "}]}"
+	jsonCfg := `{"repos":[{"id":"/.*/"}]}`
+
+	// Currently there are no deprecated flags; if flags become deprecated, add them here like so
+	//       if userConfig.SomeDeprecatedFlag {
+	//               deprecatedFlags = append(deprecatedFlags, SomeDeprecatedFlag)
+	//               // Update yamlCfg and jsonCfg to show how to replace them
+	//       }
+	//
 
 	if len(deprecatedFlags) > 0 {
 		warning := "WARNING: "

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -118,8 +118,6 @@ var testFlags = map[string]interface{}{
 	RepoAllowlistFlag:                "github.com/runatlantis/atlantis",
 	RepoConfigFlag:                   "",
 	RepoConfigJSONFlag:               "",
-	RequireApprovalFlag:              true,
-	RequireMergeableFlag:             true,
 	SilenceNoProjectsFlag:            false,
 	SilenceForkPRErrorsFlag:          true,
 	SilenceAllowlistErrorsFlag:       true,

--- a/runatlantis.io/docs/command-requirements.md
+++ b/runatlantis.io/docs/command-requirements.md
@@ -20,7 +20,6 @@ by at least one person other than the author.
 
 #### Usage
 The `approved` requirement by:
-1. Passing the `--require-approval` flag to `atlantis server` or
 1. Creating a `repos.yaml` file with the `apply_requirements` key:
    ```yaml
    repos:
@@ -62,7 +61,6 @@ The `mergeable` requirement will prevent applies unless a pull request is able t
 
 #### Usage
 Set the `mergeable` requirement by:
-1. Passing the `--require-mergeable` flag to `atlantis server` or
 1. Creating a `repos.yaml` file with the `apply_requirements` key:
    ```yaml
    repos:
@@ -196,8 +194,6 @@ having that apply requirement set.
 
 ### Project-Specific Settings
 If you only want some projects/repos to have apply requirements, then you must
-1. Not set the `--require-approval` or `--require-mergeable` flags, since those
-   will override any `repos.yaml` or `atlantis.yaml` settings
 1. Specifying which repos have which requirements via the `repos.yaml` file.
    ```yaml
    repos:

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1342,8 +1342,6 @@ func setupE2E(t *testing.T, repoDir string, opt setupOption) (events_controllers
 	globalCfgArgs := valid.GlobalCfgArgs{
 		RepoConfigFile:       opt.repoConfigFile,
 		AllowAllRepoSettings: true,
-		MergeableReq:         false,
-		ApprovedReq:          false,
 		PreWorkflowHooks:     preWorkflowHooks,
 		PostWorkflowHooks: []*valid.WorkflowHook{
 			{

--- a/server/core/config/parser_validator_test.go
+++ b/server/core/config/parser_validator_test.go
@@ -17,9 +17,6 @@ import (
 
 var globalCfgArgs = valid.GlobalCfgArgs{
 	AllowAllRepoSettings: true,
-	MergeableReq:         false,
-	ApprovedReq:          false,
-	UnDivergedReq:        false,
 }
 
 var globalCfg = valid.NewGlobalCfgFromArgs(globalCfgArgs)
@@ -105,9 +102,6 @@ func TestParseCfgs_InvalidYAML(t *testing.T) {
 			_, err = r.ParseRepoCfg(tmpDir, globalCfg, "", "")
 			ErrContains(t, c.expErr, err)
 			globalCfgArgs := valid.GlobalCfgArgs{
-				MergeableReq:  false,
-				ApprovedReq:   false,
-				UnDivergedReq: false,
 			}
 			_, err = r.ParseGlobalCfg(confPath, valid.NewGlobalCfgFromArgs(globalCfgArgs))
 			ErrContains(t, c.expErr, err)
@@ -1145,9 +1139,6 @@ workflows:
 
 	r := config.ParserValidator{}
 	globalCfgArgs := valid.GlobalCfgArgs{
-		MergeableReq:  false,
-		ApprovedReq:   false,
-		UnDivergedReq: false,
 	}
 
 	_, err = r.ParseRepoCfg(tmpDir, valid.NewGlobalCfgFromArgs(globalCfgArgs), "repo_id", "branch")
@@ -1157,9 +1148,6 @@ workflows:
 func TestParseGlobalCfg_NotExist(t *testing.T) {
 	r := config.ParserValidator{}
 	globalCfgArgs := valid.GlobalCfgArgs{
-		MergeableReq:  false,
-		ApprovedReq:   false,
-		UnDivergedReq: false,
 	}
 	_, err := r.ParseGlobalCfg("/not/exist", valid.NewGlobalCfgFromArgs(globalCfgArgs))
 	ErrEquals(t, "unable to read /not/exist file: open /not/exist: no such file or directory", err)
@@ -1167,9 +1155,6 @@ func TestParseGlobalCfg_NotExist(t *testing.T) {
 
 func TestParseGlobalCfg(t *testing.T) {
 	globalCfgArgs := valid.GlobalCfgArgs{
-		MergeableReq:  false,
-		ApprovedReq:   false,
-		UnDivergedReq: false,
 	}
 
 	defaultCfg := valid.NewGlobalCfgFromArgs(globalCfgArgs)
@@ -1623,9 +1608,6 @@ workflows:
 			Ok(t, os.WriteFile(path, []byte(c.input), 0600))
 
 			globalCfgArgs := valid.GlobalCfgArgs{
-				MergeableReq:       false,
-				ApprovedReq:        false,
-				UnDivergedReq:      false,
 				PolicyCheckEnabled: false,
 			}
 
@@ -1729,9 +1711,6 @@ func TestParserValidator_ParseGlobalCfgJSON(t *testing.T) {
 		"empty object": {
 			json: "{}",
 			exp: valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
-				MergeableReq:  false,
-				ApprovedReq:   false,
-				UnDivergedReq: false,
 			}),
 		},
 		"setting all keys": {
@@ -1800,9 +1779,6 @@ func TestParserValidator_ParseGlobalCfgJSON(t *testing.T) {
 			exp: valid.GlobalCfg{
 				Repos: []valid.Repo{
 					valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
-						MergeableReq:  false,
-						ApprovedReq:   false,
-						UnDivergedReq: false,
 					}).Repos[0],
 					{
 						IDRegex:              regexp.MustCompile(".*"),
@@ -1824,9 +1800,6 @@ func TestParserValidator_ParseGlobalCfgJSON(t *testing.T) {
 				},
 				Workflows: map[string]valid.Workflow{
 					"default": valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
-						MergeableReq:  false,
-						ApprovedReq:   false,
-						UnDivergedReq: false,
 					}).Workflows["default"],
 					"custom": customWorkflow,
 				},
@@ -1849,9 +1822,6 @@ func TestParserValidator_ParseGlobalCfgJSON(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			pv := &config.ParserValidator{}
 			globalCfgArgs := valid.GlobalCfgArgs{
-				MergeableReq:  false,
-				ApprovedReq:   false,
-				UnDivergedReq: false,
 			}
 			cfg, err := pv.ParseGlobalCfgJSON(c.json, valid.NewGlobalCfgFromArgs(globalCfgArgs))
 			if c.expErr != "" {
@@ -1914,9 +1884,6 @@ func TestParseRepoCfg_V2ShellParsing(t *testing.T) {
 			p := &config.ParserValidator{}
 			globalCfgArgs := valid.GlobalCfgArgs{
 				AllowAllRepoSettings: true,
-				MergeableReq:         false,
-				ApprovedReq:          false,
-				UnDivergedReq:        false,
 			}
 			v2Cfg, err := p.ParseRepoCfg(v2Dir, valid.NewGlobalCfgFromArgs(globalCfgArgs), "", "")
 			if c.expV2Err != "" {
@@ -1928,9 +1895,6 @@ func TestParseRepoCfg_V2ShellParsing(t *testing.T) {
 			}
 			globalCfgArgs = valid.GlobalCfgArgs{
 				AllowAllRepoSettings: true,
-				MergeableReq:         false,
-				ApprovedReq:          false,
-				UnDivergedReq:        false,
 			}
 			v3Cfg, err := p.ParseRepoCfg(v3Dir, valid.NewGlobalCfgFromArgs(globalCfgArgs), "", "")
 			Ok(t, err)

--- a/server/core/config/valid/global_cfg.go
+++ b/server/core/config/valid/global_cfg.go
@@ -180,9 +180,6 @@ type GlobalCfgArgs struct {
 	// but useful for tests to set to true to not require enumeration of allowed settings
 	// on the repo side
 	AllowAllRepoSettings bool
-	MergeableReq         bool
-	ApprovedReq          bool
-	UnDivergedReq        bool
 	PolicyCheckEnabled   bool
 	PreWorkflowHooks     []*WorkflowHook
 	PostWorkflowHooks    []*WorkflowHook
@@ -203,15 +200,6 @@ func NewGlobalCfgFromArgs(args GlobalCfgArgs) GlobalCfg {
 	allowedOverrides := []string{}
 	allowedWorkflows := []string{}
 	policyCheck := false
-	if args.MergeableReq {
-		commandReqs = append(commandReqs, MergeableCommandReq)
-	}
-	if args.ApprovedReq {
-		commandReqs = append(commandReqs, ApprovedCommandReq)
-	}
-	if args.UnDivergedReq {
-		commandReqs = append(commandReqs, UnDivergedCommandReq)
-	}
 	if args.PolicyCheckEnabled {
 		commandReqs = append(commandReqs, PoliciesPassedCommandReq)
 		policyCheck = true

--- a/server/core/config/valid/global_cfg_test.go
+++ b/server/core/config/valid/global_cfg_test.go
@@ -93,113 +93,31 @@ func TestNewGlobalCfg(t *testing.T) {
 
 	cases := []struct {
 		allowAllRepoSettings bool
-		approvedReq          bool
-		mergeableReq         bool
-		unDivergedReq        bool
 		policyCheckEnabled   bool
 	}{
 		{
 			allowAllRepoSettings: false,
-			approvedReq:          false,
-			mergeableReq:         false,
-			unDivergedReq:        false,
 			policyCheckEnabled:   false,
 		},
 		{
 			allowAllRepoSettings: true,
-			approvedReq:          false,
-			mergeableReq:         false,
-			unDivergedReq:        false,
-			policyCheckEnabled:   false,
-		},
-		{
-			allowAllRepoSettings: false,
-			approvedReq:          true,
-			mergeableReq:         false,
-			unDivergedReq:        false,
-			policyCheckEnabled:   false,
-		},
-		{
-			allowAllRepoSettings: false,
-			approvedReq:          false,
-			mergeableReq:         true,
-			unDivergedReq:        false,
-			policyCheckEnabled:   false,
-		},
-		{
-			allowAllRepoSettings: false,
-			approvedReq:          true,
-			mergeableReq:         true,
-			unDivergedReq:        false,
 			policyCheckEnabled:   false,
 		},
 		{
 			allowAllRepoSettings: true,
-			approvedReq:          true,
-			mergeableReq:         true,
-			unDivergedReq:        false,
-			policyCheckEnabled:   false,
+			policyCheckEnabled:   true,
 		},
 		{
 			allowAllRepoSettings: false,
-			approvedReq:          false,
-			mergeableReq:         false,
-			unDivergedReq:        true,
-			policyCheckEnabled:   false,
-		},
-		{
-			allowAllRepoSettings: true,
-			approvedReq:          false,
-			mergeableReq:         false,
-			unDivergedReq:        true,
-			policyCheckEnabled:   false,
-		},
-		{
-			allowAllRepoSettings: false,
-			approvedReq:          true,
-			mergeableReq:         false,
-			unDivergedReq:        true,
-			policyCheckEnabled:   false,
-		},
-		{
-			allowAllRepoSettings: false,
-			approvedReq:          false,
-			mergeableReq:         true,
-			unDivergedReq:        true,
-			policyCheckEnabled:   false,
-		},
-		{
-			allowAllRepoSettings: false,
-			approvedReq:          true,
-			mergeableReq:         true,
-			unDivergedReq:        true,
-			policyCheckEnabled:   false,
-		},
-		{
-			allowAllRepoSettings: true,
-			approvedReq:          true,
-			mergeableReq:         true,
-			unDivergedReq:        true,
-			policyCheckEnabled:   false,
-		},
-		{
-			allowAllRepoSettings: true,
-			approvedReq:          true,
-			mergeableReq:         true,
-			unDivergedReq:        true,
 			policyCheckEnabled:   true,
 		},
 	}
 
 	for _, c := range cases {
-		caseName := fmt.Sprintf("allow_repo: %t, approved: %t, mergeable: %t, undiverged: %t, policy_check: %t",
-			c.allowAllRepoSettings, c.approvedReq, c.mergeableReq, c.unDivergedReq, c.policyCheckEnabled)
+		caseName := fmt.Sprintf("allow_repo: %t, policy_check: %t", c.allowAllRepoSettings, c.policyCheckEnabled)
 		t.Run(caseName, func(t *testing.T) {
 			globalCfgArgs := valid.GlobalCfgArgs{
 				AllowAllRepoSettings: c.allowAllRepoSettings,
-				MergeableReq:         c.mergeableReq,
-				ApprovedReq:          c.approvedReq,
-				UnDivergedReq:        c.unDivergedReq,
 				PolicyCheckEnabled:   c.policyCheckEnabled,
 			}
 			act := valid.NewGlobalCfgFromArgs(globalCfgArgs)
@@ -212,21 +130,6 @@ func TestNewGlobalCfg(t *testing.T) {
 			if c.allowAllRepoSettings {
 				exp.Repos[0].AllowCustomWorkflows = Bool(true)
 				exp.Repos[0].AllowedOverrides = []string{"plan_requirements", "apply_requirements", "import_requirements", "workflow", "delete_source_branch_on_merge", "repo_locking", "policy_check"}
-			}
-			if c.mergeableReq {
-				exp.Repos[0].PlanRequirements = append(exp.Repos[0].PlanRequirements, "mergeable")
-				exp.Repos[0].ApplyRequirements = append(exp.Repos[0].ApplyRequirements, "mergeable")
-				exp.Repos[0].ImportRequirements = append(exp.Repos[0].ImportRequirements, "mergeable")
-			}
-			if c.approvedReq {
-				exp.Repos[0].PlanRequirements = append(exp.Repos[0].PlanRequirements, "approved")
-				exp.Repos[0].ApplyRequirements = append(exp.Repos[0].ApplyRequirements, "approved")
-				exp.Repos[0].ImportRequirements = append(exp.Repos[0].ImportRequirements, "approved")
-			}
-			if c.unDivergedReq {
-				exp.Repos[0].PlanRequirements = append(exp.Repos[0].PlanRequirements, "undiverged")
-				exp.Repos[0].ApplyRequirements = append(exp.Repos[0].ApplyRequirements, "undiverged")
-				exp.Repos[0].ImportRequirements = append(exp.Repos[0].ImportRequirements, "undiverged")
 			}
 			if c.policyCheckEnabled {
 				exp.Repos[0].PlanRequirements = append(exp.Repos[0].PlanRequirements, "policies_passed")
@@ -265,9 +168,6 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 				Repos: []valid.Repo{
 					valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
 						AllowAllRepoSettings: true,
-						MergeableReq:         false,
-						ApprovedReq:          false,
-						UnDivergedReq:        false,
 					}).Repos[0],
 					{
 						ID:                   "github.com/owner/repo",
@@ -298,9 +198,6 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 				Repos: []valid.Repo{
 					valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
 						AllowAllRepoSettings: true,
-						MergeableReq:         false,
-						ApprovedReq:          false,
-						UnDivergedReq:        false,
 					}).Repos[0],
 					{
 						ID:                   "github.com/owner/repo",
@@ -331,9 +228,6 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 				Repos: []valid.Repo{
 					valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
 						AllowAllRepoSettings: true,
-						MergeableReq:         false,
-						ApprovedReq:          false,
-						UnDivergedReq:        false,
 					}).Repos[0],
 					{
 						ID:                   "github.com/owner/repo",
@@ -366,9 +260,6 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 				Repos: []valid.Repo{
 					valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
 						AllowAllRepoSettings: true,
-						MergeableReq:         false,
-						ApprovedReq:          false,
-						UnDivergedReq:        false,
 					}).Repos[0],
 					{
 						ID:                   "github.com/owner/repo",
@@ -401,9 +292,6 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 				Repos: []valid.Repo{
 					valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
 						AllowAllRepoSettings: true,
-						MergeableReq:         false,
-						ApprovedReq:          false,
-						UnDivergedReq:        false,
 					}).Repos[0],
 					{
 						ID:                   "github.com/owner/repo",
@@ -434,9 +322,6 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 				Repos: []valid.Repo{
 					valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
 						AllowAllRepoSettings: true,
-						MergeableReq:         false,
-						ApprovedReq:          false,
-						UnDivergedReq:        false,
 					}).Repos[0],
 					{
 						ID:                   "github.com/owner/repo",
@@ -465,9 +350,6 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 		"workflow not allowed": {
 			gCfg: valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
 				AllowAllRepoSettings: false,
-				MergeableReq:         false,
-				ApprovedReq:          false,
-				UnDivergedReq:        false,
 			}),
 			rCfg: valid.RepoCfg{
 				Projects: []valid.Project{
@@ -482,9 +364,6 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 		"custom workflows not allowed": {
 			gCfg: valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
 				AllowAllRepoSettings: false,
-				MergeableReq:         false,
-				ApprovedReq:          false,
-				UnDivergedReq:        false,
 			}),
 			rCfg: valid.RepoCfg{
 				Workflows: map[string]valid.Workflow{
@@ -497,9 +376,6 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 		"custom workflows allowed": {
 			gCfg: valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
 				AllowAllRepoSettings: true,
-				MergeableReq:         false,
-				ApprovedReq:          false,
-				UnDivergedReq:        false,
 			}),
 			rCfg: valid.RepoCfg{
 				Workflows: map[string]valid.Workflow{
@@ -512,9 +388,6 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 		"repo uses custom workflow defined on repo": {
 			gCfg: valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
 				AllowAllRepoSettings: true,
-				MergeableReq:         false,
-				ApprovedReq:          false,
-				UnDivergedReq:        false,
 			}),
 			rCfg: valid.RepoCfg{
 				Projects: []valid.Project{
@@ -536,9 +409,6 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 				Repos: []valid.Repo{
 					valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
 						AllowAllRepoSettings: false,
-						MergeableReq:         false,
-						ApprovedReq:          false,
-						UnDivergedReq:        false,
 					}).Repos[0],
 					{
 						ID:                   "github.com/owner/repo",
@@ -557,9 +427,6 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 		"repo uses global workflow": {
 			gCfg: valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
 				AllowAllRepoSettings: true,
-				MergeableReq:         false,
-				ApprovedReq:          false,
-				UnDivergedReq:        false,
 			}),
 			rCfg: valid.RepoCfg{
 				Projects: []valid.Project{
@@ -576,9 +443,6 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 		"plan_reqs not allowed": {
 			gCfg: valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
 				AllowAllRepoSettings: false,
-				MergeableReq:         false,
-				ApprovedReq:          false,
-				UnDivergedReq:        false,
 			}),
 			rCfg: valid.RepoCfg{
 				Projects: []valid.Project{
@@ -595,9 +459,6 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 		"apply_reqs not allowed": {
 			gCfg: valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
 				AllowAllRepoSettings: false,
-				MergeableReq:         false,
-				ApprovedReq:          false,
-				UnDivergedReq:        false,
 			}),
 			rCfg: valid.RepoCfg{
 				Projects: []valid.Project{
@@ -614,9 +475,6 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 		"import_reqs not allowed": {
 			gCfg: valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
 				AllowAllRepoSettings: false,
-				MergeableReq:         false,
-				ApprovedReq:          false,
-				UnDivergedReq:        false,
 			}),
 			rCfg: valid.RepoCfg{
 				Projects: []valid.Project{
@@ -633,9 +491,6 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 		"repo workflow doesn't exist": {
 			gCfg: valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{
 				AllowAllRepoSettings: true,
-				MergeableReq:         false,
-				ApprovedReq:          false,
-				UnDivergedReq:        false,
 			}),
 			rCfg: valid.RepoCfg{
 				Projects: []valid.Project{
@@ -778,18 +633,12 @@ policies:
 				var err error
 				globalCfgArgs := valid.GlobalCfgArgs{
 					AllowAllRepoSettings: false,
-					MergeableReq:         false,
-					ApprovedReq:          false,
-					UnDivergedReq:        false,
 				}
 				global, err = (&config.ParserValidator{}).ParseGlobalCfg(path, valid.NewGlobalCfgFromArgs(globalCfgArgs))
 				Ok(t, err)
 			} else {
 				globalCfgArgs := valid.GlobalCfgArgs{
 					AllowAllRepoSettings: false,
-					MergeableReq:         false,
-					ApprovedReq:          false,
-					UnDivergedReq:        false,
 				}
 				global = valid.NewGlobalCfgFromArgs(globalCfgArgs)
 			}
@@ -1150,9 +999,6 @@ repos:
 				var err error
 				globalCfgArgs := valid.GlobalCfgArgs{
 					AllowAllRepoSettings: false,
-					MergeableReq:         false,
-					ApprovedReq:          false,
-					UnDivergedReq:        false,
 				}
 
 				global, err = (&config.ParserValidator{}).ParseGlobalCfg(path, valid.NewGlobalCfgFromArgs(globalCfgArgs))
@@ -1160,9 +1006,6 @@ repos:
 			} else {
 				globalCfgArgs := valid.GlobalCfgArgs{
 					AllowAllRepoSettings: false,
-					MergeableReq:         false,
-					ApprovedReq:          false,
-					UnDivergedReq:        false,
 				}
 				global = valid.NewGlobalCfgFromArgs(globalCfgArgs)
 			}
@@ -1507,9 +1350,6 @@ repos:
 			var err error
 			globalCfgArgs := valid.GlobalCfgArgs{
 				AllowAllRepoSettings: false,
-				MergeableReq:         false,
-				ApprovedReq:          false,
-				UnDivergedReq:        false,
 				PolicyCheckEnabled:   c.gPolicyCheck,
 			}
 

--- a/server/events/project_command_builder_internal_test.go
+++ b/server/events/project_command_builder_internal_test.go
@@ -639,9 +639,6 @@ projects:
 			Ok(t, os.WriteFile(globalCfgPath, []byte(c.globalCfg), 0600))
 			parser := &config.ParserValidator{}
 			globalCfgArgs := valid.GlobalCfgArgs{
-				MergeableReq:  false,
-				ApprovedReq:   false,
-				UnDivergedReq: false,
 			}
 			globalCfg, err := parser.ParseGlobalCfg(globalCfgPath, valid.NewGlobalCfgFromArgs(globalCfgArgs))
 			Ok(t, err)
@@ -857,9 +854,6 @@ projects:
 			Ok(t, os.WriteFile(globalCfgPath, []byte(c.globalCfg), 0600))
 			parser := &config.ParserValidator{}
 			globalCfgArgs := valid.GlobalCfgArgs{
-				MergeableReq:  false,
-				ApprovedReq:   false,
-				UnDivergedReq: false,
 			}
 			globalCfg, err := parser.ParseGlobalCfg(globalCfgPath, valid.NewGlobalCfgFromArgs(globalCfgArgs))
 			Ok(t, err)
@@ -1106,9 +1100,6 @@ workflows:
 			Ok(t, os.WriteFile(globalCfgPath, []byte(c.globalCfg), 0600))
 			parser := &config.ParserValidator{}
 			globalCfgArgs := valid.GlobalCfgArgs{
-				MergeableReq:       false,
-				ApprovedReq:        false,
-				UnDivergedReq:      false,
 				PolicyCheckEnabled: true,
 			}
 
@@ -1263,9 +1254,6 @@ projects:
 			Ok(t, os.WriteFile(globalCfgPath, []byte(globalCfg), 0600))
 			parser := &config.ParserValidator{}
 			globalCfgArgs := valid.GlobalCfgArgs{
-				MergeableReq:  false,
-				ApprovedReq:   false,
-				UnDivergedReq: false,
 			}
 
 			globalCfg, err := parser.ParseGlobalCfg(globalCfgPath, valid.NewGlobalCfgFromArgs(globalCfgArgs))
@@ -1407,9 +1395,6 @@ projects:
 			parser := &config.ParserValidator{}
 			globalCfgArgs := valid.GlobalCfgArgs{
 				AllowAllRepoSettings: false,
-				MergeableReq:         false,
-				ApprovedReq:          false,
-				UnDivergedReq:        false,
 			}
 
 			globalCfg, err := parser.ParseGlobalCfg(globalCfgPath, valid.NewGlobalCfgFromArgs(globalCfgArgs))

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -170,9 +170,6 @@ projects:
 			}
 
 			globalCfgArgs := valid.GlobalCfgArgs{
-				MergeableReq:  false,
-				ApprovedReq:   false,
-				UnDivergedReq: false,
 			}
 
 			builder := events.NewProjectCommandBuilder(
@@ -525,9 +522,6 @@ projects:
 
 				globalCfgArgs := valid.GlobalCfgArgs{
 					AllowAllRepoSettings: true,
-					MergeableReq:         false,
-					ApprovedReq:          false,
-					UnDivergedReq:        false,
 				}
 
 				terraformClient := terraform_mocks.NewMockClient()
@@ -716,9 +710,6 @@ projects:
 
 			globalCfgArgs := valid.GlobalCfgArgs{
 				AllowAllRepoSettings: true,
-				MergeableReq:         false,
-				ApprovedReq:          false,
-				UnDivergedReq:        false,
 			}
 
 			terraformClient := terraform_mocks.NewMockClient()
@@ -1048,9 +1039,6 @@ projects:
 
 			globalCfgArgs := valid.GlobalCfgArgs{
 				AllowAllRepoSettings: true,
-				MergeableReq:         false,
-				ApprovedReq:          false,
-				UnDivergedReq:        false,
 			}
 
 			terraformClient := terraform_mocks.NewMockClient()
@@ -1151,9 +1139,6 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply(t *testing.T) {
 	userConfig := defaultUserConfig
 
 	globalCfgArgs := valid.GlobalCfgArgs{
-		MergeableReq:  false,
-		ApprovedReq:   false,
-		UnDivergedReq: false,
 	}
 	scope, _, _ := metrics.NewLoggingScope(logger, "atlantis")
 
@@ -1245,9 +1230,6 @@ projects:
 
 	globalCfgArgs := valid.GlobalCfgArgs{
 		AllowAllRepoSettings: true,
-		MergeableReq:         false,
-		ApprovedReq:          false,
-		UnDivergedReq:        false,
 	}
 	logger := logging.NewNoopLogger(t)
 	scope, _, _ := metrics.NewLoggingScope(logger, "atlantis")
@@ -1339,9 +1321,6 @@ func TestDefaultProjectCommandBuilder_EscapeArgs(t *testing.T) {
 
 			globalCfgArgs := valid.GlobalCfgArgs{
 				AllowAllRepoSettings: true,
-				MergeableReq:         false,
-				ApprovedReq:          false,
-				UnDivergedReq:        false,
 			}
 
 			terraformClient := terraform_mocks.NewMockClient()
@@ -1503,9 +1482,6 @@ projects:
 
 			globalCfgArgs := valid.GlobalCfgArgs{
 				AllowAllRepoSettings: true,
-				MergeableReq:         false,
-				ApprovedReq:          false,
-				UnDivergedReq:        false,
 			}
 
 			terraformClient := terraform_mocks.NewMockClient()
@@ -1624,9 +1600,6 @@ projects:
 
 		globalCfgArgs := valid.GlobalCfgArgs{
 			AllowAllRepoSettings: true,
-			MergeableReq:         false,
-			ApprovedReq:          false,
-			UnDivergedReq:        false,
 		}
 		scope, _, _ := metrics.NewLoggingScope(logger, "atlantis")
 		terraformClient := terraform_mocks.NewMockClient()
@@ -1693,9 +1666,6 @@ func TestDefaultProjectCommandBuilder_WithPolicyCheckEnabled_BuildAutoplanComman
 
 	globalCfgArgs := valid.GlobalCfgArgs{
 		AllowAllRepoSettings: false,
-		MergeableReq:         false,
-		ApprovedReq:          false,
-		UnDivergedReq:        false,
 		PolicyCheckEnabled:   true,
 	}
 
@@ -1789,9 +1759,6 @@ func TestDefaultProjectCommandBuilder_BuildVersionCommand(t *testing.T) {
 
 	globalCfgArgs := valid.GlobalCfgArgs{
 		AllowAllRepoSettings: false,
-		MergeableReq:         false,
-		ApprovedReq:          false,
-		UnDivergedReq:        false,
 	}
 	terraformClient := terraform_mocks.NewMockClient()
 	When(terraformClient.ListAvailableVersions(Any[logging.SimpleLogging]())).ThenReturn([]string{}, nil)
@@ -1898,9 +1865,6 @@ func TestDefaultProjectCommandBuilder_BuildPlanCommands_Single_With_RestrictFile
 
 	globalCfgArgs := valid.GlobalCfgArgs{
 		AllowAllRepoSettings: true,
-		MergeableReq:         false,
-		ApprovedReq:          false,
-		UnDivergedReq:        false,
 	}
 
 	logger := logging.NewNoopLogger(t)
@@ -2011,9 +1975,6 @@ func TestDefaultProjectCommandBuilder_BuildPlanCommands_with_IncludeGitUntracked
 
 	globalCfgArgs := valid.GlobalCfgArgs{
 		AllowAllRepoSettings: true,
-		MergeableReq:         false,
-		ApprovedReq:          false,
-		UnDivergedReq:        false,
 	}
 
 	logger := logging.NewNoopLogger(t)

--- a/server/events/repo_branch_test.go
+++ b/server/events/repo_branch_test.go
@@ -68,9 +68,6 @@ projects:
 	require.NoError(t, err)
 
 	globalCfgArgs := valid.GlobalCfgArgs{
-		MergeableReq:  false,
-		ApprovedReq:   false,
-		UnDivergedReq: false,
 	}
 
 	parser := &config.ParserValidator{}

--- a/server/server.go
+++ b/server/server.go
@@ -198,9 +198,6 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 
 	globalCfg := valid.NewGlobalCfgFromArgs(
 		valid.GlobalCfgArgs{
-			MergeableReq:       userConfig.RequireMergeable,
-			ApprovedReq:        userConfig.RequireApproval,
-			UnDivergedReq:      userConfig.RequireUnDiverged,
 			PolicyCheckEnabled: userConfig.EnablePolicyChecksFlag,
 		})
 	if userConfig.RepoConfig != "" {

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -84,17 +84,8 @@ type UserConfig struct {
 	RepoConfigJSON                  string `mapstructure:"repo-config-json"`
 	RepoAllowlist                   string `mapstructure:"repo-allowlist"`
 
-	// RequireApproval is whether to require pull request approval before
-	// allowing terraform apply's to be run.
-	RequireApproval bool `mapstructure:"require-approval"`
-	// RequireMergeable is whether to require pull requests to be mergeable before
-	// allowing terraform apply's to run.
-	RequireMergeable bool `mapstructure:"require-mergeable"`
 	// SilenceNoProjects is whether Atlantis should respond to a PR if no projects are found.
-	SilenceNoProjects bool `mapstructure:"silence-no-projects"`
-	// RequireUnDiverged is whether to require pull requests to rebase default branch before
-	// allowing terraform apply's to run.
-	RequireUnDiverged   bool `mapstructure:"require-undiverged"`
+	SilenceNoProjects   bool `mapstructure:"silence-no-projects"`
 	SilenceForkPRErrors bool `mapstructure:"silence-fork-pr-errors"`
 	// SilenceVCSStatusNoPlans is whether autoplan should set commit status if no plans
 	// are found.


### PR DESCRIPTION
## what

Require settings in user_config.go for RequireApproval, RequireMergeable, and RequireUndiverged, and remove the flags RequireApproval and RequireMergeable.


## why

Requested by #2992, the options were deprecated by https://github.com/runatlantis/atlantis/commit/d78b106cab5c28d9e50e75034bcd7020b561ef63.

The vast majority of the use cases of these flags were by setting them to `false` in tests which called `NewGlobalCfgFromArgs`. Indeed, the only time they were explicitly set to true was in `TestNewGlobalCfgFromArgs` itself.

RequireUndiverged was actually not set as an actual flag, despite being set in server/user_config.go, so no flag configuration to be removed then.

This change left deprecationWarnings() a functional no-op. We switched from cobra's "deprecated" to "hidden" in https://github.com/runatlantis/atlantis/commit/b12d487cb with the creation of this function. Maybe in the future if we want to deprecate a field we can go back to using cobra's "MarkDeprecated()", or we can continue to use this dedicated function? That's probably a question best answered at the time.

## tests

```
atlantis % go run main.go server --require-approval 
Error: unknown flag: --require-approval
atlantis % go run main.go server --require-mergeable
Error: unknown flag: --require-mergeable
```

There should be no functional changes, since both of these flags were hidden and defaulted to false.

## references

- closes: #2992
