### PR TITLE
fix: Prevent download terraform with version 1.8.2 or higher

### DIFF
--- a/server/core/terraform/terraform_client_test.go
+++ b/server/core/terraform/terraform_client_test.go
@@ -398,6 +398,7 @@ terraform {
 		// we need to block any version higher than 1.8.1 until proper solution is implemented.
 		// More details on the issue here - https://github.com/runatlantis/atlantis/issues/4471
 		">= 1.3.0": "1.8.1",
+		">= 1.8.2": "",
 	}
 
 	type testCase struct {

--- a/server/core/terraform/terraform_client_test.go
+++ b/server/core/terraform/terraform_client_test.go
@@ -393,6 +393,11 @@ terraform {
 		// cannot use ~> 1.3 or ~> 1.0 since that is a moving target since it will always
 		// resolve to the latest terraform 1.x
 		"~> 1.3.0": "1.3.10",
+		// Since terraform version 1.8.2, terraform is not a single file download anymore and
+		// Atlantis fails to download version 1.8.2 and higher. So, as a short-term fix,
+		// we need to block any version higher than 1.8.1 until proper solution is implemented.
+		// More details on the issue here - https://github.com/runatlantis/atlantis/issues/4471
+		">= 1.3.0": "1.8.1",
 	}
 
 	type testCase struct {


### PR DESCRIPTION
## what

Short-term fix for #4471. With this change Atlantis will only download terraform version `1.8.1` or lower, still respecting constraints set in `required_version` field. If `required_version` is set to `>=1.8.2` or higher Atlantis will fallback to default version. 

## why

Terraform packaging was changed in release 1.8.2 (see https://github.com/hashicorp/terraform/releases/tag/v1.8.2) and Atlantis throws an error for every default and custom workflow when trying to download it. Proper, long-term fix is described here - https://github.com/runatlantis/atlantis/issues/4472#issuecomment-2075001953.

## tests

I have added two test cases to an existing test, but haven't run full Atlantis with this change.

## references

- See #4471 and #4472 for more info about issue and various workarounds.

