### PR TITLE
fix: download conftest binary for correct arch

### DIFF
--- a/server/core/runtime/policy/conftest_client.go
+++ b/server/core/runtime/policy/conftest_client.go
@@ -20,8 +20,6 @@ import (
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/logging"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 const (
@@ -113,8 +111,13 @@ type ConfTestVersionDownloader struct {
 func (c ConfTestVersionDownloader) downloadConfTestVersion(v *version.Version, destPath string) (runtime_models.FilePath, error) {
 	versionURLPrefix := fmt.Sprintf("%s%s", conftestDownloadURLPrefix, v.Original())
 
+	conftestPlatform := getPlatform()
+	if conftestPlatform == "" {
+		return runtime_models.LocalFilePath(""), fmt.Errorf("don't know where to find conftest for %s on %s", runtime.GOOS, runtime.GOARCH)
+	}
+
 	// download binary in addition to checksum file
-	binURL := fmt.Sprintf("%s/conftest_%s_%s_%s.tar.gz", versionURLPrefix, v.Original(), cases.Title(language.English).String(runtime.GOOS), conftestArch)
+	binURL := fmt.Sprintf("%s/conftest_%s_%s.tar.gz", versionURLPrefix, v.Original(), conftestPlatform)
 	checksumURL := fmt.Sprintf("%s/checksums.txt", versionURLPrefix)
 
 	// underlying implementation uses go-getter so the URL is formatted as such.
@@ -312,4 +315,21 @@ func hasFailures(output string) bool {
 		return true
 	}
 	return false
+}
+
+func getPlatform() string {
+	platform := runtime.GOOS + "_" + runtime.GOARCH
+
+	switch platform {
+	case "linux_amd64":
+		return "Linux_x86_64"
+	case "linux_arm64":
+		return "Linux_arm64"
+	case "darwin_amd64":
+		return "Darwin_x86_64"
+	case "darwin_arm64":
+		return "Darwin_arm64"
+	default:
+		return ""
+	}
 }

--- a/server/core/runtime/policy/conftest_client.go
+++ b/server/core/runtime/policy/conftest_client.go
@@ -26,7 +26,6 @@ const (
 	DefaultConftestVersionEnvKey = "DEFAULT_CONFTEST_VERSION"
 	conftestBinaryName           = "conftest"
 	conftestDownloadURLPrefix    = "https://github.com/open-policy-agent/conftest/releases/download/v"
-	conftestArch                 = "x86_64"
 )
 
 type Arg struct {

--- a/server/core/runtime/policy/conftest_client_test.go
+++ b/server/core/runtime/policy/conftest_client_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/hashicorp/go-version"
@@ -17,17 +16,14 @@ import (
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/logging"
 	. "github.com/runatlantis/atlantis/testing"
-
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 func TestConfTestVersionDownloader(t *testing.T) {
 
 	version, _ := version.NewVersion("0.25.0")
 	destPath := "some/path"
-
-	fullURL := fmt.Sprintf("https://github.com/open-policy-agent/conftest/releases/download/v0.25.0/conftest_0.25.0_%s_x86_64.tar.gz?checksum=file:https://github.com/open-policy-agent/conftest/releases/download/v0.25.0/checksums.txt", cases.Title(language.English).String(runtime.GOOS))
+	platform := getPlatform()
+	fullURL := fmt.Sprintf("https://github.com/open-policy-agent/conftest/releases/download/v0.25.0/conftest_0.25.0_%s.tar.gz?checksum=file:https://github.com/open-policy-agent/conftest/releases/download/v0.25.0/checksums.txt", platform)
 
 	RegisterMockTestingT(t)
 


### PR DESCRIPTION
## what
Download the conftest binary that corresponds to the correct architecture

## why
The current conftest binary architecture is hardcoded, causing failures on ARM-based instances. This pull request will dynamically determine the architecture and download the correct binary.

## tests

N/A


