### PR TITLE
chore: cherry-pick #4461 into release-0.27

### DIFF
--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -36,6 +36,7 @@ const (
 )
 
 func NewInstrumentedProjectCommandBuilder(
+	logger logging.SimpleLogging,
 	policyChecksSupported bool,
 	parserValidator *config.ParserValidator,
 	projectFinder ProjectFinder,

--- a/server/server.go
+++ b/server/server.go
@@ -578,6 +578,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		Router:              router,
 	}
 	projectCommandBuilder := events.NewInstrumentedProjectCommandBuilder(
+		logger,
 		policyChecksEnabled,
 		validator,
 		&events.DefaultProjectFinder{},


### PR DESCRIPTION
## what

Cherry pick logger nil pointer in instrumented_project_command_builder (#4461) into release-0.27

## why

A fix we want in the release.

## tests

N/A

## references

#4461