### PR TITLE
fix: Update lock for e2e tests

### DIFF
--- a/scripts/pin_ci_terraform_providers.sh
+++ b/scripts/pin_ci_terraform_providers.sh
@@ -3,7 +3,7 @@
 # Script to pin terraform providers in e2e tests
 
 RANDOM_PROVIDER_VERSION="3.6.1"
-NULL_PROVIDER_VERSION="3.2.2"
+NULL_PROVIDER_VERSION="3.2.3"
 
 TEST_REPOS_DIR="server/controllers/events/testdata/test-repos"
 

--- a/server/controllers/events/testdata/null_provider_lockfile_old_version
+++ b/server/controllers/events/testdata/null_provider_lockfile_old_version
@@ -2,24 +2,24 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/null" {
-  version     = "3.2.2"
-  constraints = "3.2.2"
+  version     = "3.2.3"
+  constraints = "3.2.3"
   hashes = [
-    "h1:Gef5VGfobY5uokA5nV/zFvWeMNR2Pmq79DH94QnNZPM=",
-    "h1:IMVAUHKoydFrlPrl9OzasDnw/8ntZFerCC9iXw1rXQY=",
-    "h1:vWAsYRd7MjYr3adj8BVKRohVfHpWQdvkIwUQ2Jf5FVM=",
-    "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
-    "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
-    "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
-    "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",
-    "zh:4c2f1faee67af104f5f9e711c4574ff4d298afaa8a420680b0cb55d7bbc65606",
-    "zh:544b33b757c0b954dbb87db83a5ad921edd61f02f1dc86c6186a5ea86465b546",
-    "zh:696cf785090e1e8cf1587499516b0494f47413b43cb99877ad97f5d0de3dc539",
-    "zh:6e301f34757b5d265ae44467d95306d61bef5e41930be1365f5a8dcf80f59452",
+    "h1:+AnORRgFbRO6qqcfaQyeX80W0eX3VmjadjnUFUJTiXo=",
+    "h1:I0Um8UkrMUb81Fxq/dxbr3HLP2cecTH2WMJiwKSrwQY=",
+    "h1:nKUqWEza6Lcv3xRlzeiRQrHtqvzX1BhIzjaOVXRYQXQ=",
+    "h1:obXguGZUWtNAO09f1f9Cb7hsPCOGXuGdN8bn/ohKRBQ=",
+    "zh:22d062e5278d872fe7aed834f5577ba0a5afe34a3bdac2b81f828d8d3e6706d2",
+    "zh:23dead00493ad863729495dc212fd6c29b8293e707b055ce5ba21ee453ce552d",
+    "zh:28299accf21763ca1ca144d8f660688d7c2ad0b105b7202554ca60b02a3856d3",
+    "zh:55c9e8a9ac25a7652df8c51a8a9a422bd67d784061b1de2dc9fe6c3cb4e77f2f",
+    "zh:756586535d11698a216291c06b9ed8a5cc6a4ec43eee1ee09ecd5c6a9e297ac1",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:913a929070c819e59e94bb37a2a253c228f83921136ff4a7aa1a178c7cce5422",
-    "zh:aa9015926cd152425dbf86d1abdbc74bfe0e1ba3d26b3db35051d7b9ca9f72ae",
-    "zh:bb04798b016e1e1d49bcc76d62c53b56c88c63d6f2dfe38821afef17c416a0e1",
-    "zh:c23084e1b23577de22603cff752e59128d83cfecc2e6819edadd8cf7a10af11e",
+    "zh:9d5eea62fdb587eeb96a8c4d782459f4e6b73baeece4d04b4a40e44faaee9301",
+    "zh:a6355f596a3fb8fc85c2fb054ab14e722991533f87f928e7169a486462c74670",
+    "zh:b5a65a789cff4ada58a5baffc76cb9767dc26ec6b45c00d2ec8b1b027f6db4ed",
+    "zh:db5ab669cf11d0e9f81dc380a6fdfcac437aea3d69109c7aef1a5426639d2d65",
+    "zh:de655d251c470197bcbb5ac45d289595295acb8f829f6c781d4a75c8c8b7c7dd",
+    "zh:f5c68199f2e6076bce92a12230434782bf768103a427e9bb9abee99b116af7b5",
   ]
 }


### PR DESCRIPTION
## what

Fixes the e2e tests. Some open PRs are failing on the e2e tests with an outdated lockfile. I've updated the null provider from 3.2.2. to 3.2.3, and locked it with the same platforms is seemed to be locked with before:

```
terraform providers lock -platform=linux_amd64 -platform=linux_arm64 -platform=darwin_amd64 -platform=darwin_arm64 
```

Current error: 

> running "/usr/local/bin/terraform init -input=false" in "/tmp/TestSimpleWorkflow_terraformLockFilesimple_with_plan_comment_lockfile_staged3170145570/001/repos/runatlantis/atlantis-tests/2/default": exit status 1
            Initializing the backend...
            Initializing provider plugins...
            - Reusing previous version of hashicorp/null from the dependency lock file
            ╷
            │ Error: Failed to query available provider packages
            │ 
            │ Could not retrieve the list of available versions for provider
            │ hashicorp/null: locked provider registry.terraform.io/hashicorp/null 3.2.2
            │ does not match configured version constraint 3.2.3; must use terraform init
            │ -upgrade to allow selection of new versions
            ╵

I didn't run the `scripts/pin_ci_terraform_providers.sh` script, as it seemed to make a bunch of changes that didn't change the behaviour, I think the files it edits may have been updated by hand.


## why

Fixes test, thought best to raise in a separate PR, as it affects a few open PRs

## tests

I have run `make test-all` locally, and it is passing on my machine. Hopefully this PR triggers the action, and it passes there too.

## references


