### PR TITLE
chore: do not store context in struct for e2e tests

### DIFF
--- a/e2e/github.go
+++ b/e2e/github.go
@@ -14,13 +14,10 @@
 package main
 
 import (
-	"context"
-
 	"github.com/google/go-github/v59/github"
 )
 
 type GithubClient struct {
 	client   *github.Client
-	ctx      context.Context
 	username string
 }


### PR DESCRIPTION
## what

Remove `context.Context` from struct in `GithubClient` in e2e tests.

## why

Storing context in a struct is explicitly discouraged: https://go.dev/blog/context-and-structs

The reason I'm doing this now is because I am starting to work on #4582, so simplifying the code here first will make this easier.

## tests

I ran ./scripts/e2e.sh manually and it passed.

## references

https://go.dev/blog/context-and-structs