### PR TITLE
fix: auto-discover workspaces when in subdirectories

### DIFF
--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -524,9 +524,10 @@ func (p *DefaultProjectCommandBuilder) buildAllCommandsByCfg(ctx *command.Contex
 			len(modifiedProjects), modifiedProjects)
 		for _, mp := range modifiedProjects {
 			ctx.Log.Debug("determining config for project at dir: %q", mp.Path)
-			pWorkspace, err := p.ProjectFinder.DetermineWorkspaceFromHCL(ctx.Log, repoDir)
+			absProjectDir := filepath.Join(repoDir, mp.Path)
+			pWorkspace, err := p.ProjectFinder.DetermineWorkspaceFromHCL(ctx.Log, absProjectDir)
 			if err != nil {
-				return nil, errors.Wrapf(err, "looking for Terraform Cloud workspace from configuration %s", repoDir)
+				return nil, errors.Wrapf(err, "looking for Terraform Cloud workspace from configuration %s", absProjectDir)
 			}
 
 			pCfg := p.GlobalCfg.DefaultProjCfg(ctx.Log, ctx.Pull.BaseRepo.ID(), mp.Path, pWorkspace)


### PR DESCRIPTION
## what

Detect workspaces from subdirectories during autodiscovery.

## why

* When using terraform cloud configurations for multiple projects / modules in a single repo the default Atlantis workflow will fail

## tests

- [x] I have tested my changes by building a local version of Atlantis and deploying it against a repo that previously failed auto discovery
- [x] I have created unit tests to verify this functionality continues to work going forward

## references

closes #3252 
supersedes #3253 

