### PR TITLE
chore: Use existing github env vars for e2e

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,8 +107,8 @@ jobs:
     if: github.event.pull_request.head.repo.fork == false
     env:
       TERRAFORM_VERSION: 1.8.3
-      ATLANTISBOT_GITHUB_USERNAME: ${{ secrets.ATLANTISBOT_GITHUB_USERNAME }}
-      ATLANTISBOT_GITHUB_TOKEN: ${{ secrets.ATLANTISBOT_GITHUB_TOKEN }}
+      ATLANTIS_GH_USER: ${{ secrets.ATLANTISBOT_GITHUB_USERNAME }}
+      ATLANTIS_GH_TOKEN: ${{ secrets.ATLANTISBOT_GITHUB_TOKEN }}
       NGROK_AUTH_TOKEN: ${{ secrets.ATLANTISBOT_NGROK_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4

--- a/e2e/github.go
+++ b/e2e/github.go
@@ -34,13 +34,13 @@ type GithubClient struct {
 
 func NewGithubClient() *GithubClient {
 
-	githubUsername := os.Getenv("ATLANTISBOT_GITHUB_USERNAME")
+	githubUsername := os.Getenv("ATLANTIS_GH_USER")
 	if githubUsername == "" {
-		log.Fatalf("ATLANTISBOT_GITHUB_USERNAME cannot be empty")
+		log.Fatalf("ATLANTIS_GH_USER cannot be empty")
 	}
-	githubToken := os.Getenv("ATLANTISBOT_GITHUB_TOKEN")
+	githubToken := os.Getenv("ATLANTIS_GH_TOKEN")
 	if githubToken == "" {
-		log.Fatalf("ATLANTISBOT_GITHUB_TOKEN cannot be empty")
+		log.Fatalf("ATLANTIS_GH_TOKEN cannot be empty")
 	}
 	ownerName := os.Getenv("GITHUB_REPO_OWNER_NAME")
 	if ownerName == "" {

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -5,8 +5,6 @@ IFS=$'\n\t'
 
 # start atlantis server in the background and wait for it to start
 ./atlantis server \
-  --gh-user="$ATLANTISBOT_GITHUB_USERNAME" \
-  --gh-token="$ATLANTISBOT_GITHUB_TOKEN" \
   --data-dir="/tmp" \
   --log-level="debug" \
   --repo-allowlist="github.com/runatlantis/atlantis-tests" \


### PR DESCRIPTION
## what

Use standard `ATLANTIS_` env vars for configuring e2e instead of bespoke `ATLANTISBOT` ones.


## why

Consolidate and simplify.

This will also make #4582 a bit easier

## tests

Ran ./scripts/e2e.sh manually.

## references

Working towards: #4582

