### PR TITLE
chore: revert "fix: added a space line"

### DIFF
--- a/server/events/templates/policy_check_results_wrapped.tmpl
+++ b/server/events/templates/policy_check_results_wrapped.tmpl
@@ -20,7 +20,6 @@
   ```
 {{- else }}
 </details>
-
 #### Policy Approval Status:
 ```
 {{ .PolicyApprovalSummary }}


### PR DESCRIPTION
Reverts runatlantis/atlantis#4787

---

this is causing all tests failing, thus reverting it.