### PR TITLE
fix: null pointer exception on cfg error log

### DIFF
--- a/server/events/instrumented_project_command_builder.go
+++ b/server/events/instrumented_project_command_builder.go
@@ -9,8 +9,8 @@ import (
 
 type InstrumentedProjectCommandBuilder struct {
 	ProjectCommandBuilder
-	Logger logging.SimpleLogging
-	scope  tally.Scope
+	Log   logging.SimpleLogging
+	Scope tally.Scope
 }
 
 func (b *InstrumentedProjectCommandBuilder) BuildApplyCommands(ctx *command.Context, comment *CommentCommand) ([]command.ProjectContext, error) {
@@ -62,17 +62,17 @@ func (b *InstrumentedProjectCommandBuilder) buildAndEmitStats(
 	command string,
 	execute func() ([]command.ProjectContext, error),
 ) ([]command.ProjectContext, error) {
-	timer := b.scope.Timer(metrics.ExecutionTimeMetric).Start()
+	timer := b.Scope.Timer(metrics.ExecutionTimeMetric).Start()
 	defer timer.Stop()
 
-	executionSuccess := b.scope.Counter(metrics.ExecutionSuccessMetric)
-	executionError := b.scope.Counter(metrics.ExecutionErrorMetric)
+	executionSuccess := b.Scope.Counter(metrics.ExecutionSuccessMetric)
+	executionError := b.Scope.Counter(metrics.ExecutionErrorMetric)
 
 	projectCmds, err := execute()
 
 	if err != nil {
 		executionError.Inc(1)
-		b.Logger.Err("Error building %s commands: %s", command, err)
+		b.Log.Err("Error building %s commands: %s", command, err)
 	} else {
 		executionSuccess.Inc(1)
 	}

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/core/terraform"
+	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/metrics"
 
 	"github.com/pkg/errors"
@@ -57,6 +58,7 @@ func NewInstrumentedProjectCommandBuilder(
 	AutoDiscoverMode string,
 	scope tally.Scope,
 	terraformClient terraform.Client,
+	logger logging.SimpleLogging,
 ) *InstrumentedProjectCommandBuilder {
 	scope = scope.SubScope("builder")
 
@@ -89,7 +91,8 @@ func NewInstrumentedProjectCommandBuilder(
 			scope,
 			terraformClient,
 		),
-		scope: scope,
+		Scope: scope,
+		Log:   logger,
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -622,6 +622,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		userConfig.AutoDiscoverModeFlag,
 		statsScope,
 		terraformClient,
+		logger,
 	)
 
 	showStepRunner, err := runtime.NewShowStepRunner(terraformClient, defaultTfVersion)


### PR DESCRIPTION
## what

Atlantis workflow is crushing on configuration validation due to the unassigned logger in `InstrumentedProjectCommandBuilder`. Config validation errors are not printed to the user (or Atlantis log) but crush with a stack trace:

```
runtime error: invalid memory address or nil pointer dereference
/usr/local/Cellar/go/1.22.2/libexec/src/runtime/panic.go:261 (0x454c17)
/usr/local/Cellar/go/1.22.2/libexec/src/runtime/signal_unix.go:881 (0x454be5)
/Users/a.svenke/git-repos/os/atlantis/server/events/instrumented_project_command_builder.go:75 (0x106bc7a)
/Users/a.svenke/git-repos/os/atlantis/server/events/instrumented_project_command_builder.go:35 (0x106b7ca)
/Users/a.svenke/git-repos/os/atlantis/server/events/plan_command_runner.go:196 (0x10740f2)
/Users/a.svenke/git-repos/os/atlantis/server/events/plan_command_runner.go:310 (0x10759a4)
/Users/a.svenke/git-repos/os/atlantis/server/events/command_runner.go:367 (0x10596e3)
/usr/local/Cellar/go/1.22.2/libexec/src/runtime/asm_amd64.s:1695 (0x4724e0)
```

The problem is in defined but not assigned Logger in `InstrumentedProjectCommandBuilder`. When an error is returned, the call to `b.Logger.Err` causes the error.

I did a bit of var names refactoring as well, to keep the code style consistent.

## why

Because bugs are bad.

## tests

- [x] I have tested my changes by configuring the workflow that attempts to overwrite a parameter that is not allowed in the server-side repo config. Initially, it was returning the above-posted stack trace, and after the changes, it is returning the expected error message of `parsing atlantis.yaml: repo config not allowed to set...`

## references

None