### PR TITLE
fix: avoid resetting fetch head when doing branch fetch unshallow

### DIFF
--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -353,6 +353,12 @@ func (w *FileWorkspace) mergeToBaseBranch(logger logging.SimpleLogging, c wrappe
 		if err := w.wrappedGit(logger, c, "fetch", "--unshallow"); err != nil {
 			return err
 		}
+
+		// fetch once more, otherwise `FETCH_HEAD` was reset to base when we ran
+		// fetch --unshallow
+		if err := w.wrappedGit(c, "fetch", fetchRemote, fetchRef); err != nil {
+			return err
+		}
 	}
 
 	// We use --no-ff because we always want there to be a merge commit.

--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -356,7 +356,7 @@ func (w *FileWorkspace) mergeToBaseBranch(logger logging.SimpleLogging, c wrappe
 
 		// fetch once more, otherwise `FETCH_HEAD` was reset to base when we ran
 		// fetch --unshallow
-		if err := w.wrappedGit(c, "fetch", fetchRemote, fetchRef); err != nil {
+		if err := w.wrappedGit(logger, c, "fetch", fetchRemote, fetchRef); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
When doing merge strategy with shallow clones, git will set FETCH_HEAD to base branch when doing unshallow. This fetches another time to reset it back, as we depend on the value later.

## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

When using `merge` strategy with a `checkout-depth` and the shallow branch can't find a common base with the base branch, a full branch must be fetched with `--unshallow`. This PR does another fetch from the feature branch after doing this, to keep the `FETCH_HEAD` as expected for future operations.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

When doing `merge` strategy with shallow clones, git will set `FETCH_HEAD` to base branch when doing unshallow. `FETCH_HEAD` is later used as the ref when doing a merge to base branch, effectively merging it with itself. This in turn causes Atlantis to plan/apply against the base branch and presenting "no changes", even when there should be changes.

## tests

We have been running a fork with this fix for a few month, using a `merge` strategy with a `checkout-depth` value that triggers a full clone relatively often. We have not experienced plans against the base branch since this fix, while we experienced them quite often before.

## references

While the original issue seems to be referring to a different situation, there is [as issue comment](https://github.com/runatlantis/atlantis/issues/2952#issuecomment-1609479450) describing this situation. The bug being fixed would also present errors like the ones in the issue, though I don't think this PR fixes that specific issue.

