### PR TITLE
chore: Make e2e tests more vcs agnostic

### DIFF
--- a/e2e/github.go
+++ b/e2e/github.go
@@ -153,9 +153,23 @@ func (g GithubClient) ClosePullRequest(ctx context.Context, pullRequestNumber in
 }
 func (g GithubClient) DeleteBranch(ctx context.Context, branchName string) error {
 
-	_, err := g.client.Git.DeleteRef(ctx, g.ownerName, g.repoName, branchName)
+	deleteBranchName := fmt.Sprintf("%s/%s", "heads", branchName)
+	_, err := g.client.Git.DeleteRef(ctx, g.ownerName, g.repoName, deleteBranchName)
 	if err != nil {
 		return fmt.Errorf("error while deleting branch %s: %v", branchName, err)
 	}
 	return nil
+}
+
+func (g GithubClient) IsAtlantisInProgress(state string) bool {
+	for _, s := range []string{"success", "error", "failure"} {
+		if state == s {
+			return false
+		}
+	}
+	return true
+}
+
+func (g GithubClient) DidAtlantisSucceed(state string) bool {
+	return state == "success"
 }

--- a/e2e/vcs.go
+++ b/e2e/vcs.go
@@ -23,4 +23,6 @@ type VCSClient interface {
 	GetAtlantisStatus(ctx context.Context, branchName string) (string, error)
 	ClosePullRequest(ctx context.Context, pullRequestNumber int) error
 	DeleteBranch(ctx context.Context, branchName string) error
+	IsAtlantisInProgress(state string) bool
+	DidAtlantisSucceed(state string) bool
 }


### PR DESCRIPTION
## what

- Have `DeleteBranch()` take the bare branch name, not `heads/<branchName>` (the latter is apparently a github implementation detail)
- Instead of hard-coding the semantics of the "status" of an atlantis run, defer into the VCS. For example, Github has a state called `failure` whereas gitlab has a state called `failed`, both of which mean the same thing, and indicate that the run is done


## why

Make the e2e tests more agnostic to which VCS they are being run on. This will make it more straightforward to add new VCSs.

## tests

The e2e tests themselves passing should be good enough.

## references

Working towards #4582.

