### PR TITLE
fix: fix nav bar typo with `Glossary`

### DIFF
--- a/runatlantis.io/.vitepress/sidebars.ts
+++ b/runatlantis.io/.vitepress/sidebars.ts
@@ -98,7 +98,7 @@ const en = [
             {text: "Events Controller", link: "/contributing/events-controller"},
         ]
       },
-      {text: "Glossry", link: "/contributing/glossary"},
+      {text: "Glosssry", link: "/contributing/glossary"},
     ]
 
   }

--- a/runatlantis.io/.vitepress/sidebars.ts
+++ b/runatlantis.io/.vitepress/sidebars.ts
@@ -98,7 +98,7 @@ const en = [
             {text: "Events Controller", link: "/contributing/events-controller"},
         ]
       },
-      {text: "Glosssry", link: "/contributing/glossary"},
+      {text: "Glossary", link: "/contributing/glossary"},
     ]
 
   }


### PR DESCRIPTION

## what

Replace spelling error in Docs sidebar :  Glossry w/ Glossary


## why

Professionalism.

## tests

Not a code change.
