### PR TITLE
ci(pr-size): disable message, add files to ignore

### DIFF
--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -20,9 +20,11 @@ jobs:
           l_max_size: '10000'
           xl_label: 'size/xl'
           fail_if_xl: 'false'
-          message_if_xl: >
-            This PR exceeds the recommended size of 1000 lines.
-            Please make sure you are NOT addressing multiple issues with one PR.
-            Note this PR might be rejected due to its size.
+          # An empty string disables this
+          message_if_xl: ''
           github_api_url: 'https://api.github.com'
-          files_to_ignore: ''
+          files_to_ignore: |
+            "package-lock.json"
+            "go.sum"
+            "runatlantis.io/*"
+            "pnpm-lock.yml"


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- disable message
- add files to ignore

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- The message is annoying. My emptying it, according to the upstream code, it should skip commenting PRs.
- Added some noisy files to ignore

## tests

<!--
- [ ] I have tested my changes by ...
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Previous PR #4529 
- https://github.com/CodelyTV/pr-size-labeler/blob/main/README.md
- https://github.com/CodelyTV/pr-size-labeler/blob/13d17c48b702e11c1b7199bd9f9220c2b747cf5f/src/labeler.sh#L27-L29
