### PR TITLE
fix: add app to the github app installation id

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -90,7 +90,7 @@ const (
 	GHAppKeyFlag                     = "gh-app-key"
 	GHAppKeyFileFlag                 = "gh-app-key-file"
 	GHAppSlugFlag                    = "gh-app-slug"
-	GHInstallationIDFlag             = "gh-installation-id"
+	GHAppInstallationIDFlag          = "gh-app-installation-id"
 	GHOrganizationFlag               = "gh-org"
 	GHWebhookSecretFlag              = "gh-webhook-secret"               // nolint: gosec
 	GHAllowMergeableBypassApply      = "gh-allow-mergeable-bypass-apply" // nolint: gosec
@@ -620,8 +620,8 @@ var int64Flags = map[string]int64Flag{
 		description:  "GitHub App Id. If defined, initializes the GitHub client with app-based credentials",
 		defaultValue: 0,
 	},
-	GHInstallationIDFlag: {
-		description: "GitHub Installation Id. If defined, initializes the GitHub client with app-based credentials " +
+	GHAppInstallationIDFlag: {
+		description: "GitHub App Installation Id. If defined, initializes the GitHub client with app-based credentials " +
 			"using this specific GitHub Application Installation ID, otherwise it attempts to auto-detect it. " +
 			"Note that this value must be set if you want to have one App and multiple installations of that same " +
 			"application.",

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -91,7 +91,7 @@ var testFlags = map[string]interface{}{
 	GHAppKeyFlag:                     "",
 	GHAppKeyFileFlag:                 "",
 	GHAppSlugFlag:                    "atlantis",
-	GHInstallationIDFlag:             int64(0),
+	GHAppInstallationIDFlag:          int64(0),
 	GHOrganizationFlag:               "",
 	GHWebhookSecretFlag:              "secret",
 	GiteaBaseURLFlag:                 "http://localhost",
@@ -750,16 +750,16 @@ func TestExecute_GithubApp(t *testing.T) {
 func TestExecute_GithubAppWithInstallationID(t *testing.T) {
 	t.Log("Should pass the installation ID to the config.")
 	c := setup(map[string]interface{}{
-		GHAppKeyFlag:         testdata.GithubPrivateKey,
-		GHAppIDFlag:          "1",
-		GHInstallationIDFlag: "2",
-		RepoAllowlistFlag:    "*",
+		GHAppKeyFlag:            testdata.GithubPrivateKey,
+		GHAppIDFlag:             "1",
+		GHAppInstallationIDFlag: "2",
+		RepoAllowlistFlag:       "*",
 	}, t)
 	err := c.Execute()
 	Ok(t, err)
 
 	Equals(t, int64(1), passedConfig.GithubAppID)
-	Equals(t, int64(2), passedConfig.GithubInstallationID)
+	Equals(t, int64(2), passedConfig.GithubAppInstallationID)
 }
 
 func TestExecute_GiteaUser(t *testing.T) {

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -687,12 +687,12 @@ and set `--autoplan-modules` to `false`.
   Hostname of your GitHub Enterprise installation. If using [GitHub.com](https://github.com),
   don't set. Defaults to `github.com`.
 
-### `--gh-installation-id`
+### `--gh-app-installation-id`
 
   ```bash
-  atlantis server --gh-installation-id="123"
+  atlantis server --gh-app-installation-id="123"
   # or
-  ATLANTIS_GH_INSTALLATION_ID="123"
+  ATLANTIS_GH_APP_INSTALLATION_ID="123"
   ```
 
 The installation ID of a specific instance of a GitHub application. Normally this value is

--- a/server/server.go
+++ b/server/server.go
@@ -240,7 +240,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 			}
 			githubCredentials = &vcs.GithubAppCredentials{
 				AppID:          userConfig.GithubAppID,
-				InstallationID: userConfig.GithubInstallationID,
+				InstallationID: userConfig.GithubAppInstallationID,
 				Key:            privateKey,
 				Hostname:       userConfig.GithubHostname,
 				AppSlug:        userConfig.GithubAppSlug,
@@ -249,7 +249,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		} else if userConfig.GithubAppID != 0 && userConfig.GithubAppKey != "" {
 			githubCredentials = &vcs.GithubAppCredentials{
 				AppID:          userConfig.GithubAppID,
-				InstallationID: userConfig.GithubInstallationID,
+				InstallationID: userConfig.GithubAppInstallationID,
 				Key:            []byte(userConfig.GithubAppKey),
 				Hostname:       userConfig.GithubHostname,
 				AppSlug:        userConfig.GithubAppSlug,

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -57,7 +57,7 @@ type UserConfig struct {
 	GithubAppKey                    string `mapstructure:"gh-app-key"`
 	GithubAppKeyFile                string `mapstructure:"gh-app-key-file"`
 	GithubAppSlug                   string `mapstructure:"gh-app-slug"`
-	GithubInstallationID            int64  `mapstructure:"gh-installation-id"`
+	GithubAppInstallationID         int64  `mapstructure:"gh-app-installation-id"`
 	GithubTeamAllowlist             string `mapstructure:"gh-team-allowlist"`
 	GiteaBaseURL                    string `mapstructure:"gitea-base-url"`
 	GiteaToken                      string `mapstructure:"gitea-token"`


### PR DESCRIPTION
## what

A tiny fix to correct the terminology used for the Github App Installation ID so it includes "App" as does the rest of the Github App configuration items.

This is a trivial PR to build on @john-tipper 's fine work - it's not intended to devalue the serious effort made to address the original requirement (thank you!) 

## why

purely for naming consistency and ease of use.

## tests

Existing tests updated to use the new name.
Documentation updated too.

## references

fixes #4579 
