### PR TITLE
fix: unnamed jobs in ui

### DIFF
--- a/server/controllers/templates/web_templates.go
+++ b/server/controllers/templates/web_templates.go
@@ -164,21 +164,33 @@ var IndexTemplate = template.Must(template.New("index.html.tmpl").Parse(`
   <section>
     <p class="title-heading small"><strong>Jobs</strong></p>
     {{ if .PullToJobMapping }}
-    <div class="pulls-grid">
+    <div class="lock-grid">
     <div class="lock-header">
       <span>Repository</span>
       <span>Project</span>
       <span>Workspace</span>
-      <span>Jobs</span>
+      <span>Date/Time</span>
+      <span>Step</span>
+      <span>Description</span>
     </div>
     {{ range .PullToJobMapping }}
       <div class="pulls-row">
-      <span class="pulls-element">{{.Pull.RepoFullName}} #{{.Pull.PullNum}}</span>
-      <span class="pulls-element"><code>{{.Pull.Path}}</code></span>
-      <span class="pulls-element"><code>{{.Pull.Workspace}}</code></span>
+      <span class="pulls-element">{{ .Pull.RepoFullName }} #{{ .Pull.PullNum }}</span>
+      <span class="pulls-element">{{ if .Pull.Path }}<code>{{ .Pull.Path }}</code>{{ end }}</span>
+      <span class="pulls-element">{{ if .Pull.Workspace }}<code>{{ .Pull.Workspace }}</code>{{ end }}</span>
       <span class="pulls-element">
       {{ range .JobIDInfos }}
-        <div><a href="{{ $basePath }}{{ .JobIDUrl }}" target="_blank">{{ .TimeFormatted }}</a></div>
+        <div><span class="lock-datetime">{{ .TimeFormatted }}</span></div>
+      {{ end }}
+      </span>
+      <span class="pulls-element">
+      {{ range .JobIDInfos }}
+        <div><a href="{{ $basePath }}{{ .JobIDUrl }}" target="_blank">{{ .JobStep }}</a></div>
+      {{ end }}
+      </span>
+      <span class="pulls-element">
+      {{ range .JobIDInfos }}
+        <div>{{ .JobDescription }}</div>
       {{ end }}
       </span>
       </div>

--- a/server/controllers/templates/web_templates_test.go
+++ b/server/controllers/templates/web_templates_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/runatlantis/atlantis/server/jobs"
 	. "github.com/runatlantis/atlantis/testing"
 )
 
@@ -28,6 +29,21 @@ func TestIndexTemplate(t *testing.T) {
 		},
 		AtlantisVersion: "v0.0.0",
 		CleanedBasePath: "/path",
+		PullToJobMapping: []jobs.PullInfoWithJobIDs{
+			{
+				Pull: jobs.PullInfo{
+					PullNum:      1,
+					Repo:         "repo",
+					RepoFullName: "repo full name",
+					ProjectName:  "project name",
+					Path:         "path",
+					Workspace:    "workspace",
+				},
+				JobIDInfos: []jobs.JobIDInfo{
+					{JobID: "job id", JobIDUrl: "job id url", JobDescription: "job description", Time: time.Now(), TimeFormatted: "02-01-2006 15:04:05", JobStep: "job step"},
+				},
+			},
+		},
 	})
 	Ok(t, err)
 }

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -611,27 +611,39 @@ func (p ProjectPlanStatus) String() string {
 type WorkflowHookCommandContext struct {
 	// BaseRepo is the repository that the pull request will be merged into.
 	BaseRepo Repo
-	// HeadRepo is the repository that is getting merged into the BaseRepo.
-	// If the pull request branch is from the same repository then HeadRepo will
-	// be the same as BaseRepo.
-	HeadRepo Repo
-	// Log is a logger that's been set up for this context.
-	Log logging.SimpleLogging
-	// Pull is the pull request we're responding to.
-	Pull PullRequest
-	// User is the user that triggered this command.
-	User User
-	// Verbose is true when the user would like verbose output.
-	Verbose bool
+	// The name of the command that is being executed, i.e. 'plan', 'apply' etc.
+	CommandName string
 	// EscapedCommentArgs are the extra arguments that were added to the atlantis
 	// command, ex. atlantis plan -- -target=resource. We then escape them
 	// by adding a \ before each character so that they can be used within
 	// sh -c safely, i.e. sh -c "terraform plan $(touch bad)".
 	EscapedCommentArgs []string
+	// HeadRepo is the repository that is getting merged into the BaseRepo.
+	// If the pull request branch is from the same repository then HeadRepo will
+	// be the same as BaseRepo.
+	HeadRepo Repo
+	// HookDescription is a description of the hook that is being executed.
+	HookDescription string
 	// UUID for reference
 	HookID string
-	// The name of the command that is being executed, i.e. 'plan', 'apply' etc.
-	CommandName string
+	// HookStepName is the name of the step that is being executed.
+	HookStepName string
+	// Log is a logger that's been set up for this context.
+	Log logging.SimpleLogging
+	// Pull is the pull request we're responding to.
+	Pull PullRequest
+	// ProjectName is the name of the project set in atlantis.yaml. If there was
+	// no name this will be an empty string.
+	ProjectName string
+	// RepoRelDir is the directory of this project relative to the repo root.
+	RepoRelDir string
+	// User is the user that triggered this command.
+	User User
+	// Verbose is true when the user would like verbose output.
+	Verbose bool
+	// Workspace is the Terraform workspace this project is in. It will always
+	// be set.
+	Workspace string
 }
 
 // PlanSuccessStats holds stats for a plan.

--- a/server/events/post_workflow_hooks_command_runner.go
+++ b/server/events/post_workflow_hooks_command_runner.go
@@ -104,20 +104,22 @@ func (w *DefaultPostWorkflowHooksCommandRunner) runHooks(
 ) error {
 
 	for i, hook := range postWorkflowHooks {
-		hookDescription := hook.StepDescription
-		if hookDescription == "" {
-			hookDescription = fmt.Sprintf("Post workflow hook #%d", i)
+		ctx.HookDescription = hook.StepDescription
+		if ctx.HookDescription == "" {
+			ctx.HookDescription = fmt.Sprintf("Post workflow hook #%d", i)
 		}
 
+		ctx.HookStepName = fmt.Sprintf("post %s #%d", ctx.CommandName, i)
+
 		ctx.Log.Debug("Processing post workflow hook '%s', Command '%s', Target commands [%s]",
-			hookDescription, ctx.CommandName, hook.Commands)
+			ctx.HookDescription, ctx.CommandName, hook.Commands)
 		if hook.Commands != "" && !strings.Contains(hook.Commands, ctx.CommandName) {
 			ctx.Log.Debug("Skipping post workflow hook '%s' as command '%s' is not in Commands [%s]",
-				hookDescription, ctx.CommandName, hook.Commands)
+				ctx.HookDescription, ctx.CommandName, hook.Commands)
 			continue
 		}
 
-		ctx.Log.Debug("Running post workflow hook: '%s'", hookDescription)
+		ctx.Log.Debug("Running post workflow hook: '%s'", ctx.HookDescription)
 		ctx.HookID = uuid.NewString()
 		shell := hook.Shell
 		if shell == "" {
@@ -134,20 +136,20 @@ func (w *DefaultPostWorkflowHooksCommandRunner) runHooks(
 			return err
 		}
 
-		if err := w.CommitStatusUpdater.UpdatePostWorkflowHook(ctx.Pull, models.PendingCommitStatus, hookDescription, "", url); err != nil {
+		if err := w.CommitStatusUpdater.UpdatePostWorkflowHook(ctx.Pull, models.PendingCommitStatus, ctx.HookDescription, "", url); err != nil {
 			ctx.Log.Warn("unable to update post workflow hook status: %s", err)
 		}
 
 		_, runtimeDesc, err := w.PostWorkflowHookRunner.Run(ctx, hook.RunCommand, shell, shellArgs, repoDir)
 
 		if err != nil {
-			if err := w.CommitStatusUpdater.UpdatePostWorkflowHook(ctx.Pull, models.FailedCommitStatus, hookDescription, runtimeDesc, url); err != nil {
+			if err := w.CommitStatusUpdater.UpdatePostWorkflowHook(ctx.Pull, models.FailedCommitStatus, ctx.HookDescription, runtimeDesc, url); err != nil {
 				ctx.Log.Warn("unable to update post workflow hook status: %s", err)
 			}
 			return err
 		}
 
-		if err := w.CommitStatusUpdater.UpdatePostWorkflowHook(ctx.Pull, models.SuccessCommitStatus, hookDescription, runtimeDesc, url); err != nil {
+		if err := w.CommitStatusUpdater.UpdatePostWorkflowHook(ctx.Pull, models.SuccessCommitStatus, ctx.HookDescription, runtimeDesc, url); err != nil {
 			ctx.Log.Warn("unable to update post workflow hook status: %s", err)
 		}
 	}

--- a/server/static/css/custom.css
+++ b/server/static/css/custom.css
@@ -256,7 +256,6 @@ tbody {
 
 .lock-row {
   display: contents;
-  text-transform: uppercase;
 }
 
 .lock-row a {
@@ -311,7 +310,6 @@ tbody {
 
 .pulls-row {
   display: contents;
-  text-transform: uppercase;
 }
 
 .pulls-element {


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- Correct naming of pre and post workflow with their description fields
- Uppercase removed from main page

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
As correctly described in #4132, the jobs were not clearly identifiable on the home page. 
Several fields have been added to the output structure of the various jobs to enable them to be displayed. 
On the PR, with a repos yaml like this :

```yaml
  pre_workflow_hooks: 
    - run: echo toto
      description: echo toto
    - run: echo toto2
  
  post_workflow_hooks: 
    - run: echo tata
      description: echo tata

  workflow: custom

workflows:
  custom:
    plan:
      steps:
      - run: echo hi
      - init
      - plan
      - run: echo hello
```

the page looks like this :

<img width="1668" alt="Screenshot 2024-01-10 at 09 30 35" src="https://github.com/runatlantis/atlantis/assets/43377784/5d49bf88-e9d6-40c5-8940-c24c29a435df">



Unfortunately, the project and workspace fields will remain empty due to the differences between a job and hook context. 

## tests

<!--
- [ ] I have tested my changes by ...
-->
The templating test has been enhanced with jobToMapping data.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- closes #4132

