### PR TITLE
fix(docs): Fix Content-Security-Policy (CSP) rules for website

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -21,7 +21,7 @@
   [headers.values]
     X-Frame-Options = "DENY"
     X-XSS-Protection = "1; mode=block"
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:"
+    Content-Security-Policy = "default-src 'self'; frame-src 'self' https://app.netlify.com; script-src 'self' https://*.google-analytics.com https://www.googletagmanager.com https://*.algolianet.com https://*.algolia.net 'unsafe-inline'; style-src 'self' https://fonts.googleapis.com https://*.algolianet.com https://*.algolia.net 'unsafe-inline'; img-src 'self' https://*.google-analytics.com data:; font-src 'self' data: https://fonts.googleapis.com https://fonts.gstatic.com; connect-src 'self' https://*.google-analytics.com https://www.googletagmanager.com https://*.algolianet.com https://*.algolia.net"
     Cache-Control = "public, max-age=86400, must-revalidate"
     Strict-Transport-Security = "max-age=86400; includeSubDomains; preload"
     Referrer-Policy = "no-referrer"


### PR DESCRIPTION
## what

Fix Content-Security-Policy (CSP) errors on the new site.

* Google Analytics work
* Netlify "preview" iframe works
* Google Tag Manager works
* Algolia search works

Considering there are no auth or PII on the site, I wonder if it would be simpler to just not enforce CSP to begin with though 🤔 

Preview site: https://deploy-preview-4567--runatlantis.netlify.app/