### PR TITLE
fix logger nil pointer

### DIFF
--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/core/terraform"
+	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/metrics"
 
 	"github.com/pkg/errors"
@@ -35,6 +36,7 @@ const (
 )
 
 func NewInstrumentedProjectCommandBuilder(
+	logger logging.SimpleLogging,
 	policyChecksSupported bool,
 	parserValidator *config.ParserValidator,
 	projectFinder ProjectFinder,
@@ -89,7 +91,8 @@ func NewInstrumentedProjectCommandBuilder(
 			scope,
 			terraformClient,
 		),
-		scope: scope,
+		Logger: logger,
+		scope:  scope,
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -600,6 +600,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		Router:              router,
 	}
 	projectCommandBuilder := events.NewInstrumentedProjectCommandBuilder(
+		logger,
 		policyChecksEnabled,
 		validator,
 		&events.DefaultProjectFinder{},


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

Running the latest `main` on testing yielded this message from Atlantis.

Submitting it as-is since its end-of-week, and others might be hitting the issue.

```
runtime error: invalid memory address or nil pointer dereference
runtime/panic.go:261 (0x454cb7)
runtime/signal_unix.go:881 (0x454c85)
github.com/runatlantis/atlantis/server/events/instrumented_project_command_builder.go:75 (0x106ba3a)
github.com/runatlantis/atlantis/server/events/instrumented_project_command_builder.go:35 (0x106b58a)
github.com/runatlantis/atlantis/server/events/plan_command_runner.go:194 (0x1074081)
github.com/runatlantis/atlantis/server/events/plan_command_runner.go:306 (0x1075844)
github.com/runatlantis/atlantis/server/events/command_runner.go:367 (0x1059483)
runtime/asm_amd64.s:1695 (0x4725c0)
```

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

A refactor should have passed in the logger to the struct.

## tests

- No more nil-pointer panics in our testing environment
