### PR TITLE
fix: ensure the MR log line prints an integer and not a rune

### DIFF
--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -374,7 +374,7 @@ func (p *DefaultProjectCommandBuilder) buildAllCommandsByCfg(ctx *command.Contex
 					if err != nil {
 						return nil, err
 					}
-					ctx.Log.Info("%d projects are changed on MR %q based on their when_modified config", len(matchingProjects), ctx.Pull.Num)
+					ctx.Log.Info("%d projects are changed on MR %d based on their when_modified config", len(matchingProjects), ctx.Pull.Num)
 					if len(matchingProjects) == 0 {
 						ctx.Log.Info("skipping repo clone since no project was modified")
 						return []command.ProjectContext{}, nil


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

This changes the log line for projects changed on MR to print an integer instead of a character literal.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

`%q` prints out a [a single-quoted character literal safely escaped with Go syntax.](https://pkg.go.dev/fmt) when given an integer for formatting. This results in log lines that look like:

```
0 projects are changed on MR '墤' based on their when_modified config
```

or are completely empty. This changes the format string from `%q` to `%d` so that an integer is printed instead of a character literal.

## tests

<!--
- [ ] I have tested my changes by ...
-->

I have run atlantis locally and verified the log output.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

