### PR TITLE
build: fix build terraform/opentofu build pathing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,8 +147,8 @@ RUN addgroup atlantis && \
 # copy atlantis binary
 COPY --from=builder /app/atlantis /usr/local/bin/atlantis
 # copy terraform binaries
-COPY --from=deps /usr/local/bin/terraform* /usr/local/bin/
-COPY --from=deps /usr/local/bin/tofu* /usr/local/bin/
+COPY --from=deps /usr/local/bin/terraform/terraform* /usr/local/bin/
+COPY --from=deps /usr/local/bin/tofu/tofu* /usr/local/bin/
 # copy dependencies
 COPY --from=deps /usr/local/bin/conftest /usr/local/bin/conftest
 COPY --from=deps /usr/bin/git-lfs /usr/bin/git-lfs
@@ -187,8 +187,8 @@ RUN useradd --create-home --user-group --shell /bin/bash atlantis && \
 # copy atlantis binary
 COPY --from=builder /app/atlantis /usr/local/bin/atlantis
 # copy terraform binaries
-COPY --from=deps /usr/local/bin/terraform* /usr/local/bin/
-COPY --from=deps /usr/local/bin/tofu* /usr/local/bin/
+COPY --from=deps /usr/local/bin/terraform/terraform* /usr/local/bin/
+COPY --from=deps /usr/local/bin/tofu/tofu* /usr/local/bin/
 # copy dependencies
 COPY --from=deps /usr/local/bin/conftest /usr/local/bin/conftest
 COPY --from=deps /usr/bin/git-lfs /usr/bin/git-lfs

--- a/scripts/download-release.sh
+++ b/scripts/download-release.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 COMMAND_NAME=${1:-terraform}
 TARGETPLATFORM=${2:-"linux/amd64"}
-DEFAULT_VERSION=${3:-"1.6.2"}
-AVAILABLE_VERSIONS=${4:-"1.6.2"}
+DEFAULT_VERSION=${3:-"1.8.0"}
+AVAILABLE_VERSIONS=${4:-"1.8.0"}
 case "${TARGETPLATFORM}" in
   "linux/amd64") ARCH=amd64 ;;
   "linux/arm64") ARCH=arm64 ;;
@@ -13,11 +13,11 @@ for VERSION in ${AVAILABLE_VERSIONS}; do
   case "${COMMAND_NAME}" in
     "terraform")
       DOWNLOAD_URL_FORMAT=$(printf 'https://releases.hashicorp.com/terraform/%s/%s_%s' "$VERSION" "$COMMAND_NAME" "$VERSION")
-      COMMAND_DIR=/usr/local/bin/tf
+      COMMAND_DIR=/usr/local/bin/terraform
       ;;
     "tofu")
       DOWNLOAD_URL_FORMAT=$(printf 'https://github.com/opentofu/opentofu/releases/download/v%s/%s_%s' "$VERSION" "$COMMAND_NAME" "$VERSION")
-      COMMAND_DIR=/usr/local/bin/opentofu
+      COMMAND_DIR=/usr/local/bin/tofu
       ;;
     *) echo "ERROR: 'COMMAND_NAME' value unexpected: ${COMMAND_NAME}"; exit 1 ;;
   esac
@@ -26,8 +26,8 @@ for VERSION in ${AVAILABLE_VERSIONS}; do
   sed -n "/${COMMAND_NAME}_${VERSION}_linux_${ARCH}.zip/p" "${COMMAND_NAME}_${VERSION}_SHA256SUMS" | sha256sum -c
   mkdir -p "${COMMAND_DIR}/${VERSION}"
   unzip "${COMMAND_NAME}_${VERSION}_linux_${ARCH}.zip" -d "${COMMAND_DIR}/${VERSION}"
-  ln -s "${COMMAND_DIR}/${VERSION}/${COMMAND_NAME}" "${COMMAND_NAME}${VERSION}"
+  ln -s "${COMMAND_DIR}/${VERSION}/${COMMAND_NAME}" "${COMMAND_DIR}/${COMMAND_NAME}${VERSION}"
   rm "${COMMAND_NAME}_${VERSION}_linux_${ARCH}.zip"
   rm "${COMMAND_NAME}_${VERSION}_SHA256SUMS"
 done
-ln -s "${COMMAND_DIR}/${DEFAULT_VERSION}/${COMMAND_NAME}" "${COMMAND_NAME}"
+ln -s "${COMMAND_DIR}/${DEFAULT_VERSION}/${COMMAND_NAME}" "${COMMAND_DIR}/${COMMAND_NAME}"


### PR DESCRIPTION
## what

Fixes pathing when copying opentofu/terraform bins to release image

It seems in the deps container it symlinks to `/tmp/build/{tofu,terraform}${version}`. Not sure if that was intended and the `COPY` from deps was just forgotten 🤷. Let me know the intention and I can edit the PR.

Thanks

## why

In the current on dev image the terraform bins do not exist:

```
➜  ~ docker run -it ghcr.io/runatlantis/atlantis:dev-debian bash
No files found in /docker-entrypoint.d/, skipping
atlantis@616313fed2f9:/$ terraform -v
bash: terraform: command not found
atlantis@616313fed2f9:/$ find -name terraform
find: './etc/ssl/private': Permission denied
find: './proc/tty/driver': Permission denied
find: './var/cache/ldconfig': Permission denied
find: './var/cache/apt/archives/partial': Permission denied
find: './root': Permission denied
atlantis@616313fed2f9:/$
```

vs previous

```
➜  ~ docker run -it ghcr.io/runatlantis/atlantis:latest bash
No files found in /docker-entrypoint.d/, skipping
a2c9ab7d1aee:/$ which terraform
/usr/local/bin/terraform
a2c9ab7d1aee:/$ find -name terraform
find: ./proc/tty/driver: Permission denied
./usr/local/bin/terraform
find: ./root: Permission denied
a2c9ab7d1aee:/$
```

## tests

- [X] I have tested my changes by building locally validating the dirs/executabls

```
➜  atlantis git:(fix/build) ✗ docker run --rm -it --entrypoint bash hello:hello -c "ls -la /usr/local/bin/tofu* && which tofu && tofu -v"
-rwxr-xr-x 1 root root 75497472 Feb 22 12:14 /usr/local/bin/tofu
-rwxr-xr-x 1 root root 75497472 Feb 22 12:14 /usr/local/bin/tofu1.6.2
/usr/local/bin/tofu
OpenTofu v1.6.2
on linux_arm64
➜  atlantis git:(fix/build) ✗ docker run --rm -it --entrypoint bash hello:hello -c "ls -la /usr/local/bin/tofu* && which tofu && tofu -v"
-rwxr-xr-x 1 root root 75497472 Feb 22 12:14 /usr/local/bin/tofu
-rwxr-xr-x 1 root root 75497472 Feb 22 12:14 /usr/local/bin/tofu1.6.2
/usr/local/bin/tofu
OpenTofu v1.6.2
on linux_arm64
```

## references
- Previous PR https://github.com/runatlantis/atlantis/pull/4341