### PR TITLE
fix: Apkfix-cherrypick-0.28

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1@sha256:a57df69d0ea827fb7266491f2813635de6f17269be881f696fbfdf2d83dda33e
 # what distro is the image being built for
-ARG ALPINE_TAG=3.20.0@sha256:77726ef6b57ddf65bb551896826ec38bc3e53f75cdde31354fbffb4f25238ebd
-ARG DEBIAN_TAG=12.5-slim@sha256:67f3931ad8cb1967beec602d8c0506af1e37e8d73c2a0b38b181ec5d8560d395
-ARG GOLANG_TAG=1.22.4-alpine@sha256:6522f0ca555a7b14c46a2c9f50b86604a234cdc72452bf6a268cae6461d9000b
+ARG ALPINE_TAG=3.20.1@sha256:b89d9c93e9ed3597455c90a0b88a8bbb5cb7188438f70953fede212a0c4394e0
+ARG DEBIAN_TAG=12.6-slim@sha256:f528891ab1aa484bf7233dbcc84f3c806c3e427571d75510a9d74bb5ec535b33
+ARG GOLANG_TAG=1.22.5-alpine@sha256:8c9183f715b0b4eca05b8b3dbf59766aaedb41ec07477b132ee2891ac0110a07
 
 # renovate: datasource=github-releases depName=hashicorp/terraform versioning=hashicorp
 ARG DEFAULT_TERRAFORM_VERSION=1.8.5
@@ -157,7 +157,7 @@ COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 # Install packages needed to run Atlantis.
 # We place this last as it will bust less docker layer caches when packages update
 RUN apk add --no-cache \
-        ca-certificates~=20240226-r0 \
+        ca-certificates~=20240705-r0 \
         curl~=8 \
         git~=2 \
         unzip~=6 \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/runatlantis/atlantis
 
-go 1.22.4
+go 1.22.5
 
 require (
 	code.gitea.io/sdk/gitea v0.18.0

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.4@sha256:c2010b9c2342431a24a2e64e33d9eb2e484af49e72c820e200d332d214d5e61f
+FROM golang:1.22.5@sha256:fcae9e0e7313c6467a7c6632ebb5e5fab99bd39bd5eb6ee34a211353e647827a
 
 RUN apt-get update && apt-get --no-install-recommends -y install unzip \
     && apt-get clean \


### PR DESCRIPTION
Signed-off-by: Rui Chen <rui@chenrui.dev>
Co-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>
Co-authored-by: Rui Chen <rui@chenrui.dev>

## what

Fix Ca-cert package for Alpine
Update go 


## why

Images are not building in alpine

## tests

tested localy and in githubaction

## references

https://github.com/runatlantis/atlantis/actions/runs/9943081422/job/27466060928

