### PR TITLE
feat: Log error on cleanup in e2e

### DIFF
--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -114,7 +114,12 @@ func (t *E2ETester) Start(ctx context.Context) (*E2EResult, error) {
 	log.Printf("created pull request %s", url)
 
 	// defer closing pull request and delete remote branch
-	defer cleanUp(ctx, t, pullId, branchName) // nolint: errcheck
+	defer func() {
+		err := cleanUp(ctx, t, pullId, branchName)
+		if err != nil {
+			log.Printf("Failed to cleanup: %v", err)
+		}
+	}()
 
 	// wait for atlantis to respond to webhook and autoplan.
 	time.Sleep(2 * time.Second)


### PR DESCRIPTION
## what

Log error that comes from `cleanup()` function in e2e tests.

## why

Since the cleanup function is deferred, we swallow the error and there's no way for the end user to know that it occurred.

I decided against trying to return this error from the main function, or even something like a log.Fatal, since it's just for cleanup, so stopping earlier isn't going to help anyone.

## tests

After this PR goes up I will make sure the github e2e runs correctly, then introduce an intentional error in cleanup and make sure that's logged as expected.

## references

Found while working on #4582
