### PR TITLE
docs: Failed policy checks block apply regardless of `mergeable` apply requirement

### DIFF
--- a/runatlantis.io/docs/policy-checking.md
+++ b/runatlantis.io/docs/policy-checking.md
@@ -10,7 +10,7 @@ for using this step include:
 
 ## How it works?
 
-Enabling "policy checking" in addition to the [mergeable apply requirement](/docs/command-requirements.html#supported-requirements) blocks applies on plans that fail any of the defined conftest policies.
+Enabling "policy checking" blocks applies on plans that fail any of the defined conftest policies.
 
 ![Policy Check Apply Failure](./images/policy-check-apply-failure.png)
 


### PR DESCRIPTION
## what

The docs indicate that the `mergeable` apply requirement needs to be active in order to block applies based on failing policy checks. This isn't true.


## why

Simply enabling policy checks appears to cause enforcement of `policies_passed` requirement for apply.

## tests

I use policy checks without the `mergeable` apply requirement and they block apply when failing.

## references

`ValidateApplyProject` checks `PolicyCleared` independently from `MergeableRequirement` ([ref](https://github.com/runatlantis/atlantis/blob/9fa4cd3c344df2387baca5d50557bc4710e8be13/server/events/command_requirement_handler.go#L53))

