### PR TITLE
feat: GitHub - Support loading git token from disk

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -91,6 +91,7 @@ const (
 	GHHostnameFlag                   = "gh-hostname"
 	GHTeamAllowlistFlag              = "gh-team-allowlist"
 	GHTokenFlag                      = "gh-token"
+	GHTokenFileFlag                  = "gh-token-file" // nolint: gosec
 	GHUserFlag                       = "gh-user"
 	GHAppIDFlag                      = "gh-app-id"
 	GHAppKeyFlag                     = "gh-app-key"
@@ -316,6 +317,9 @@ var stringFlags = map[string]stringFlag{
 	},
 	GHTokenFlag: {
 		description: "GitHub token of API user. Can also be specified via the ATLANTIS_GH_TOKEN environment variable.",
+	},
+	GHTokenFileFlag: {
+		description: "A path to a file containing the GitHub token of API user. Can also be specified via the ATLANTIS_GH_TOKEN_FILE environment variable.",
 	},
 	GHAppKeyFlag: {
 		description:  "The GitHub App's private key",
@@ -965,26 +969,29 @@ func (s *ServerCmd) validate(userConfig server.UserConfig) error {
 	}
 
 	// The following combinations are valid.
-	// 1. github user and token set
+	// 1. github user and (token or token file)
 	// 2. github app ID and (key file set or key set)
 	// 3. gitea user and token set
 	// 4. gitlab user and token set
 	// 5. bitbucket user and token set
 	// 6. azuredevops user and token set
 	// 7. any combination of the above
-	vcsErr := fmt.Errorf("--%s/--%s or --%s/--%s or --%s/--%s or --%s/--%s or --%s/--%s or --%s/--%s or --%s/--%s must be set", GHUserFlag, GHTokenFlag, GHAppIDFlag, GHAppKeyFileFlag, GHAppIDFlag, GHAppKeyFlag, GiteaUserFlag, GiteaTokenFlag, GitlabUserFlag, GitlabTokenFlag, BitbucketUserFlag, BitbucketTokenFlag, ADUserFlag, ADTokenFlag)
-	if ((userConfig.GithubUser == "") != (userConfig.GithubToken == "")) ||
-		((userConfig.GiteaUser == "") != (userConfig.GiteaToken == "")) ||
+	vcsErr := fmt.Errorf("--%s/--%s or --%s/--%s or --%s/--%s or --%s/--%s or --%s/--%s or --%s/--%s or --%s/--%s or --%s/--%s must be set", GHUserFlag, GHTokenFlag, GHUserFlag, GHTokenFileFlag, GHAppIDFlag, GHAppKeyFileFlag, GHAppIDFlag, GHAppKeyFlag, GiteaUserFlag, GiteaTokenFlag, GitlabUserFlag, GitlabTokenFlag, BitbucketUserFlag, BitbucketTokenFlag, ADUserFlag, ADTokenFlag)
+	if ((userConfig.GiteaUser == "") != (userConfig.GiteaToken == "")) ||
 		((userConfig.GitlabUser == "") != (userConfig.GitlabToken == "")) ||
 		((userConfig.BitbucketUser == "") != (userConfig.BitbucketToken == "")) ||
 		((userConfig.AzureDevopsUser == "") != (userConfig.AzureDevopsToken == "")) {
 		return vcsErr
 	}
-	if (userConfig.GithubAppID != 0) && ((userConfig.GithubAppKey == "") && (userConfig.GithubAppKeyFile == "")) {
-		return vcsErr
+	if userConfig.GithubUser != "" {
+		if (userConfig.GithubToken == "") == (userConfig.GithubTokenFile == "") {
+			return vcsErr
+		}
 	}
-	if (userConfig.GithubAppID == 0) && ((userConfig.GithubAppKey != "") || (userConfig.GithubAppKeyFile != "")) {
-		return vcsErr
+	if userConfig.GithubAppID != 0 {
+		if (userConfig.GithubAppKey == "") == (userConfig.GithubAppKeyFile == "") {
+			return vcsErr
+		}
 	}
 	// At this point, we know that there can't be a single user/token without
 	// its partner, but we haven't checked if any user/token is set at all.
@@ -1026,6 +1033,7 @@ func (s *ServerCmd) validate(userConfig server.UserConfig) error {
 	// Warn if any tokens have newlines.
 	for name, token := range map[string]string{
 		GHTokenFlag:                userConfig.GithubToken,
+		GHTokenFileFlag:            userConfig.GithubTokenFile,
 		GHWebhookSecretFlag:        userConfig.GithubWebhookSecret,
 		GitlabTokenFlag:            userConfig.GitlabToken,
 		GitlabWebhookSecretFlag:    userConfig.GitlabWebhookSecret,

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -86,6 +86,7 @@ var testFlags = map[string]interface{}{
 	GHHostnameFlag:                   "ghhostname",
 	GHTeamAllowlistFlag:              "",
 	GHTokenFlag:                      "token",
+	GHTokenFileFlag:                  "",
 	GHUserFlag:                       "user",
 	GHAppIDFlag:                      int64(0),
 	GHAppKeyFlag:                     "",
@@ -433,7 +434,7 @@ func TestExecute_ValidateSSLConfig(t *testing.T) {
 }
 
 func TestExecute_ValidateVCSConfig(t *testing.T) {
-	expErr := "--gh-user/--gh-token or --gh-app-id/--gh-app-key-file or --gh-app-id/--gh-app-key or --gitea-user/--gitea-token or --gitlab-user/--gitlab-token or --bitbucket-user/--bitbucket-token or --azuredevops-user/--azuredevops-token must be set"
+	expErr := "--gh-user/--gh-token or --gh-user/--gh-token-file or --gh-app-id/--gh-app-key-file or --gh-app-id/--gh-app-key or --gitea-user/--gitea-token or --gitlab-user/--gitlab-token or --bitbucket-user/--bitbucket-token or --azuredevops-user/--azuredevops-token must be set"
 	cases := []struct {
 		description string
 		flags       map[string]interface{}
@@ -582,6 +583,23 @@ func TestExecute_ValidateVCSConfig(t *testing.T) {
 				GHTokenFlag: "token",
 			},
 			false,
+		},
+		{
+			"github user and github token file and should be successful",
+			map[string]interface{}{
+				GHUserFlag:      "user",
+				GHTokenFileFlag: "/path/to/token",
+			},
+			false,
+		},
+		{
+			"github user, github token, and github token file and should fail",
+			map[string]interface{}{
+				GHUserFlag:      "user",
+				GHTokenFlag:     "token",
+				GHTokenFileFlag: "/path/to/token",
+			},
+			true,
 		},
 		{
 			"gitea user and gitea token set and should be successful",

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -743,6 +743,16 @@ based on the organization or user that triggered the webhook.
 
   GitHub token of API user.
 
+### `--gh-token-file`
+
+  ```bash
+  atlantis server --gh-token-file="/path/to/token"
+  # or
+  ATLANTIS_GH_TOKEN_FILE="/path/to/token"
+  ```
+
+  GitHub token of API user. The token is loaded from disk regularly to allow for rotation of the token without the need to restart the Atlantis server.
+
 ### `--gh-user`
 
   ```bash

--- a/server/events/vcs/git_cred_writer.go
+++ b/server/events/vcs/git_cred_writer.go
@@ -47,7 +47,7 @@ func WriteGitCreds(gitUser string, gitToken string, gitHostname string, home str
 				if err := fileLineReplace(config, gitUser, gitHostname, credsFile); err != nil {
 					return errors.Wrap(err, "replacing git credentials line for github app")
 				}
-				logger.Info("updated git app credentials in %s", credsFile)
+				logger.Info("updated git credentials in %s", credsFile)
 			} else {
 				if err := fileAppend(config, credsFile); err != nil {
 					return err

--- a/server/events/vcs/github_client_internal_test.go
+++ b/server/events/vcs/github_client_internal_test.go
@@ -22,14 +22,14 @@ import (
 
 // If the hostname is github.com, should use normal BaseURL.
 func TestNewGithubClient_GithubCom(t *testing.T) {
-	client, err := NewGithubClient("github.com", &GithubUserCredentials{"user", "pass"}, GithubConfig{}, 0, logging.NewNoopLogger(t))
+	client, err := NewGithubClient("github.com", &GithubUserCredentials{"user", "pass", ""}, GithubConfig{}, 0, logging.NewNoopLogger(t))
 	Ok(t, err)
 	Equals(t, "https://api.github.com/", client.client.BaseURL.String())
 }
 
 // If the hostname is a non-github hostname should use the right BaseURL.
 func TestNewGithubClient_NonGithub(t *testing.T) {
-	client, err := NewGithubClient("example.com", &GithubUserCredentials{"user", "pass"}, GithubConfig{}, 0, logging.NewNoopLogger(t))
+	client, err := NewGithubClient("example.com", &GithubUserCredentials{"user", "pass", ""}, GithubConfig{}, 0, logging.NewNoopLogger(t))
 	Ok(t, err)
 	Equals(t, "https://example.com/api/v3/", client.client.BaseURL.String())
 	// If possible in the future, test the GraphQL client's URL as well. But at the

--- a/server/events/vcs/github_client_test.go
+++ b/server/events/vcs/github_client_test.go
@@ -63,7 +63,7 @@ func TestGithubClient_GetModifiedFiles(t *testing.T) {
 
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
-	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, vcs.GithubConfig{}, 0, logger)
+	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass", ""}, vcs.GithubConfig{}, 0, logger)
 	Ok(t, err)
 	defer disableSSLVerification()()
 
@@ -121,7 +121,7 @@ func TestGithubClient_GetModifiedFilesMovedFile(t *testing.T) {
 
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
-	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, vcs.GithubConfig{}, 0, logging.NewNoopLogger(t))
+	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass", ""}, vcs.GithubConfig{}, 0, logging.NewNoopLogger(t))
 	Ok(t, err)
 	defer disableSSLVerification()()
 
@@ -218,7 +218,7 @@ func TestGithubClient_PaginatesComments(t *testing.T) {
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
 
-	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, vcs.GithubConfig{}, 0, logging.NewNoopLogger(t))
+	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass", ""}, vcs.GithubConfig{}, 0, logging.NewNoopLogger(t))
 	Ok(t, err)
 	defer disableSSLVerification()()
 
@@ -334,7 +334,7 @@ func TestGithubClient_HideOldComments(t *testing.T) {
 			testServerURL, err := url.Parse(testServer.URL)
 			Ok(t, err)
 
-			client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{atlantisUser, "pass"}, vcs.GithubConfig{}, 0,
+			client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{atlantisUser, "pass", ""}, vcs.GithubConfig{}, 0,
 				logging.NewNoopLogger(t))
 			Ok(t, err)
 			defer disableSSLVerification()()
@@ -407,7 +407,7 @@ func TestGithubClient_UpdateStatus(t *testing.T) {
 
 			testServerURL, err := url.Parse(testServer.URL)
 			Ok(t, err)
-			client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, vcs.GithubConfig{}, 0, logging.NewNoopLogger(t))
+			client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass", ""}, vcs.GithubConfig{}, 0, logging.NewNoopLogger(t))
 			Ok(t, err)
 			defer disableSSLVerification()()
 
@@ -496,7 +496,7 @@ func TestGithubClient_PullIsApproved(t *testing.T) {
 
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
-	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, vcs.GithubConfig{}, 0, logging.NewNoopLogger(t))
+	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass", ""}, vcs.GithubConfig{}, 0, logging.NewNoopLogger(t))
 	Ok(t, err)
 	defer disableSSLVerification()()
 
@@ -591,7 +591,7 @@ func TestGithubClient_PullIsMergeable(t *testing.T) {
 				}))
 			testServerURL, err := url.Parse(testServer.URL)
 			Ok(t, err)
-			client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, vcs.GithubConfig{}, 0, logging.NewNoopLogger(t))
+			client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass", ""}, vcs.GithubConfig{}, 0, logging.NewNoopLogger(t))
 			Ok(t, err)
 			defer disableSSLVerification()()
 
@@ -874,7 +874,7 @@ func TestGithubClient_PullIsMergeableWithAllowMergeableBypassApply(t *testing.T)
 				}))
 			testServerURL, err := url.Parse(testServer.URL)
 			Ok(t, err)
-			client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, vcs.GithubConfig{AllowMergeableBypassApply: true}, 0, logging.NewNoopLogger(t))
+			client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass", ""}, vcs.GithubConfig{AllowMergeableBypassApply: true}, 0, logging.NewNoopLogger(t))
 			Ok(t, err)
 			defer disableSSLVerification()()
 
@@ -959,7 +959,7 @@ func TestGithubClient_MergePullHandlesError(t *testing.T) {
 
 			testServerURL, err := url.Parse(testServer.URL)
 			Ok(t, err)
-			client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, vcs.GithubConfig{}, 0, logging.NewNoopLogger(t))
+			client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass", ""}, vcs.GithubConfig{}, 0, logging.NewNoopLogger(t))
 			Ok(t, err)
 			defer disableSSLVerification()()
 
@@ -1139,7 +1139,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 
 			testServerURL, err := url.Parse(testServer.URL)
 			Ok(t, err)
-			client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, vcs.GithubConfig{}, 0, logging.NewNoopLogger(t))
+			client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass", ""}, vcs.GithubConfig{}, 0, logging.NewNoopLogger(t))
 			Ok(t, err)
 			defer disableSSLVerification()()
 
@@ -1173,7 +1173,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 }
 
 func TestGithubClient_MarkdownPullLink(t *testing.T) {
-	client, err := vcs.NewGithubClient("hostname", &vcs.GithubUserCredentials{"user", "pass"}, vcs.GithubConfig{}, 0, logging.NewNoopLogger(t))
+	client, err := vcs.NewGithubClient("hostname", &vcs.GithubUserCredentials{"user", "pass", ""}, vcs.GithubConfig{}, 0, logging.NewNoopLogger(t))
 	Ok(t, err)
 	pull := models.PullRequest{Num: 1}
 	s, _ := client.MarkdownPullLink(pull)
@@ -1229,7 +1229,7 @@ func TestGithubClient_SplitComments(t *testing.T) {
 
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
-	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, vcs.GithubConfig{}, 0, logging.NewNoopLogger(t))
+	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass", ""}, vcs.GithubConfig{}, 0, logging.NewNoopLogger(t))
 	Ok(t, err)
 	defer disableSSLVerification()()
 	pull := models.PullRequest{Num: 1}
@@ -1288,7 +1288,7 @@ func TestGithubClient_Retry404(t *testing.T) {
 
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
-	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, vcs.GithubConfig{}, 0, logging.NewNoopLogger(t))
+	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass", ""}, vcs.GithubConfig{}, 0, logging.NewNoopLogger(t))
 	Ok(t, err)
 	defer disableSSLVerification()()
 	repo := models.Repo{
@@ -1334,7 +1334,7 @@ func TestGithubClient_Retry404Files(t *testing.T) {
 
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
-	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, vcs.GithubConfig{}, 0, logging.NewNoopLogger(t))
+	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass", ""}, vcs.GithubConfig{}, 0, logging.NewNoopLogger(t))
 	Ok(t, err)
 	defer disableSSLVerification()()
 	repo := models.Repo{
@@ -1387,7 +1387,7 @@ func TestGithubClient_GetTeamNamesForUser(t *testing.T) {
 		}))
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
-	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, vcs.GithubConfig{}, 0, logger)
+	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass", ""}, vcs.GithubConfig{}, 0, logger)
 	Ok(t, err)
 	defer disableSSLVerification()()
 
@@ -1585,7 +1585,7 @@ func TestGithubClient_DiscardReviews(t *testing.T) {
 				}))
 			testServerURL, err := url.Parse(testServer.URL)
 			Ok(t, err)
-			client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, vcs.GithubConfig{}, 0, logging.NewNoopLogger(t))
+			client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass", ""}, vcs.GithubConfig{}, 0, logging.NewNoopLogger(t))
 			Ok(t, err)
 			defer disableSSLVerification()()
 			if err := client.DiscardReviews(tt.args.repo, tt.args.pull); (err != nil) != tt.wantErr {
@@ -1654,7 +1654,7 @@ func TestGithubClient_GetPullLabels(t *testing.T) {
 		}))
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
-	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, vcs.GithubConfig{}, 0, logger)
+	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass", ""}, vcs.GithubConfig{}, 0, logger)
 	Ok(t, err)
 	defer disableSSLVerification()()
 
@@ -1691,7 +1691,7 @@ func TestGithubClient_GetPullLabels_EmptyResponse(t *testing.T) {
 		}))
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
-	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, vcs.GithubConfig{}, 0, logger)
+	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass", ""}, vcs.GithubConfig{}, 0, logger)
 	Ok(t, err)
 	defer disableSSLVerification()()
 

--- a/server/events/vcs/github_credentials.go
+++ b/server/events/vcs/github_credentials.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
@@ -42,17 +43,45 @@ func (c *GithubAnonymousCredentials) GetToken() (string, error) {
 
 // GithubUserCredentials implements GithubCredentials for the personal auth token flow.
 type GithubUserCredentials struct {
-	User  string
-	Token string
+	User      string
+	Token     string
+	TokenFile string
+}
+
+type GitHubUserTransport struct {
+	Credentials *GithubUserCredentials
+	Transport   *github.BasicAuthTransport
+}
+
+func (t *GitHubUserTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// update token
+	token, err := t.Credentials.GetToken()
+	if err != nil {
+		return nil, err
+	}
+	t.Transport.Password = token
+
+	// defer to the underlying transport
+	return t.Transport.RoundTrip(req)
 }
 
 // Client returns a client for basic auth user credentials.
 func (c *GithubUserCredentials) Client() (*http.Client, error) {
-	tr := &github.BasicAuthTransport{
-		Username: strings.TrimSpace(c.User),
-		Password: strings.TrimSpace(c.Token),
+	password, err := c.GetToken()
+	if err != nil {
+		return nil, err
 	}
-	return tr.Client(), nil
+
+	client := &http.Client{
+		Transport: &GitHubUserTransport{
+			Credentials: c,
+			Transport: &github.BasicAuthTransport{
+				Username: strings.TrimSpace(c.User),
+				Password: strings.TrimSpace(password),
+			},
+		},
+	}
+	return client, nil
 }
 
 // GetUser returns the username for these credentials.
@@ -62,6 +91,15 @@ func (c *GithubUserCredentials) GetUser() (string, error) {
 
 // GetToken returns the user token.
 func (c *GithubUserCredentials) GetToken() (string, error) {
+	if c.TokenFile != "" {
+		content, err := os.ReadFile(c.TokenFile)
+		if err != nil {
+			return "", fmt.Errorf("failed reading github token file: %w", err)
+		}
+
+		return string(content), nil
+	}
+
 	return c.Token, nil
 }
 

--- a/server/events/vcs/github_token_rotator.go
+++ b/server/events/vcs/github_token_rotator.go
@@ -8,37 +8,40 @@ import (
 	"github.com/runatlantis/atlantis/server/scheduled"
 )
 
-// GitCredsTokenRotator continuously tries to rotate the github app access token every 30 seconds and writes the ~/.git-credentials file
-type GitCredsTokenRotator interface {
+// GithubTokenRotator continuously tries to rotate the github app access token every 30 seconds and writes the ~/.git-credentials file
+type GithubTokenRotator interface {
 	Run()
 	GenerateJob() (scheduled.JobDefinition, error)
 }
 
-type githubAppTokenRotator struct {
+type githubTokenRotator struct {
 	log               logging.SimpleLogging
 	githubCredentials GithubCredentials
 	githubHostname    string
+	gitUser           string
 	homeDirPath       string
 }
 
-func NewGithubAppTokenRotator(
+func NewGithubTokenRotator(
 	log logging.SimpleLogging,
 	githubCredentials GithubCredentials,
 	githubHostname string,
-	homeDirPath string) GitCredsTokenRotator {
+	gitUser string,
+	homeDirPath string) GithubTokenRotator {
 
-	return &githubAppTokenRotator{
+	return &githubTokenRotator{
 		log:               log,
 		githubCredentials: githubCredentials,
 		githubHostname:    githubHostname,
+		gitUser:           gitUser,
 		homeDirPath:       homeDirPath,
 	}
 }
 
 // make sure interface is implemented correctly
-var _ GitCredsTokenRotator = (*githubAppTokenRotator)(nil)
+var _ GithubTokenRotator = (*githubTokenRotator)(nil)
 
-func (r *githubAppTokenRotator) GenerateJob() (scheduled.JobDefinition, error) {
+func (r *githubTokenRotator) GenerateJob() (scheduled.JobDefinition, error) {
 
 	return scheduled.JobDefinition{
 		Job:    r,
@@ -46,7 +49,7 @@ func (r *githubAppTokenRotator) GenerateJob() (scheduled.JobDefinition, error) {
 	}, r.rotate()
 }
 
-func (r *githubAppTokenRotator) Run() {
+func (r *githubTokenRotator) Run() {
 	err := r.rotate()
 	if err != nil {
 		// at least log the error message here, as we want to notify the that user that the key rotation wasn't successful
@@ -54,8 +57,8 @@ func (r *githubAppTokenRotator) Run() {
 	}
 }
 
-func (r *githubAppTokenRotator) rotate() error {
-	r.log.Debug("Refreshing git tokens for Github App")
+func (r *githubTokenRotator) rotate() error {
+	r.log.Debug("Refreshing Github tokens for .git-credentials")
 
 	token, err := r.githubCredentials.GetToken()
 	if err != nil {
@@ -64,7 +67,7 @@ func (r *githubAppTokenRotator) rotate() error {
 	r.log.Debug("Token successfully refreshed")
 
 	// https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#http-based-git-access-by-an-installation
-	if err := WriteGitCreds("x-access-token", token, r.githubHostname, r.homeDirPath, r.log, true); err != nil {
+	if err := WriteGitCreds(r.gitUser, token, r.githubHostname, r.homeDirPath, r.log, true); err != nil {
 		return errors.Wrap(err, "Writing ~/.git-credentials file")
 	}
 	return nil

--- a/server/events/vcs/github_token_rotator_test.go
+++ b/server/events/vcs/github_token_rotator_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/runatlantis/atlantis/testing"
 )
 
-func Test_githubAppTokenRotator_GenerateJob(t *testing.T) {
+func Test_githubTokenRotator_GenerateJob(t *testing.T) {
 	logger := logging.NewNoopLogger(t)
 	defer disableSSLVerification()()
 	testServer, err := testdata.GithubAppTestServer(t)
@@ -68,10 +68,10 @@ func Test_githubAppTokenRotator_GenerateJob(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			t.Setenv("HOME", tmpDir)
-			r := vcs.NewGithubAppTokenRotator(logging.NewNoopLogger(t), tt.fields.githubCredentials, testServer, tmpDir)
+			r := vcs.NewGithubTokenRotator(logging.NewNoopLogger(t), tt.fields.githubCredentials, testServer, "x-access-token", tmpDir)
 			got, err := r.GenerateJob()
 			if (err != nil) != tt.wantErr {
-				t.Errorf("githubAppTokenRotator.GenerateJob() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("githubTokenRotator.GenerateJob() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if tt.credsFileWritten {

--- a/server/server.go
+++ b/server/server.go
@@ -230,8 +230,9 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		supportedVCSHosts = append(supportedVCSHosts, models.Github)
 		if userConfig.GithubUser != "" {
 			githubCredentials = &vcs.GithubUserCredentials{
-				User:  userConfig.GithubUser,
-				Token: userConfig.GithubToken,
+				User:      userConfig.GithubUser,
+				Token:     userConfig.GithubToken,
+				TokenFile: userConfig.GithubTokenFile,
 			}
 		} else if userConfig.GithubAppID != 0 && userConfig.GithubAppKeyFile != "" {
 			privateKey, err := os.ReadFile(userConfig.GithubAppKeyFile)
@@ -514,8 +515,17 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 			GithubHostname: userConfig.GithubHostname,
 		}
 
-		githubAppTokenRotator := vcs.NewGithubAppTokenRotator(logger, githubCredentials, userConfig.GithubHostname, home)
+		githubAppTokenRotator := vcs.NewGithubTokenRotator(logger, githubCredentials, userConfig.GithubHostname, "x-access-token", home)
 		tokenJd, err := githubAppTokenRotator.GenerateJob()
+		if err != nil {
+			return nil, errors.Wrap(err, "could not write credentials")
+		}
+		scheduledExecutorService.AddJob(tokenJd)
+	}
+
+	if userConfig.GithubUser != "" && userConfig.GithubTokenFile != "" && userConfig.WriteGitCreds {
+		githubTokenRotator := vcs.NewGithubTokenRotator(logger, githubCredentials, userConfig.GithubHostname, userConfig.GithubUser, home)
+		tokenJd, err := githubTokenRotator.GenerateJob()
 		if err != nil {
 			return nil, errors.Wrap(err, "could not write credentials")
 		}

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -50,6 +50,7 @@ type UserConfig struct {
 	GithubAllowMergeableBypassApply bool   `mapstructure:"gh-allow-mergeable-bypass-apply"`
 	GithubHostname                  string `mapstructure:"gh-hostname"`
 	GithubToken                     string `mapstructure:"gh-token"`
+	GithubTokenFile                 string `mapstructure:"gh-token-file"`
 	GithubUser                      string `mapstructure:"gh-user"`
 	GithubWebhookSecret             string `mapstructure:"gh-webhook-secret"`
 	GithubOrg                       string `mapstructure:"gh-org"`


### PR DESCRIPTION
## what

Adds a `gh-token-file` server setting that can be used instead of `gh-token`. The token is read from disk as part of the GitHub client transport, allowing the token to be rotated without needing to restart the Atlantis process. I've also re-used the `.git-credentials` token rotator from the GitHub app integration to ensure that `write-git-creds` will update the `.git-credentials` file as the `gh-token-file` is updated. This only works for GitHub, we use a --gh-* prefixed flag like the other gh configs. This could be extended to the other VCS options as needed.

## why

We run about ~150 Atlantis instances in our organisation in our GitHub org. GitHub have a hard limit on 100 GitHub apps per org, and charge a seat per service account user. To get around these challenges we have developed a GitHub app which issues scoped token for each Atlantis and loads them as Kubernetes secrets. The app is also responsible for forwarding and re-signing the webhooks with per instance webhook secrets to the correct Atlantis instance. I'd potentially be interested in opening the source code for this app if there is interest. There are still a few issues we are working through, like this one, and it is currently in a complicated relationship with Keda.

We run Atlantis as a GitHub app, but configure it with short term credentials to run as a GitHub user. The tokens only last one hour, so we manage restarts as part of scale-to-zero to ensure that Atlantis is always running with a valid token.

If the Atlantis instance fails to restart within an hour due to high activity or long running plan or applies, the commands will finish, but results will fail to be commented back to the GitHub pull request.

With this change we can load the token from disk, and as our GitHub app rotates the token, it is immediately picked up by the running Atlantis instance, allowing it to run uninterrupted for longer periods of time.

## tests

I ran an apply with the follow Terraform that used to fail to comment back:

```hcl
resource "time_sleep" "wait_over_hour" {
  create_duration = "4000s"
}
```

I also ran some `cat` commands agains the `.git-credentials` file with `--write-git-creds` was specified to ensure that it was getting updated as the token was being rotated.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

