### PR TITLE
docs: Remove todo and link to slack documentation

### DIFF
--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -1197,7 +1197,7 @@ This is useful when you have many projects and want to keep the pull request cle
   ATLANTIS_SLACK_TOKEN='token'
   ```
 
-  API token for Slack notifications. Slack is not fully supported. TODO: Slack docs.
+  API token for Slack notifications. See [Using Slack hooks](using-slack-hooks.md)
 
 ### `--ssl-cert-file`
 

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -1197,7 +1197,7 @@ This is useful when you have many projects and want to keep the pull request cle
   ATLANTIS_SLACK_TOKEN='token'
   ```
 
-  API token for Slack notifications. See [Using Slack hooks](using-slack-hooks.md)
+  API token for Slack notifications. See [Using Slack hooks](using-slack-hooks.md).
 
 ### `--ssl-cert-file`
 


### PR DESCRIPTION
## what

Update configuration docs to link to slack docs for slack api token


## why

Currently says slack is not fully supported.

## tests

doc only



