### PR TITLE
docs: typo in server-configuration.md

### DIFF
--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -385,7 +385,7 @@ and set `--autoplan-modules` to `false`.
   ```bash
   atlantis server --disable-markdown-folding
   # or
-  ATLANTIS_DISABLE_MARKDOWN_FOLDER=true
+  ATLANTIS_DISABLE_MARKDOWN_FOLDING=true
   ```
   Disable folding in markdown output using the `<details>` html tag.
 


### PR DESCRIPTION
## what
Fixing misspelled environment variable of `--disable-markdown-folding` server config option. If using current environment variable, it won't function.


## why
Reduce confusion of atlantis users, who wants to disable markdown folding feature through environment variable.

## tests
`ATLANTIS_DISABLE_MARKDOWN_FOLDER=true` didn't have any effect on atlantis behaviour, `ATLANTIS_DISABLE_MARKDOWN_FOLDING=true` did the job.

## references
- https://www.runatlantis.io/docs/server-configuration.html#disable-markdown-folding