### PR TITLE
feat: Prevent unused flags

### DIFF
--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -223,7 +223,7 @@ func TestUserConfigAllTested(t *testing.T) {
 		userConfigKey := u.Field(i).Tag.Get("mapstructure")
 		t.Run(userConfigKey, func(t *testing.T) {
 			// By default, we expect all fields in UserConfig to have flags defined in server.go and tested here in server_test.go
-			// Some fields are too complicated to have flags, so are only expressible in the yaml
+			// Some fields are too complicated to have flags, so are only expressible in the config yaml
 			flagKey := u.Field(i).Tag.Get("flag")
 			if flagKey == "false" {
 				return
@@ -231,7 +231,7 @@ func TestUserConfigAllTested(t *testing.T) {
 			// If a setting is configured in server.UserConfig, it should be tested here. If there is no corresponding const
 			// for specifying the flag, that probably means one *also* needs to be added to server.go
 			if _, ok := testFlags[userConfigKey]; !ok {
-				t.Errorf("server.UserConfig has field with mapstructure %s that is either not tested or not configured as a flag. Either add it to server_test.testFlags, or remove it from server.UserConfig", userConfigKey)
+				t.Errorf("server.UserConfig has field with mapstructure %s that is not tested, and potentially also not configured as a flag. Either add it to testFlags (and potentially as a const in cmd/server), or remove it from server.UserConfig", userConfigKey)
 			}
 		})
 

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -221,7 +221,7 @@ func TestExecute_Flags(t *testing.T) {
 	}
 }
 
-func TestUserConfigNoExtra(t *testing.T) {
+func TestUserConfigAllTested(t *testing.T) {
 	t.Log("All settings in userConfig should be tested.")
 
 	u := reflect.TypeOf(server.UserConfig{})
@@ -238,7 +238,7 @@ func TestUserConfigNoExtra(t *testing.T) {
 				return
 			}
 			if !ok {
-				t.Errorf("server.UserConfig has field with mapstructure %s that is either not tested, or not in use in server.go", userConfigKey)
+				t.Errorf("server.UserConfig has field with mapstructure %s that is either not tested. Either add it to server_test.testFlags, or remove it from server.UserConfig", userConfigKey)
 			}
 		})
 

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -108,7 +108,7 @@ type UserConfig struct {
 	VarFileAllowlist           string          `mapstructure:"var-file-allowlist"`
 	VCSStatusName              string          `mapstructure:"vcs-status-name"`
 	DefaultTFVersion           string          `mapstructure:"default-tf-version"`
-	Webhooks                   []WebhookConfig `mapstructure:"webhooks"`
+	Webhooks                   []WebhookConfig `mapstructure:"webhooks" flag:"false"`
 	WebBasicAuth               bool            `mapstructure:"web-basic-auth"`
 	WebUsername                string          `mapstructure:"web-username"`
 	WebPassword                string          `mapstructure:"web-password"`


### PR DESCRIPTION
## what

Add a unit test to make sure that all the values in server.UserConfig appear in server_test.testFlags

## why

When you add a flag you're supposed to add it to four places: cmd/server.go as a const, cmd/server.go as part of a map for flags, cmd/server_test.go to test, and the configuration struct in server/server.UserConfig. Per #4063, if you forget some combination of these a unit test already fails (example: https://github.com/runatlantis/atlantis/blob/v0.27.1/cmd/server_test.go#L124). This adds an additional unit test to make sure a different misconfiguration doesn't occur.

## tests

Ran unit tests.

## references

Partially addresses: #4063
Prevents recurrence of issues like: #4183, #4064