### PR TITLE
feat: selfapprove flag for approving policies

### DIFF
--- a/runatlantis.io/docs/policy-checking.md
+++ b/runatlantis.io/docs/policy-checking.md
@@ -71,7 +71,7 @@ policies:
 - `source` - Tells atlantis where to fetch the policies from. Currently you can only host policies locally by using `local`.
 - `owners` - Defines the users/teams which are able to approve a specific policy set.
 - `approve_count` - Defines the number of approvals needed to bypass policy checks. Defaults to the top-level policies configuration, if not specified.
-- `self_approve` - Defines whether the PR author can approve policies (the author must be in owners)
+- `prevent_self_approve` - Defines whether the PR author can approve policies
 
 By default conftest is configured to only run the `main` package. If you wish to run specific/multiple policies consider passing `--namespace` or `--all-namespaces` to conftest with [`extra_args`](custom-workflows.md#adding-extra-arguments-to-terraform-commands) via a custom workflow as shown in the below example.
 

--- a/runatlantis.io/docs/policy-checking.md
+++ b/runatlantis.io/docs/policy-checking.md
@@ -71,6 +71,7 @@ policies:
 - `source` - Tells atlantis where to fetch the policies from. Currently you can only host policies locally by using `local`.
 - `owners` - Defines the users/teams which are able to approve a specific policy set.
 - `approve_count` - Defines the number of approvals needed to bypass policy checks. Defaults to the top-level policies configuration, if not specified.
+- `self_approve` - Defines whether the PR author can approve policies (the author must be in owners)
 
 By default conftest is configured to only run the `main` package. If you wish to run specific/multiple policies consider passing `--namespace` or `--all-namespaces` to conftest with [`extra_args`](custom-workflows.md#adding-extra-arguments-to-terraform-commands) via a custom workflow as shown in the below example.
 

--- a/runatlantis.io/docs/server-side-repo-config.md
+++ b/runatlantis.io/docs/server-side-repo-config.md
@@ -607,12 +607,12 @@ mode: on_apply
 
 ### PolicySet
 
-| Key          | Type   | Default | Required | Description                                                                                                   |
-| ------       | ------ | ------- | -------- | --------------------------------------------------------------------------------------------------------------|
-| name         | string | none    | yes      | unique name for the policy set                                                                                |
-| path         | string | none    | yes      | path to the rego policies directory                                                                           |
-| source       | string | none    | yes      | only `local` is supported at this time                                                                        |
-| self_approve | bool   | false   | no       | Whether or not the author of PR can approve policies. Defaults to `false` (the author must also be in owners) |
+| Key                  | Type   | Default | Required | Description                                                                                                   |
+| ------               | ------ | ------- | -------- | --------------------------------------------------------------------------------------------------------------|
+| name                 | string | none    | yes      | unique name for the policy set                                                                                |
+| path                 | string | none    | yes      | path to the rego policies directory                                                                           |
+| source               | string | none    | yes      | only `local` is supported at this time                                                                        |
+| prevent_self_approve | bool   | false   | no       | Whether or not the author of PR can approve policies. Defaults to `false` (the author must also be in owners) |
 
 ### Metrics
 

--- a/runatlantis.io/docs/server-side-repo-config.md
+++ b/runatlantis.io/docs/server-side-repo-config.md
@@ -607,11 +607,12 @@ mode: on_apply
 
 ### PolicySet
 
-| Key    | Type   | Default | Required | Description                            |
-| ------ | ------ | ------- | -------- | -------------------------------------- |
-| name   | string | none    | yes      | unique name for the policy set         |
-| path   | string | none    | yes      | path to the rego policies directory    |
-| source | string | none    | yes      | only `local` is supported at this time |
+| Key          | Type   | Default | Required | Description                                                                                                   |
+| ------       | ------ | ------- | -------- | --------------------------------------------------------------------------------------------------------------|
+| name         | string | none    | yes      | unique name for the policy set                                                                                |
+| path         | string | none    | yes      | path to the rego policies directory                                                                           |
+| source       | string | none    | yes      | only `local` is supported at this time                                                                        |
+| self_approve | bool   | false   | no       | Whether or not the author of PR can approve policies. Defaults to `false` (the author must also be in owners) |
 
 ### Metrics
 

--- a/server/core/config/raw/policies.go
+++ b/server/core/config/raw/policies.go
@@ -75,6 +75,7 @@ type PolicySet struct {
 	Name         string       `yaml:"name" json:"name"`
 	Owners       PolicyOwners `yaml:"owners,omitempty" json:"owners,omitempty"`
 	ApproveCount int          `yaml:"approve_count,omitempty" json:"approve_count,omitempty"`
+	SelfApprove  bool         `yaml:"self_approve,omitempty" json:"self_approve,omitempty"`
 }
 
 func (p PolicySet) Validate() error {
@@ -94,6 +95,7 @@ func (p PolicySet) ToValid() valid.PolicySet {
 	policySet.Path = p.Path
 	policySet.Source = p.Source
 	policySet.ApproveCount = p.ApproveCount
+	policySet.SelfApprove = p.SelfApprove
 	policySet.Owners = p.Owners.ToValid()
 
 	return policySet

--- a/server/core/config/raw/policies.go
+++ b/server/core/config/raw/policies.go
@@ -70,12 +70,12 @@ func (o PolicyOwners) ToValid() valid.PolicyOwners {
 }
 
 type PolicySet struct {
-	Path         string       `yaml:"path" json:"path"`
-	Source       string       `yaml:"source" json:"source"`
-	Name         string       `yaml:"name" json:"name"`
-	Owners       PolicyOwners `yaml:"owners,omitempty" json:"owners,omitempty"`
-	ApproveCount int          `yaml:"approve_count,omitempty" json:"approve_count,omitempty"`
-	SelfApprove  bool         `yaml:"self_approve,omitempty" json:"self_approve,omitempty"`
+	Path               string       `yaml:"path" json:"path"`
+	Source             string       `yaml:"source" json:"source"`
+	Name               string       `yaml:"name" json:"name"`
+	Owners             PolicyOwners `yaml:"owners,omitempty" json:"owners,omitempty"`
+	ApproveCount       int          `yaml:"approve_count,omitempty" json:"approve_count,omitempty"`
+	PreventSelfApprove bool         `yaml:"self_approve,omitempty" json:"prevent_self_approve,omitempty"`
 }
 
 func (p PolicySet) Validate() error {
@@ -95,7 +95,7 @@ func (p PolicySet) ToValid() valid.PolicySet {
 	policySet.Path = p.Path
 	policySet.Source = p.Source
 	policySet.ApproveCount = p.ApproveCount
-	policySet.SelfApprove = p.SelfApprove
+	policySet.PreventSelfApprove = p.PreventSelfApprove
 	policySet.Owners = p.Owners.ToValid()
 
 	return policySet

--- a/server/core/config/valid/policies.go
+++ b/server/core/config/valid/policies.go
@@ -27,12 +27,12 @@ type PolicyOwners struct {
 }
 
 type PolicySet struct {
-	Source       string
-	Path         string
-	Name         string
-	ApproveCount int
-	Owners       PolicyOwners
-	SelfApprove  bool
+	Source             string
+	Path               string
+	Name               string
+	ApproveCount       int
+	Owners             PolicyOwners
+	PreventSelfApprove bool
 }
 
 func (p *PolicySets) HasPolicies() bool {

--- a/server/core/config/valid/policies.go
+++ b/server/core/config/valid/policies.go
@@ -32,6 +32,7 @@ type PolicySet struct {
 	Name         string
 	ApproveCount int
 	Owners       PolicyOwners
+	SelfApprove  bool
 }
 
 func (p *PolicySets) HasPolicies() bool {

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -377,7 +377,7 @@ func (p *DefaultProjectCommandRunner) doApprovePolicies(ctx command.ProjectConte
 					ignorePolicy = true
 				}
 				// Increment approval if user is owner.
-				if isOwner && !ignorePolicy && (ctx.User.Username != ctx.Pull.Author || policySet.SelfApprove) {
+				if isOwner && !ignorePolicy && (ctx.User.Username != ctx.Pull.Author || !policySet.PreventSelfApprove) {
 					if !ctx.ClearPolicyApproval {
 						prjPolicyStatus[i].Approvals = policyStatus.Approvals + 1
 					} else {

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -377,7 +377,7 @@ func (p *DefaultProjectCommandRunner) doApprovePolicies(ctx command.ProjectConte
 					ignorePolicy = true
 				}
 				// Increment approval if user is owner.
-				if isOwner && !ignorePolicy {
+				if isOwner && !ignorePolicy && (ctx.User.Username != ctx.Pull.Author || policySet.SelfApprove) {
 					if !ctx.ClearPolicyApproval {
 						prjPolicyStatus[i].Approvals = policyStatus.Approvals + 1
 					} else {
@@ -391,6 +391,7 @@ func (p *DefaultProjectCommandRunner) doApprovePolicies(ctx command.ProjectConte
 				if !policyStatus.Passed && (prjPolicyStatus[i].Approvals != policySet.ApproveCount) {
 					allPassed = false
 				}
+
 				prjPolicySetResults = append(prjPolicySetResults, models.PolicySetResult{
 					PolicySetName: policySet.Name,
 					Passed:        policyStatus.Passed,

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -791,10 +791,12 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 					{
 						Name:         "policy1",
 						ApproveCount: 1,
+						SelfApprove:  true,
 					},
 					{
 						Name:         "policy2",
 						ApproveCount: 2,
+						SelfApprove:  true,
 					},
 				},
 			},
@@ -823,10 +825,12 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy1",
 						ApproveCount: 1,
+						SelfApprove:  true,
 					},
 					{
 						Name:         "policy2",
 						ApproveCount: 2,
+						SelfApprove:  true,
 					},
 				},
 			},
@@ -855,10 +859,12 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 					{
 						Name:         "policy1",
 						ApproveCount: 1,
+						SelfApprove:  true,
 					},
 					{
 						Name:         "policy2",
 						ApproveCount: 1,
+						SelfApprove:  true,
 					},
 				},
 			},
@@ -888,10 +894,12 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy1",
 						ApproveCount: 1,
+						SelfApprove:  true,
 					},
 					{
 						Name:         "policy2",
 						ApproveCount: 1,
+						SelfApprove:  true,
 					},
 				},
 			},
@@ -920,6 +928,7 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy1",
 						ApproveCount: 2,
+						SelfApprove:  true,
 					},
 				},
 			},
@@ -950,6 +959,7 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy1",
 						ApproveCount: 2,
+						SelfApprove:  true,
 					},
 				},
 			},
@@ -983,6 +993,7 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy1",
 						ApproveCount: 1,
+						SelfApprove:  true,
 					},
 					{
 						Owners: valid.PolicyOwners{
@@ -990,6 +1001,7 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy2",
 						ApproveCount: 1,
+						SelfApprove:  true,
 					},
 				},
 			},
@@ -1032,6 +1044,7 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy1",
 						ApproveCount: 1,
+						SelfApprove:  true,
 					},
 					{
 						Owners: valid.PolicyOwners{
@@ -1039,6 +1052,7 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy2",
 						ApproveCount: 2,
+						SelfApprove:  true,
 					},
 				},
 			},
@@ -1081,6 +1095,7 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy1",
 						ApproveCount: 1,
+						SelfApprove:  true,
 					},
 					{
 						Owners: valid.PolicyOwners{
@@ -1088,6 +1103,7 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy2",
 						ApproveCount: 2,
+						SelfApprove:  true,
 					},
 				},
 			},
@@ -1131,6 +1147,7 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy1",
 						ApproveCount: 1,
+						SelfApprove:  true,
 					},
 					{
 						Owners: valid.PolicyOwners{
@@ -1138,6 +1155,7 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy2",
 						ApproveCount: 2,
+						SelfApprove:  true,
 					},
 				},
 			},
@@ -1167,6 +1185,56 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 			},
 			expFailure: `One or more policy sets require additional approval.`,
 			hasErr:     false,
+		},
+		{
+			description:         "Policy Approval should not be the Author of the PR",
+			userTeams:           []string{"someuserteam"},
+			clearPolicyApproval: false,
+			policySetCfg: valid.PolicySets{
+				PolicySets: []valid.PolicySet{
+					{
+						Owners: valid.PolicyOwners{
+							Users: []string{"lkysow"},
+						},
+						Name:         "policy1",
+						ApproveCount: 1,
+						SelfApprove:  true,
+					},
+					{
+						Owners: valid.PolicyOwners{
+							Users: []string{"lkysow"},
+						},
+						Name:         "policy2",
+						ApproveCount: 1,
+					},
+				},
+			},
+			policySetStatus: []models.PolicySetStatus{
+				{
+					PolicySetName: "policy1",
+					Approvals:     0,
+					Passed:        false,
+				},
+				{
+					PolicySetName: "policy2",
+					Approvals:     0,
+					Passed:        false,
+				},
+			},
+			expOut: []models.PolicySetResult{
+				{
+					PolicySetName: "policy1",
+					ReqApprovals:  1,
+					CurApprovals:  1,
+				},
+				{
+					PolicySetName: "policy2",
+					ReqApprovals:  1,
+					CurApprovals:  0,
+				},
+			},
+			expFailure: `One or more policy sets require additional approval.`,
+			hasErr:     true,
 		},
 	}
 
@@ -1225,7 +1293,7 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 				projPolicyStatus = c.policySetStatus
 			}
 
-			modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num}
+			modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, Author: testdata.User.Username}
 			When(runner.VcsClient.GetTeamNamesForUser(testdata.GithubRepo, testdata.User)).ThenReturn(c.userTeams, nil)
 			ctx := command.ProjectContext{
 				User:                testdata.User,

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -791,12 +791,10 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 					{
 						Name:         "policy1",
 						ApproveCount: 1,
-						SelfApprove:  true,
 					},
 					{
 						Name:         "policy2",
 						ApproveCount: 2,
-						SelfApprove:  true,
 					},
 				},
 			},
@@ -825,12 +823,10 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy1",
 						ApproveCount: 1,
-						SelfApprove:  true,
 					},
 					{
 						Name:         "policy2",
 						ApproveCount: 2,
-						SelfApprove:  true,
 					},
 				},
 			},
@@ -859,12 +855,10 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 					{
 						Name:         "policy1",
 						ApproveCount: 1,
-						SelfApprove:  true,
 					},
 					{
 						Name:         "policy2",
 						ApproveCount: 1,
-						SelfApprove:  true,
 					},
 				},
 			},
@@ -894,12 +888,10 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy1",
 						ApproveCount: 1,
-						SelfApprove:  true,
 					},
 					{
 						Name:         "policy2",
 						ApproveCount: 1,
-						SelfApprove:  true,
 					},
 				},
 			},
@@ -928,7 +920,6 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy1",
 						ApproveCount: 2,
-						SelfApprove:  true,
 					},
 				},
 			},
@@ -959,7 +950,6 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy1",
 						ApproveCount: 2,
-						SelfApprove:  true,
 					},
 				},
 			},
@@ -993,7 +983,6 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy1",
 						ApproveCount: 1,
-						SelfApprove:  true,
 					},
 					{
 						Owners: valid.PolicyOwners{
@@ -1001,7 +990,6 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy2",
 						ApproveCount: 1,
-						SelfApprove:  true,
 					},
 				},
 			},
@@ -1044,7 +1032,6 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy1",
 						ApproveCount: 1,
-						SelfApprove:  true,
 					},
 					{
 						Owners: valid.PolicyOwners{
@@ -1052,7 +1039,6 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy2",
 						ApproveCount: 2,
-						SelfApprove:  true,
 					},
 				},
 			},
@@ -1095,7 +1081,6 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy1",
 						ApproveCount: 1,
-						SelfApprove:  true,
 					},
 					{
 						Owners: valid.PolicyOwners{
@@ -1103,7 +1088,6 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy2",
 						ApproveCount: 2,
-						SelfApprove:  true,
 					},
 				},
 			},
@@ -1147,7 +1131,6 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy1",
 						ApproveCount: 1,
-						SelfApprove:  true,
 					},
 					{
 						Owners: valid.PolicyOwners{
@@ -1155,7 +1138,6 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy2",
 						ApproveCount: 2,
-						SelfApprove:  true,
 					},
 				},
 			},
@@ -1198,14 +1180,14 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 						},
 						Name:         "policy1",
 						ApproveCount: 1,
-						SelfApprove:  true,
 					},
 					{
 						Owners: valid.PolicyOwners{
 							Users: []string{"lkysow"},
 						},
-						Name:         "policy2",
-						ApproveCount: 1,
+						Name:               "policy2",
+						ApproveCount:       1,
+						PreventSelfApprove: true,
 					},
 				},
 			},


### PR DESCRIPTION
## what

introducing `SelfApprove` flag to control if the author can approve.


## why

I think it makes sense to have the ability to control if the author can approve the policy checks. 

## tests

<!--
- [ ] I have tested my changes by ...
-->

## references

- https://github.com/runatlantis/atlantis/issues/4813
