### PR TITLE
chore(goreleaser): replace changelog.skip with changelog.disable

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,7 +34,7 @@ checksum:
   name_template: "checksums.txt"
 
 changelog:
-  skip: true
+  disable: true
 
 release:
   # If set to true, will not auto-publish the release.


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

Fix `.goreleaser.yml`.
Replace `changelog.skip` with `changelog.disabled`.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

To resolve the release failure.

https://github.com/runatlantis/atlantis/actions/runs/9571387025/job/26388369837

```
GoReleaser ~> v2 installed successfully
/opt/hostedtoolcache/goreleaser-action/2.0.1/x64/goreleaser release --clean
  • starting release...
  ⨯ release failed after 0s                  error=yaml: unmarshal errors:
  line 37: field skip not found in type config.Changelog
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.0.1/x64/goreleaser' failed with exit code 1
```

`changelog.skip` was deprecated.

https://goreleaser.com/deprecations/#changelogskip

## tests

<!--
- [ ] I have tested my changes by ...
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

