### PR TITLE
chore: Add missing flag test for DisableGlobalApplyLockFlag

### DIFF
--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -77,6 +77,7 @@ var testFlags = map[string]interface{}{
 	DisableApplyAllFlag:              true,
 	DisableMarkdownFoldingFlag:       true,
 	DisableRepoLockingFlag:           true,
+	DisableGlobalApplyLockFlag:       false,
 	DiscardApprovalOnPlanFlag:        true,
 	EmojiReaction:                    "eyes",
 	ExecutableName:                   "atlantis",


### PR DESCRIPTION
## what

Add entry to testFlags for DisableGlobalApplyLockFlag


## why

Should be done for all new flags.

Note: This is too easy to happen by accident at this point, I am working on preventing these issues: #4063 

## tests

Ran CI

## references

New flag introduced in: #4158

