### PR TITLE
fix: update go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/runatlantis/atlantis
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3


### PR DESCRIPTION
```sh
$ go version
go: downloading go1.22 (darwin/arm64)
go: download go1.22 for darwin/arm64: toolchain not available
```

after the change

```sh
$ go version
go: downloading go1.22.0 (darwin/arm64)
go version go1.22.0 darwin/arm64
```

- relates to https://github.com/golang/go/issues/65568

Thanks @lukemassa for calling it out.