### PR TITLE
fix(docs): move TOC to the right nav bar to free up vertical space

### DIFF
--- a/runatlantis.io/.vitepress/config.ts
+++ b/runatlantis.io/.vitepress/config.ts
@@ -23,6 +23,10 @@ export default defineConfig({
         editLink: {
             pattern: 'https://github.com/runatlantis/atlantis/edit/main/runatlantis.io/:path'
         },
+        // headline "depth" the right nav will show for its TOC
+        //
+        // https://vitepress.dev/reference/frontmatter-config#outline
+        outline: [2, 3],
         search: {
             provider: 'algolia',
             options: {

--- a/runatlantis.io/docs/access-credentials.md
+++ b/runatlantis.io/docs/access-credentials.md
@@ -2,7 +2,6 @@
 This page describes how to create credentials for your Git host (GitHub, GitLab, Gitea, Bitbucket, or Azure DevOps)
 
 that Atlantis will use to make API calls.
-[[toc]]
 
 ## Create an Atlantis user (optional)
 We recommend creating a new user named **@atlantis** (or something close) or using a dedicated CI user.

--- a/runatlantis.io/docs/command-requirements.md
+++ b/runatlantis.io/docs/command-requirements.md
@@ -1,5 +1,4 @@
 # Command Requirements
-[[toc]]
 
 ## Intro
 Atlantis requires certain conditions be satisfied **before** `atlantis apply` and `atlantis import`

--- a/runatlantis.io/docs/configuring-webhooks.md
+++ b/runatlantis.io/docs/configuring-webhooks.md
@@ -8,7 +8,6 @@ Atlantis needs to receive Webhooks from your Git host so that it can respond to 
 :::
 
 See the instructions for your specific provider below.
-[[toc]]
 
 ## GitHub/GitHub Enterprise
 You can install your webhook at the [organization](https://docs.github.com/en/get-started/learning-about-github/types-of-github-accounts) level, or for each individual repository.

--- a/runatlantis.io/docs/custom-workflows.md
+++ b/runatlantis.io/docs/custom-workflows.md
@@ -3,7 +3,6 @@
 Custom workflows can be defined to override the default commands that Atlantis
 runs.
 
-[[toc]]
 
 ## Usage
 Custom workflows can be specified in the Server-Side Repo Config or in the Repo-Level

--- a/runatlantis.io/docs/deployment.md
+++ b/runatlantis.io/docs/deployment.md
@@ -6,7 +6,6 @@ This page covers getting Atlantis up and running in your infrastructure.
 * You have created a [webhook secret](webhook-secrets.md)
 :::
 
-[[toc]]
 
 ## Architecture Overview
 ### Runtime

--- a/runatlantis.io/docs/locking.md
+++ b/runatlantis.io/docs/locking.md
@@ -12,7 +12,6 @@ Which links them to the pull request that holds the lock.
 Only the directory in the repo and Terraform workspace are locked, not the whole repo.
 :::
 
-[[toc]]
 
 ## Why
 1. Because `atlantis apply` is being done before the pull request is merged, after

--- a/runatlantis.io/docs/post-workflow-hooks.md
+++ b/runatlantis.io/docs/post-workflow-hooks.md
@@ -6,7 +6,6 @@ workflows](custom-workflows.md#custom-run-command) in that they are run
 outside of Atlantis commands. Which means they do not surface their output
 back to the PR as a comment.
 
-[[toc]]
 
 ## Usage
 

--- a/runatlantis.io/docs/pre-workflow-hooks.md
+++ b/runatlantis.io/docs/pre-workflow-hooks.md
@@ -9,7 +9,6 @@ workflows](custom-workflows.md#custom-run-command) in several ways.
 2. Pre workflow hooks are run outside of Atlantis commands. Which means
    they do not surface their output back to the PR as a comment.
 
-[[toc]]
 
 ## Usage
 

--- a/runatlantis.io/docs/repo-level-atlantis-yaml.md
+++ b/runatlantis.io/docs/repo-level-atlantis-yaml.md
@@ -2,7 +2,6 @@
 An `atlantis.yaml` file specified at the root of a Terraform repo allows you
 to instruct Atlantis on the structure of your repo and set custom workflows.
 
-[[toc]]
 
 ## Do I need an atlantis.yaml file?
 `atlantis.yaml` files are only required if you wish to customize some aspect of Atlantis.

--- a/runatlantis.io/docs/requirements.md
+++ b/runatlantis.io/docs/requirements.md
@@ -2,7 +2,6 @@
 Atlantis works with most Git hosts and Terraform setups. Read on to confirm
 it works with yours.
 
-[[toc]]
 
 ## Git Host
 Atlantis integrates with the following Git hosts:

--- a/runatlantis.io/docs/security.md
+++ b/runatlantis.io/docs/security.md
@@ -1,5 +1,4 @@
 # Security
-[[toc]]
 ## Exploits
 Because you usually run Atlantis on a server with credentials that allow access to your infrastructure it's important that you deploy Atlantis securely.
 

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -4,7 +4,6 @@ This page explains how to configure the `atlantis server` command.
 Configuration to `atlantis server` can be specified via command line flags,
  environment variables, a config file or a mix of the three.
 
-[[toc]]
 
 ## Environment Variables
 All flags can be specified as environment variables.

--- a/runatlantis.io/docs/server-side-repo-config.md
+++ b/runatlantis.io/docs/server-side-repo-config.md
@@ -4,7 +4,6 @@ A Server-Side Config file is used for more groups of server config that can't re
 One such usecase is to control per-repo behaviour
 and what users can do in repo-level `atlantis.yaml` files.
 
-[[toc]]
 
 ## Do I Need A Server-Side Config File?
 You do not need a server-side repo config file unless you want to customize

--- a/runatlantis.io/docs/terraform-cloud.md
+++ b/runatlantis.io/docs/terraform-cloud.md
@@ -11,7 +11,6 @@ Atlantis integrates seamlessly with Terraform Cloud and Terraform Enterprise, wh
 * A Private Installation of Terraform Enterprise
 
 Read the docs below :point_down: depending on your use-case.
-[[toc]]
 
 ## Using Atlantis With Free Remote State Storage
 To use Atlantis with Free Remote State Storage, you need to:

--- a/runatlantis.io/docs/using-atlantis.md
+++ b/runatlantis.io/docs/using-atlantis.md
@@ -14,7 +14,6 @@ You can use following executable names.
 :::
 
 Currently, Atlantis supports the following commands.
-[[toc]]
 
 ---
 ## atlantis help

--- a/runatlantis.io/guide/testing-locally.md
+++ b/runatlantis.io/guide/testing-locally.md
@@ -8,7 +8,6 @@ If you want to set up a production-ready Atlantis installation, read [Deployment
 
 Steps:
 
-[[toc]]
 
 ## Install Terraform
 `terraform` needs to be in the `$PATH` for Atlantis.


### PR DESCRIPTION
## what

Moving the Table of Content to the TOC right-bar to free up space 

![Zight 2024-05-14 at 9 09 11 PM jpg](https://github.com/runatlantis/atlantis/assets/22841/4d98cf66-0d48-4cf3-be5c-364ea51a2fba)

## why

It makes it easier to navigate long pages such as the `Server Configuration` page by having the TOC persistently available on the right side.

There can be follow-up tuning trimming down the individual headlines a bit to make it easier to scan, but feel like it should be its own change set.
