### PR TITLE
fix: only lookup user team memberships if using team authz

### DIFF
--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -156,19 +156,21 @@ func (c *DefaultCommandRunner) RunAutoplanCommand(baseRepo models.Repo, headRepo
 	defer timer.Stop()
 
 	// Check if the user who triggered the autoplan has permissions to run 'plan'.
-	err = c.fetchUserTeams(baseRepo, &user)
-	if err != nil {
-		c.Logger.Err("Unable to fetch user teams: %s", err)
-		return
-	}
+	if c.TeamAllowlistChecker != nil && c.TeamAllowlistChecker.HasRules() {
+		err := c.fetchUserTeams(baseRepo, &user)
+		if err != nil {
+			c.Logger.Err("Unable to fetch user teams: %s", err)
+			return
+		}
 
-	ok, err := c.checkUserPermissions(baseRepo, user, "plan")
-	if err != nil {
-		c.Logger.Err("Unable to check user permissions: %s", err)
-		return
-	}
-	if !ok {
-		return
+		ok, err := c.checkUserPermissions(baseRepo, user, "plan")
+		if err != nil {
+			c.Logger.Err("Unable to check user permissions: %s", err)
+			return
+		}
+		if !ok {
+			return
+		}
 	}
 
 	ctx := &command.Context{


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

* Reverts user team lookup behavior for autoplans to be conditional, instead of always performing a lookup


## why

* Team authorization change in #4864 caused lookup behavior for autoplans to always fetch membership, instead of conditionally like comment commands.  This changed the required scope of Github tokens to add additional permissions that weren't needed.
<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

* Fixes breaking change introduced in #4864 
