### PR TITLE
fix: CI for markdown renderer

### DIFF
--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -176,7 +176,7 @@ $$$
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * $atlantis apply$
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * $atlantis unlock$
 `,
 		},
@@ -215,7 +215,7 @@ $$$
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * $atlantis apply$
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * $atlantis unlock$
 `,
 		},
@@ -252,7 +252,7 @@ $$$
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * $atlantis apply$
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * $atlantis unlock$
 `,
 		},
@@ -320,7 +320,7 @@ $$$
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * $atlantis apply$
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * $atlantis unlock$
 `,
 		},
@@ -395,7 +395,7 @@ $$$
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * $atlantis apply$
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * $atlantis unlock$
 `,
 		},
@@ -550,7 +550,7 @@ $$$
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * $atlantis apply$
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * $atlantis unlock$
 `,
 		},
@@ -628,7 +628,7 @@ $$$
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * $atlantis apply$
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * $atlantis unlock$
 `,
 		},
@@ -763,7 +763,7 @@ $$$
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * $atlantis apply$
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * $atlantis unlock$
 `,
 		},
@@ -860,7 +860,7 @@ $$$
 ---
 * :heavy_check_mark: To **approve** all unapplied plans from this pull request, comment:
     * $atlantis approve_policies$
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * $atlantis unlock$
 * :repeat: To re-run policies **plan** this project again by commenting:
     * $atlantis plan$
@@ -1615,7 +1615,7 @@ No changes. Infrastructure is up-to-date.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * $atlantis apply$
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * $atlantis unlock$`
 						} else {
 							exp = `Ran Plan for dir: $.$ workspace: $default$
@@ -1633,7 +1633,7 @@ $$$
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * $atlantis apply$
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * $atlantis unlock$`
 						}
 					case command.Apply:
@@ -1795,7 +1795,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * $atlantis apply$
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * $atlantis unlock$`
 	expWithBackticks := strings.Replace(exp, "$", "`", -1)
 	Equals(t, expWithBackticks, rendered)
@@ -1960,7 +1960,7 @@ $$$
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * $atlantis apply$
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * $atlantis unlock$
 `,
 		},
@@ -1997,7 +1997,7 @@ $$$
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * $atlantis apply$
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * $atlantis unlock$
 `,
 		},
@@ -2032,7 +2032,7 @@ $$$
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * $atlantis apply$
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * $atlantis unlock$
 `,
 		},
@@ -2127,7 +2127,7 @@ $$$
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * $atlantis apply$
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * $atlantis unlock$
 `,
 		},
@@ -2257,7 +2257,7 @@ $$$
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * $atlantis apply$
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * $atlantis unlock$
 `,
 		},
@@ -2939,7 +2939,7 @@ $$$
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * $atlantis apply$
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * $atlantis unlock$
 `,
 		},
@@ -2990,7 +2990,7 @@ $$$
 
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * $atlantis apply$
-* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
     * $atlantis unlock$
 `,
 		},


### PR DESCRIPTION
## what

Fixes CI in markdown_renderer_test.go

## why

https://github.com/runatlantis/atlantis/pull/4049 broke CI by changing the produced value for a number of rendered templates. I noticed this when running `make test` locally as well as in the failing tests for an unrelated PR https://github.com/runatlantis/atlantis/actions/runs/7234266257/job/19710468454?pr=4064.

I created this PR mechanically with the following command:
```
sed -i 's/delete all plans/**delete** all plans/g' server/events/markdown_renderer_test.go
```

## tests

Before:
```
atlantis % go test github.com/runatlantis/atlantis/server/events      
% https://dev.azure.com/owner/project/_git/repo
% https://dev.azure.com/owner/project/_git/repo
% https://owner.visualstudio.com/project/_git/repo
% https://dev.azure.com/owner/project/_git/repo
% https://dev.azure.com/owner/project/_git/repo
% https://dev.azure.com/owner/project/_git/repo
% https://dev.azure.com/owner/project/_git/repo
% https://dev.azure.com/owner/project/_git/repo
% https://dev.azure.com/owner/project/_git/repo
% https://dev.azure.com/owner/project/_git/repo
% https://dev.azure.com/owner/project/_git/repo
% https://dev.azure.com/owner/project/_git/repo
% https://dev.azure.com/owner/project/_git/repo
% https://dev.azure.com/owner/project/_git/repo
% https://dev.azure.com/owner/project/_git/repo
% https://dev.azure.com/owner/project/_git/repo
% https://dev.azure.com/owner/project/_git/repo
% https://dev.azure.com/owner/project/_git/repo
% https://devops.abc.com/owner/project/_git/repo
% https://devops.abc.com/owner/project/_git/repo
% https://devops.abc.com/owner/project/_git/repo
% https://devops.abc.com/owner/project/_git/repo
% https://devops.abc.com/owner/project/_git/repo
% https://devops.abc.com/owner/project/_git/repo
% https://devops.abc.com/owner/project/_git/repo
% https://devops.abc.com/owner/project/_git/repo
% https://devops.abc.com/owner/project/_git/repo
% https://devops.abc.com/owner/project/_git/repo
% https://devops.abc.com/owner/project/_git/repo
% https://devops.abc.com/owner/project/_git/repo
% https://devops.abc.com/owner/project/_git/repo
% https://devops.abc.com/owner/project/_git/repo
% https://devops.abc.com/owner/project/_git/repo
--- FAIL: TestRenderProjectResults (0.01s)
    --- FAIL: TestRenderProjectResults/single_successful_plan (0.00s)
        --- FAIL: TestRenderProjectResults/single_successful_plan/single_successful_plan (0.00s)
            markdown_renderer_test.go:978: [Ran Plan for dir: `path` workspace: `workspace`
                
                ```diff
                terraform-output
                ```
                
                * :arrow_forward: To **apply** this plan, comment:
                    * `atlantis apply -d path -w workspace`
                * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
                * :repeat: To **plan** this project again, comment:
                    * `atlantis plan -d path -w workspace`
                
                ---
                * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
                    * `atlantis apply`
                * :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
                    * `atlantis unlock`
                
...
```

After:
```
atlantis % go test github.com/runatlantis/atlantis/server/events        
ok  	github.com/runatlantis/atlantis/server/events	28.315s
```
## references

Caused by: #4049
