### PR TITLE
chore: Cherry-pick #4462 into release-0.27

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
           filters: |
             go:
               - '**.go'
+              - '**.txt' # golden file test output
               - 'go.*'
               - '.github/workflows/test.yml'
   test:
@@ -51,6 +52,7 @@ jobs:
 
       - run: make test-all
       - run: make check-fmt
+
       ###########################################################
       # Notifying #contributors about test failure on main branch
       ###########################################################

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ check-lint: ## Run linter in CI/CD. If running locally use 'lint'
 
 .PHONY: check-fmt
 check-fmt: ## Fail if not formatted
-	if [[ $$(goimports -l $$(find . -type f -name '*.go' ! -path "./vendor/*" ! -path "**/mocks/*")) ]]; then exit 1; fi
+	./scripts/fmt.sh
 
 .PHONY: end-to-end-deps
 end-to-end-deps: ## Install e2e dependencies

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+go install golang.org/x/tools/cmd/goimports@latest
+
+gobin="$(go env GOPATH)/bin"
+declare -r gobin
+
+declare -a files
+readarray -d '' files < <(find . -type f -name '*.go' ! -name 'mock_*' ! -path './vendor/*' ! -path '**/mocks/*' -print0)
+declare -r files
+
+output="$("${gobin}"/goimports -l "${files[@]}")"
+declare -r output
+
+if [[ -n "$output" ]]; then
+    echo "These files had their 'import' changed - please fix them locally and push a fix"
+
+    echo "$output"
+
+    exit 1
+fi

--- a/server/controllers/events/testdata/test-repos/import-multiple-project/dir1/main.tf
+++ b/server/controllers/events/testdata/test-repos/import-multiple-project/dir1/main.tf
@@ -1,4 +1,3 @@
 resource "random_id" "dummy1" {
-  keepers     = {}
   byte_length = 1
 }

--- a/server/controllers/events/testdata/test-repos/import-multiple-project/dir2/main.tf
+++ b/server/controllers/events/testdata/test-repos/import-multiple-project/dir2/main.tf
@@ -1,4 +1,3 @@
 resource "random_id" "dummy2" {
-  keepers     = {}
   byte_length = 1
 }

--- a/server/controllers/events/testdata/test-repos/import-multiple-project/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/import-multiple-project/exp-output-autoplan.txt
@@ -67,15 +67,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
-### Plan Summary
-
-2 projects, 2 with changes, 0 with no changes, 0 failed
-
-* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
-  ```shell
-  atlantis apply
-  ```
-* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
-  ```shell
-  atlantis unlock
-  ```
+* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
+    * `atlantis apply`
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
+    * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/import-multiple-project/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/import-multiple-project/exp-output-autoplan.txt
@@ -21,7 +21,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -54,7 +53,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -69,7 +67,15 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
-* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
-    * `atlantis apply`
-* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
-    * `atlantis unlock`
+### Plan Summary
+
+2 projects, 2 with changes, 0 with no changes, 0 failed
+
+* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
+  ```shell
+  atlantis apply
+  ```
+* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
+  ```shell
+  atlantis unlock
+  ```

--- a/server/controllers/events/testdata/test-repos/import-multiple-project/exp-output-plan-again.txt
+++ b/server/controllers/events/testdata/test-repos/import-multiple-project/exp-output-plan-again.txt
@@ -38,7 +38,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -53,7 +52,15 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
-* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
-    * `atlantis apply`
-* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
-    * `atlantis unlock`
+### Plan Summary
+
+2 projects, 1 with changes, 1 with no changes, 0 failed
+
+* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
+  ```shell
+  atlantis apply
+  ```
+* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
+  ```shell
+  atlantis unlock
+  ```

--- a/server/controllers/events/testdata/test-repos/import-multiple-project/exp-output-plan-again.txt
+++ b/server/controllers/events/testdata/test-repos/import-multiple-project/exp-output-plan-again.txt
@@ -52,15 +52,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
-### Plan Summary
-
-2 projects, 1 with changes, 1 with no changes, 0 failed
-
-* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
-  ```shell
-  atlantis apply
-  ```
-* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
-  ```shell
-  atlantis unlock
-  ```
+* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
+    * `atlantis apply`
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
+    * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/import-single-project-var/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/import-single-project-var/exp-output-autoplan.txt
@@ -17,7 +17,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
   # random_id.for_each["default"] will be created
@@ -28,7 +27,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
 Plan: 2 to add, 0 to change, 0 to destroy.
@@ -43,7 +41,11 @@ Plan: 2 to add, 0 to change, 0 to destroy.
 Plan: 2 to add, 0 to change, 0 to destroy.
 
 ---
-* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
-    * `atlantis apply`
-* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
-    * `atlantis unlock`
+* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
+  ```shell
+  atlantis apply
+  ```
+* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
+  ```shell
+  atlantis unlock
+  ```

--- a/server/controllers/events/testdata/test-repos/import-single-project-var/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/import-single-project-var/exp-output-autoplan.txt
@@ -41,11 +41,7 @@ Plan: 2 to add, 0 to change, 0 to destroy.
 Plan: 2 to add, 0 to change, 0 to destroy.
 
 ---
-* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
-  ```shell
-  atlantis apply
-  ```
-* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
-  ```shell
-  atlantis unlock
-  ```
+* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
+    * `atlantis apply`
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
+    * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/import-single-project-var/main.tf
+++ b/server/controllers/events/testdata/test-repos/import-single-project-var/main.tf
@@ -1,12 +1,10 @@
 resource "random_id" "for_each" {
   for_each    = toset([var.var])
-  keepers     = {}
   byte_length = 1
 }
 
 resource "random_id" "count" {
   count       = 1
-  keepers     = {}
   byte_length = 1
 }
 

--- a/server/controllers/events/testdata/test-repos/import-single-project/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/import-single-project/exp-output-autoplan.txt
@@ -17,7 +17,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
   # random_id.dummy2 will be created
@@ -28,7 +27,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
 Plan: 2 to add, 0 to change, 0 to destroy.
@@ -43,7 +41,11 @@ Plan: 2 to add, 0 to change, 0 to destroy.
 Plan: 2 to add, 0 to change, 0 to destroy.
 
 ---
-* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
-    * `atlantis apply`
-* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
-    * `atlantis unlock`
+* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
+  ```shell
+  atlantis apply
+  ```
+* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
+  ```shell
+  atlantis unlock
+  ```

--- a/server/controllers/events/testdata/test-repos/import-single-project/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/import-single-project/exp-output-autoplan.txt
@@ -41,11 +41,7 @@ Plan: 2 to add, 0 to change, 0 to destroy.
 Plan: 2 to add, 0 to change, 0 to destroy.
 
 ---
-* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
-  ```shell
-  atlantis apply
-  ```
-* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
-  ```shell
-  atlantis unlock
-  ```
+* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
+    * `atlantis apply`
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
+    * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/import-single-project/main.tf
+++ b/server/controllers/events/testdata/test-repos/import-single-project/main.tf
@@ -1,9 +1,7 @@
 resource "random_id" "dummy1" {
-  keepers     = {}
   byte_length = 1
 }
 
 resource "random_id" "dummy2" {
-  keepers     = {}
   byte_length = 1
 }

--- a/server/controllers/events/testdata/test-repos/import-workspace/dir1/main.tf
+++ b/server/controllers/events/testdata/test-repos/import-workspace/dir1/main.tf
@@ -1,14 +1,12 @@
 resource "random_id" "dummy1" {
   count = terraform.workspace == "ops" ? 1 : 0
 
-  keepers     = {}
   byte_length = 1
 }
 
 resource "random_id" "dummy2" {
   count = terraform.workspace == "ops" ? 1 : 0
 
-  keepers     = {}
   byte_length = 1
 }
 

--- a/server/controllers/events/testdata/test-repos/state-rm-multiple-project/dir1/main.tf
+++ b/server/controllers/events/testdata/test-repos/state-rm-multiple-project/dir1/main.tf
@@ -1,4 +1,3 @@
 resource "random_id" "dummy" {
-  keepers     = {}
   byte_length = 1
 }

--- a/server/controllers/events/testdata/test-repos/state-rm-multiple-project/dir2/main.tf
+++ b/server/controllers/events/testdata/test-repos/state-rm-multiple-project/dir2/main.tf
@@ -1,4 +1,3 @@
 resource "random_id" "dummy" {
-  keepers     = {}
   byte_length = 1
 }

--- a/server/controllers/events/testdata/test-repos/state-rm-multiple-project/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/state-rm-multiple-project/exp-output-autoplan.txt
@@ -67,15 +67,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
-### Plan Summary
-
-2 projects, 2 with changes, 0 with no changes, 0 failed
-
-* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
-  ```shell
-  atlantis apply
-  ```
-* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
-  ```shell
-  atlantis unlock
-  ```
+* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
+    * `atlantis apply`
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
+    * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/state-rm-multiple-project/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/state-rm-multiple-project/exp-output-autoplan.txt
@@ -21,7 +21,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -54,7 +53,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -69,7 +67,15 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
-* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
-    * `atlantis apply`
-* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
-    * `atlantis unlock`
+### Plan Summary
+
+2 projects, 2 with changes, 0 with no changes, 0 failed
+
+* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
+  ```shell
+  atlantis apply
+  ```
+* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
+  ```shell
+  atlantis unlock
+  ```

--- a/server/controllers/events/testdata/test-repos/state-rm-multiple-project/exp-output-plan-again.txt
+++ b/server/controllers/events/testdata/test-repos/state-rm-multiple-project/exp-output-plan-again.txt
@@ -67,15 +67,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
-### Plan Summary
-
-2 projects, 2 with changes, 0 with no changes, 0 failed
-
-* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
-  ```shell
-  atlantis apply
-  ```
-* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
-  ```shell
-  atlantis unlock
-  ```
+* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
+    * `atlantis apply`
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
+    * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/state-rm-multiple-project/exp-output-plan-again.txt
+++ b/server/controllers/events/testdata/test-repos/state-rm-multiple-project/exp-output-plan-again.txt
@@ -21,7 +21,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -54,7 +53,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -69,7 +67,15 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
-* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
-    * `atlantis apply`
-* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
-    * `atlantis unlock`
+### Plan Summary
+
+2 projects, 2 with changes, 0 with no changes, 0 failed
+
+* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
+  ```shell
+  atlantis apply
+  ```
+* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
+  ```shell
+  atlantis unlock
+  ```

--- a/server/controllers/events/testdata/test-repos/state-rm-single-project/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/state-rm-single-project/exp-output-autoplan.txt
@@ -51,11 +51,7 @@ Plan: 3 to add, 0 to change, 0 to destroy.
 Plan: 3 to add, 0 to change, 0 to destroy.
 
 ---
-* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
-  ```shell
-  atlantis apply
-  ```
-* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
-  ```shell
-  atlantis unlock
-  ```
+* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
+    * `atlantis apply`
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
+    * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/state-rm-single-project/exp-output-autoplan.txt
+++ b/server/controllers/events/testdata/test-repos/state-rm-single-project/exp-output-autoplan.txt
@@ -17,7 +17,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
   # random_id.for_each["default"] will be created
@@ -28,7 +27,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
   # random_id.simple will be created
@@ -39,7 +37,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
 Plan: 3 to add, 0 to change, 0 to destroy.
@@ -54,7 +51,11 @@ Plan: 3 to add, 0 to change, 0 to destroy.
 Plan: 3 to add, 0 to change, 0 to destroy.
 
 ---
-* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
-    * `atlantis apply`
-* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
-    * `atlantis unlock`
+* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
+  ```shell
+  atlantis apply
+  ```
+* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
+  ```shell
+  atlantis unlock
+  ```

--- a/server/controllers/events/testdata/test-repos/state-rm-single-project/exp-output-plan-again.txt
+++ b/server/controllers/events/testdata/test-repos/state-rm-single-project/exp-output-plan-again.txt
@@ -17,7 +17,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
   # random_id.for_each["overridden"] will be created
@@ -28,7 +27,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
   # random_id.simple will be created
@@ -39,7 +37,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
 Plan: 3 to add, 0 to change, 0 to destroy.
@@ -54,7 +51,11 @@ Plan: 3 to add, 0 to change, 0 to destroy.
 Plan: 3 to add, 0 to change, 0 to destroy.
 
 ---
-* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
-    * `atlantis apply`
-* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
-    * `atlantis unlock`
+* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
+  ```shell
+  atlantis apply
+  ```
+* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
+  ```shell
+  atlantis unlock
+  ```

--- a/server/controllers/events/testdata/test-repos/state-rm-single-project/exp-output-plan-again.txt
+++ b/server/controllers/events/testdata/test-repos/state-rm-single-project/exp-output-plan-again.txt
@@ -51,11 +51,7 @@ Plan: 3 to add, 0 to change, 0 to destroy.
 Plan: 3 to add, 0 to change, 0 to destroy.
 
 ---
-* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
-  ```shell
-  atlantis apply
-  ```
-* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
-  ```shell
-  atlantis unlock
-  ```
+* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
+    * `atlantis apply`
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
+    * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/state-rm-single-project/main.tf
+++ b/server/controllers/events/testdata/test-repos/state-rm-single-project/main.tf
@@ -1,17 +1,14 @@
 resource "random_id" "simple" {
-  keepers     = {}
   byte_length = 1
 }
 
 resource "random_id" "for_each" {
   for_each    = toset([var.var])
-  keepers     = {}
   byte_length = 1
 }
 
 resource "random_id" "count" {
   count       = 1
-  keepers     = {}
   byte_length = 1
 }
 

--- a/server/controllers/events/testdata/test-repos/state-rm-workspace/dir1/main.tf
+++ b/server/controllers/events/testdata/test-repos/state-rm-workspace/dir1/main.tf
@@ -1,7 +1,6 @@
 resource "random_id" "dummy1" {
   count = terraform.workspace == "ops" ? 1 : 0
 
-  keepers     = {}
   byte_length = 1
 }
 

--- a/server/controllers/events/testdata/test-repos/state-rm-workspace/exp-output-plan-again.txt
+++ b/server/controllers/events/testdata/test-repos/state-rm-workspace/exp-output-plan-again.txt
@@ -31,11 +31,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
-* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
-  ```shell
-  atlantis apply
-  ```
-* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
-  ```shell
-  atlantis unlock
-  ```
+* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
+    * `atlantis apply`
+* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
+    * `atlantis unlock`

--- a/server/controllers/events/testdata/test-repos/state-rm-workspace/exp-output-plan-again.txt
+++ b/server/controllers/events/testdata/test-repos/state-rm-workspace/exp-output-plan-again.txt
@@ -17,7 +17,6 @@ Terraform will perform the following actions:
       + dec         = (known after apply)
       + hex         = (known after apply)
       + id          = (known after apply)
-      + keepers     = {}
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -32,7 +31,11 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 ---
-* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
-    * `atlantis apply`
-* :put_litter_in_its_place: To **delete** all plans and locks for the PR, comment:
-    * `atlantis unlock`
+* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
+  ```shell
+  atlantis apply
+  ```
+* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
+  ```shell
+  atlantis unlock
+  ```


### PR DESCRIPTION
## what

chore: Cherry-pick #4462 "GitHub tests emitting unexpected keepers = {} " into release-0.27


## why

Want this fix in 0.27

## tests

N/A

## references

#4462

