### PR TITLE
chore(dockerfile): update to use 1.4.7,1.6.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ ENV DEFAULT_TERRAFORM_VERSION=${DEFAULT_TERRAFORM_VERSION}
 
 # In the official Atlantis image, we only have the latest of each Terraform version.
 # Each binary is about 80 MB so we limit it to the 4 latest minor releases or fewer
-RUN AVAILABLE_TERRAFORM_VERSIONS="1.4.6 1.5.7 1.6.3 ${DEFAULT_TERRAFORM_VERSION}" && \
+RUN AVAILABLE_TERRAFORM_VERSIONS="1.4.7 1.5.7 1.6.6 ${DEFAULT_TERRAFORM_VERSION}" && \
     case "${TARGETPLATFORM}" in \
         "linux/amd64") TERRAFORM_ARCH=amd64 ;; \
         "linux/arm64") TERRAFORM_ARCH=arm64 ;; \


### PR DESCRIPTION
```
$ asdf list-all terraform | grep 1.4.
1.4.0-alpha20221109
1.4.0-alpha20221207
1.4.0-beta1
1.4.0-beta2
1.4.0-rc1
1.4.0
1.4.1
1.4.2
1.4.3
1.4.4
1.4.5
1.4.6
1.4.7
```

```
$ asdf list-all terraform | grep 1.5.
1.5.0-alpha20230405
1.5.0-alpha20230504
1.5.0-beta1
1.5.0-beta2
1.5.0-rc1
1.5.0-rc2
1.5.0
1.5.1
1.5.2
1.5.3
1.5.4
1.5.5
1.5.6
1.5.7
```

```
$ asdf list-all terraform | grep 1.6.
1.1.0-alpha20210616
1.1.0-alpha20210630
1.6.0-alpha20230719
1.6.0-alpha20230802
1.6.0-alpha20230816
1.6.0-beta1
1.6.0-beta2
1.6.0-beta3
1.6.0-rc1
1.6.0
1.6.1
1.6.2
1.6.3
1.6.4
1.6.5
1.6.6
```

