### PR TITLE
fix: Preventing merging without running atlantis apply on Gitlab

### DIFF
--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -119,6 +119,12 @@ func (p *PlanCommandRunner) runAutoplan(ctx *command.Context) {
 		ctx.Log.Warn("unable to update plan commit status: %s", err)
 	}
 
+	if baseRepo.VCSHost.Type ==  models.Gitlab {
+		if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.PendingCommitStatus, command.Apply, 0, len(projectCmds)); err != nil {
+			ctx.Log.Warn("unable to update apply commit status: %s", err)
+		}
+	}
+
 	// discard previous plans that might not be relevant anymore
 	ctx.Log.Debug("deleting previous plans and locks")
 	p.deletePlans(ctx)

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -119,7 +119,7 @@ func (p *PlanCommandRunner) runAutoplan(ctx *command.Context) {
 		ctx.Log.Warn("unable to update plan commit status: %s", err)
 	}
 
-	if baseRepo.VCSHost.Type ==  models.Gitlab {
+	if baseRepo.VCSHost.Type == models.Gitlab {
 		if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.PendingCommitStatus, command.Apply, 0, len(projectCmds)); err != nil {
 			ctx.Log.Warn("unable to update apply commit status: %s", err)
 		}


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
Preventing merging without running atlantis apply on Gitlab

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
Preventing merging without running atlantis apply on Gitlab
## tests

<!--
- [] I have tested my changes by ...
-->
- [X] I have tested my changes 
## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
https://github.com/runatlantis/atlantis/issues/4372
