### PR TITLE
fix: Add Template Files to CI Test Job Filters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ jobs:
               - '**.go'
               - '**.txt' # golden file test output
               - 'go.*'
+              - '**.tmpl'
               - '.github/workflows/test.yml'
   test:
     needs: [changes]


### PR DESCRIPTION
## what

Add `**.tmpl` files to the CI test job filters list.

## why

Currently, if only Go template files are updated in a PR, the test CI does not run. This has caused an issue with https://github.com/runatlantis/atlantis/pull/4787 being merged without the relevant test files being updated.
