### PR TITLE
fix(e2e-tests): add ngrok authtoken

### DIFF
--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -20,6 +20,7 @@ cd "${CIRCLE_WORKING_DIRECTORY}/e2e"
 sleep 2
 
 # start ngrok in the background and wait for it to start
+./ngrok config add-authtoken $NGROK_AUTH_TOKEN
 ./ngrok http 4141 > /tmp/ngrok.log &
 sleep 2
 


### PR DESCRIPTION
## what

Fixes ngrok tunneling so that Github webhooks can hit the private instance of Atlantis in the CircleCI runners.

## why

E2E tests are failing due to: 
```
ERROR:  authentication failed: Usage of ngrok requires a verified account and authtoken.
ERROR:  
ERROR:  Sign up for an account: https://dashboard.ngrok.com/signup
ERROR:  Install your authtoken: https://dashboard.ngrok.com/get-started/your-authtoken
ERROR:  
ERROR:  ERR_NGROK_4018
ERROR:  
```

## references

https://ngrok.com/docs/errors/err_ngrok_4018/
https://app.circleci.com/pipelines/github/runatlantis/atlantis/6186/workflows/c2454924-90a4-4564-bcad-53eb29150f31/jobs/16363
