### PR TITLE
gitlab: link latest commit to the correct pipeline

### DIFF
--- a/server/events/vcs/gitlab_client.go
+++ b/server/events/vcs/gitlab_client.go
@@ -422,9 +422,9 @@ func (g *GitlabClient) UpdateStatus(logger logging.SimpleLogging, repo models.Re
 		if err != nil {
 			return err
 		}
-		if mr.HeadPipeline != nil {
-			logger.Debug("Head pipeline found for merge request %d, source '%s'. refTarget '%s'",
-				pull.Num, mr.HeadPipeline.Source, mr.HeadPipeline.Ref)
+		if mr.HeadPipeline != nil && mr.SHA == mr.HeadPipeline.SHA {
+			logger.Debug("Head pipeline found for merge request %d, source '%s'. refTarget '%s' SHA '%s'",
+				pull.Num, mr.HeadPipeline.Source, mr.HeadPipeline.Ref, mr.HeadPipeline.SHA)
 			// set pipeline ID for the req once found
 			pipelineID = gitlab.Ptr(mr.HeadPipeline.ID)
 			break


### PR DESCRIPTION
PR #4785 was a partial fix, as it might link a commit to the wrong pipeline when GitLab is slow to update the HeadPipeline.

This patch ensures the latest commit is always linked to the correct pipeline by querying the pipeline associated with the commit's ref, instead of relying on HeadPipeline.

Tested in our environment and it looks good so far.

Signed-off-by: Raul Gutierrez Segales <rsegales@nvidia.com>
