### PR TITLE
fix: fix docker base image sha

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1@sha256:a57df69d0ea827fb7266491f2813635de6f17269be881f696fbfdf2d83dda33e
 # what distro is the image being built for
 ARG ALPINE_TAG=3.19.1@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
-ARG DEBIAN_TAG=12.5-slim@sha256:3d5df92588469a4c503adbead0e4129ef3f88e223954011c2169073897547cac
-ARG GOLANG_TAG=1.22.3-alpine@sha256:a52ec26b648564b6cef8adf7bea14348b499a32d08de3943823150ad268f0d77
+ARG DEBIAN_TAG=12.5-slim@sha256:804194b909ef23fb995d9412c9378fb3505fe2427b70f3cc425339e48a828fca
+ARG GOLANG_TAG=1.22.3-alpine@sha256:b8ded51bad03238f67994d0a6b88680609b392db04312f60c23358cc878d4902
 
 # renovate: datasource=github-releases depName=hashicorp/terraform versioning=hashicorp
 ARG DEFAULT_TERRAFORM_VERSION=1.8.3

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.3@sha256:4304d944c421bb279ad1faada14d03ac7e7edca61793d2f6a7ad94681c457887
+FROM golang:1.22.3@sha256:f43c6f049f04cbbaeb28f0aad3eea15274a7d0a7899a617d0037aec48d7ab010
 
 RUN apt-get update && apt-get --no-install-recommends -y install unzip \
     && apt-get clean \


### PR DESCRIPTION
fixes #4598 

```
$ regctl image digest golang:1.22.3
sha256:f43c6f049f04cbbaeb28f0aad3eea15274a7d0a7899a617d0037aec48d7ab010

$ regctl image digest golang:1.22.3-alpine
sha256:b8ded51bad03238f67994d0a6b88680609b392db04312f60c23358cc878d4902

$ regctl image digest debian:12.5-slim
sha256:804194b909ef23fb995d9412c9378fb3505fe2427b70f3cc425339e48a828fca

$ regctl image digest alpine:3.19.1
sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
```

---

relates to #4456