### PR TITLE
fix(docs): Add link to Survey in top bar

### DIFF
--- a/runatlantis.io/.vitepress/navbars.ts
+++ b/runatlantis.io/.vitepress/navbars.ts
@@ -4,7 +4,7 @@ const en = [
   { text: "Docs", link: "/docs" },
   { text: "Contributing", link: "/contributing" },
   { text: "Blog", link: "/blog" },
-  { text: "Survey", link: "https://docs.google.com/forms/d/1fOGWkdinDV2_46CZvzQRdz8401ypZR8Z-iwkNNt3EX0" },
+  { text: "2024 Usage Survey", link: "https://docs.google.com/forms/d/1fOGWkdinDV2_46CZvzQRdz8401ypZR8Z-iwkNNt3EX0" },
 ];
 
 export { en };

--- a/runatlantis.io/.vitepress/navbars.ts
+++ b/runatlantis.io/.vitepress/navbars.ts
@@ -4,7 +4,7 @@ const en = [
   { text: "Docs", link: "/docs" },
   { text: "Contributing", link: "/contributing" },
   { text: "Blog", link: "/blog" },
-  { text: "📢 2024 Usage Survey", link: "https://docs.google.com/forms/d/1fOGWkdinDV2_46CZvzQRdz8401ypZR8Z-iwkNNt3EX0" },
+  { text: "📢 2024 User Survey", link: "https://docs.google.com/forms/d/1fOGWkdinDV2_46CZvzQRdz8401ypZR8Z-iwkNNt3EX0" },
 ];
 
 export { en };

--- a/runatlantis.io/.vitepress/navbars.ts
+++ b/runatlantis.io/.vitepress/navbars.ts
@@ -4,6 +4,7 @@ const en = [
   { text: "Docs", link: "/docs" },
   { text: "Contributing", link: "/contributing" },
   { text: "Blog", link: "/blog" },
+  { text: "Survey", link: "https://docs.google.com/forms/d/1fOGWkdinDV2_46CZvzQRdz8401ypZR8Z-iwkNNt3EX0" },
 ];
 
 export { en };

--- a/runatlantis.io/.vitepress/navbars.ts
+++ b/runatlantis.io/.vitepress/navbars.ts
@@ -4,7 +4,7 @@ const en = [
   { text: "Docs", link: "/docs" },
   { text: "Contributing", link: "/contributing" },
   { text: "Blog", link: "/blog" },
-  { text: "📢 2024 User Survey", link: "https://docs.google.com/forms/d/1fOGWkdinDV2_46CZvzQRdz8401ypZR8Z-iwkNNt3EX0" },
+  { text: "📢 User Survey", link: "https://docs.google.com/forms/d/1fOGWkdinDV2_46CZvzQRdz8401ypZR8Z-iwkNNt3EX0" },
 ];
 
 export { en };

--- a/runatlantis.io/.vitepress/navbars.ts
+++ b/runatlantis.io/.vitepress/navbars.ts
@@ -4,7 +4,7 @@ const en = [
   { text: "Docs", link: "/docs" },
   { text: "Contributing", link: "/contributing" },
   { text: "Blog", link: "/blog" },
-  { text: "2024 Usage Survey", link: "https://docs.google.com/forms/d/1fOGWkdinDV2_46CZvzQRdz8401ypZR8Z-iwkNNt3EX0" },
+  { text: "📢 2024 Usage Survey", link: "https://docs.google.com/forms/d/1fOGWkdinDV2_46CZvzQRdz8401ypZR8Z-iwkNNt3EX0" },
 ];
 
 export { en };


### PR DESCRIPTION
In case folks dismiss the survey top bar, its still easily accessible.

I've had folks at $DayJob ask about the survey link twice today, because they dismissed the banner out of habit (looks like a banner/cookie content block) without reading it first.

I personally dismissed it at work without thinking because I needed to go to the docs fix an issue for a engineer, and the bar was visually distracting and looked like marketing - didn't even think about it, just removed it like a cookie consent banner by pure habit 

So been needing to go to the source code 3 times today to dig up the banner URL because of "click to dismiss"-habits, so thought it was likely other folks had similar experience.

Preview:  https://deploy-preview-4574--runatlantis.netlify.app/