### PR TITLE
feat: Log error on cleanup in e2e

### DIFF
--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -114,7 +114,12 @@ func (t *E2ETester) Start(ctx context.Context) (*E2EResult, error) {
 	log.Printf("created pull request %s", url)
 
 	// defer closing pull request and delete remote branch
-	defer cleanUp(ctx, t, pullId, branchName) // nolint: errcheck
+	defer func() {
+		err := cleanUp(ctx, t, pullId, branchName)
+		if err != nil {
+			log.Printf("Failed to cleanup: %v", err)
+		}
+	}()
 
 	// wait for atlantis to respond to webhook and autoplan.
 	time.Sleep(2 * time.Second)

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -175,5 +175,5 @@ func cleanUp(ctx context.Context, t *E2ETester, pullRequestNumber int, branchNam
 	}
 	log.Printf("deleted branch %s", deleteBranchName)
 
-    return fmt.Errorf("INTENTIONAL ERROR")
+	return nil
 }

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -175,5 +175,5 @@ func cleanUp(ctx context.Context, t *E2ETester, pullRequestNumber int, branchNam
 	}
 	log.Printf("deleted branch %s", deleteBranchName)
 
-	return nil
+    return fmt.Errorf("INTENTIONAL ERROR")
 }


### PR DESCRIPTION
## what

Log error that comes from `cleanup()` function in e2e tests.

## why

Since the cleanup function is deferred, we swallow the error and there's no way for the end user to know that it occurred.

I decided against trying to return this error from the main function, or even something like a log.Fatal, since it's just for cleanup, so stopping earlier isn't going to help anyone.

## tests

I ran a version of this PR with an intentional error in cleanup, and observed it did not fail the tests but did log:
https://github.com/runatlantis/atlantis/actions/runs/10356111645/job/28665262207?pr=4835#step:7:52

## references

Found while working on #4582