### PR TITLE
feat: Add PROJECT_NAME env var to custom workflow hook

### DIFF
--- a/server/core/runtime/post_workflow_hook_runner.go
+++ b/server/core/runtime/post_workflow_hook_runner.go
@@ -38,6 +38,7 @@ func (wh DefaultPostWorkflowHookRunner) Run(ctx models.WorkflowHookCommandContex
 		"HEAD_COMMIT":        ctx.Pull.HeadCommit,
 		"HEAD_REPO_NAME":     ctx.HeadRepo.Name,
 		"HEAD_REPO_OWNER":    ctx.HeadRepo.Owner,
+		"PROJECT_NAME":       ctx.ProjectName,
 		"PULL_AUTHOR":        ctx.Pull.Author,
 		"PULL_NUM":           fmt.Sprintf("%d", ctx.Pull.Num),
 		"PULL_URL":           ctx.Pull.URL,

--- a/server/core/runtime/post_workflow_hook_runner_test.go
+++ b/server/core/runtime/post_workflow_hook_runner_test.go
@@ -24,6 +24,7 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 
 	cases := []struct {
 		Command        string
+		ProjectName    string
 		Shell          string
 		ShellArgs      string
 		ExpOut         string
@@ -32,6 +33,7 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 	}{
 		{
 			Command:        "",
+			ProjectName:    "",
 			Shell:          defaultShell,
 			ShellArgs:      defaultShellArgs,
 			ExpOut:         "",
@@ -40,6 +42,7 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 		},
 		{
 			Command:        "echo hi",
+			ProjectName:    "",
 			Shell:          defaultShell,
 			ShellArgs:      defaultShellArgs,
 			ExpOut:         "hi\r\n",
@@ -48,6 +51,7 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 		},
 		{
 			Command:        `printf \'your main.tf file does not provide default region.\\ncheck\'`,
+			ProjectName:    "",
 			Shell:          defaultShell,
 			ShellArgs:      defaultShellArgs,
 			ExpOut:         `'your`,
@@ -56,6 +60,7 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 		},
 		{
 			Command:        `printf 'your main.tf file does not provide default region.\ncheck'`,
+			ProjectName:    "",
 			Shell:          defaultShell,
 			ShellArgs:      defaultShellArgs,
 			ExpOut:         "your main.tf file does not provide default region.\r\ncheck",
@@ -64,6 +69,7 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 		},
 		{
 			Command:        "echo 'a",
+			ProjectName:    "",
 			Shell:          defaultShell,
 			ShellArgs:      defaultShellArgs,
 			ExpOut:         defaultUnterminatedStringError,
@@ -72,6 +78,7 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 		},
 		{
 			Command:        "echo hi >> file && cat file",
+			ProjectName:    "",
 			Shell:          defaultShell,
 			ShellArgs:      defaultShellArgs,
 			ExpOut:         "hi\r\n",
@@ -80,6 +87,7 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 		},
 		{
 			Command:        "lkjlkj",
+			ProjectName:    "",
 			Shell:          defaultShell,
 			ShellArgs:      defaultShellArgs,
 			ExpOut:         fmt.Sprintf(defautShellCommandNotFoundErrorFormat, "lkjlkj"),
@@ -87,15 +95,17 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 			ExpDescription: "",
 		},
 		{
-			Command:        "echo base_repo_name=$BASE_REPO_NAME base_repo_owner=$BASE_REPO_OWNER head_repo_name=$HEAD_REPO_NAME head_repo_owner=$HEAD_REPO_OWNER head_branch_name=$HEAD_BRANCH_NAME head_commit=$HEAD_COMMIT base_branch_name=$BASE_BRANCH_NAME pull_num=$PULL_NUM pull_url=$PULL_URL pull_author=$PULL_AUTHOR",
+			Command:        "echo base_repo_name=$BASE_REPO_NAME base_repo_owner=$BASE_REPO_OWNER head_repo_name=$HEAD_REPO_NAME head_repo_owner=$HEAD_REPO_OWNER head_branch_name=$HEAD_BRANCH_NAME head_commit=$HEAD_COMMIT base_branch_name=$BASE_BRANCH_NAME pull_num=$PULL_NUM pull_url=$PULL_URL pull_author=$PULL_AUTHOR project=$PROJECT_NAME",
+			ProjectName:    "my/project/name",
 			Shell:          defaultShell,
 			ShellArgs:      defaultShellArgs,
-			ExpOut:         "base_repo_name=basename base_repo_owner=baseowner head_repo_name=headname head_repo_owner=headowner head_branch_name=add-feat head_commit=12345abcdef base_branch_name=main pull_num=2 pull_url=https://github.com/runatlantis/atlantis/pull/2 pull_author=acme\r\n",
+			ExpOut:         "base_repo_name=basename base_repo_owner=baseowner head_repo_name=headname head_repo_owner=headowner head_branch_name=add-feat head_commit=12345abcdef base_branch_name=main pull_num=2 pull_url=https://github.com/runatlantis/atlantis/pull/2 pull_author=acme project=my/project/name\r\n",
 			ExpErr:         "",
 			ExpDescription: "",
 		},
 		{
 			Command:        "echo user_name=$USER_NAME",
+			ProjectName:    "",
 			Shell:          defaultShell,
 			ShellArgs:      defaultShellArgs,
 			ExpOut:         "user_name=acme-user\r\n",
@@ -104,6 +114,7 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 		},
 		{
 			Command:        "echo something > $OUTPUT_STATUS_FILE",
+			ProjectName:    "",
 			Shell:          defaultShell,
 			ShellArgs:      defaultShellArgs,
 			ExpOut:         "",
@@ -112,6 +123,7 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 		},
 		{
 			Command:        "echo shell test 1",
+			ProjectName:    "",
 			Shell:          "bash",
 			ShellArgs:      defaultShellArgs,
 			ExpOut:         "shell test 1\r\n",
@@ -120,6 +132,7 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 		},
 		{
 			Command:        "echo shell test 2",
+			ProjectName:    "",
 			Shell:          defaultShell,
 			ShellArgs:      "-cx",
 			ExpOut:         "+ echo shell test 2\r\nshell test 2\r\n",
@@ -128,6 +141,7 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 		},
 		{
 			Command:        "echo shell test 3",
+			ProjectName:    "",
 			Shell:          "bash",
 			ShellArgs:      "-cv",
 			ExpOut:         "echo shell test 3\r\nshell test 3\r\n",
@@ -176,6 +190,7 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 				},
 				Log:         logger,
 				CommandName: "plan",
+				ProjectName: c.ProjectName,
 			}
 			_, desc, err := r.Run(ctx, c.Command, c.Shell, c.ShellArgs, tmpDir)
 			if c.ExpErr != "" {

--- a/server/core/runtime/pre_workflow_hook_runner.go
+++ b/server/core/runtime/pre_workflow_hook_runner.go
@@ -38,6 +38,7 @@ func (wh DefaultPreWorkflowHookRunner) Run(ctx models.WorkflowHookCommandContext
 		"HEAD_COMMIT":        ctx.Pull.HeadCommit,
 		"HEAD_REPO_NAME":     ctx.HeadRepo.Name,
 		"HEAD_REPO_OWNER":    ctx.HeadRepo.Owner,
+		"PROJECT_NAME":       ctx.ProjectName,
 		"PULL_AUTHOR":        ctx.Pull.Author,
 		"PULL_NUM":           fmt.Sprintf("%d", ctx.Pull.Num),
 		"PULL_URL":           ctx.Pull.URL,

--- a/server/core/runtime/pre_workflow_hook_runner_test.go
+++ b/server/core/runtime/pre_workflow_hook_runner_test.go
@@ -44,6 +44,7 @@ func TestPreWorkflowHookRunner_Run(t *testing.T) {
 
 	cases := []struct {
 		Command        string
+		ProjectName    string
 		Shell          string
 		ShellArgs      string
 		ExpOut         string
@@ -52,6 +53,7 @@ func TestPreWorkflowHookRunner_Run(t *testing.T) {
 	}{
 		{
 			Command:        "",
+			ProjectName:    "",
 			Shell:          defaultShell,
 			ShellArgs:      defaultShellArgs,
 			ExpOut:         "",
@@ -60,6 +62,7 @@ func TestPreWorkflowHookRunner_Run(t *testing.T) {
 		},
 		{
 			Command:        "echo hi",
+			ProjectName:    "",
 			Shell:          defaultShell,
 			ShellArgs:      defaultShellArgs,
 			ExpOut:         "hi\r\n",
@@ -68,6 +71,7 @@ func TestPreWorkflowHookRunner_Run(t *testing.T) {
 		},
 		{
 			Command:        `printf \'your main.tf file does not provide default region.\\ncheck\'`,
+			ProjectName:    "",
 			Shell:          defaultShell,
 			ShellArgs:      defaultShellArgs,
 			ExpOut:         `'your`,
@@ -76,6 +80,7 @@ func TestPreWorkflowHookRunner_Run(t *testing.T) {
 		},
 		{
 			Command:        `printf 'your main.tf file does not provide default region.\ncheck'`,
+			ProjectName:    "",
 			Shell:          defaultShell,
 			ShellArgs:      defaultShellArgs,
 			ExpOut:         "your main.tf file does not provide default region.\r\ncheck",
@@ -84,6 +89,7 @@ func TestPreWorkflowHookRunner_Run(t *testing.T) {
 		},
 		{
 			Command:        "echo 'a",
+			ProjectName:    "",
 			Shell:          defaultShell,
 			ShellArgs:      defaultShellArgs,
 			ExpOut:         defaultUnterminatedStringError,
@@ -92,6 +98,7 @@ func TestPreWorkflowHookRunner_Run(t *testing.T) {
 		},
 		{
 			Command:        "echo hi >> file && cat file",
+			ProjectName:    "",
 			Shell:          defaultShell,
 			ShellArgs:      defaultShellArgs,
 			ExpOut:         "hi\r\n",
@@ -100,6 +107,7 @@ func TestPreWorkflowHookRunner_Run(t *testing.T) {
 		},
 		{
 			Command:        "lkjlkj",
+			ProjectName:    "",
 			Shell:          defaultShell,
 			ShellArgs:      defaultShellArgs,
 			ExpOut:         fmt.Sprintf(defautShellCommandNotFoundErrorFormat, "lkjlkj"),
@@ -107,15 +115,17 @@ func TestPreWorkflowHookRunner_Run(t *testing.T) {
 			ExpDescription: "",
 		},
 		{
-			Command:        "echo base_repo_name=$BASE_REPO_NAME base_repo_owner=$BASE_REPO_OWNER head_repo_name=$HEAD_REPO_NAME head_repo_owner=$HEAD_REPO_OWNER head_branch_name=$HEAD_BRANCH_NAME head_commit=$HEAD_COMMIT base_branch_name=$BASE_BRANCH_NAME pull_num=$PULL_NUM pull_url=$PULL_URL pull_author=$PULL_AUTHOR",
+			Command:        "echo base_repo_name=$BASE_REPO_NAME base_repo_owner=$BASE_REPO_OWNER head_repo_name=$HEAD_REPO_NAME head_repo_owner=$HEAD_REPO_OWNER head_branch_name=$HEAD_BRANCH_NAME head_commit=$HEAD_COMMIT base_branch_name=$BASE_BRANCH_NAME pull_num=$PULL_NUM pull_url=$PULL_URL pull_author=$PULL_AUTHOR project=$PROJECT_NAME",
+			ProjectName:    "my/project/name",
 			Shell:          defaultShell,
 			ShellArgs:      defaultShellArgs,
-			ExpOut:         "base_repo_name=basename base_repo_owner=baseowner head_repo_name=headname head_repo_owner=headowner head_branch_name=add-feat head_commit=12345abcdef base_branch_name=main pull_num=2 pull_url=https://github.com/runatlantis/atlantis/pull/2 pull_author=acme\r\n",
+			ExpOut:         "base_repo_name=basename base_repo_owner=baseowner head_repo_name=headname head_repo_owner=headowner head_branch_name=add-feat head_commit=12345abcdef base_branch_name=main pull_num=2 pull_url=https://github.com/runatlantis/atlantis/pull/2 pull_author=acme project=my/project/name\r\n",
 			ExpErr:         "",
 			ExpDescription: "",
 		},
 		{
 			Command:        "echo user_name=$USER_NAME",
+			ProjectName:    "",
 			Shell:          defaultShell,
 			ShellArgs:      defaultShellArgs,
 			ExpOut:         "user_name=acme-user\r\n",
@@ -124,6 +134,7 @@ func TestPreWorkflowHookRunner_Run(t *testing.T) {
 		},
 		{
 			Command:        "echo something > $OUTPUT_STATUS_FILE",
+			ProjectName:    "",
 			Shell:          defaultShell,
 			ShellArgs:      defaultShellArgs,
 			ExpOut:         "",
@@ -132,6 +143,7 @@ func TestPreWorkflowHookRunner_Run(t *testing.T) {
 		},
 		{
 			Command:        "echo shell test 1",
+			ProjectName:    "",
 			Shell:          "bash",
 			ShellArgs:      defaultShellArgs,
 			ExpOut:         "shell test 1\r\n",
@@ -140,6 +152,7 @@ func TestPreWorkflowHookRunner_Run(t *testing.T) {
 		},
 		{
 			Command:        "echo shell test 2",
+			ProjectName:    "",
 			Shell:          defaultShell,
 			ShellArgs:      "-cx",
 			ExpOut:         "+ echo shell test 2\r\nshell test 2\r\n",
@@ -148,6 +161,7 @@ func TestPreWorkflowHookRunner_Run(t *testing.T) {
 		},
 		{
 			Command:        "echo shell test 3",
+			ProjectName:    "",
 			Shell:          "bash",
 			ShellArgs:      "-cv",
 			ExpOut:         "echo shell test 3\r\nshell test 3\r\n",
@@ -196,6 +210,7 @@ func TestPreWorkflowHookRunner_Run(t *testing.T) {
 				},
 				Log:         logger,
 				CommandName: "plan",
+				ProjectName: c.ProjectName,
 			}
 			_, desc, err := r.Run(ctx, c.Command, c.Shell, c.ShellArgs, tmpDir)
 			if c.ExpErr != "" {


### PR DESCRIPTION
## what

I'd like to be able to use `$PROJECT_NAME` in the `post_workflow_hooks`  (and `pre_workflow_hooks`) configuration section. It's already available to `run` on custom workflows.

## why

I'd like to label the PR with info about which TF project was applied.

## tests

I updated the tests for these two hooks to test PROJECT_NAME, but I'm still seeing two test errors that seem unrelated in:

```
--- FAIL: TestRenderProjectResults (0.00s)
    logger.go:146: 2024-08-02T14:38:41.327-0400	INFO	log
    --- FAIL: TestRenderProjectResults/single_successful_policy_check_with_project_name (0.00s)
        --- FAIL: TestRenderProjectResults/single_successful_policy_check_with_project_name/single_successful_policy_check_with_project_name (0.00s)
            markdown_renderer_test.go:1192: [Ran Policy Check for project: `projectname` dir: `path` workspace: `workspace`
            ...
            ...
        --- FAIL: TestRenderProjectResults/single_successful_policy_check_with_project_name/single_successful_policy_check_with_project_name#01 (0.00s)
            markdown_renderer_test.go:1189: [Ran Policy Check for project: `projectname` dir: `path` workspace: `workspace`
            ...
            ...
```

If I should fix these too, I just need someone who can point in the right direction.

## references

* https://github.com/runatlantis/atlantis/issues/539
* https://github.com/runatlantis/atlantis/pull/578