### PR TITLE
chore: fix label type in gitlab testdata

### DIFF
--- a/server/events/vcs/testdata/gitlab-changes-pending.json
+++ b/server/events/vcs/testdata/gitlab-changes-pending.json
@@ -23,7 +23,7 @@
   "reviewers": [],
   "source_project_id": 3771,
   "target_project_id": 3771,
-  "labels": "",
+  "labels": [],
   "description": "",
   "draft": false,
   "work_in_progress": false,


### PR DESCRIPTION
## what

Change type of `labels` from string to array in gitlab test data.


## why

Debugging why unit tests on https://github.com/runatlantis/atlantis/pull/4028 are failing, it turns out that label parsing was updated in `0.95` such that the empty string is failing:

```
unexpected error: json: cannot unmarshal string into Go struct field alias.labels of type gitlab.Labels
```

This doesn't appear to correspond to any actual changes in the API, so I don't think any non-test code needs to be updated, it's just whenever this testdata was written it was filled in with the wrong type. If you look even now at an MR in the gitlab API, you'll see it's an empty array, not an empty string:

```
atlantis % curl -sS 'https://gitlab.com/api/v4/projects/lkysow%2Fatlantis-example/merge_requests/13'  | jq .labels
[]
```

## tests

Running unit tests in #4028 and noting that it passes where it failed before.

## references

Makes #4028 pass

