### PR TITLE
chore: Cherry pick #4376 into release 0.27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -157,7 +157,7 @@ COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 # Install packages needed to run Atlantis.
 # We place this last as it will bust less docker layer caches when packages update
 RUN apk add --no-cache \
-        ca-certificates~=20230506 \
+        ca-certificates~=20240226-r0 \
         curl~=8 \
         git~=2 \
         unzip~=6 \


### PR DESCRIPTION
## what

Cherry picking fix #4376 into release-0.27.

## why

Needed to get tests to pass there.

## tests

N/A

## references

#4376 

