### PR TITLE
fix: GitHub tests emitting unexpected keepers = {}

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
 
       - run: make test-all
       - run: make check-fmt
+
       ###########################################################
       # Notifying #contributors about test failure on main branch
       ###########################################################

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
           filters: |
             go:
               - '**.go'
+              - '**.txt' # golden file test output
               - 'go.*'
               - '.github/workflows/test.yml'
   test:

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ check-lint: ## Run linter in CI/CD. If running locally use 'lint'
 
 .PHONY: check-fmt
 check-fmt: ## Fail if not formatted
-	if [[ $$(goimports -l $$(find . -type f -name '*.go' ! -path "./vendor/*" ! -path "**/mocks/*")) ]]; then exit 1; fi
+	./scripts/fmt.sh
 
 .PHONY: end-to-end-deps
 end-to-end-deps: ## Install e2e dependencies

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+go install golang.org/x/tools/cmd/goimports@latest
+
+gobin="$(go env GOPATH)/bin"
+declare -r gobin
+
+declare -a files
+readarray -d '' files < <(find . -type f -name '*.go' ! -name 'mock_*' ! -path './vendor/*' ! -path '**/mocks/*' -print0)
+declare -r files
+
+output="$("${gobin}"/goimports -l "${files[@]}")"
+declare -r output
+
+if [[ -n "$output" ]]; then
+    echo "These files had their 'import' changed - please fix them locally and push a fix"
+
+    echo "$output"
+
+    exit 1
+fi

--- a/server/controllers/events/testdata/test-repos/import-multiple-project/dir1/main.tf
+++ b/server/controllers/events/testdata/test-repos/import-multiple-project/dir1/main.tf
@@ -1,4 +1,3 @@
 resource "random_id" "dummy1" {
-  keepers     = {}
   byte_length = 1
 }

--- a/server/controllers/events/testdata/test-repos/import-multiple-project/dir2/main.tf
+++ b/server/controllers/events/testdata/test-repos/import-multiple-project/dir2/main.tf
@@ -1,4 +1,3 @@
 resource "random_id" "dummy2" {
-  keepers     = {}
   byte_length = 1
 }

--- a/server/controllers/events/testdata/test-repos/import-multiple-project/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/import-multiple-project/exp-output-autoplan.txt
@@ -22,7 +22,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -59,7 +58,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.

--- a/server/controllers/events/testdata/test-repos/import-multiple-project/exp-output-plan-again.txt
+++ b/server/controllers/events/testdata/test-repos/import-multiple-project/exp-output-plan-again.txt
@@ -43,7 +43,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.

--- a/server/controllers/events/testdata/test-repos/import-single-project-var/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/import-single-project-var/exp-output-autoplan.txt
@@ -17,7 +17,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
   # random_id.for_each["default"] will be created
@@ -28,7 +27,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
 Plan: 2 to add, 0 to change, 0 to destroy.

--- a/server/controllers/events/testdata/test-repos/import-single-project-var/main.tf
+++ b/server/controllers/events/testdata/test-repos/import-single-project-var/main.tf
@@ -1,12 +1,10 @@
 resource "random_id" "for_each" {
   for_each    = toset([var.var])
-  keepers     = {}
   byte_length = 1
 }
 
 resource "random_id" "count" {
   count       = 1
-  keepers     = {}
   byte_length = 1
 }
 

--- a/server/controllers/events/testdata/test-repos/import-single-project/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/import-single-project/exp-output-autoplan.txt
@@ -17,7 +17,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
   # random_id.dummy2 will be created
@@ -28,7 +27,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
 Plan: 2 to add, 0 to change, 0 to destroy.

--- a/server/controllers/events/testdata/test-repos/import-single-project/main.tf
+++ b/server/controllers/events/testdata/test-repos/import-single-project/main.tf
@@ -1,9 +1,7 @@
 resource "random_id" "dummy1" {
-  keepers     = {}
   byte_length = 1
 }
 
 resource "random_id" "dummy2" {
-  keepers     = {}
   byte_length = 1
 }

--- a/server/controllers/events/testdata/test-repos/import-workspace/dir1/main.tf
+++ b/server/controllers/events/testdata/test-repos/import-workspace/dir1/main.tf
@@ -1,14 +1,12 @@
 resource "random_id" "dummy1" {
   count = terraform.workspace == "ops" ? 1 : 0
 
-  keepers     = {}
   byte_length = 1
 }
 
 resource "random_id" "dummy2" {
   count = terraform.workspace == "ops" ? 1 : 0
 
-  keepers     = {}
   byte_length = 1
 }
 

--- a/server/controllers/events/testdata/test-repos/state-rm-multiple-project/dir1/main.tf
+++ b/server/controllers/events/testdata/test-repos/state-rm-multiple-project/dir1/main.tf
@@ -1,4 +1,3 @@
 resource "random_id" "dummy" {
-  keepers     = {}
   byte_length = 1
 }

--- a/server/controllers/events/testdata/test-repos/state-rm-multiple-project/dir2/main.tf
+++ b/server/controllers/events/testdata/test-repos/state-rm-multiple-project/dir2/main.tf
@@ -1,4 +1,3 @@
 resource "random_id" "dummy" {
-  keepers     = {}
   byte_length = 1
 }

--- a/server/controllers/events/testdata/test-repos/state-rm-multiple-project/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/state-rm-multiple-project/exp-output-autoplan.txt
@@ -22,7 +22,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -59,7 +58,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.

--- a/server/controllers/events/testdata/test-repos/state-rm-multiple-project/exp-output-plan-again.txt
+++ b/server/controllers/events/testdata/test-repos/state-rm-multiple-project/exp-output-plan-again.txt
@@ -22,7 +22,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -59,7 +58,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.

--- a/server/controllers/events/testdata/test-repos/state-rm-single-project/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/state-rm-single-project/exp-output-autoplan.txt
@@ -17,7 +17,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
   # random_id.for_each["default"] will be created
@@ -28,7 +27,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
   # random_id.simple will be created
@@ -39,7 +37,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
 Plan: 3 to add, 0 to change, 0 to destroy.

--- a/server/controllers/events/testdata/test-repos/state-rm-single-project/exp-output-plan-again.txt
+++ b/server/controllers/events/testdata/test-repos/state-rm-single-project/exp-output-plan-again.txt
@@ -17,7 +17,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
   # random_id.for_each["overridden"] will be created
@@ -28,7 +27,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
   # random_id.simple will be created
@@ -39,7 +37,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
 Plan: 3 to add, 0 to change, 0 to destroy.

--- a/server/controllers/events/testdata/test-repos/state-rm-single-project/main.tf
+++ b/server/controllers/events/testdata/test-repos/state-rm-single-project/main.tf
@@ -1,17 +1,14 @@
 resource "random_id" "simple" {
-  keepers     = {}
   byte_length = 1
 }
 
 resource "random_id" "for_each" {
   for_each    = toset([var.var])
-  keepers     = {}
   byte_length = 1
 }
 
 resource "random_id" "count" {
   count       = 1
-  keepers     = {}
   byte_length = 1
 }
 

--- a/server/controllers/events/testdata/test-repos/state-rm-workspace/dir1/main.tf
+++ b/server/controllers/events/testdata/test-repos/state-rm-workspace/dir1/main.tf
@@ -1,7 +1,6 @@
 resource "random_id" "dummy1" {
   count = terraform.workspace == "ops" ? 1 : 0
 
-  keepers     = {}
   byte_length = 1
 }
 

--- a/server/controllers/events/testdata/test-repos/state-rm-workspace/exp-output-plan-again.txt
+++ b/server/controllers/events/testdata/test-repos/state-rm-workspace/exp-output-plan-again.txt
@@ -17,7 +17,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

Version v3.6.1 of the `random` provider changed the behavior of `keepers` in https://github.com/hashicorp/terraform-provider-random/pull/385

This upstream change caused the extra `keepers = {}` output in our test output due to how the `value` of `keepers` inside the provider is processed. 

Since `keepers` are optional in the provider and `{}` is same as `absent` (or `null`) for our use-cases, I'm removing the empty `keepers = {}` from the `.tf` files

I also fixed `make check-fmt` since it was failing silently with `goimports` not being installed in CI.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

I like tests passing 

## tests

All changes are test related - and pure output focused - shouldn't affect any _actual_ behavior

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

* https://github.com/hashicorp/terraform-provider-random/pull/385
* https://github.com/hashicorp/terraform-provider-random/releases/tag/v3.6.1