### PR TITLE
feat: allow masking output on comments

### DIFF
--- a/runatlantis.io/docs/custom-workflows.md
+++ b/runatlantis.io/docs/custom-workflows.md
@@ -40,7 +40,7 @@ workflows:
           extra_args: ["-var-file", "staging.tfvars"]
     # NOTE: no need to define the apply stage because it will default
     # to the normal apply stage.
-    
+
   production:
     plan:
       steps:
@@ -147,11 +147,11 @@ workflows:
       - run:
           command: terraform init -input=false
           output: hide
-      
+
       # If you're using workspaces you need to select the workspace using the
       # $WORKSPACE environment variable.
       - run: terraform workspace select $WORKSPACE
-      
+
       # You MUST output the plan using -out $PLANFILE because Atlantis expects
       # plans to be in a specific location.
       - run: terraform plan -input=false -refresh -out $PLANFILE
@@ -234,7 +234,7 @@ $ tree --gitignore
 
 1. Container orchestrator (k8s/fargate/ecs/etc) uses the custom docker image of atlantis with `cdktf` installed with
 the `--autoplan-file-list` to trigger on `cdk.tf.json` files and `--include-git-untracked-files` set to include the
-CDKTF dynamically generated Terraform files in the Atlantis plan. 
+CDKTF dynamically generated Terraform files in the Atlantis plan.
 1. PR branch is pushed up containing `cdktf` code changes.
 1. Atlantis checks out the branch in the repo.
 1. Atlantis runs the `npm i && cdktf get && cdktf synth` command in the repo root as a step in `pre_workflow_hooks`,
@@ -335,7 +335,10 @@ workflows:
           value: 'true'
       - run:
           command: terragrunt plan -input=false -out=$PLANFILE
-          output: strip_refreshing
+          output: strip_refreshing_with_custom_regex
+          # Filters text matching 'mySecret: "aaa"' -> 'mySecret: "<redacted>"'
+          regex_filter: "((?i)secret:\\s\")[^\"]*"
+
     apply:
       steps:
       - env:
@@ -380,7 +383,7 @@ isn't set, Atlantis will use the default plan workflow which is what we want in 
 * A custom command will only terminate if all output file descriptors are closed.
 Therefore a custom command can only be sent to the background (e.g. for an SSH tunnel during
 the terraform run) when its output is redirected to a different location. For example, Atlantis
-will execute a custom script containing the following code to create a SSH tunnel correctly: 
+will execute a custom script containing the following code to create a SSH tunnel correctly:
 `ssh -f -M -S /tmp/ssh_tunnel -L 3306:database:3306 -N bastion 1>/dev/null 2>&1`. Without
 the redirect, the script would block the Atlantis workflow.
 :::
@@ -501,20 +504,22 @@ Compact:
 
 Full
 ```yaml
-- run: 
+- run:
     command: custom-command arg1 arg2
     output: show
+    custom_regex: .*
 ```
-| Key | Type                                                         | Default | Required | Description                                                                                                                                                                                                                                                                                                                                                                                             |
-|-----|--------------------------------------------------------------|---------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| run | map[string -> string] | none    | no       | Run a custom command                                                                                                                                                                                                                                                                                                                                                                                    |
-| run.command | string                                                       | none | yes      | Shell command to run                                                                                                                                                                                                                                                                                                                                                                                    |
-| run.output | string                                                       | "show" | no       | How to post-process the output of this command when posted in the PR comment. The options are<br/>* `show` - preserve the full output<br/>* `hide` - hide output from comment (still visible in the real-time streaming output)<br/> * `strip_refreshing` - hide all output up until and including the last line containing "Refreshing...". This matches the behavior of the built-in `plan` command |
+| Key               | Type                  | Default | Required  | Description           |
+|-------------------|-----------------------|---------|-----------|-----------------------|
+| run               | map[string -> string] | none    | no        | Run a custom command  |
+| run.command       | string                | none    | yes       | Shell command to run  |
+| run.output        | string                | "show"  | no        | How to post-process the output of this command when posted in the PR comment. The options are<br/>* `show` - preserve the full output<br/>* `hide` - hide output from comment (still visible in the real-time streaming output)<br/> * `strip_refreshing` - hide all output up until and including the last line containing "Refreshing...". This matches the behavior of the built-in `plan` command<br/> * `custom_regex` - filters the comment output based on the regex specified on `run.regex_filter` by replacing matched patterns with the text `<redacted`. Note: this filter only applies to the comments posted by Atlantis, the plan output on the URL job is untouched <br/> * `strip_refreshing_with_custom_regex` - applies `strip_refreshing` and `custom_regex` to the output |
+| run.custom_regex  | string                | none    | no        | Regex filter to be applied to output. Required when `run.output` is `custom_regex` or `strip_refreshing_with_custom_regex` |
 
 ::: tip Notes
-* `run` steps in the main `workflow` are executed with the following environment variables:  
+* `run` steps in the main `workflow` are executed with the following environment variables:
   note: these variables are not available to `pre` or `post` workflows
-    * `WORKSPACE` - The Terraform workspace used for this project, ex. `default`.  
+    * `WORKSPACE` - The Terraform workspace used for this project, ex. `default`.
       NOTE: if the step is executed before `init` then Atlantis won't have switched to this workspace yet.
     * `ATLANTIS_TERRAFORM_VERSION` - The version of Terraform used for this project, ex. `0.11.0`.
     * `DIR` - Absolute path to the current directory.
@@ -544,10 +549,10 @@ Full
 * A custom command will only terminate if all output file descriptors are closed.
 Therefore a custom command can only be sent to the background (e.g. for an SSH tunnel during
 the terraform run) when its output is redirected to a different location. For example, Atlantis
-will execute a custom script containing the following code to create a SSH tunnel correctly: 
+will execute a custom script containing the following code to create a SSH tunnel correctly:
 `ssh -f -M -S /tmp/ssh_tunnel -L 3306:database:3306 -N bastion 1>/dev/null 2>&1`. Without
 the redirect, the script would block the Atlantis workflow.
-* If a workflow step returns a non-zero exit code, the workflow will stop. 
+* If a workflow step returns a non-zero exit code, the workflow will stop.
 :::
 
 #### Environment Variable `env` Command
@@ -574,7 +579,7 @@ as the environment variable value.
 
 ::: tip Notes
 * `env` `command`'s can use any of the built-in environment variables available
-  to `run` commands. 
+  to `run` commands.
 :::
 
 #### Multiple Environment Variables `multienv` Command
@@ -594,5 +599,5 @@ The name-value pairs in the result are added as environment variables if success
 
 ::: tip Notes
 * `multienv` `command`'s can use any of the built-in environment variables available
-  to `run` commands. 
+  to `run` commands.
 :::

--- a/server/core/config/raw/step.go
+++ b/server/core/config/raw/step.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -12,21 +13,22 @@ import (
 )
 
 const (
-	ExtraArgsKey        = "extra_args"
-	NameArgKey          = "name"
-	CommandArgKey       = "command"
-	ValueArgKey         = "value"
-	OutputArgKey        = "output"
-	RunStepName         = "run"
-	PlanStepName        = "plan"
-	ShowStepName        = "show"
-	PolicyCheckStepName = "policy_check"
-	ApplyStepName       = "apply"
-	InitStepName        = "init"
-	EnvStepName         = "env"
-	MultiEnvStepName    = "multienv"
-	ImportStepName      = "import"
-	StateRmStepName     = "state_rm"
+	ExtraArgsKey         = "extra_args"
+	NameArgKey           = "name"
+	CommandArgKey        = "command"
+	ValueArgKey          = "value"
+	OutputArgKey         = "output"
+	OutputRegexFilterKey = "regex_filter"
+	RunStepName          = "run"
+	PlanStepName         = "plan"
+	ShowStepName         = "show"
+	PolicyCheckStepName  = "policy_check"
+	ApplyStepName        = "apply"
+	InitStepName         = "init"
+	EnvStepName          = "env"
+	MultiEnvStepName     = "multienv"
+	ImportStepName       = "import"
+	StateRmStepName      = "state_rm"
 )
 
 // Step represents a single action/command to perform. In YAML, it can be set as
@@ -43,6 +45,10 @@ const (
 //   - run:
 //     command: my custom command
 //     output: hide
+//   - run:
+//     command: my custom command
+//     output: custom_regex
+//     regex_filter: .*
 //
 // 3. A map for a built-in command and extra_args:
 //   - plan:
@@ -203,8 +209,19 @@ func (s Step) Validate() error {
 			}
 			delete(args, CommandArgKey)
 			if v, ok := args[OutputArgKey]; ok {
-				if !(v == valid.PostProcessRunOutputShow || v == valid.PostProcessRunOutputHide || v == valid.PostProcessRunOutputStripRefreshing) {
-					return fmt.Errorf("run step %q option must be one of %q, %q, or %q", OutputArgKey, valid.PostProcessRunOutputShow, valid.PostProcessRunOutputHide, valid.PostProcessRunOutputStripRefreshing)
+				if !valid.MatchesAnyPostProcessRunOutputOptions(v) {
+					return fmt.Errorf("run step %q option must be one of %q", OutputArgKey, strings.Join(valid.PostProcessRunOutputOptions(), ","))
+				}
+				// When output requires regex option
+				if v == valid.PostProcessRunOutputCustomRegex || v == valid.PostProcessRunOutputStripRefreshingWithCustomRegex {
+					if regex, ok := args[OutputRegexFilterKey]; ok {
+						if _, err := regexp.Compile(regex); err != nil {
+							return fmt.Errorf("run step %q option with expression %q is not a valid regex: %w", OutputRegexFilterKey, regex, err)
+						}
+						delete(args, OutputRegexFilterKey)
+					} else {
+						return fmt.Errorf("run step %q option requires %q to be set", OutputArgKey, OutputRegexFilterKey)
+					}
 				}
 			}
 			delete(args, OutputArgKey)
@@ -274,11 +291,12 @@ func (s Step) ToValid() valid.Step {
 		// step name so we just use the first one.
 		for stepName, stepArgs := range s.EnvOrRun {
 			step := valid.Step{
-				StepName:    stepName,
-				EnvVarName:  stepArgs[NameArgKey],
-				RunCommand:  stepArgs[CommandArgKey],
-				EnvVarValue: stepArgs[ValueArgKey],
-				Output:      valid.PostProcessRunOutputOption(stepArgs[OutputArgKey]),
+				StepName:          stepName,
+				EnvVarName:        stepArgs[NameArgKey],
+				RunCommand:        stepArgs[CommandArgKey],
+				EnvVarValue:       stepArgs[ValueArgKey],
+				Output:            valid.PostProcessRunOutputOption(stepArgs[OutputArgKey]),
+				OutputRegexFilter: stepArgs[OutputRegexFilterKey],
 			}
 			if step.StepName == RunStepName && step.Output == "" {
 				step.Output = valid.PostProcessRunOutputShow

--- a/server/core/config/raw/step_test.go
+++ b/server/core/config/raw/step_test.go
@@ -574,6 +574,24 @@ func TestStep_ToValid(t *testing.T) {
 				Output:     "hide",
 			},
 		},
+		{
+			description: "run step with regex",
+			input: raw.Step{
+				EnvOrRun: EnvOrRunType{
+					"run": {
+						"command":      "my 'run command'",
+						"output":       "regex_filter",
+						"regex_filter": ".*",
+					},
+				},
+			},
+			exp: valid.Step{
+				StepName:          "run",
+				RunCommand:        "my 'run command'",
+				Output:            "regex_filter",
+				OutputRegexFilter: ".*",
+			},
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {

--- a/server/core/config/valid/repo_cfg.go
+++ b/server/core/config/valid/repo_cfg.go
@@ -177,10 +177,34 @@ type Autoplan struct {
 type PostProcessRunOutputOption string
 
 const (
-	PostProcessRunOutputShow            = "show"
-	PostProcessRunOutputHide            = "hide"
-	PostProcessRunOutputStripRefreshing = "strip_refreshing"
+	PostProcessRunOutputShow                           = "show"
+	PostProcessRunOutputHide                           = "hide"
+	PostProcessRunOutputStripRefreshing                = "strip_refreshing"
+	PostProcessRunOutputCustomRegex                    = "custom_regex"
+	PostProcessRunOutputStripRefreshingWithCustomRegex = "strip_refreshing_with_custom_regex"
 )
+
+// PostProcessRunOutputOptions returns the available post processing options
+// This list needs to be manually updated
+func PostProcessRunOutputOptions() []string {
+	return []string{
+		PostProcessRunOutputShow,
+		PostProcessRunOutputHide,
+		PostProcessRunOutputStripRefreshing,
+		PostProcessRunOutputCustomRegex,
+		PostProcessRunOutputStripRefreshingWithCustomRegex,
+	}
+}
+
+// MatchesAnyPostProcessRunOutputOptions returns true when the input matches any of the available post processing options
+func MatchesAnyPostProcessRunOutputOptions(option string) bool {
+	for _, c := range PostProcessRunOutputOptions() {
+		if option == c {
+			return true
+		}
+	}
+	return false
+}
 
 type Stage struct {
 	Steps []Step
@@ -194,6 +218,8 @@ type Step struct {
 	RunCommand string
 	// Output is option for post-processing a RunCommand output
 	Output PostProcessRunOutputOption
+	// OutputRegexFilter is a required option when post-processing uses a regex filter output
+	OutputRegexFilter string
 	// EnvVarName is the name of the
 	// environment variable that should be set by this step.
 	EnvVarName string

--- a/server/core/runtime/env_step_runner.go
+++ b/server/core/runtime/env_step_runner.go
@@ -21,7 +21,7 @@ func (r *EnvStepRunner) Run(ctx command.ProjectContext, command string, value st
 	}
 	// Pass `false` for streamOutput because this isn't interesting to the user reading the build logs
 	// in the web UI.
-	res, err := r.RunStepRunner.Run(ctx, command, path, envs, false, valid.PostProcessRunOutputShow)
+	res, err := r.RunStepRunner.Run(ctx, command, path, envs, false, valid.PostProcessRunOutputShow, "")
 	// Trim newline from res to support running `echo env_value` which has
 	// a newline. We don't recommend users run echo -n env_value to remove the
 	// newline because -n doesn't work in the sh shell which is what we use

--- a/server/core/runtime/mocks/mock_pull_approved_checker.go
+++ b/server/core/runtime/mocks/mock_pull_approved_checker.go
@@ -6,6 +6,7 @@ package mocks
 import (
 	pegomock "github.com/petergtz/pegomock/v4"
 	models "github.com/runatlantis/atlantis/server/events/models"
+	logging "github.com/runatlantis/atlantis/server/logging"
 	"reflect"
 	"time"
 )
@@ -25,11 +26,11 @@ func NewMockPullApprovedChecker(options ...pegomock.Option) *MockPullApprovedChe
 func (mock *MockPullApprovedChecker) SetFailHandler(fh pegomock.FailHandler) { mock.fail = fh }
 func (mock *MockPullApprovedChecker) FailHandler() pegomock.FailHandler      { return mock.fail }
 
-func (mock *MockPullApprovedChecker) PullIsApproved(baseRepo models.Repo, pull models.PullRequest) (models.ApprovalStatus, error) {
+func (mock *MockPullApprovedChecker) PullIsApproved(logger logging.SimpleLogging, baseRepo models.Repo, pull models.PullRequest) (models.ApprovalStatus, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockPullApprovedChecker().")
 	}
-	params := []pegomock.Param{baseRepo, pull}
+	params := []pegomock.Param{logger, baseRepo, pull}
 	result := pegomock.GetGenericMockFrom(mock).Invoke("PullIsApproved", params, []reflect.Type{reflect.TypeOf((*models.ApprovalStatus)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 models.ApprovalStatus
 	var ret1 error
@@ -81,8 +82,8 @@ type VerifierMockPullApprovedChecker struct {
 	timeout                time.Duration
 }
 
-func (verifier *VerifierMockPullApprovedChecker) PullIsApproved(baseRepo models.Repo, pull models.PullRequest) *MockPullApprovedChecker_PullIsApproved_OngoingVerification {
-	params := []pegomock.Param{baseRepo, pull}
+func (verifier *VerifierMockPullApprovedChecker) PullIsApproved(logger logging.SimpleLogging, baseRepo models.Repo, pull models.PullRequest) *MockPullApprovedChecker_PullIsApproved_OngoingVerification {
+	params := []pegomock.Param{logger, baseRepo, pull}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "PullIsApproved", params, verifier.timeout)
 	return &MockPullApprovedChecker_PullIsApproved_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -92,21 +93,25 @@ type MockPullApprovedChecker_PullIsApproved_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockPullApprovedChecker_PullIsApproved_OngoingVerification) GetCapturedArguments() (models.Repo, models.PullRequest) {
-	baseRepo, pull := c.GetAllCapturedArguments()
-	return baseRepo[len(baseRepo)-1], pull[len(pull)-1]
+func (c *MockPullApprovedChecker_PullIsApproved_OngoingVerification) GetCapturedArguments() (logging.SimpleLogging, models.Repo, models.PullRequest) {
+	logger, baseRepo, pull := c.GetAllCapturedArguments()
+	return logger[len(logger)-1], baseRepo[len(baseRepo)-1], pull[len(pull)-1]
 }
 
-func (c *MockPullApprovedChecker_PullIsApproved_OngoingVerification) GetAllCapturedArguments() (_param0 []models.Repo, _param1 []models.PullRequest) {
+func (c *MockPullApprovedChecker_PullIsApproved_OngoingVerification) GetAllCapturedArguments() (_param0 []logging.SimpleLogging, _param1 []models.Repo, _param2 []models.PullRequest) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]models.Repo, len(c.methodInvocations))
+		_param0 = make([]logging.SimpleLogging, len(c.methodInvocations))
 		for u, param := range params[0] {
-			_param0[u] = param.(models.Repo)
+			_param0[u] = param.(logging.SimpleLogging)
 		}
-		_param1 = make([]models.PullRequest, len(c.methodInvocations))
+		_param1 = make([]models.Repo, len(c.methodInvocations))
 		for u, param := range params[1] {
-			_param1[u] = param.(models.PullRequest)
+			_param1[u] = param.(models.Repo)
+		}
+		_param2 = make([]models.PullRequest, len(c.methodInvocations))
+		for u, param := range params[2] {
+			_param2[u] = param.(models.PullRequest)
 		}
 	}
 	return

--- a/server/core/runtime/multienv_step_runner.go
+++ b/server/core/runtime/multienv_step_runner.go
@@ -17,7 +17,7 @@ type MultiEnvStepRunner struct {
 // Run runs the multienv step command.
 // The command must return a json string containing the array of name-value pairs that are being added as extra environment variables
 func (r *MultiEnvStepRunner) Run(ctx command.ProjectContext, command string, path string, envs map[string]string) (string, error) {
-	res, err := r.RunStepRunner.Run(ctx, command, path, envs, false, valid.PostProcessRunOutputShow)
+	res, err := r.RunStepRunner.Run(ctx, command, path, envs, false, valid.PostProcessRunOutputShow, "")
 	if err != nil {
 		return "", err
 	}

--- a/server/core/runtime/plan_step_runner.go
+++ b/server/core/runtime/plan_step_runner.go
@@ -265,6 +265,15 @@ func StripRefreshingFromPlanOutput(output string, tfVersion *version.Version) st
 	return output
 }
 
+func CustomRegexFromPlanOutput(output string, outputFilterRegex string) string {
+	if outputFilterRegex == "" {
+		return output
+	}
+	// Regex was validated previously
+	r := regexp.MustCompile(outputFilterRegex)
+	return r.ReplaceAllString(output, "${1}<redacted>$2")
+}
+
 // remoteOpsErr01114 is the error terraform plan will return if this project is
 // using TFE remote operations in TF 0.11.15.
 var remoteOpsErr01114 = `Error: Saving a generated plan is currently not supported!

--- a/server/core/runtime/plan_step_runner_test.go
+++ b/server/core/runtime/plan_step_runner_test.go
@@ -536,6 +536,31 @@ Plan: 0 to add, 0 to change, 1 to destroy.`, output)
 	}
 }
 
+// Test custom regex on output method
+func TestCustomRegexFromPlanOutputFromPlanOutput(t *testing.T) {
+	cases := []struct {
+		in    string
+		out   string
+		regex string
+	}{
+		{
+			remotePlanOutput,
+			remotePlanOutput,
+			"",
+		},
+		{
+			remotePlanOutputSensitive,
+			remotePlanOutputSensitiveMasked,
+			`((?i)secret:\s")[^"]*`,
+		},
+	}
+
+	for _, c := range cases {
+		output := runtime.CustomRegexFromPlanOutput(c.in, c.regex)
+		Equals(t, c.out, output)
+	}
+}
+
 type remotePlanMock struct {
 	// LinesToSend will be sent on the channel.
 	LinesToSend string
@@ -603,3 +628,63 @@ Terraform will perform the following actions:
 
 
 Plan: 0 to add, 0 to change, 1 to destroy.`
+
+var remotePlanOutputSensitive = `Terraform will perform the following actions:
+
+  # kubectl_manifest.test[0] will be updated in-place
+!   resource "kubectl_manifest" "test" {
+        id                      = "/apis/argoproj.io/v1alpha1/namespaces/test/applications/test"
+        name                    = "test"
+!       yaml_body               = (sensitive value)
+!       yaml_body_parsed        = <<-EOT
+            apiVersion: argoproj.io/v1alpha1
+            kind: Application
+            metadata:
+              name: test
+              namespace: test
+            spec:
+              destination:
+                namespace: test
+                server: https://kubernetes.default.svc
+              project: default
+              source:
+                helm:
+                  values: |-
+-                   clientID: "test_id"
+-                   clientSecret: "super_secret_old"
++                   clientID: "test_id"
++                   clientSecret: "super_secret_new"
+        EOT
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.`
+
+var remotePlanOutputSensitiveMasked = `Terraform will perform the following actions:
+
+  # kubectl_manifest.test[0] will be updated in-place
+!   resource "kubectl_manifest" "test" {
+        id                      = "/apis/argoproj.io/v1alpha1/namespaces/test/applications/test"
+        name                    = "test"
+!       yaml_body               = (sensitive value)
+!       yaml_body_parsed        = <<-EOT
+            apiVersion: argoproj.io/v1alpha1
+            kind: Application
+            metadata:
+              name: test
+              namespace: test
+            spec:
+              destination:
+                namespace: test
+                server: https://kubernetes.default.svc
+              project: default
+              source:
+                helm:
+                  values: |-
+-                   clientID: "test_id"
+-                   clientSecret: "<redacted>"
++                   clientID: "test_id"
++                   clientSecret: "<redacted>"
+        EOT
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.`

--- a/server/core/runtime/run_step_runner.go
+++ b/server/core/runtime/run_step_runner.go
@@ -22,7 +22,7 @@ type RunStepRunner struct {
 	ProjectCmdOutputHandler jobs.ProjectCommandOutputHandler
 }
 
-func (r *RunStepRunner) Run(ctx command.ProjectContext, command string, path string, envs map[string]string, streamOutput bool, postProcessOutput valid.PostProcessRunOutputOption) (string, error) {
+func (r *RunStepRunner) Run(ctx command.ProjectContext, command string, path string, envs map[string]string, streamOutput bool, postProcessOutput valid.PostProcessRunOutputOption, postProcessRegexFilter string) (string, error) {
 	tfVersion := r.DefaultTFVersion
 	if ctx.TerraformVersion != nil {
 		tfVersion = ctx.TerraformVersion
@@ -85,6 +85,10 @@ func (r *RunStepRunner) Run(ctx command.ProjectContext, command string, path str
 		return "", nil
 	case valid.PostProcessRunOutputStripRefreshing:
 		return StripRefreshingFromPlanOutput(output, tfVersion), nil
+	case valid.PostProcessRunOutputCustomRegex:
+		return CustomRegexFromPlanOutput(output, postProcessRegexFilter), nil
+	case valid.PostProcessRunOutputStripRefreshingWithCustomRegex:
+		return CustomRegexFromPlanOutput(StripRefreshingFromPlanOutput(output, tfVersion), postProcessRegexFilter), nil
 	case valid.PostProcessRunOutputShow:
 		return output, nil
 	default:

--- a/server/core/runtime/run_step_runner_test.go
+++ b/server/core/runtime/run_step_runner_test.go
@@ -1,4 +1,4 @@
-package runtime_test
+package runtime
 
 import (
 	"fmt"
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/go-version"
 	. "github.com/petergtz/pegomock/v4"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
-	"github.com/runatlantis/atlantis/server/core/runtime"
 	"github.com/runatlantis/atlantis/server/core/terraform/mocks"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
@@ -111,7 +110,7 @@ func TestRunStepRunner_Run(t *testing.T) {
 		projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
 		tmpDir := t.TempDir()
 
-		r := runtime.RunStepRunner{
+		r := RunStepRunner{
 			TerraformExecutor:       terraform,
 			DefaultTFVersion:        defaultVersion,
 			TerraformBinDir:         "/bin/dir",
@@ -145,7 +144,7 @@ func TestRunStepRunner_Run(t *testing.T) {
 				ProjectName:        c.ProjectName,
 				EscapedCommentArgs: []string{"-target=resource1", "-target=resource2"},
 			}
-			out, err := r.Run(ctx, c.Command, tmpDir, map[string]string{"test": "var"}, true, valid.PostProcessRunOutputShow)
+			out, err := r.Run(ctx, c.Command, tmpDir, map[string]string{"test": "var"}, true, valid.PostProcessRunOutputShow, "")
 			if c.ExpErr != "" {
 				ErrContains(t, c.ExpErr, err)
 				return

--- a/server/events/mocks/mock_custom_step_runner.go
+++ b/server/events/mocks/mock_custom_step_runner.go
@@ -26,11 +26,11 @@ func NewMockCustomStepRunner(options ...pegomock.Option) *MockCustomStepRunner {
 func (mock *MockCustomStepRunner) SetFailHandler(fh pegomock.FailHandler) { mock.fail = fh }
 func (mock *MockCustomStepRunner) FailHandler() pegomock.FailHandler      { return mock.fail }
 
-func (mock *MockCustomStepRunner) Run(ctx command.ProjectContext, cmd string, path string, envs map[string]string, streamOutput bool, postProcessOutput valid.PostProcessRunOutputOption) (string, error) {
+func (mock *MockCustomStepRunner) Run(ctx command.ProjectContext, cmd string, path string, envs map[string]string, streamOutput bool, postProcessOutput valid.PostProcessRunOutputOption, postProcessRegexFilter string) (string, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockCustomStepRunner().")
 	}
-	params := []pegomock.Param{ctx, cmd, path, envs, streamOutput, postProcessOutput}
+	params := []pegomock.Param{ctx, cmd, path, envs, streamOutput, postProcessOutput, postProcessRegexFilter}
 	result := pegomock.GetGenericMockFrom(mock).Invoke("Run", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 string
 	var ret1 error
@@ -82,8 +82,8 @@ type VerifierMockCustomStepRunner struct {
 	timeout                time.Duration
 }
 
-func (verifier *VerifierMockCustomStepRunner) Run(ctx command.ProjectContext, cmd string, path string, envs map[string]string, streamOutput bool, postProcessOutput valid.PostProcessRunOutputOption) *MockCustomStepRunner_Run_OngoingVerification {
-	params := []pegomock.Param{ctx, cmd, path, envs, streamOutput, postProcessOutput}
+func (verifier *VerifierMockCustomStepRunner) Run(ctx command.ProjectContext, cmd string, path string, envs map[string]string, streamOutput bool, postProcessOutput valid.PostProcessRunOutputOption, postProcessRegexFilter string) *MockCustomStepRunner_Run_OngoingVerification {
+	params := []pegomock.Param{ctx, cmd, path, envs, streamOutput, postProcessOutput, postProcessRegexFilter}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "Run", params, verifier.timeout)
 	return &MockCustomStepRunner_Run_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -93,12 +93,12 @@ type MockCustomStepRunner_Run_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockCustomStepRunner_Run_OngoingVerification) GetCapturedArguments() (command.ProjectContext, string, string, map[string]string, bool, valid.PostProcessRunOutputOption) {
-	ctx, cmd, path, envs, streamOutput, postProcessOutput := c.GetAllCapturedArguments()
-	return ctx[len(ctx)-1], cmd[len(cmd)-1], path[len(path)-1], envs[len(envs)-1], streamOutput[len(streamOutput)-1], postProcessOutput[len(postProcessOutput)-1]
+func (c *MockCustomStepRunner_Run_OngoingVerification) GetCapturedArguments() (command.ProjectContext, string, string, map[string]string, bool, valid.PostProcessRunOutputOption, string) {
+	ctx, cmd, path, envs, streamOutput, postProcessOutput, postProcessRegexFilter := c.GetAllCapturedArguments()
+	return ctx[len(ctx)-1], cmd[len(cmd)-1], path[len(path)-1], envs[len(envs)-1], streamOutput[len(streamOutput)-1], postProcessOutput[len(postProcessOutput)-1], postProcessRegexFilter[len(postProcessRegexFilter)-1]
 }
 
-func (c *MockCustomStepRunner_Run_OngoingVerification) GetAllCapturedArguments() (_param0 []command.ProjectContext, _param1 []string, _param2 []string, _param3 []map[string]string, _param4 []bool, _param5 []valid.PostProcessRunOutputOption) {
+func (c *MockCustomStepRunner_Run_OngoingVerification) GetAllCapturedArguments() (_param0 []command.ProjectContext, _param1 []string, _param2 []string, _param3 []map[string]string, _param4 []bool, _param5 []valid.PostProcessRunOutputOption, _param6 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]command.ProjectContext, len(c.methodInvocations))
@@ -124,6 +124,10 @@ func (c *MockCustomStepRunner_Run_OngoingVerification) GetAllCapturedArguments()
 		_param5 = make([]valid.PostProcessRunOutputOption, len(c.methodInvocations))
 		for u, param := range params[5] {
 			_param5[u] = param.(valid.PostProcessRunOutputOption)
+		}
+		_param6 = make([]string, len(c.methodInvocations))
+		for u, param := range params[6] {
+			_param6[u] = param.(string)
 		}
 	}
 	return

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -65,7 +65,7 @@ type StepRunner interface {
 // CustomStepRunner runs custom run steps.
 type CustomStepRunner interface {
 	// Run cmd in path.
-	Run(ctx command.ProjectContext, cmd string, path string, envs map[string]string, streamOutput bool, postProcessOutput valid.PostProcessRunOutputOption) (string, error)
+	Run(ctx command.ProjectContext, cmd string, path string, envs map[string]string, streamOutput bool, postProcessOutput valid.PostProcessRunOutputOption, postProcessRegexFilter string) (string, error)
 }
 
 //go:generate pegomock generate --package mocks -o mocks/mock_env_step_runner.go EnvStepRunner
@@ -777,7 +777,7 @@ func (p *DefaultProjectCommandRunner) runSteps(steps []valid.Step, ctx command.P
 		case "state_rm":
 			out, err = p.StateRmStepRunner.Run(ctx, step.ExtraArgs, absPath, envs)
 		case "run":
-			out, err = p.RunStepRunner.Run(ctx, step.RunCommand, absPath, envs, true, step.Output)
+			out, err = p.RunStepRunner.Run(ctx, step.RunCommand, absPath, envs, true, step.Output, step.OutputRegexFilter)
 		case "env":
 			out, err = p.EnvStepRunner.Run(ctx, step.RunCommand, step.EnvVarValue, absPath, envs)
 			envs[step.EnvVarName] = out

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -111,7 +111,7 @@ func TestDefaultProjectCommandRunner_Plan(t *testing.T) {
 	When(mockInit.Run(ctx, nil, repoDir, expEnvs)).ThenReturn("init", nil)
 	When(mockPlan.Run(ctx, nil, repoDir, expEnvs)).ThenReturn("plan", nil)
 	When(mockApply.Run(ctx, nil, repoDir, expEnvs)).ThenReturn("apply", nil)
-	When(mockRun.Run(ctx, "", repoDir, expEnvs, true, "")).ThenReturn("run", nil)
+	When(mockRun.Run(ctx, "", repoDir, expEnvs, true, "", "")).ThenReturn("run", nil)
 	res := runner.Plan(ctx)
 
 	Assert(t, res.PlanSuccess != nil, "exp plan success")
@@ -127,7 +127,7 @@ func TestDefaultProjectCommandRunner_Plan(t *testing.T) {
 		case "apply":
 			mockApply.VerifyWasCalledOnce().Run(ctx, nil, repoDir, expEnvs)
 		case "run":
-			mockRun.VerifyWasCalledOnce().Run(ctx, "", repoDir, expEnvs, true, "")
+			mockRun.VerifyWasCalledOnce().Run(ctx, "", repoDir, expEnvs, true, "", "")
 		}
 	}
 }
@@ -456,7 +456,7 @@ func TestDefaultProjectCommandRunner_Apply(t *testing.T) {
 			When(mockInit.Run(ctx, nil, repoDir, expEnvs)).ThenReturn("init", nil)
 			When(mockPlan.Run(ctx, nil, repoDir, expEnvs)).ThenReturn("plan", nil)
 			When(mockApply.Run(ctx, nil, repoDir, expEnvs)).ThenReturn("apply", nil)
-			When(mockRun.Run(ctx, "", repoDir, expEnvs, true, "")).ThenReturn("run", nil)
+			When(mockRun.Run(ctx, "", repoDir, expEnvs, true, "", "")).ThenReturn("run", nil)
 			When(mockEnv.Run(ctx, "", "value", repoDir, make(map[string]string))).ThenReturn("value", nil)
 
 			res := runner.Apply(ctx)
@@ -472,7 +472,7 @@ func TestDefaultProjectCommandRunner_Apply(t *testing.T) {
 				case "apply":
 					mockApply.VerifyWasCalledOnce().Run(ctx, nil, repoDir, expEnvs)
 				case "run":
-					mockRun.VerifyWasCalledOnce().Run(ctx, "", repoDir, expEnvs, true, "")
+					mockRun.VerifyWasCalledOnce().Run(ctx, "", repoDir, expEnvs, true, "", "")
 				case "env":
 					mockEnv.VerifyWasCalledOnce().Run(ctx, "", "value", repoDir, expEnvs)
 				}

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -90,7 +90,7 @@ func NewGithubClient(hostname string, credentials GithubCredentials, config Gith
 		graphqlURL = "https://api.github.com/graphql"
 	} else {
 		apiURL := resolveGithubAPIURL(hostname)
-		client, err = github.NewEnterpriseClient(apiURL.String(), apiURL.String(), transport)
+		client, err = github.NewEnterpriseClient(apiURL.String(), apiURL.String(), transport) // nolint: staticcheck
 		if err != nil {
 			return nil, err
 		}

--- a/server/events/vcs/mocks/mock_github_pull_request_getter.go
+++ b/server/events/vcs/mocks/mock_github_pull_request_getter.go
@@ -7,6 +7,7 @@ import (
 	github "github.com/google/go-github/v59/github"
 	pegomock "github.com/petergtz/pegomock/v4"
 	models "github.com/runatlantis/atlantis/server/events/models"
+	logging "github.com/runatlantis/atlantis/server/logging"
 	"reflect"
 	"time"
 )
@@ -26,11 +27,11 @@ func NewMockGithubPullRequestGetter(options ...pegomock.Option) *MockGithubPullR
 func (mock *MockGithubPullRequestGetter) SetFailHandler(fh pegomock.FailHandler) { mock.fail = fh }
 func (mock *MockGithubPullRequestGetter) FailHandler() pegomock.FailHandler      { return mock.fail }
 
-func (mock *MockGithubPullRequestGetter) GetPullRequest(repo models.Repo, pullNum int) (*github.PullRequest, error) {
+func (mock *MockGithubPullRequestGetter) GetPullRequest(logger logging.SimpleLogging, repo models.Repo, pullNum int) (*github.PullRequest, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockGithubPullRequestGetter().")
 	}
-	params := []pegomock.Param{repo, pullNum}
+	params := []pegomock.Param{logger, repo, pullNum}
 	result := pegomock.GetGenericMockFrom(mock).Invoke("GetPullRequest", params, []reflect.Type{reflect.TypeOf((**github.PullRequest)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 *github.PullRequest
 	var ret1 error
@@ -82,8 +83,8 @@ type VerifierMockGithubPullRequestGetter struct {
 	timeout                time.Duration
 }
 
-func (verifier *VerifierMockGithubPullRequestGetter) GetPullRequest(repo models.Repo, pullNum int) *MockGithubPullRequestGetter_GetPullRequest_OngoingVerification {
-	params := []pegomock.Param{repo, pullNum}
+func (verifier *VerifierMockGithubPullRequestGetter) GetPullRequest(logger logging.SimpleLogging, repo models.Repo, pullNum int) *MockGithubPullRequestGetter_GetPullRequest_OngoingVerification {
+	params := []pegomock.Param{logger, repo, pullNum}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "GetPullRequest", params, verifier.timeout)
 	return &MockGithubPullRequestGetter_GetPullRequest_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -93,21 +94,25 @@ type MockGithubPullRequestGetter_GetPullRequest_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockGithubPullRequestGetter_GetPullRequest_OngoingVerification) GetCapturedArguments() (models.Repo, int) {
-	repo, pullNum := c.GetAllCapturedArguments()
-	return repo[len(repo)-1], pullNum[len(pullNum)-1]
+func (c *MockGithubPullRequestGetter_GetPullRequest_OngoingVerification) GetCapturedArguments() (logging.SimpleLogging, models.Repo, int) {
+	logger, repo, pullNum := c.GetAllCapturedArguments()
+	return logger[len(logger)-1], repo[len(repo)-1], pullNum[len(pullNum)-1]
 }
 
-func (c *MockGithubPullRequestGetter_GetPullRequest_OngoingVerification) GetAllCapturedArguments() (_param0 []models.Repo, _param1 []int) {
+func (c *MockGithubPullRequestGetter_GetPullRequest_OngoingVerification) GetAllCapturedArguments() (_param0 []logging.SimpleLogging, _param1 []models.Repo, _param2 []int) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]models.Repo, len(c.methodInvocations))
+		_param0 = make([]logging.SimpleLogging, len(c.methodInvocations))
 		for u, param := range params[0] {
-			_param0[u] = param.(models.Repo)
+			_param0[u] = param.(logging.SimpleLogging)
 		}
-		_param1 = make([]int, len(c.methodInvocations))
+		_param1 = make([]models.Repo, len(c.methodInvocations))
 		for u, param := range params[1] {
-			_param1[u] = param.(int)
+			_param1[u] = param.(models.Repo)
+		}
+		_param2 = make([]int, len(c.methodInvocations))
+		for u, param := range params[2] {
+			_param2[u] = param.(int)
 		}
 	}
 	return


### PR DESCRIPTION
## what

Part of https://github.com/runatlantis/atlantis/issues/163#issuecomment-1986854570.

## why

I have the requirements to mask some values that are passed to the comments posted by Atlantis, building up on `strip_refreshing` I added two new configurations that will allow this via a regex configured on the run step.

Example (added to the docs):
```yaml
workflows:
  terragrunt:
    plan:
      steps:
      - run:
          command: terragrunt plan -input=false -out=$PLANFILE
          output: strip_refreshing_with_custom_regex
          # Filters text matching 'mySecret: "aaa"' -> 'mySecret: "<redacted>"'
          regex_filter: "((?i)secret:\\s\")[^\"]*"
```

Note that the changes related to mocks were automatically generated with `make go-generate`.

## tests

- Running all the tests and increasing coverage for new use cases
- Build and deployed this version with the new config from feature and tested that `atlantis plan` provides the desired masked output on GitHub 😄 

## references

Part of https://github.com/runatlantis/atlantis/issues/163#issuecomment-1986854570.