### PR TITLE
fix: Run dumb-init with --single-child for graceful termination

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,7 +167,8 @@ RUN apk add --no-cache \
         bash~=5 \
         openssh~=9 \
         dumb-init~=1 \
-        gcompat~=1
+        gcompat~=1 \
+        coreutils-env~=9
 
 # Set the entry point to the atlantis user and run the atlantis command
 USER atlantis

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,10 @@
-#!/usr/bin/dumb-init /bin/sh
+#!/usr/bin/env -S dumb-init --single-child /bin/sh
+
+# dumb-init is run in single child mode. By default dumb-init will forward
+# interrupts to all child processes, causing Terraform to cancel and Terraform
+# providers to exit uncleanly. We forward the signal to Atlantis only, allowing
+# it to trap the interrupt, and exit gracefully.
+
 set -e
 
 # Modified: https://github.com/hashicorp/docker-consul/blob/2c2873f9d619220d1eef0bc46ec78443f55a10b5/0.X/docker-entrypoint.sh


### PR DESCRIPTION
## what

By default, dumb init forward SIGTERM signals to all child processes. This causes Atlantis to shutdown ungracefully when running a Terraform command. The process tree looks as follows:

> dumb-init -> atlantis -> sh -> terraform -> provider(s).

When the container runtime stops the container while Atlantis is running a Terraform command (E.g Kubernetes node scale down), dumb-init will forward the SIGTERM to all these processes in reverse order. Both Terraform and Atlantis will trap the signal and try to exit gracefully, however the provider will crash, resulting in Atlantis commenting the following on a PR:

```
Stopping operation...

Interrupt received.
Please wait for Terraform to exit or data loss may occur.
Gracefully shutting down...

╷
│ Error: execution halted
│ 
│ 
╵
╷
│ Error: execution halted
│ 
│ 
╵
╷
│ Error: Plugin did not respond
│ 
│   with time_sleep.wait_30_seconds,
│   on main.tf line 1, in resource "time_sleep" "wait_30_seconds":
│    1: resource "time_sleep" "wait_30_seconds" {
│ 
│ The plugin encountered an error, and failed to respond to the
│ plugin.(*GRPCProvider).ApplyResourceChange call. The plugin logs may
│ contain more details.
╵
```

This is consistently reproducible by using the `time_sleep` resource (as above) and stopping the container during an apply.

The impact of this behaviour can be partial applies that need manual clean up, particularly in the case that the provider has created an asset, but has not finished waiting for it to converge. It will exist, but not be tracked in the statefile. Some crashes, like resource updates can be resolved just by planning and applying again.

## why

There are a few options here, we've set the `DUMB_INIT_SETSID=0` environment variable to all of our Atlantis instances, which has resolved this issue for us. Atlantis will finish the Terraform command before finishing scale down. We could also set the `--single-child` flag in the entrypoint script (might be cleaner, but was not as easy to test as adding this env var in my environment). More details on how dumb init works here: https://github.com/Yelp/dumb-init?tab=readme-ov-file#what-dumb-init-does. Another option would be to remove it entirely, and just use `#!/bin/sh` as the entrypoint.

## tests

Tested within Kubernetes. I reproduced it by deleting a pod during an apply. Adding this env var then trying again results in Atlantis finishing the command then scaling down.

## references

None, I debugged this yesterday. I have some `strace` output if anyone is interested. It shows that PID 1 (dumb-init)
is sending `SIGTERM` to all the child PIDs (Atlantis, Terraform, provider etc...)
