### PR TITLE
fix: Make PolicyCheckSummary rendering optional

### DIFF
--- a/server/events/templates/policy_check_results_wrapped.tmpl
+++ b/server/events/templates/policy_check_results_wrapped.tmpl
@@ -36,8 +36,11 @@
   ```
 {{- if eq .Command "Policy Check" }}
 
+{{- if ne .PolicyCheckSummary "" }}
 ```
 {{ .PolicyCheckSummary }}
 ```
+{{- end }}
+
 {{- end }}
 {{ end -}}


### PR DESCRIPTION
## what
When using custom policy checking, PolicyCheckSummary is empty. This creates an empty codeblock in the output which is misleading.
Example Image
<img width="500" alt="Screenshot 2024-03-24 at 1 49 49 PM" src="https://github.com/runatlantis/atlantis/assets/146818014/891991c8-0bc1-41ca-89db-f5211fcb2dc7">

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->


## why

Empty codeblock is misleading! At first glance, it gives the impression that it is an empty output / policy checks have passed.

## tests

<!--
- [ ] I have tested my changes by ...
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

