### PR TITLE
fix: Docker terraform/tofu binaries not copied to final Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -146,9 +146,12 @@ RUN addgroup atlantis && \
 
 # copy atlantis binary
 COPY --from=builder /app/atlantis /usr/local/bin/atlantis
-# copy terraform binaries
-COPY --from=deps /usr/local/bin/terraform* /usr/local/bin/
-COPY --from=deps /usr/local/bin/tofu* /usr/local/bin/
+# copy terraform & tofu binaries
+COPY --from=deps /usr/local/bin/tf /usr/local/bin/tf
+COPY --from=deps /usr/local/bin/opentofu /usr/local/bin/opentofu
+# copy terraform & tofu symlinks to their default version
+COPY --from=deps /usr/local/bin/terraform /usr/local/bin/
+COPY --from=deps /usr/local/bin/tofu /usr/local/bin/
 # copy dependencies
 COPY --from=deps /usr/local/bin/conftest /usr/local/bin/conftest
 COPY --from=deps /usr/bin/git-lfs /usr/bin/git-lfs
@@ -186,9 +189,12 @@ RUN useradd --create-home --user-group --shell /bin/bash atlantis && \
 
 # copy atlantis binary
 COPY --from=builder /app/atlantis /usr/local/bin/atlantis
-# copy terraform binaries
-COPY --from=deps /usr/local/bin/terraform* /usr/local/bin/
-COPY --from=deps /usr/local/bin/tofu* /usr/local/bin/
+# copy terraform & tofu binaries
+COPY --from=deps /usr/local/bin/tf /usr/local/bin/tf
+COPY --from=deps /usr/local/bin/opentofu /usr/local/bin/opentofu
+# copy terraform & tofu symlinks to their default version
+COPY --from=deps /usr/local/bin/terraform /usr/local/bin/
+COPY --from=deps /usr/local/bin/tofu /usr/local/bin/
 # copy dependencies
 COPY --from=deps /usr/local/bin/conftest /usr/local/bin/conftest
 COPY --from=deps /usr/bin/git-lfs /usr/bin/git-lfs

--- a/scripts/download-release.sh
+++ b/scripts/download-release.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -ex
+
 COMMAND_NAME=${1:-terraform}
 TARGETPLATFORM=${2:-"linux/amd64"}
 DEFAULT_VERSION=${3:-"1.6.2"}
@@ -30,4 +32,4 @@ for VERSION in ${AVAILABLE_VERSIONS}; do
   rm "${COMMAND_NAME}_${VERSION}_linux_${ARCH}.zip"
   rm "${COMMAND_NAME}_${VERSION}_SHA256SUMS"
 done
-ln -s "${COMMAND_DIR}/${DEFAULT_VERSION}/${COMMAND_NAME}" "${COMMAND_NAME}"
+ln -s "${COMMAND_DIR}/${DEFAULT_VERSION}/${COMMAND_NAME}" "/usr/local/bin/${COMMAND_NAME}"


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

I pulled in `main` to my internal testing site, and the container image failed to start with this error.

```
Error: initializing server: initializing terraform: terraform not found in $PATH. Set --default-tf-version or download terraform from https://developer.hashicorp.com/terraform/downloads
```

When I inspected `/usr/local/bin` in the container, I noticed none of the binaries were present.

```
$ find /usr/local/bin
/usr/local/bin
/usr/local/bin/docker-entrypoint.sh
/usr/local/bin/conftest
/usr/local/bin/atlantis
```

## why

It looks like the #4341 refactor did not account for the new paths to be copied into the container.

This change rectifies this - `/usr/local/bin` now looks like this

```
$ find /usr/local/bin/
/usr/local/bin/
/usr/local/bin/docker-entrypoint.sh
/usr/local/bin/conftest
/usr/local/bin/tofu
/usr/local/bin/terraform
/usr/local/bin/opentofu
/usr/local/bin/opentofu/1.6.2
/usr/local/bin/opentofu/1.6.2/CHANGELOG.md
/usr/local/bin/opentofu/1.6.2/tofu
/usr/local/bin/opentofu/1.6.2/LICENSE
/usr/local/bin/opentofu/1.6.2/README.md
/usr/local/bin/tf
/usr/local/bin/tf/1.5.7
/usr/local/bin/tf/1.5.7/terraform
/usr/local/bin/tf/1.8.0
/usr/local/bin/tf/1.8.0/terraform
/usr/local/bin/tf/1.6.6
/usr/local/bin/tf/1.6.6/terraform
/usr/local/bin/tf/1.7.5
/usr/local/bin/tf/1.7.5/terraform
/usr/local/bin/atlantis
```

## tests

* `docker run --rm -it ghcr.io/runatlantis/atlantis:$(TAG) ls /usr/local/bin` should return the files
* `docker run --rm -it ghcr.io/runatlantis/atlantis:$(TAG) tofu` should work
* `docker run --rm -it ghcr.io/runatlantis/atlantis:$(TAG) terraform` should work