### PR TITLE
feat(app): #4981 skip ci by adding [skip ci] in commit msg

### DIFF
--- a/cmd/skipci.go
+++ b/cmd/skipci.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// CheckSkipCI checks if the latest commit message contains the "[skip ci]" flag.
+func CheckSkipCI() bool {
+	// Fetch the latest commit message
+	cmd := exec.Command("git", "log", "-1", "--pretty=%B")
+	output, err := cmd.Output()
+	if err != nil {
+		errors.Wrap(err, "failed to fetch the latest commit message")
+	}
+	commitMessage := string(output)
+
+	// Check if the commit message contains "[skip ci]"
+	return strings.Contains(commitMessage, "[skip ci]")
+}

--- a/main.go
+++ b/main.go
@@ -50,6 +50,12 @@ func main() {
 
 	atlantisVersion := fmt.Sprintf("%s (commit: %s) (build date: %s)", version, sha, date)
 
+	// Check if the latest commit message contains "[skip ci]"
+	if cmd.CheckSkipCI() {
+		logger.Info("Skipping autoplan due to [skip ci] flag in commit message")
+		return
+	}
+
 	// We're creating commands manually here rather than using init() functions
 	// (as recommended by cobra) because it makes testing easier.
 	server := &cmd.ServerCmd{


### PR DESCRIPTION
## what

Added a new command to check for the `[skip ci]` flag in the latest commit message.
Updated main.go to conditionally skip autoplan commands based on the presence of the `[skip ci]` flag.


## why

- To prevent unnecessary autoplan runs when committing generated configuration files

## tests

- [x] Verified that the [skip ci] flag in the commit message correctly skips the autoplan commands.
- [x] Tested the usual workflow to ensure that autoplan commands run as expected when the [skip ci] flag is not present.

## references

Closes #4981 

