### PR TITLE
feat: add opentofu binary to container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 *
 !cmd/
+!scripts/download-release.sh
 !server/
 !testdrive/
 !main.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,18 @@
 # what distro is the image being built for
 ARG ALPINE_TAG=3.19.1
 ARG DEBIAN_TAG=12.5-slim
+ARG GOLANG_VERSION=1.22.1
 
 # renovate: datasource=github-releases depName=hashicorp/terraform versioning=hashicorp
 ARG DEFAULT_TERRAFORM_VERSION=1.7.2
+# renovate: datasource=github-releases depName=hashicorp/terraform versioning=hashicorp
+ARG DEFAULT_OPENTOFU_VERSION=1.6.2
 # renovate: datasource=github-releases depName=open-policy-agent/conftest
 ARG DEFAULT_CONFTEST_VERSION=0.49.1
 
 # Stage 1: build artifact and download deps
 
-FROM golang:1.22.1-alpine AS builder
+FROM golang:${GOLANG_VERSION}-alpine AS builder
 
 ARG ATLANTIS_VERSION=dev
 ENV ATLANTIS_VERSION=${ATLANTIS_VERSION}
@@ -68,7 +71,6 @@ ARG TARGETPLATFORM
 WORKDIR /tmp/build
 
 # install conftest
-# renovate: datasource=github-releases depName=open-policy-agent/conftest
 ARG DEFAULT_CONFTEST_VERSION
 ENV DEFAULT_CONFTEST_VERSION=${DEFAULT_CONFTEST_VERSION}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -106,31 +108,26 @@ RUN case ${TARGETPLATFORM} in \
     git-lfs --version
 
 # install terraform binaries
-# renovate: datasource=github-releases depName=hashicorp/terraform versioning=hashicorp
 ARG DEFAULT_TERRAFORM_VERSION
 ENV DEFAULT_TERRAFORM_VERSION=${DEFAULT_TERRAFORM_VERSION}
+ARG DEFAULT_OPENTOFU_VERSION
+ENV DEFAULT_OPENTOFU_VERSION=${DEFAULT_OPENTOFU_VERSION}
+
+# COPY scripts/download-release.sh .
+COPY --from=builder /app/scripts/download-release.sh download-release.sh
 
 # In the official Atlantis image, we only have the latest of each Terraform version.
 # Each binary is about 80 MB so we limit it to the 4 latest minor releases or fewer
-RUN AVAILABLE_TERRAFORM_VERSIONS="1.4.7 1.5.7 1.6.6 ${DEFAULT_TERRAFORM_VERSION}" && \
-    case "${TARGETPLATFORM}" in \
-        "linux/amd64") TERRAFORM_ARCH=amd64 ;; \
-        "linux/arm64") TERRAFORM_ARCH=arm64 ;; \
-        "linux/arm/v7") TERRAFORM_ARCH=arm ;; \
-        *) echo "ERROR: 'TARGETPLATFORM' value expected: ${TARGETPLATFORM}"; exit 1 ;; \
-    esac && \
-    for VERSION in ${AVAILABLE_TERRAFORM_VERSIONS}; do \
-        curl -LOs "https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_linux_${TERRAFORM_ARCH}.zip" && \
-        curl -LOs "https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_SHA256SUMS" && \
-        sed -n "/terraform_${VERSION}_linux_${TERRAFORM_ARCH}.zip/p" "terraform_${VERSION}_SHA256SUMS" | sha256sum -c && \
-        mkdir -p "/usr/local/bin/tf/versions/${VERSION}" && \
-        unzip "terraform_${VERSION}_linux_${TERRAFORM_ARCH}.zip" -d "/usr/local/bin/tf/versions/${VERSION}" && \
-        ln -s "/usr/local/bin/tf/versions/${VERSION}/terraform" "/usr/local/bin/terraform${VERSION}" && \
-        rm "terraform_${VERSION}_linux_${TERRAFORM_ARCH}.zip" && \
-        rm "terraform_${VERSION}_SHA256SUMS"; \
-    done && \
-    ln -s "/usr/local/bin/tf/versions/${DEFAULT_TERRAFORM_VERSION}/terraform" /usr/local/bin/terraform
-
+RUN ./download-release.sh \
+        "terraform" \
+        "${TARGETPLATFORM}" \
+        "${DEFAULT_TERRAFORM_VERSION}" \
+        "1.4.7 1.5.7 1.6.6 ${DEFAULT_TERRAFORM_VERSION}" \
+    && ./download-release.sh \
+        "tofu" \
+        "${TARGETPLATFORM}" \
+        "${DEFAULT_OPENTOFU_VERSION}" \
+        "${DEFAULT_OPENTOFU_VERSION}"
 
 # Stage 2 - Alpine
 # Creating the individual distro builds using targets
@@ -151,6 +148,7 @@ RUN addgroup atlantis && \
 COPY --from=builder /app/atlantis /usr/local/bin/atlantis
 # copy terraform binaries
 COPY --from=deps /usr/local/bin/terraform* /usr/local/bin/
+COPY --from=deps /usr/local/bin/tofu* /usr/local/bin/
 # copy dependencies
 COPY --from=deps /usr/local/bin/conftest /usr/local/bin/conftest
 COPY --from=deps /usr/bin/git-lfs /usr/bin/git-lfs
@@ -167,7 +165,6 @@ RUN apk add --no-cache \
         openssh~=9 \
         dumb-init~=1 \
         gcompat~=1
-
 
 # Set the entry point to the atlantis user and run the atlantis command
 USER atlantis
@@ -191,6 +188,7 @@ RUN useradd --create-home --user-group --shell /bin/bash atlantis && \
 COPY --from=builder /app/atlantis /usr/local/bin/atlantis
 # copy terraform binaries
 COPY --from=deps /usr/local/bin/terraform* /usr/local/bin/
+COPY --from=deps /usr/local/bin/tofu* /usr/local/bin/
 # copy dependencies
 COPY --from=deps /usr/local/bin/conftest /usr/local/bin/conftest
 COPY --from=deps /usr/bin/git-lfs /usr/bin/git-lfs

--- a/scripts/download-release.sh
+++ b/scripts/download-release.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+COMMAND_NAME=${1:-terraform}
+TARGETPLATFORM=${2:-"linux/amd64"}
+DEFAULT_VERSION=${3:-"1.6.2"}
+AVAILABLE_VERSIONS=${4:-"1.6.2"}
+case "${TARGETPLATFORM}" in
+  "linux/amd64") ARCH=amd64 ;;
+  "linux/arm64") ARCH=arm64 ;;
+  "linux/arm/v7") ARCH=arm ;;
+  *) echo "ERROR: 'TARGETPLATFORM' value unexpected: ${TARGETPLATFORM}"; exit 1 ;;
+esac
+for VERSION in ${AVAILABLE_VERSIONS}; do
+  case "${COMMAND_NAME}" in
+    "terraform")
+      DOWNLOAD_URL_FORMAT=$(printf 'https://releases.hashicorp.com/terraform/%s/%s_%s' "$VERSION" "$COMMAND_NAME" "$VERSION")
+      COMMAND_DIR=/usr/local/bin/tf
+      ;;
+    "tofu")
+      DOWNLOAD_URL_FORMAT=$(printf 'https://github.com/opentofu/opentofu/releases/download/v%s/%s_%s' "$VERSION" "$COMMAND_NAME" "$VERSION")
+      COMMAND_DIR=/usr/local/bin/opentofu
+      ;;
+    *) echo "ERROR: 'COMMAND_NAME' value unexpected: ${COMMAND_NAME}"; exit 1 ;;
+  esac
+  curl -LOs "${DOWNLOAD_URL_FORMAT}_linux_${ARCH}.zip"
+  curl -LOs "${DOWNLOAD_URL_FORMAT}_SHA256SUMS"
+  sed -n "/${COMMAND_NAME}_${VERSION}_linux_${ARCH}.zip/p" "${COMMAND_NAME}_${VERSION}_SHA256SUMS" | sha256sum -c
+  mkdir -p "${COMMAND_DIR}/${VERSION}"
+  unzip "${COMMAND_NAME}_${VERSION}_linux_${ARCH}.zip" -d "${COMMAND_DIR}/${VERSION}"
+  ln -s "${COMMAND_DIR}/${VERSION}/${COMMAND_NAME}" "${COMMAND_NAME}${VERSION}"
+  rm "${COMMAND_NAME}_${VERSION}_linux_${ARCH}.zip"
+  rm "${COMMAND_NAME}_${VERSION}_SHA256SUMS"
+done
+ln -s "${COMMAND_DIR}/${DEFAULT_VERSION}/${COMMAND_NAME}" "${COMMAND_NAME}"


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- [x] add opentofu binary to container
- [x] reuse code for both opentofu and hashi
- [x] `shellcheck` on `scripts/download-release.sh`
- [x] `hadolint` on `Dockerfile`

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- Add the opentofu binary so it's available to users who customize their workflows
- I kept the `COMMAND_DIR` for backwards compatibility but I don't think we should store a directory of terraform versions in here because using tf instead of terraform and opentofu instead of tofu is inconsistent. It's also necessary or there will be softlink conflicts. I'd prefer to store the binaries in a separate directory so we can keep the dir names consistent with the binaries.
- The reason `tofu` is used instead of `opentofu` is because `tofu` is their official binary name

## tests

- [x] I have tested my changes by running the following commands

```bash
✗ shellcheck scripts/download-release.sh
✗
```

```bash
✗ hadolint Dockerfile
✗
```

```bash
✗ docker build -t atlantis-test:latest -f ./Dockerfile .
 => exporting to image                                                                                                1.1s
 => => exporting layers                                                                                               1.1s
 => => writing image sha256:e69a34ffad7ac6589f23881d651808ea25e24a25d7ce4d8dc984624b7aa96383                          0.0s
 => => naming to docker.io/library/atlantis-test:latest 
✗ docker run --rm -it --entrypoint sh atlantis-test:latest -c 'ls -la /usr/local/bin/tofu*'
-rwxr-xr-x 1 root root 79339520 Feb 22 12:14 /usr/local/bin/tofu
-rwxr-xr-x 1 root root 79339520 Feb 22 12:14 /usr/local/bin/tofu1.6.2
✗ docker run --rm -it --entrypoint sh atlantis-test:latest -c 'ls -la /usr/local/bin/terraform*'
-rwxr-xr-x 1 root root 84475904 Jan 31 14:19 /usr/local/bin/terraform
-rwxr-xr-x 1 root root 64626688 Sep 13 14:28 /usr/local/bin/terraform1.4.7
-rwxr-xr-x 1 root root 65200128 Sep  7  2023 /usr/local/bin/terraform1.5.7
-rwxr-xr-x 1 root root 81002496 Dec 13 17:58 /usr/local/bin/terraform1.6.6
-rwxr-xr-x 1 root root 84475904 Jan 31 14:19 /usr/local/bin/terraform1.7.2
```

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Closes #4337
- OpenTofu releases https://github.com/opentofu/opentofu/releases
