### PR TITLE
chore: Upgrade yaml v3

### DIFF
--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -24,7 +24,7 @@ import (
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/runatlantis/atlantis/server"
 	"github.com/runatlantis/atlantis/server/events/vcs/testdata"

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	go.uber.org/zap v1.26.0
 	golang.org/x/term v0.16.0
 	golang.org/x/text v0.14.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -132,5 +132,4 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -764,7 +764,6 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/server/core/config/parser_validator.go
+++ b/server/core/config/parser_validator.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/core/config/raw"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
-	yaml "gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 )
 
 // ParserValidator parses and validates server-side repo config files and

--- a/server/core/config/parser_validator.go
+++ b/server/core/config/parser_validator.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -58,7 +60,12 @@ func (p *ParserValidator) ParseRepoCfg(absRepoDir string, globalCfg valid.Global
 
 func (p *ParserValidator) ParseRepoCfgData(repoCfgData []byte, globalCfg valid.GlobalCfg, repoID string, branch string) (valid.RepoCfg, error) {
 	var rawConfig raw.RepoCfg
-	if err := yaml.UnmarshalStrict(repoCfgData, &rawConfig); err != nil {
+
+	decoder := yaml.NewDecoder(bytes.NewReader(repoCfgData))
+	decoder.KnownFields(true)
+
+	err := decoder.Decode(&rawConfig)
+	if err != nil && !errors.Is(err, io.EOF) {
 		return valid.RepoCfg{}, err
 	}
 
@@ -98,7 +105,7 @@ func (p *ParserValidator) ParseRepoCfgData(repoCfgData []byte, globalCfg valid.G
 		}
 	}
 
-	err := globalCfg.ValidateRepoCfg(validConfig, repoID)
+	err = globalCfg.ValidateRepoCfg(validConfig, repoID)
 	return validConfig, err
 }
 
@@ -115,7 +122,12 @@ func (p *ParserValidator) ParseGlobalCfg(configFile string, defaultCfg valid.Glo
 	}
 
 	var rawCfg raw.GlobalCfg
-	if err := yaml.UnmarshalStrict(configData, &rawCfg); err != nil {
+
+	decoder := yaml.NewDecoder(bytes.NewReader(configData))
+	decoder.KnownFields(true)
+
+	err = decoder.Decode(&rawCfg)
+	if err != nil && !errors.Is(err, io.EOF) {
 		return valid.GlobalCfg{}, err
 	}
 

--- a/server/core/config/parser_validator_test.go
+++ b/server/core/config/parser_validator_test.go
@@ -192,7 +192,7 @@ projects:`,
 			input: `
 version: 3
 projects:
-- `,
+- {}`,
 			expErr: "projects: (0: (dir: cannot be blank.).).",
 		},
 		{
@@ -625,7 +625,7 @@ projects:
 			input: `
 version: 3
 projects:
--`,
+- {}`,
 			expErr: "projects: (0: (dir: cannot be blank.).).",
 		},
 		{
@@ -634,7 +634,7 @@ projects:
 version: 3
 projects:
 - dir: "."
--`,
+- {}`,
 			expErr: "projects: (1: (dir: cannot be blank.).).",
 		},
 		{

--- a/server/core/config/raw/autodiscover_test.go
+++ b/server/core/config/raw/autodiscover_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/raw"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	. "github.com/runatlantis/atlantis/testing"
-	yaml "gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 )
 
 func TestAutoDiscover_UnmarshalYAML(t *testing.T) {

--- a/server/core/config/raw/autodiscover_test.go
+++ b/server/core/config/raw/autodiscover_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/raw"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	. "github.com/runatlantis/atlantis/testing"
-	yaml "gopkg.in/yaml.v3"
 )
 
 func TestAutoDiscover_UnmarshalYAML(t *testing.T) {
@@ -37,7 +36,7 @@ mode: enabled
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
 			var a raw.AutoDiscover
-			err := yaml.UnmarshalStrict([]byte(c.input), &a)
+			err := unmarshalString(c.input, &a)
 			Ok(t, err)
 			Equals(t, c.exp, a)
 		})

--- a/server/core/config/raw/autoplan_test.go
+++ b/server/core/config/raw/autoplan_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/raw"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	. "github.com/runatlantis/atlantis/testing"
-	yaml "gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 )
 
 func TestAutoPlan_UnmarshalYAML(t *testing.T) {

--- a/server/core/config/raw/autoplan_test.go
+++ b/server/core/config/raw/autoplan_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/raw"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	. "github.com/runatlantis/atlantis/testing"
-	yaml "gopkg.in/yaml.v3"
 )
 
 func TestAutoPlan_UnmarshalYAML(t *testing.T) {
@@ -50,7 +49,7 @@ when_modified: ["something-else"]
 			input: `
 enabled: false
 when_modified:
--
+- ""
 `,
 			exp: raw.Autoplan{
 				Enabled:      Bool(false),
@@ -62,7 +61,7 @@ when_modified:
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
 			var a raw.Autoplan
-			err := yaml.UnmarshalStrict([]byte(c.input), &a)
+			err := unmarshalString(c.input, &a)
 			Ok(t, err)
 			Equals(t, c.exp, a)
 		})

--- a/server/core/config/raw/metrics_test.go
+++ b/server/core/config/raw/metrics_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/runatlantis/atlantis/server/core/config/raw"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func TestMetrics_Unmarshal(t *testing.T) {

--- a/server/core/config/raw/metrics_test.go
+++ b/server/core/config/raw/metrics_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/runatlantis/atlantis/server/core/config/raw"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
 )
 
 func TestMetrics_Unmarshal(t *testing.T) {
@@ -22,7 +21,7 @@ prometheus:
 
 		var result raw.Metrics
 
-		err := yaml.UnmarshalStrict([]byte(rawYaml), &result)
+		err := unmarshalString(rawYaml, &result)
 		assert.NoError(t, err)
 	})
 

--- a/server/core/config/raw/policies_test.go
+++ b/server/core/config/raw/policies_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/raw"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	. "github.com/runatlantis/atlantis/testing"
-	yaml "gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 )
 
 func TestPolicySetsConfig_YAMLMarshalling(t *testing.T) {

--- a/server/core/config/raw/policies_test.go
+++ b/server/core/config/raw/policies_test.go
@@ -42,7 +42,7 @@ policy_sets:
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
 			var got raw.PolicySets
-			err := yaml.UnmarshalStrict([]byte(c.input), &got)
+			err := unmarshalString(c.input, &got)
 			if c.expErr != "" {
 				ErrEquals(t, c.expErr, err)
 				return
@@ -54,7 +54,7 @@ policy_sets:
 			Ok(t, err)
 
 			var got2 raw.PolicySets
-			err = yaml.UnmarshalStrict([]byte(c.input), &got2)
+			err = unmarshalString(c.input, &got2)
 			Ok(t, err)
 			Equals(t, got2, got)
 		})

--- a/server/core/config/raw/project_test.go
+++ b/server/core/config/raw/project_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/raw"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	. "github.com/runatlantis/atlantis/testing"
-	yaml "gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 )
 
 func TestProject_UnmarshalYAML(t *testing.T) {

--- a/server/core/config/raw/project_test.go
+++ b/server/core/config/raw/project_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/raw"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	. "github.com/runatlantis/atlantis/testing"
-	yaml "gopkg.in/yaml.v3"
 )
 
 func TestProject_UnmarshalYAML(t *testing.T) {
@@ -74,7 +73,7 @@ execution_order_group: 10`,
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
 			var p raw.Project
-			err := yaml.UnmarshalStrict([]byte(c.input), &p)
+			err := unmarshalString(c.input, &p)
 			Ok(t, err)
 			Equals(t, c.exp, p)
 		})

--- a/server/core/config/raw/raw_test.go
+++ b/server/core/config/raw/raw_test.go
@@ -20,7 +20,7 @@ func Int(v int) *int { return &v }
 // to store v and returns a pointer to it.
 func String(v string) *string { return &v }
 
-// Helper function to unmarshal strings
+// Helper function to unmarshal from strings
 func unmarshalString(in string, out interface{}) error {
 	decoder := yaml.NewDecoder(strings.NewReader(in))
 	decoder.KnownFields(true)

--- a/server/core/config/raw/raw_test.go
+++ b/server/core/config/raw/raw_test.go
@@ -1,5 +1,13 @@
 package raw_test
 
+import (
+	"io"
+	"strings"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+)
+
 // Bool is a helper routine that allocates a new bool value
 // to store v and returns a pointer to it.
 func Bool(v bool) *bool { return &v }
@@ -11,3 +19,15 @@ func Int(v int) *int { return &v }
 // String is a helper routine that allocates a new string value
 // to store v and returns a pointer to it.
 func String(v string) *string { return &v }
+
+// Helper function to unmarshal strings
+func unmarshalString(in string, out interface{}) error {
+	decoder := yaml.NewDecoder(strings.NewReader(in))
+	decoder.KnownFields(true)
+
+	err := decoder.Decode(out)
+	if errors.Is(err, io.EOF) {
+		return nil
+	}
+	return err
+}

--- a/server/core/config/raw/repo_cfg_test.go
+++ b/server/core/config/raw/repo_cfg_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/raw"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	. "github.com/runatlantis/atlantis/testing"
-	yaml "gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 )
 
 func TestConfig_UnmarshalYAML(t *testing.T) {

--- a/server/core/config/raw/repo_cfg_test.go
+++ b/server/core/config/raw/repo_cfg_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/raw"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	. "github.com/runatlantis/atlantis/testing"
-	yaml "gopkg.in/yaml.v3"
 )
 
 func TestConfig_UnmarshalYAML(t *testing.T) {
@@ -190,7 +189,7 @@ allowed_regexp_prefixes:
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
 			var conf raw.RepoCfg
-			err := yaml.UnmarshalStrict([]byte(c.input), &conf)
+			err := unmarshalString(c.input, &conf)
 			if c.expErr != "" {
 				ErrEquals(t, c.expErr, err)
 				return

--- a/server/core/config/raw/stage_test.go
+++ b/server/core/config/raw/stage_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/raw"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	. "github.com/runatlantis/atlantis/testing"
-	yaml "gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 )
 
 func TestStage_UnmarshalYAML(t *testing.T) {

--- a/server/core/config/raw/stage_test.go
+++ b/server/core/config/raw/stage_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/raw"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	. "github.com/runatlantis/atlantis/testing"
-	yaml "gopkg.in/yaml.v3"
 )
 
 func TestStage_UnmarshalYAML(t *testing.T) {
@@ -41,7 +40,7 @@ steps: [step1]
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
 			var a raw.Stage
-			err := yaml.UnmarshalStrict([]byte(c.input), &a)
+			err := unmarshalString(c.input, &a)
 			Ok(t, err)
 			Equals(t, c.exp, a)
 		})

--- a/server/core/config/raw/step_test.go
+++ b/server/core/config/raw/step_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/raw"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	. "github.com/runatlantis/atlantis/testing"
-	yaml "gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 )
 
 func TestStepConfig_YAMLMarshalling(t *testing.T) {

--- a/server/core/config/raw/step_test.go
+++ b/server/core/config/raw/step_test.go
@@ -155,7 +155,7 @@ key:
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
 			var got raw.Step
-			err := yaml.UnmarshalStrict([]byte(c.input), &got)
+			err := unmarshalString(c.input, &got)
 			if c.expErr != "" {
 				ErrEquals(t, c.expErr, err)
 				return
@@ -167,7 +167,7 @@ key:
 			Ok(t, err)
 
 			var got2 raw.Step
-			err = yaml.UnmarshalStrict([]byte(c.input), &got2)
+			err = unmarshalString(c.input, &got2)
 			Ok(t, err)
 			Equals(t, got2, got)
 		})

--- a/server/core/config/raw/workflow_step_test.go
+++ b/server/core/config/raw/workflow_step_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/raw"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	. "github.com/runatlantis/atlantis/testing"
-	yaml "gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 )
 
 func TestWorkflowHook_YAMLMarshalling(t *testing.T) {

--- a/server/core/config/raw/workflow_step_test.go
+++ b/server/core/config/raw/workflow_step_test.go
@@ -54,7 +54,7 @@ key:
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
 			var got raw.WorkflowHook
-			err := yaml.UnmarshalStrict([]byte(c.input), &got)
+			err := unmarshalString(c.input, &got)
 			if c.expErr != "" {
 				ErrEquals(t, c.expErr, err)
 				return
@@ -66,7 +66,7 @@ key:
 			Ok(t, err)
 
 			var got2 raw.WorkflowHook
-			err = yaml.UnmarshalStrict([]byte(c.input), &got2)
+			err = unmarshalString(c.input, &got2)
 			Ok(t, err)
 			Equals(t, got2, got)
 		})

--- a/server/core/config/raw/workflow_test.go
+++ b/server/core/config/raw/workflow_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/raw"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	. "github.com/runatlantis/atlantis/testing"
-	yaml "gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 )
 
 func TestWorkflow_UnmarshalYAML(t *testing.T) {

--- a/server/core/config/raw/workflow_test.go
+++ b/server/core/config/raw/workflow_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/raw"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	. "github.com/runatlantis/atlantis/testing"
-	yaml "gopkg.in/yaml.v3"
 )
 
 func TestWorkflow_UnmarshalYAML(t *testing.T) {
@@ -106,7 +105,7 @@ apply:
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
 			var w raw.Workflow
-			err := yaml.UnmarshalStrict([]byte(c.input), &w)
+			err := unmarshalString(c.input, &w)
 			if c.expErr != "" {
 				ErrEquals(t, c.expErr, err)
 				return


### PR DESCRIPTION
## what

Upgrade `gopkg.in/yaml` from v2 to v3.

## why

Keeping dependencies up to date.

This was built off of a failing renovate run. There are two issues to deal with upgrading from v2 to v3.
1. UnmarshalStrict is no longer available (https://github.com/go-yaml/yaml/issues/602). You have to use Decode() with KnownFields set to true. Decode has slightly different semantics to Unmarshal (https://github.com/go-yaml/yaml/issues/805), so I wrapped these calls in the unit tests. In the actual code I just write the full implementation out so it's more clear, but that would have been quite a bit of copy/paste for unit tests.
2. There's a bug in yaml v3 where it doesn't parse empty elements in arrays properly (https://github.com/go-yaml/yaml/issues/805). We were only doing this in unit tests, so I had to in a few places replace `- ` with `- {}`.
## tests

Unit tests

## references

Obsoletes: #3974

