### PR TITLE
fix: improve git error log while running 'atlantis apply'

### DIFF
--- a/server/events/pending_plan_finder.go
+++ b/server/events/pending_plan_finder.go
@@ -58,8 +58,8 @@ func (p *DefaultPendingPlanFinder) findWithAbsPaths(pullDir string) ([]PendingPl
 		lsCmd.Dir = repoDir
 		lsOut, err := lsCmd.CombinedOutput()
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "running git ls-files . "+
-				"--others: %s", string(lsOut))
+			return nil, nil, errors.Wrapf(err, "running 'git ls-files . --others' in '%s' directory: %s",
+				repoDir, string(lsOut))
 		}
 		for _, file := range strings.Split(string(lsOut), "\n") {
 			if filepath.Ext(file) == ".tfplan" {


### PR DESCRIPTION
## what

Improve error message printed by atlantis in case of errors coming from `git ls-files . --others` command when calling `atlantis apply`

## why

For make debugging easier. My case was that I had defined Terragrunt cache directory (which is not git repository) just parallel to workspace directories. At first glance it was not obvious seeing such error what is going about, but after take a look in source code I found what exactly atlantis does under the hood. Improved error message could make cause finding much faster.
![image](https://github.com/runatlantis/atlantis/assets/75946923/8df4cc8e-5a84-4a5b-9f76-cb6ac546fa19)

## tests
Added unit test on previously uncovered code

## references
It may also be helpful by debugging already existing issues like e.g. #2168 or #3139 



