### PR TITLE
fix(docs): fix placement of top header

### DIFF
--- a/runatlantis.io/.vitepress/theme/index.scss
+++ b/runatlantis.io/.vitepress/theme/index.scss
@@ -21,9 +21,6 @@ $MQMobileNarrow: 419px;
 
 $homeWidth: 960px;
 
-.container {
-  padding-top: 3.6rem;
-}
 
 .home {
   padding: 0 2rem;


### PR DESCRIPTION
## what

The header is placed kinda odd (pic 1) and not aligned with the rest of the header

![Zight 2024-05-14 at 10 35 12 PM jpg](https://github.com/runatlantis/atlantis/assets/22841/efd782f6-987a-4ad9-89b8-17cc324f7791) 

leading to content scrolling "behind" the header (pic 2)

![Zight 2024-05-14 at 10 35 51 PM jpg](https://github.com/runatlantis/atlantis/assets/22841/f4aeec7b-5b3e-4d8c-81f5-2c590b8e72c3)

if we remove the `padding-top` it looks correct (pic 3)

![Zight 2024-05-14 at 10 36 28 PM jpg](https://github.com/runatlantis/atlantis/assets/22841/ad5389d0-3bf0-4bec-83d7-7b54d3889215)

and matches the native vitepress design  (pic 4)

![Zight 2024-05-14 at 10 37 29 PM jpg](https://github.com/runatlantis/atlantis/assets/22841/9059bd5a-9540-476a-b8d2-f2675759588b)





## why

It looks nice

## tests

N/A

## references

N/A