### PR TITLE
fix: Sort results in command builder before comparing

### DIFF
--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -288,7 +288,7 @@ terraform {
 			Ok(t, err)
 			Equals(t, len(c.exp), len(ctxs))
 
-			// Sort so comparisons are determinisitic
+			// Sort so comparisons are deterministic
 			sort.Slice(ctxs, func(i, j int) bool {
 				if ctxs[i].ProjectName != ctxs[j].ProjectName {
 					return ctxs[i].ProjectName < ctxs[j].ProjectName

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -3,6 +3,7 @@ package events_test
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -195,13 +196,13 @@ terraform {
 			exp: []expCtxFields{
 				{
 					ProjectName: "",
-					RepoRelDir:  "work",
-					Workspace:   "test-workspace1",
+					RepoRelDir:  "test",
+					Workspace:   "test-workspace12",
 				},
 				{
 					ProjectName: "",
-					RepoRelDir:  "test",
-					Workspace:   "test-workspace12",
+					RepoRelDir:  "work",
+					Workspace:   "test-workspace1",
 				},
 			},
 		},
@@ -286,6 +287,17 @@ terraform {
 			})
 			Ok(t, err)
 			Equals(t, len(c.exp), len(ctxs))
+
+			// Sort so comparisons are determinisitic
+			sort.Slice(ctxs, func(i, j int) bool {
+				if ctxs[i].ProjectName != ctxs[j].ProjectName {
+					return ctxs[i].ProjectName < ctxs[j].ProjectName
+				}
+				if ctxs[i].RepoRelDir != ctxs[j].RepoRelDir {
+					return ctxs[i].RepoRelDir < ctxs[j].RepoRelDir
+				}
+				return ctxs[i].Workspace < ctxs[j].Workspace
+			})
 			for i, actCtx := range ctxs {
 				expCtx := c.exp[i]
 				Equals(t, expCtx.ProjectName, actCtx.ProjectName)


### PR DESCRIPTION
## what

Sort results of `builder.BuildAutoplanCommands` before comparing to expected values in tests.

## why

The tests are currently flakey, per: https://github.com/runatlantis/atlantis/pull/4363#issuecomment-2016939837.

A potential follow up might be to have `BuildAutoplanCommands` return a sorted list, but that might have more implications so I'll leave that for now.

## tests

`make test` now consistently passes.

## references

https://github.com/runatlantis/atlantis/pull/4363#issuecomment-2016939837.