### PR TITLE
docs: comment out banner

### DIFF
--- a/runatlantis.io/.vitepress/components/Banner.vue
+++ b/runatlantis.io/.vitepress/components/Banner.vue
@@ -21,14 +21,8 @@ const dismiss = () => {
 </script>
 
 <template>
-  <div ref="el" class="banner">
+  <!-- <div ref="el" class="banner">
     <div class="text">
-      <p>
-      In April 2024, the Core Atlantis Team launched an anonymous survey to better understand our community's needs and help prioritize our roadmap, see the results <a href="/blog/2024/april-2024-survey-results">here!</a>
-      </p>
-      <p style="color: #FFD700; font-weight: bold;">
-        Exciting news! The Atlantis project is now in the CNCF TOC vote—show your support and cast your vote <a href="https://github.com/cncf/sandbox/issues/60#issuecomment-2161214347">here</a>.
-      </p>
     </div>
 
     <button type="button" @click="dismiss">
@@ -42,7 +36,7 @@ const dismiss = () => {
         />
       </svg>
     </button>
-  </div>
+  </div> -->
 </template>
 
 <style>


### PR DESCRIPTION
now with both announcements in the new release, time to comment out the banner for the next round of use. 

<img width="1550" alt="image" src="https://github.com/runatlantis/atlantis/assets/1580956/e12093a7-9242-469b-af21-a68daf734fc1">

