### PR TITLE
chore(renovate): update warrensbox once a week

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -81,7 +81,7 @@
     },
     {
       "matchManagers": [
-        "go"
+        "gomod"
       ],
       "matchPackagePrefixes": [
         "github.com/warrensbox/terraform-switcher"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -79,6 +79,17 @@
       versioning: 'go',
       groupName: 'go'
     },
+    {
+      "matchManagers": [
+        "go"
+      ],
+      "matchPackagePrefixes": [
+        "github.com/warrensbox/terraform-switcher"
+      ],
+      "schedule": [
+        "after 9pm on sunday"
+      ]
+    },
   ],
   customManagers: [
     {


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- update warrensbox once a week

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- package frequently updates and this will reduce the number of PRs
- the warrensbox package has releases and the last one was 3 weeks ago. Im unsure why we keep moving towards the latest commit. I wonder if we're using the unstable version in our go.mod.
    Latest version is 1.0.2 and we're using 0.1.1 with a commit hash and it always seems to be the latest. I wonder if a better fix, instead of updating renovatebot, it would be better to update the go.mod to be 1.0.2.
    https://github.com/runatlantis/atlantis/blob/11d47f3c9fcc2c8bab89931bf4e7935e4911f74f/go.mod#L45

## tests

<!--
- [ ] I have tested my changes by ...
-->
n/a

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- https://docs.renovatebot.com/key-concepts/scheduling/
- https://github.com/warrensbox/terraform-switcher
