### PR TITLE
fix: Permission for GitHub app to support mergeable minus apply check

### DIFF
--- a/runatlantis.io/docs/access-credentials.md
+++ b/runatlantis.io/docs/access-credentials.md
@@ -95,6 +95,8 @@ GitHub App needs these permissions. These are automatically set when a GitHub ap
 Since v0.19.7, a new permission for `Administration` has been added. If you have already created a GitHub app, updating Atlantis to v0.19.7 will not automatically add this permission, so you will need to set it manually.
 
 Since v0.22.3, a new permission for `Members` has been added, which is required for features that apply permissions to an organizations team members rather than individual users. Like the `Administration` permission above, updating Atlantis will not automatically add this permission, so if you wish to use features that rely on checking team membership you will need to add this manually.
+
+A new permission for `Actions` has been added, which is required for checking if a pull request is mergbeably bypassing the apply check. Updating Atlantis will not automatically add this permission, so you will need to add this manually.
 :::
 
 | Type            | Access              |
@@ -108,6 +110,7 @@ Since v0.22.3, a new permission for `Members` has been added, which is required 
 | Pull requests   | Read and write      |
 | Webhooks        | Read and write      |
 | Members         | Read-only           |
+| Actions         | Read-only           |
 
 ### GitLab
 

--- a/server/controllers/github_app_controller.go
+++ b/server/controllers/github_app_controller.go
@@ -123,6 +123,7 @@ func (g *GithubAppController) New(w http.ResponseWriter, _ *http.Request) {
 			"statuses":         "write",
 			"administration":   "read",
 			"members":          "read",
+			"actions":          "read",
 		},
 	}
 


### PR DESCRIPTION
## what

Adds the `actions:read` permission to the GitHub app. Both to the documentation and to the setup endpoint.

## why

As of https://github.com/runatlantis/atlantis/commit/ed7b744695ca057ac2bd995b0f6bb6d92d2aa259, this permission is needed when the `--gh-allow-mergeable-bypass-apply` setting is enabled.

## tests

<!--
- [ ] I have tested my changes by ...
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

