### PR TITLE
fix(deps): Update alpine ca-certificates package version to 20240226-r0 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -159,7 +159,7 @@ COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 # Install packages needed to run Atlantis.
 # We place this last as it will bust less docker layer caches when packages update
 RUN apk add --no-cache \
-        ca-certificates~=20230506 \
+        ca-certificates~=20240226-r0 \
         curl~=8 \
         git~=2 \
         unzip~=6 \


### PR DESCRIPTION
## what
The [current Alpine build fails](https://github.com/runatlantis/atlantis/actions/runs/8328227196/job/22787734568) with

```
unable to select packages:
0.731   ca-certificates-20240226-r0:
0.732     breaks: world[ca-certificates~20230506]
0.734     satisfies: libcurl-8.5.0-r0[ca-certificates]
```

## why

I would like for it to successfully build

## tests

It should build 

## references

N/A