### PR TITLE
fix(docs): fix home header width so the menu doesn't jump around when navigating

### DIFF
--- a/runatlantis.io/.vitepress/theme/index.scss
+++ b/runatlantis.io/.vitepress/theme/index.scss
@@ -20,11 +20,8 @@ $MQMobile: 719px;
 $MQMobileNarrow: 419px;
 
 $homeWidth: 960px;
-
-
 .home {
   padding: 0 2rem;
-  max-width: $homeWidth;
   margin: 0px auto 80px;
   .hero {
     text-align: center;


### PR DESCRIPTION
## what

The `home` page had a forced `max-width` of `960px` for the top nav bar, making it look like this (pic 1)

![Zight 2024-05-14 at 10 43 52 PM jpg](https://github.com/runatlantis/atlantis/assets/22841/f2265f5c-a7d5-46a1-b13e-2cd98cde11fd)

meaning that when you navigate to _any_ other page, the top bar would "jump" and all icons/menus would get new placements, making for a surprising change in layout and "jolt" to the reading process (pic 2)
![Zight 2024-05-14 at 10 44 40 PM jpg](https://github.com/runatlantis/atlantis/assets/22841/0cd37a59-d0a7-415f-83a7-f597006cd50f)

With this change, the top bar is consistently sized and placed across all pages (pic 3), making for a more consistent and easier to scan experience for folks

![Zight 2024-05-14 at 10 46 12 PM jpg](https://github.com/runatlantis/atlantis/assets/22841/9b6fb52e-10bf-4205-a104-83f30cb6cb3d)

This is consistent with how the native VitePress them work as well

--

Navigating from [homepage](https://deploy-preview-4560--runatlantis.netlify.app/) to [docs](https://deploy-preview-4560--runatlantis.netlify.app/docs.html) and then going back and forth in history shows this clearly
