### PR TITLE
chore: pin terraform versions in CI

### DIFF
--- a/scripts/pin_ci_terraform_providers.sh
+++ b/scripts/pin_ci_terraform_providers.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Script to pin terraform providers in e2e tests
+
+RANDOM_PROVIDER_VERSION="3.6.1"
+NULL_PROVIDER_VERSION="3.2.2"
+
+TEST_REPOS_DIR="server/controllers/events/testdata/test-repos"
+
+for file in $(find $TEST_REPOS_DIR -name '*.tf')
+do
+    basename=$(basename $file)
+    if [[ "$basename" == "versions.tf" ]]
+    then
+        continue
+    fi
+    if [[ "$basename" != "main.tf" ]]
+    then
+        echo "Found unexpected file: $file"
+        exit 1
+    fi
+    has_null_provider=false
+    has_random_provider=false
+
+    version_file="$(dirname $file)/versions.tf"
+    for resource in $(cat $file | grep '^resource' | awk '{print $2}' | tr -d '"')
+    do
+        if [[ "$resource" == "null_resource" ]]
+        then
+            has_null_provider=true
+        elif [[ "$resource" == "random_id" ]]
+        then
+            has_random_provider=true
+        else
+            echo "Unknown resource $resource in $file"
+            exit 1
+        fi
+    done
+    if ! $has_null_provider && ! $has_random_provider
+    then
+        echo "No providers needed for $file"
+        continue
+    fi
+    echo "Adding $version_file for $file"
+    rm -f $version_file
+    if $has_null_provider
+    then
+        echo 'provider "null" {}' >> $version_file
+    fi
+    if $has_random_provider
+    then
+        echo 'provider "random" {}' >> $version_file
+    fi
+    echo "terraform {" >> $version_file
+    echo "  required_providers {" >> $version_file
+
+    if $has_random_provider
+    then
+        echo "    random = {" >> $version_file
+        echo '      source  = "hashicorp/random"' >> $version_file
+        echo "      version = \"= $RANDOM_PROVIDER_VERSION\"" >> $version_file
+        echo "    }" >> $version_file
+    fi
+    if $has_null_provider
+    then
+        echo "    null = {" >> $version_file
+        echo '      source  = "hashicorp/null"' >> $version_file
+        echo "      version = \"= $NULL_PROVIDER_VERSION\"" >> $version_file
+        echo "    }" >> $version_file
+    fi
+    echo "  }" >> $version_file
+    echo "}" >> $version_file
+
+done

--- a/server/controllers/events/testdata/test-repos/automerge/dir1/versions.tf
+++ b/server/controllers/events/testdata/test-repos/automerge/dir1/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/automerge/dir2/versions.tf
+++ b/server/controllers/events/testdata/test-repos/automerge/dir2/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/import-multiple-project/dir1/versions.tf
+++ b/server/controllers/events/testdata/test-repos/import-multiple-project/dir1/versions.tf
@@ -1,0 +1,9 @@
+provider "random" {}
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "= 3.6.1"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/import-multiple-project/dir2/versions.tf
+++ b/server/controllers/events/testdata/test-repos/import-multiple-project/dir2/versions.tf
@@ -1,0 +1,9 @@
+provider "random" {}
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "= 3.6.1"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/import-single-project-var/versions.tf
+++ b/server/controllers/events/testdata/test-repos/import-single-project-var/versions.tf
@@ -1,0 +1,9 @@
+provider "random" {}
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "= 3.6.1"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/import-single-project/versions.tf
+++ b/server/controllers/events/testdata/test-repos/import-single-project/versions.tf
@@ -1,0 +1,9 @@
+provider "random" {}
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "= 3.6.1"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/import-workspace/dir1/versions.tf
+++ b/server/controllers/events/testdata/test-repos/import-workspace/dir1/versions.tf
@@ -1,0 +1,9 @@
+provider "random" {}
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "= 3.6.1"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/modules-yaml/modules/null/versions.tf
+++ b/server/controllers/events/testdata/test-repos/modules-yaml/modules/null/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/modules/modules/null/versions.tf
+++ b/server/controllers/events/testdata/test-repos/modules/modules/null/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/policy-checks-apply-reqs/versions.tf
+++ b/server/controllers/events/testdata/test-repos/policy-checks-apply-reqs/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/policy-checks-clear-approval/versions.tf
+++ b/server/controllers/events/testdata/test-repos/policy-checks-clear-approval/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/policy-checks-custom-run-steps/versions.tf
+++ b/server/controllers/events/testdata/test-repos/policy-checks-custom-run-steps/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/policy-checks-diff-owner/versions.tf
+++ b/server/controllers/events/testdata/test-repos/policy-checks-diff-owner/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/policy-checks-disabled-previous-match/versions.tf
+++ b/server/controllers/events/testdata/test-repos/policy-checks-disabled-previous-match/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/policy-checks-disabled-repo-server-side/versions.tf
+++ b/server/controllers/events/testdata/test-repos/policy-checks-disabled-repo-server-side/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/policy-checks-disabled-repo/versions.tf
+++ b/server/controllers/events/testdata/test-repos/policy-checks-disabled-repo/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/policy-checks-enabled-repo-server-side/versions.tf
+++ b/server/controllers/events/testdata/test-repos/policy-checks-enabled-repo-server-side/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/policy-checks-enabled-repo/versions.tf
+++ b/server/controllers/events/testdata/test-repos/policy-checks-enabled-repo/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/policy-checks-extra-args/versions.tf
+++ b/server/controllers/events/testdata/test-repos/policy-checks-extra-args/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/policy-checks-multi-projects/dir1/versions.tf
+++ b/server/controllers/events/testdata/test-repos/policy-checks-multi-projects/dir1/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/policy-checks-multi-projects/dir2/versions.tf
+++ b/server/controllers/events/testdata/test-repos/policy-checks-multi-projects/dir2/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/policy-checks/versions.tf
+++ b/server/controllers/events/testdata/test-repos/policy-checks/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/repo-config-file/infrastructure/production/versions.tf
+++ b/server/controllers/events/testdata/test-repos/repo-config-file/infrastructure/production/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/repo-config-file/infrastructure/staging/versions.tf
+++ b/server/controllers/events/testdata/test-repos/repo-config-file/infrastructure/staging/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/server-side-cfg/versions.tf
+++ b/server/controllers/events/testdata/test-repos/server-side-cfg/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/simple-with-lockfile/versions.tf
+++ b/server/controllers/events/testdata/test-repos/simple-with-lockfile/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/simple-yaml/versions.tf
+++ b/server/controllers/events/testdata/test-repos/simple-yaml/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/simple/versions.tf
+++ b/server/controllers/events/testdata/test-repos/simple/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/state-rm-multiple-project/dir1/versions.tf
+++ b/server/controllers/events/testdata/test-repos/state-rm-multiple-project/dir1/versions.tf
@@ -1,0 +1,9 @@
+provider "random" {}
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "= 3.6.1"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/state-rm-multiple-project/dir2/versions.tf
+++ b/server/controllers/events/testdata/test-repos/state-rm-multiple-project/dir2/versions.tf
@@ -1,0 +1,9 @@
+provider "random" {}
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "= 3.6.1"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/state-rm-single-project/versions.tf
+++ b/server/controllers/events/testdata/test-repos/state-rm-single-project/versions.tf
@@ -1,0 +1,9 @@
+provider "random" {}
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "= 3.6.1"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/state-rm-workspace/dir1/versions.tf
+++ b/server/controllers/events/testdata/test-repos/state-rm-workspace/dir1/versions.tf
@@ -1,0 +1,9 @@
+provider "random" {}
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "= 3.6.1"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/tfvars-yaml-no-autoplan/versions.tf
+++ b/server/controllers/events/testdata/test-repos/tfvars-yaml-no-autoplan/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/tfvars-yaml/versions.tf
+++ b/server/controllers/events/testdata/test-repos/tfvars-yaml/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/workspace-parallel-yaml/production/versions.tf
+++ b/server/controllers/events/testdata/test-repos/workspace-parallel-yaml/production/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}

--- a/server/controllers/events/testdata/test-repos/workspace-parallel-yaml/staging/versions.tf
+++ b/server/controllers/events/testdata/test-repos/workspace-parallel-yaml/staging/versions.tf
@@ -1,0 +1,9 @@
+provider "null" {}
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "= 3.2.2"
+    }
+  }
+}


### PR DESCRIPTION
## what

Add a script to add `versions.tf` to all test dirs that pin all necessary providers; run the script.


## why

Help with CI stability if providers are pinned.

Adding a script means that we can easily bump all versions simultaneously in the future if we need to.

## tests

Ran CI.

## references

close #4484.

