### PR TITLE
chore(release): remove pre-release refs

### DIFF
--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -6,8 +6,7 @@ on:
       - 'main'
       - 'release-**'
     tags:
-      - v*.*.* # stable release like, v0.19.2
-      - v*.*.*-pre.* # pre release like, v0.19.0-pre.calendardate
+      - v*.*.*
   pull_request:
     branches:
       - 'main'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,7 @@ name: release
 on:
   push:
     tags:
-      - v*.*.* # stable release like, v0.19.2
-      - v*.*.*-pre.* # pre release like, v0.19.0-pre.calendardate
+      - v*.*.*
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
we dont do pre-release nowadays, removing the refs to avoid confusion.