### PR TITLE
chore: renovate both docker and go.mod in one pr

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -72,10 +72,6 @@
       versioning: 'node',
     },
     {
-      matchDatasources: [
-        'go',
-        'golang-version'
-      ],
       matchPackageNames: [
         'go',
         'golang',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -71,6 +71,18 @@
       ],
       versioning: 'node',
     },
+    {
+      matchDatasources: [
+        'go',
+        'golang-version'
+      ],
+      matchPackageNames: [
+        'go',
+        'golang',
+      ],
+      versioning: 'go',
+      groupName: 'go'
+    },
   ],
   customManagers: [
     {

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -12,6 +12,11 @@ on:
     branches:
       - 'main'
       - 'release-**'
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- create a package rule to match both go and golang

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- renovate go version in multiple places instead of a single place
- Uses the same pr `types` as the lint and other actions. This is because when I switched from draft to ready-for-review, it did not trigger the required checks.

## tests

<!--
- [ ] I have tested my changes by ...
-->
None. Opened a discussion in renovatebot and this was suggested.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- https://github.com/renovatebot/renovate/discussions/28402#discussioncomment-9110035
- Fixes PRs like #4405 where go.mod is updated but dockerfile is not
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
