### PR TITLE
feat: Add /docker-entrypoint.d directory into image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -153,6 +153,8 @@ COPY --from=deps /usr/local/bin/tofu/tofu* /usr/local/bin/
 COPY --from=deps /usr/local/bin/conftest /usr/local/bin/conftest
 COPY --from=deps /usr/bin/git-lfs /usr/bin/git-lfs
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+# create entrypoint scripts directory
+RUN mkdir /docker-entrypoint.d
 
 # Install packages needed to run Atlantis.
 # We place this last as it will bust less docker layer caches when packages update
@@ -194,6 +196,8 @@ COPY --from=deps /usr/local/bin/conftest /usr/local/bin/conftest
 COPY --from=deps /usr/bin/git-lfs /usr/bin/git-lfs
 # copy docker-entrypoint.sh
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+# create entrypoint scripts directory
+RUN mkdir /docker-entrypoint.d
 
 # Set the entry point to the atlantis user and run the atlantis command
 USER atlantis


### PR DESCRIPTION
## what

Create the `/docker-entrypoint.d` directory 

## why

AWS ECS requires the target folder to exist if you want to map an EFS volume into it.

## tests

### Before
```
╰─❯ docker run -it --rm ghcr.io/runatlantis/atlantis:latest ls -lah /docker-entrypoint.d
No files found in /docker-entrypoint.d/, skipping
ls: /docker-entrypoint.d: No such file or directory
```

### After
```
╰─❯ docker run -it --rm atltest:latest ls -lah /docker-entrypoint.d
No files found in /docker-entrypoint.d/, skipping
total 8.0K
drwxr-xr-x 2 root root 4.0K May 10 20:59 .
drwxr-xr-x 1 root root 4.0K May 10 21:02 ..
```

## references

Closes #4537
Allows workaround suggested in #3778 to actually work

