### PR TITLE
fix: Add support for the X-Hub-Signature-256 header

### DIFF
--- a/server/controllers/events/events_controller.go
+++ b/server/controllers/events/events_controller.go
@@ -49,6 +49,7 @@ const bitbucketEventTypeHeader = "X-Event-Key"
 const bitbucketCloudRequestIDHeader = "X-Request-UUID"
 const bitbucketServerRequestIDHeader = "X-Request-ID"
 const bitbucketServerSignatureHeader = "X-Hub-Signature"
+const bitbucketServerSignatureHeader256 = "X-Hub-Signature-256"
 
 // The URL used for Azure DevOps test webhooks
 const azuredevopsTestURL = "https://fabrikam.visualstudio.com/DefaultCollection/_apis/git/repositories/4bc14d40-c903-45e2-872e-0462c7748079"
@@ -244,7 +245,10 @@ func (e *VCSEventsController) handleBitbucketCloudPost(w http.ResponseWriter, r 
 func (e *VCSEventsController) handleBitbucketServerPost(w http.ResponseWriter, r *http.Request) {
 	eventType := r.Header.Get(bitbucketEventTypeHeader)
 	reqID := r.Header.Get(bitbucketServerRequestIDHeader)
-	sig := r.Header.Get(bitbucketServerSignatureHeader)
+	sig := r.Header.Get(bitbucketServerSignatureHeader256)
+	if sig == "" {
+		sig = r.Header.Get(bitbucketServerSignatureHeader)
+	}
 	defer r.Body.Close() // nolint: errcheck
 	body, err := io.ReadAll(r.Body)
 	if err != nil {


### PR DESCRIPTION
## what
Add support for the X-Hub-Signature-256 header 

## why

Set the SHA256 header as the default and falling back to the SHA1 header when the SHA256 header is empty. The GitHub documentation [recommends](https://docs.github.com/en/developers/webhooks-and-events/securing-your-webhooks#validating-payloads-from-github) using the SHA256 header so I don't expect the fallback to be needed in a live environment. Still, this fallback prevents introducing breaking changes when used in tests.

## tests

- Updated unit tests
- Ran atlantis new docker image and validated against github events

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

This solution is based on [this PR](https://github.com/google/go-github/pull/1783) from @reinoudk

