### PR TITLE
feat: Add logic for project name into lock

### DIFF
--- a/server/core/db/boltdb_test.go
+++ b/server/core/db/boltdb_test.go
@@ -233,6 +233,18 @@ func TestLockingExistingLock(t *testing.T) {
 		Equals(t, true, acquired)
 		Equals(t, newLock, currLock)
 	}
+	// TODO: How should we handle different name?
+	/*
+		t.Log("...succeed if the new project has a different name")
+		{
+			newLock := lock
+			newLock.Project = models.NewProject(project.RepoFullName, project.Path, "different-name")
+			acquired, currLock, err := b.TryLock(newLock)
+			Ok(t, err)
+			Equals(t, true, acquired)
+			Equals(t, newLock, currLock)
+		}
+	*/
 
 	t.Log("...not succeed if the new project only has a different pullNum")
 	{

--- a/server/core/db/boltdb_test.go
+++ b/server/core/db/boltdb_test.go
@@ -29,7 +29,7 @@ import (
 
 var lockBucket = "bucket"
 var configBucket = "configBucket"
-var project = models.NewProject("owner/repo", "parent/child")
+var project = models.NewProject("owner/repo", "parent/child", "")
 var workspace = "default"
 var pullNum = 1
 var lock = models.ProjectLock{
@@ -155,7 +155,7 @@ func TestListMultipleLocks(t *testing.T) {
 
 	for _, r := range repos {
 		newLock := lock
-		newLock.Project = models.NewProject(r, "path")
+		newLock.Project = models.NewProject(r, "path", "")
 		_, _, err := b.TryLock(newLock)
 		Ok(t, err)
 	}
@@ -207,7 +207,7 @@ func TestLockingExistingLock(t *testing.T) {
 	t.Log("...succeed if the new project has a different path")
 	{
 		newLock := lock
-		newLock.Project = models.NewProject(project.RepoFullName, "different/path")
+		newLock.Project = models.NewProject(project.RepoFullName, "different/path", "")
 		acquired, currLock, err := b.TryLock(newLock)
 		Ok(t, err)
 		Equals(t, true, acquired)
@@ -227,7 +227,7 @@ func TestLockingExistingLock(t *testing.T) {
 	t.Log("...succeed if the new project has a different repoName")
 	{
 		newLock := lock
-		newLock.Project = models.NewProject("different/repo", project.Path)
+		newLock.Project = models.NewProject("different/repo", project.Path, "")
 		acquired, currLock, err := b.TryLock(newLock)
 		Ok(t, err)
 		Equals(t, true, acquired)

--- a/server/core/locking/locking_test.go
+++ b/server/core/locking/locking_test.go
@@ -28,7 +28,7 @@ import (
 	. "github.com/runatlantis/atlantis/testing"
 )
 
-var project = models.NewProject("owner/repo", "path")
+var project = models.NewProject("owner/repo", "path", "")
 var workspace = "workspace"
 var pull = models.PullRequest{}
 var user = models.User{}

--- a/server/core/redis/redis_test.go
+++ b/server/core/redis/redis_test.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/runatlantis/atlantis/testing"
 )
 
-var project = models.NewProject("owner/repo", "parent/child")
+var project = models.NewProject("owner/repo", "parent/child", "")
 var workspace = "default"
 var pullNum = 1
 var lock = models.ProjectLock{
@@ -191,7 +191,7 @@ func TestListMultipleLocks(t *testing.T) {
 
 	for _, r := range repos {
 		newLock := lock
-		newLock.Project = models.NewProject(r, "path")
+		newLock.Project = models.NewProject(r, "path", "")
 		_, _, err := rdb.TryLock(newLock)
 		Ok(t, err)
 	}
@@ -243,7 +243,7 @@ func TestLockingExistingLock(t *testing.T) {
 	t.Log("...succeed if the new project has a different path")
 	{
 		newLock := lock
-		newLock.Project = models.NewProject(project.RepoFullName, "different/path")
+		newLock.Project = models.NewProject(project.RepoFullName, "different/path", "")
 		acquired, currLock, err := rdb.TryLock(newLock)
 		Ok(t, err)
 		Equals(t, true, acquired)
@@ -263,7 +263,7 @@ func TestLockingExistingLock(t *testing.T) {
 	t.Log("...succeed if the new project has a different repoName")
 	{
 		newLock := lock
-		newLock.Project = models.NewProject("different/repo", project.Path)
+		newLock.Project = models.NewProject("different/repo", project.Path, "")
 		acquired, currLock, err := rdb.TryLock(newLock)
 		Ok(t, err)
 		Equals(t, true, acquired)

--- a/server/core/redis/redis_test.go
+++ b/server/core/redis/redis_test.go
@@ -270,6 +270,19 @@ func TestLockingExistingLock(t *testing.T) {
 		Equals(t, newLock, currLock)
 	}
 
+	// TODO: How should we handle different name?
+	/*
+		t.Log("...succeed if the new project has a different name")
+		{
+			newLock := lock
+			newLock.Project = models.NewProject(project.RepoFullName, project.Path, "different-name")
+			acquired, currLock, err := rdb.TryLock(newLock)
+			Ok(t, err)
+			Equals(t, true, acquired)
+			Equals(t, newLock, currLock)
+		}
+	*/
+
 	t.Log("...not succeed if the new project only has a different pullNum")
 	{
 		newLock := lock

--- a/server/events/delete_lock_command.go
+++ b/server/events/delete_lock_command.go
@@ -33,10 +33,7 @@ func (l *DefaultDeleteLockCommand) DeleteLock(id string) (*models.ProjectLock, e
 		return nil, nil
 	}
 
-	// The locks controller currently has no implementation of Atlantis project names, so this is hardcoded to an empty string.
-	projectName := ""
-
-	removeErr := l.WorkingDir.DeletePlan(lock.Pull.BaseRepo, lock.Pull, lock.Workspace, lock.Project.Path, projectName)
+	removeErr := l.WorkingDir.DeletePlan(lock.Pull.BaseRepo, lock.Pull, lock.Workspace, lock.Project.Path, lock.Project.ProjectName)
 	if removeErr != nil {
 		l.Logger.Warn("Failed to delete plan: %s", removeErr)
 		return nil, removeErr

--- a/server/events/delete_lock_command.go
+++ b/server/events/delete_lock_command.go
@@ -54,13 +54,10 @@ func (l *DefaultDeleteLockCommand) DeleteLocksByPull(repoFullName string, pullNu
 		return numLocks, nil
 	}
 
-	// The locks controller currently has no implementation of Atlantis project names, so this is hardcoded to an empty string.
-	projectName := ""
-
 	for i := 0; i < numLocks; i++ {
 		lock := locks[i]
 
-		err := l.WorkingDir.DeletePlan(lock.Pull.BaseRepo, lock.Pull, lock.Workspace, lock.Project.Path, projectName)
+		err := l.WorkingDir.DeletePlan(lock.Pull.BaseRepo, lock.Pull, lock.Workspace, lock.Project.Path, lock.Project.ProjectName)
 		if err != nil {
 			l.Logger.Warn("Failed to delete plan: %s", err)
 			return numLocks, err

--- a/server/events/delete_lock_command_test.go
+++ b/server/events/delete_lock_command_test.go
@@ -119,7 +119,7 @@ func TestDeleteLocksByPull_SingleSuccess(t *testing.T) {
 	pullNum := 2
 	path := "."
 	workspace := "default"
-	projectName := ""
+	projectName := "projectname"
 
 	RegisterMockTestingT(t)
 	l := lockmocks.NewMockLocker()
@@ -135,6 +135,7 @@ func TestDeleteLocksByPull_SingleSuccess(t *testing.T) {
 			Project: models.Project{
 				Path:         path,
 				RepoFullName: pull.BaseRepo.FullName,
+				ProjectName:  projectName,
 			},
 		},
 	}, nil,

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -258,6 +258,7 @@ type Project struct {
 }
 
 func (p Project) String() string {
+	// TODO: Incorporate ProjectName?
 	return fmt.Sprintf("repofullname=%s path=%s", p.RepoFullName, p.Path)
 }
 

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -244,6 +244,8 @@ type ProjectLock struct {
 // Terraform projects in a single repo we also include Path to the project
 // root relative to the repo root.
 type Project struct {
+	// ProjectName of the project
+	ProjectName string
 	// RepoFullName is the owner and repo name, ex. "runatlantis/atlantis"
 	RepoFullName string
 	// Path to project root in the repo.
@@ -271,12 +273,13 @@ type Plan struct {
 
 // NewProject constructs a Project. Use this constructor because it
 // sets Path correctly.
-func NewProject(repoFullName string, path string) Project {
+func NewProject(repoFullName string, path string, projectName string) Project {
 	path = paths.Clean(path)
 	if path == "/" {
 		path = "."
 	}
 	return Project{
+		ProjectName:  projectName,
 		RepoFullName: repoFullName,
 		Path:         path,
 	}

--- a/server/events/models/models_test.go
+++ b/server/events/models/models_test.go
@@ -187,7 +187,7 @@ func TestNewProject(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.path, func(t *testing.T) {
-			p := models.NewProject("repo/owner", c.path)
+			p := models.NewProject("repo/owner", c.path, "")
 			Equals(t, c.expPath, p.Path)
 		})
 	}

--- a/server/events/models/models_test.go
+++ b/server/events/models/models_test.go
@@ -168,27 +168,47 @@ func TestProject_String(t *testing.T) {
 
 func TestNewProject(t *testing.T) {
 	cases := []struct {
-		path    string
-		expPath string
+		repo       string
+		path       string
+		name       string
+		expProject models.Project
 	}{
 		{
-			"/",
-			".",
+			repo: "foo/bar",
+			path: "/",
+			name: "",
+			expProject: models.Project{
+				ProjectName:  "",
+				RepoFullName: "foo/bar",
+				Path:         ".",
+			},
 		},
 		{
-			"./another/path",
-			"another/path",
+			repo: "baz/foo",
+			path: "./another/path",
+			name: "somename",
+			expProject: models.Project{
+				ProjectName:  "somename",
+				RepoFullName: "baz/foo",
+				Path:         "another/path",
+			},
 		},
 		{
-			".",
-			".",
+			repo: "baz/foo",
+			path: ".",
+			name: "somename",
+			expProject: models.Project{
+				ProjectName:  "somename",
+				RepoFullName: "baz/foo",
+				Path:         ".",
+			},
 		},
 	}
 
 	for _, c := range cases {
-		t.Run(c.path, func(t *testing.T) {
-			p := models.NewProject("repo/owner", c.path, "")
-			Equals(t, c.expPath, p.Path)
+		t.Run(fmt.Sprintf("%s_%s", c.name, c.path), func(t *testing.T) {
+			p := models.NewProject(c.repo, c.path, c.name)
+			Equals(t, c.expProject, p)
 		})
 	}
 }

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -320,7 +320,7 @@ func (p *DefaultProjectCommandRunner) StateRm(ctx command.ProjectContext) comman
 
 func (p *DefaultProjectCommandRunner) doApprovePolicies(ctx command.ProjectContext) (*models.PolicyCheckResults, string, error) {
 	// Acquire Atlantis lock for this repo/dir/workspace.
-	lockAttempt, err := p.Locker.TryLock(ctx.Log, ctx.Pull, ctx.User, ctx.Workspace, models.NewProject(ctx.Pull.BaseRepo.FullName, ctx.RepoRelDir), ctx.RepoLocking)
+	lockAttempt, err := p.Locker.TryLock(ctx.Log, ctx.Pull, ctx.User, ctx.Workspace, models.NewProject(ctx.Pull.BaseRepo.FullName, ctx.RepoRelDir, ctx.ProjectName), ctx.RepoLocking)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "acquiring lock")
 	}
@@ -417,7 +417,7 @@ func (p *DefaultProjectCommandRunner) doPolicyCheck(ctx command.ProjectContext) 
 	// we will attempt to capture the lock here but fail to get the working directory
 	// at which point we will unlock again to preserve functionality
 	// If we fail to capture the lock here (super unlikely) then we error out and the user is forced to replan
-	lockAttempt, err := p.Locker.TryLock(ctx.Log, ctx.Pull, ctx.User, ctx.Workspace, models.NewProject(ctx.Pull.BaseRepo.FullName, ctx.RepoRelDir), ctx.RepoLocking)
+	lockAttempt, err := p.Locker.TryLock(ctx.Log, ctx.Pull, ctx.User, ctx.Workspace, models.NewProject(ctx.Pull.BaseRepo.FullName, ctx.RepoRelDir, ctx.ProjectName), ctx.RepoLocking)
 
 	if err != nil {
 		return nil, "", errors.Wrap(err, "acquiring lock")
@@ -536,7 +536,7 @@ func (p *DefaultProjectCommandRunner) doPolicyCheck(ctx command.ProjectContext) 
 
 func (p *DefaultProjectCommandRunner) doPlan(ctx command.ProjectContext) (*models.PlanSuccess, string, error) {
 	// Acquire Atlantis lock for this repo/dir/workspace.
-	lockAttempt, err := p.Locker.TryLock(ctx.Log, ctx.Pull, ctx.User, ctx.Workspace, models.NewProject(ctx.Pull.BaseRepo.FullName, ctx.RepoRelDir), ctx.RepoLocking)
+	lockAttempt, err := p.Locker.TryLock(ctx.Log, ctx.Pull, ctx.User, ctx.Workspace, models.NewProject(ctx.Pull.BaseRepo.FullName, ctx.RepoRelDir, ctx.ProjectName), ctx.RepoLocking)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "acquiring lock")
 	}
@@ -682,7 +682,7 @@ func (p *DefaultProjectCommandRunner) doImport(ctx command.ProjectContext) (out 
 	}
 
 	// Acquire Atlantis lock for this repo/dir/workspace.
-	lockAttempt, err := p.Locker.TryLock(ctx.Log, ctx.Pull, ctx.User, ctx.Workspace, models.NewProject(ctx.Pull.BaseRepo.FullName, ctx.RepoRelDir), ctx.RepoLocking)
+	lockAttempt, err := p.Locker.TryLock(ctx.Log, ctx.Pull, ctx.User, ctx.Workspace, models.NewProject(ctx.Pull.BaseRepo.FullName, ctx.RepoRelDir, ctx.ProjectName), ctx.RepoLocking)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "acquiring lock")
 	}
@@ -723,7 +723,7 @@ func (p *DefaultProjectCommandRunner) doStateRm(ctx command.ProjectContext) (out
 	}
 
 	// Acquire Atlantis lock for this repo/dir/workspace.
-	lockAttempt, err := p.Locker.TryLock(ctx.Log, ctx.Pull, ctx.User, ctx.Workspace, models.NewProject(ctx.Pull.BaseRepo.FullName, ctx.RepoRelDir), ctx.RepoLocking)
+	lockAttempt, err := p.Locker.TryLock(ctx.Log, ctx.Pull, ctx.User, ctx.Workspace, models.NewProject(ctx.Pull.BaseRepo.FullName, ctx.RepoRelDir, ctx.ProjectName), ctx.RepoLocking)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "acquiring lock")
 	}

--- a/server/events/project_finder.go
+++ b/server/events/project_finder.go
@@ -167,7 +167,11 @@ func (p *DefaultProjectFinder) DetermineProjects(log logging.SimpleLogging, modi
 	exists := p.removeNonExistingDirs(uniqueDirs, absRepoDir)
 
 	for _, p := range exists {
-		projects = append(projects, models.NewProject(repoFullName, p, "???????????"))
+		// It's unclear how we are supposed to determine the project name at this point
+		// For now, we'll just add the default projectName
+		// TODO: Add support for non-default projectName
+		projectName := ""
+		projects = append(projects, models.NewProject(repoFullName, p, projectName))
 	}
 	log.Info("there are %d modified project(s) at path(s): %v",
 		len(projects), strings.Join(exists, ", "))

--- a/server/events/project_finder.go
+++ b/server/events/project_finder.go
@@ -167,7 +167,7 @@ func (p *DefaultProjectFinder) DetermineProjects(log logging.SimpleLogging, modi
 	exists := p.removeNonExistingDirs(uniqueDirs, absRepoDir)
 
 	for _, p := range exists {
-		projects = append(projects, models.NewProject(repoFullName, p))
+		projects = append(projects, models.NewProject(repoFullName, p, "???????????"))
 	}
 	log.Info("there are %d modified project(s) at path(s): %v",
 		len(projects), strings.Join(exists, ", "))

--- a/server/events/pull_closed_executor_test.go
+++ b/server/events/pull_closed_executor_test.go
@@ -107,7 +107,7 @@ func TestCleanUpPullComments(t *testing.T) {
 			"single lock, empty path",
 			[]models.ProjectLock{
 				{
-					Project:   models.NewProject("owner/repo", ""),
+					Project:   models.NewProject("owner/repo", "", ""),
 					Workspace: "default",
 				},
 			},
@@ -117,7 +117,7 @@ func TestCleanUpPullComments(t *testing.T) {
 			"single lock, non-empty path",
 			[]models.ProjectLock{
 				{
-					Project:   models.NewProject("owner/repo", "path"),
+					Project:   models.NewProject("owner/repo", "path", ""),
 					Workspace: "default",
 				},
 			},
@@ -127,11 +127,11 @@ func TestCleanUpPullComments(t *testing.T) {
 			"single path, multiple workspaces",
 			[]models.ProjectLock{
 				{
-					Project:   models.NewProject("owner/repo", "path"),
+					Project:   models.NewProject("owner/repo", "path", ""),
 					Workspace: "workspace1",
 				},
 				{
-					Project:   models.NewProject("owner/repo", "path"),
+					Project:   models.NewProject("owner/repo", "path", ""),
 					Workspace: "workspace2",
 				},
 			},
@@ -141,19 +141,19 @@ func TestCleanUpPullComments(t *testing.T) {
 			"multiple paths, multiple workspaces",
 			[]models.ProjectLock{
 				{
-					Project:   models.NewProject("owner/repo", "path"),
+					Project:   models.NewProject("owner/repo", "path", ""),
 					Workspace: "workspace1",
 				},
 				{
-					Project:   models.NewProject("owner/repo", "path"),
+					Project:   models.NewProject("owner/repo", "path", ""),
 					Workspace: "workspace2",
 				},
 				{
-					Project:   models.NewProject("owner/repo", "path2"),
+					Project:   models.NewProject("owner/repo", "path2", ""),
 					Workspace: "workspace1",
 				},
 				{
-					Project:   models.NewProject("owner/repo", "path2"),
+					Project:   models.NewProject("owner/repo", "path2", ""),
 					Workspace: "workspace2",
 				},
 			},
@@ -260,7 +260,7 @@ func TestCleanUpLogStreaming(t *testing.T) {
 
 		locks := []models.ProjectLock{
 			{
-				Project:   models.NewProject(testdata.GithubRepo.FullName, ""),
+				Project:   models.NewProject(testdata.GithubRepo.FullName, "", ""),
 				Workspace: "default",
 			},
 		}

--- a/server/events/pull_closed_executor_test.go
+++ b/server/events/pull_closed_executor_test.go
@@ -114,6 +114,17 @@ func TestCleanUpPullComments(t *testing.T) {
 			"- dir: `.` workspace: `default`",
 		},
 		{
+			"single lock, named project",
+			[]models.ProjectLock{
+				{
+					Project:   models.NewProject("owner/repo", "", "projectname"),
+					Workspace: "default",
+				},
+			},
+			// TODO: Should project name be included in output?
+			"- dir: `.` workspace: `default`",
+		},
+		{
 			"single lock, non-empty path",
 			[]models.ProjectLock{
 				{


### PR DESCRIPTION
## what

Add logic of project name into locks.

## why

I'm actually not totally sure why `Project` in models didn't have a `ProjectName` before. Adding this made it so we can, e.g., correctly identify the project plan files that need to be deleted when we run atlantis unlock (See #3845)

This is not a total fix, and instead kicks the can down the road a little bit. Specifically, I do *not* implement `project_finder()` to understand about project names, because frankly I'm not totally sure how, so I just assume the project doesn't have a name (i.e. empty string for ProjectName). That said, this is *no worse* than the current implementation, which *implicitly* assumes the project doesn't have a name "deeper" in the call stack.

In this sense, in my opinion this PR is a net positive, in that it moves us in the right direction, fixes a particular bug, and (as far as I know) doesn't introduce any regressions.

## tests

*Confirming the expected behavior change*

I configured a workspace with a name `projectname`, did a plan, then attempted to unlock.
Before:
```
{"level":"error","ts":"2024-02-05T23:35:23.329-0500","caller":"events/unlock_command_runner.go:62","msg":"failed to delete locks by pull remove /Users/lukemassa/.atlantis/repos/cloud/playground/lmassa-test-atlantis/36/lmassa/lmassa.tfplan: no such file or directory","json":{"repo":"cloud/playground/lmassa-test-atlantis","pull":"36"},"stacktrace":"github.com/runatlantis/atlantis/server/events.(*UnlockCommandRunner).Run\n\t/Users/lukemassa/atlantis/server/events/unlock_command_runner.go:62\ngithub.com/runatlantis/atlantis/server/events.(*DefaultCommandRunner).RunCommentCommand\n\t/Users/lukemassa/atlantis/server/events/command_runner.go:365"}
```

After:
```
{"level":"info","ts":"2024-02-05T23:41:15.515-0500","caller":"events/working_dir.go:426","msg":"Deleting plan: /Users/lukemassa/.atlantis/repos/cloud/playground/lmassa-test-atlantis/36/lmassa/projectname-lmassa.tfplan","json":{}}
```

*Confirming no regressions*

1. If `name` is absent, the behavior is as before:
```
{"level":"info","ts":"2024-02-07T14:39:26.711-0500","caller":"events/working_dir.go:426","msg":"Deleting plan: /Users/lukemassa/.atlantis/repos/cloud/playground/lmassa-test-atlantis/36/lmassa/lmassa.tfplan","json":{}}
```
2. Whether or not `name` is present, closing the PR itself retains its previous behavior of blowing away the entire directory (and there is no log line of atlantis even attempting to delete the plan file)
```
{"level":"info","ts":"2024-02-07T14:44:49.270-0500","caller":"events/working_dir.go:393","msg":"Deleting repo pull directory: /Users/lukemassa/.atlantis/repos/cloud/playground/lmassa-test-atlantis/36","json":{}}
```

## references

Closes: #3845
