### PR TITLE
fix: Revert node version update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Atlantis <!-- omit in toc -->
 
+
 [![Latest Release](https://img.shields.io/github/release/runatlantis/atlantis.svg)](https://github.com/runatlantis/atlantis/releases/latest)
 [![SuperDopeBadge](./runatlantis.io/.vuepress/public/hightower-super-dope.svg)](https://twitter.com/kelseyhightower/status/893260922222813184)
 [![Go Report Card](https://goreportcard.com/badge/github.com/runatlantis/atlantis)](https://goreportcard.com/report/github.com/runatlantis/atlantis)


### PR DESCRIPTION
## what

Reverts: #4136


## why

It broke unit tests: <link>

## tests

Ran through unit tests

## references

Reverts: #4136

