### PR TITLE
fix: update working_dir.go

### DIFF
--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -294,7 +294,7 @@ func (w *FileWorkspace) mergeAgain(c wrappedGitContext) error {
 	}
 
 	// Reset branch as if it was cloned again
-	if err := w.wrappedGit(c, "reset", "--hard", fmt.Sprintf("refs/remotes/head/%s", c.pr.BaseBranch)); err != nil {
+	if err := w.wrappedGit(c, "reset", "--hard", fmt.Sprintf("refs/remotes/origin/%s", c.pr.BaseBranch)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
fix mergeAgain function for when the PR is created from a fork

## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
Fixes https://github.com/runatlantis/atlantis/issues/4034. When the PR is generated from a fork, mergeAgain function is incorrectly merging against baseBranch from the fork repository, instead of baseBranch from baseRepository.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

mergeAgain() is called because merge strategy is enabled, and the workdir is not up to date with the last changes on the upstream repository base branch (origin) (https://github.com/alanbover/atlantis/blob/main/server/events/working_dir.go#L132)

Hence, mergeAgain() replicates the state from forceClone() https://github.com/alanbover/atlantis/blob/main/server/events/working_dir.go#L263. But note that head remote is added in a later step https://github.com/alanbover/atlantis/blob/main/server/events/working_dir.go#L272, hence the right place to clone from is origin.

## tests

<!--
- [ ] I have tested my changes by ...
-->
I have tested the changes building this locally, and it indeed fixes the problem

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

https://github.com/runatlantis/atlantis/issues/4034