### PR TITLE
fix: dont log GitHub app token in logs

### DIFF
--- a/server/events/vcs/gh_app_creds_rotator.go
+++ b/server/events/vcs/gh_app_creds_rotator.go
@@ -61,7 +61,7 @@ func (r *githubAppTokenRotator) rotate() error {
 	if err != nil {
 		return errors.Wrap(err, "Getting github token")
 	}
-	r.log.Debug("token %s", token)
+	r.log.Debug("Token successfully refreshed")
 
 	// https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#http-based-git-access-by-an-installation
 	if err := WriteGitCreds("x-access-token", token, r.githubHostname, r.homeDirPath, r.log, true); err != nil {


### PR DESCRIPTION
## what

Change the log line to prevent logging the GitHub App token in logs.

## why

- Resolves https://github.com/runatlantis/atlantis/issues/4060
- Tokens should not be in the logs due to security implications

## tests

Confirmed Atlantis continues to successfully start.

## references

- Close https://github.com/runatlantis/atlantis/issues/4060

