### PR TITLE
revert: regression: remote ops detection TF v1.1

### DIFF
--- a/server/core/runtime/plan_step_runner.go
+++ b/server/core/runtime/plan_step_runner.go
@@ -294,9 +294,10 @@ locally at this time.
 
 // remoteOpsErr110 is the error terraform plan will return if this project is
 // using Terraform Cloud remote operations in TF 1.1.0 and above
+// note: the trailing whitespace is intentional
 var remoteOpsErr110 = `╷
 │ Error: Saving a generated plan is currently not supported
-│
+│ 
 │ Terraform Cloud does not support saving the generated execution plan
 │ locally at this time.
 ╵

--- a/server/core/runtime/plan_step_runner_test.go
+++ b/server/core/runtime/plan_step_runner_test.go
@@ -357,7 +357,7 @@ locally at this time.
 			tfVersion: "1.1.0",
 			remoteOpsErr: `╷
 │ Error: Saving a generated plan is currently not supported
-│
+│ 
 │ Terraform Cloud does not support saving the generated execution plan
 │ locally at this time.
 ╵


### PR DESCRIPTION
Reverts linter change from https://github.com/runatlantis/atlantis/commit/56e38b415135c9f9e7b0df7fb52210f532afebda (#3690) which breaks TF v1.1 detection

## what

Reverts a simple commit for a single file to fix remote operations for TF v1.1+

## why

Without this revert you can't use Atlantis with Terraform Cloud v1.1+, see #2793 for why this was introduced in the first place.

## tests

To prepare this I did
`git checkout 2e6758e -- server/core/runtime/plan_step_runner.go`
and picked the corresponding change from `server/core/runtime/plan_step_runner_test.go`

## references

