### PR TITLE
chore: 12.5-slim tag is no longer receiving updates, switch to 12.6-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1@sha256:e87caa74dcb7d46cd820352bfea12591f3dba3ddc4285e19c7dcd13359f7cefd
 # what distro is the image being built for
 ARG ALPINE_TAG=3.20.1@sha256:b89d9c93e9ed3597455c90a0b88a8bbb5cb7188438f70953fede212a0c4394e0
-ARG DEBIAN_TAG=12.5-slim@sha256:67f3931ad8cb1967beec602d8c0506af1e37e8d73c2a0b38b181ec5d8560d395
+ARG DEBIAN_TAG=12.6-slim@sha256:f528891ab1aa484bf7233dbcc84f3c806c3e427571d75510a9d74bb5ec535b33
 ARG GOLANG_TAG=1.22.4-alpine@sha256:ace6cc3fe58d0c7b12303c57afe6d6724851152df55e08057b43990b927ad5e8
 
 # renovate: datasource=github-releases depName=hashicorp/terraform versioning=hashicorp


### PR DESCRIPTION
## what

Changes the base Debian image from 12.5-slim to 12.6-slim

## why

The last update to 12.5-slim was 20 days ago

## tests

Building the container and running it via Docker Desktop

## references

12.5 is no longer listed as a supported tag on [Docker Hub](https://hub.docker.com/_/debian)
