### PR TITLE
chore: Improve process management in e2e test

### DIFF
--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -2,20 +2,67 @@
 
 set -euo pipefail
 IFS=$'\n\t'
+ATLANTIS_PID=""
+NGROK_PID=""
+
+function cleanup() {
+    cleanupPid "$ATLANTIS_PID"
+    cleanupPid "$NGROK_PID"
+}
+
+function cleanupPid() {
+    local pid="$1"
+    # Never set, no need to clean up
+    if [[ "$pid" == "" ]]
+    then
+        return
+    fi
+    # Somehow pid was not number, just being careful
+    if ! [[ "$pid" =~ ^[0-9]+$ ]]
+    then
+        return
+    fi
+    # Not currently running, no need to kill
+    if ! ps -p "$pid" &>/dev/null
+    then
+        return
+    fi
+    kill $pid
+}
+
 
 # start atlantis server in the background and wait for it to start
+# It's the responsibility of the caller of this script to set the github, gitlab, etc.
+# permissions via environment variable
 ./atlantis server \
   --data-dir="/tmp" \
   --log-level="debug" \
   --repo-allowlist="github.com/runatlantis/atlantis-tests" \
   --repo-config-json='{"repos":[{"id":"/.*/", "allowed_overrides":["apply_requirements","workflow"], "allow_custom_workflows":true}]}' \
   &> /tmp/atlantis-server.log &
+ATLANTIS_PID=$!
 sleep 2
+if ! ps -p "$ATLANTIS_PID" &>/dev/null
+then
+    echo "Atlantis failed to start"
+    cat /tmp/atlantis-server.log
+    exit 1
+fi
+echo "Atlantis is running..."
 
 # start ngrok in the background and wait for it to start
 ./ngrok config add-authtoken $NGROK_AUTH_TOKEN > /dev/null 2>&1
 ./ngrok http 4141 > /tmp/ngrok.log 2>&1 &
+NGROK_PID=$!
 sleep 2
+if ! ps -p "$NGROK_PID" &>/dev/null
+then
+    cleanup
+    echo "Ngrok failed to start"
+    cat /tmp/ngrok.log
+    exit 1
+fi
+echo "Ngrok is running..."
 
 # find out what URL ngrok has given us
 export ATLANTIS_URL=$(curl -s 'http://localhost:4040/api/tunnels' | jq -r '.tunnels[] | select(.proto=="https") | .public_url')
@@ -27,6 +74,7 @@ make build
 
 echo "Running e2e test: 'make run'"
 set +e
+estatus=0
 make run
 if [[ $? -eq 0 ]]
 then
@@ -35,5 +83,7 @@ else
   echo "e2e tests failed"
   echo "atlantis logs:"
   cat /tmp/atlantis-server.log
-  exit 1
+  estatus=1
 fi
+cleanup
+exit $estatus


### PR DESCRIPTION
## what

Make it so when the e2e.sh script ends, it also cleans up the background processes of atlantis and ngrok.

Additionally, quit the script early if atlantis or ngrok fail to start up.

## why

While I was working on the e2e golang code, it ended up that multiple copies of both atlantis and ngrok were running on my computer, which got confusing.

Another annoyance was if atlantis or ngrok fail to start, the script kept going, then failed in a confusing way. Now the script makes sure the process stays up after the two second pause.

## tests

I ran the script locally. Also the CI ran successfully, including my new output.

## references


