### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 # These owners will be the default owners for everything in the repo.
-*    @runatlantis/maintainers
+*    @runatlantis/maintainers @runatlantis/core-contributors


### PR DESCRIPTION
## what

Updating alongside the GOVERNANCE update to add the new core-contributors team for code reviews.

## why

Core Contributors is a new role that will allow code reviews

## references

#4074 

