### PR TITLE
feat: set the shell for workflow command steps

### DIFF
--- a/runatlantis.io/docs/custom-workflows.md
+++ b/runatlantis.io/docs/custom-workflows.md
@@ -599,6 +599,7 @@ Full
 ```yaml
 - run:
     command: custom-command arg1 arg2
+    shell: sh
     output: show
 ```
 
@@ -606,6 +607,7 @@ Full
 |-----|--------------------------------------------------------------|---------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | run | map\[string -> string\] | none    | no       | Run a custom command                                                                                                                                                                                                                                                                                                                                                                                    |
 | run.command | string                                                       | none | yes      | Shell command to run                                                                                                                                                                                                                                                                                                                                                                                    |
+| run.shell   | string | "sh" | no | Name of the shell to use for command execution (valid values are "sh" and "bash") |                                                    |
 | run.output | string                                                       | "show" | no       | How to post-process the output of this command when posted in the PR comment. The options are<br/>*`show` - preserve the full output<br/>* `hide` - hide output from comment (still visible in the real-time streaming output)<br/> * `strip_refreshing` - hide all output up until and including the last line containing "Refreshing...". This matches the behavior of the built-in `plan` command |
 
 ::: tip Notes
@@ -664,6 +666,10 @@ as the environment variable value.
 - env:
     name: ENV_NAME_2
     command: 'echo "dynamic-value-$(date)"'
+- env:
+    name: ENV_NAME_3
+    command: echo ${DIR%$REPO_REL_DIR}
+    shell: bash
 ```
 
 | Key             | Type                  | Default | Required | Description                                                                                                     |
@@ -672,6 +678,7 @@ as the environment variable value.
 | env.name | string | none | yes | Name of the environment variable                                                                                |
 | env.value | string | none | no | Set the value of the environment variable to a hard-coded string. Cannot be set at the same time as `command`   |
 | env.command | string | none | no | Set the value of the environment variable to the output of a command. Cannot be set at the same time as `value` |
+| env.shell   | string | "sh" | no | Name of the shell to use for command execution (valid values are "sh" and "bash"). Cannot be set without `command`|                                                    |
 
 ::: tip Notes
 
@@ -699,6 +706,7 @@ Full:
 ```yaml
 - multienv:
     command: custom-command
+    shell: bash
     output: show
 ```
 
@@ -706,6 +714,7 @@ Full:
 |------------------|-----------------------|---------|----------|-------------------------------------------------------------------------------------|
 | multienv         | map[string -> string] | none    | no       | Run a custom command and add printed environment variables                          |
 | multienv.command | string                | none    | yes      | Name of the custom script to run                                                    |
+| multienv.shell   | string                | "sh"    | no       | Name of the shell to use for command execution (valid values are "sh" and "bash")   |                                                    |
 | multienv.output  | string                | "show"  | no       | Setting output to "hide" will supress the message obout added environment variables |
 
 The output of the command execution must have the following format:

--- a/server/core/config/raw/step_test.go
+++ b/server/core/config/raw/step_test.go
@@ -371,7 +371,7 @@ func TestStep_Validate(t *testing.T) {
 					},
 				},
 			},
-			expErr: "env steps only support keys \"name\", \"value\" and \"command\", found key \"abc\"",
+			expErr: "env steps only support keys \"name\", \"value\", \"command\" and \"shell\", found key \"abc\"",
 		},
 		{
 			description: "env step with both command and value set",
@@ -385,6 +385,19 @@ func TestStep_Validate(t *testing.T) {
 				},
 			},
 			expErr: "env steps only support one of the \"value\" or \"command\" keys, found both",
+		},
+		{
+			description: "env step with both shell and value set",
+			input: raw.Step{
+				CommandMap: EnvType{
+					"env": {
+						"name":  "name",
+						"shell": "shell",
+						"value": "value",
+					},
+				},
+			},
+			expErr: "env steps only support \"shell\" key in combination with \"command\" key",
 		},
 		{
 			// For atlantis.yaml v2, this wouldn't parse, but now there should

--- a/server/core/config/valid/repo_cfg.go
+++ b/server/core/config/valid/repo_cfg.go
@@ -185,6 +185,8 @@ const (
 	PostProcessRunOutputStripRefreshing = "strip_refreshing"
 )
 
+var AllowedRunShellValues = []string{"sh", "bash"}
+
 type Stage struct {
 	Steps []Step
 }
@@ -202,6 +204,8 @@ type Step struct {
 	EnvVarName string
 	// EnvVarValue is the value to set EnvVarName to.
 	EnvVarValue string
+	// The Shell to use for RunCommand execution.
+	RunShell string
 }
 
 type Workflow struct {

--- a/server/core/runtime/env_step_runner.go
+++ b/server/core/runtime/env_step_runner.go
@@ -15,13 +15,20 @@ type EnvStepRunner struct {
 // Run runs the env step command.
 // value is the value for the environment variable. If set this is returned as
 // the value. Otherwise command is run and its output is the value returned.
-func (r *EnvStepRunner) Run(ctx command.ProjectContext, command string, value string, path string, envs map[string]string) (string, error) {
+func (r *EnvStepRunner) Run(
+	ctx command.ProjectContext,
+	shell string,
+	command string,
+	value string,
+	path string,
+	envs map[string]string,
+) (string, error) {
 	if value != "" {
 		return value, nil
 	}
 	// Pass `false` for streamOutput because this isn't interesting to the user reading the build logs
 	// in the web UI.
-	res, err := r.RunStepRunner.Run(ctx, command, path, envs, false, valid.PostProcessRunOutputShow)
+	res, err := r.RunStepRunner.Run(ctx, shell, command, path, envs, false, valid.PostProcessRunOutputShow)
 	// Trim newline from res to support running `echo env_value` which has
 	// a newline. We don't recommend users run echo -n env_value to remove the
 	// newline because -n doesn't work in the sh shell which is what we use

--- a/server/core/runtime/models/shell_command_runner.go
+++ b/server/core/runtime/models/shell_command_runner.go
@@ -16,6 +16,7 @@ import (
 
 // Setting the buffer size to 10mb
 const BufioScannerBufferSize = 10 * 1024 * 1024
+const DefaultRunShell = "sh"
 
 // Line represents a line that was output from a shell command.
 type Line struct {
@@ -35,8 +36,19 @@ type ShellCommandRunner struct {
 	cmd           *exec.Cmd
 }
 
-func NewShellCommandRunner(command string, environ []string, workingDir string, streamOutput bool, outputHandler jobs.ProjectCommandOutputHandler) *ShellCommandRunner {
-	cmd := exec.Command("sh", "-c", command) // #nosec
+func NewShellCommandRunner(
+	shell string,
+	command string,
+	environ []string,
+	workingDir string,
+	streamOutput bool,
+	outputHandler jobs.ProjectCommandOutputHandler,
+) *ShellCommandRunner {
+	if shell == "" {
+		shell = DefaultRunShell
+	}
+
+	cmd := exec.Command(shell, "-c", command) // #nosec
 	cmd.Env = environ
 	cmd.Dir = workingDir
 

--- a/server/core/runtime/multienv_step_runner.go
+++ b/server/core/runtime/multienv_step_runner.go
@@ -16,8 +16,15 @@ type MultiEnvStepRunner struct {
 
 // Run runs the multienv step command.
 // The command must return a json string containing the array of name-value pairs that are being added as extra environment variables
-func (r *MultiEnvStepRunner) Run(ctx command.ProjectContext, command string, path string, envs map[string]string, postProcessOutput valid.PostProcessRunOutputOption) (string, error) {
-	res, err := r.RunStepRunner.Run(ctx, command, path, envs, false, postProcessOutput)
+func (r *MultiEnvStepRunner) Run(
+	ctx command.ProjectContext,
+	shell string,
+	command string,
+	path string,
+	envs map[string]string,
+	postProcessOutput valid.PostProcessRunOutputOption,
+) (string, error) {
+	res, err := r.RunStepRunner.Run(ctx, shell, command, path, envs, false, postProcessOutput)
 	if err != nil {
 		return "", err
 	}

--- a/server/core/runtime/run_step_runner.go
+++ b/server/core/runtime/run_step_runner.go
@@ -22,7 +22,15 @@ type RunStepRunner struct {
 	ProjectCmdOutputHandler jobs.ProjectCommandOutputHandler
 }
 
-func (r *RunStepRunner) Run(ctx command.ProjectContext, command string, path string, envs map[string]string, streamOutput bool, postProcessOutput valid.PostProcessRunOutputOption) (string, error) {
+func (r *RunStepRunner) Run(
+	ctx command.ProjectContext,
+	shell string,
+	command string,
+	path string,
+	envs map[string]string,
+	streamOutput bool,
+	postProcessOutput valid.PostProcessRunOutputOption,
+) (string, error) {
 	tfVersion := r.DefaultTFVersion
 	if ctx.TerraformVersion != nil {
 		tfVersion = ctx.TerraformVersion
@@ -68,7 +76,7 @@ func (r *RunStepRunner) Run(ctx command.ProjectContext, command string, path str
 		finalEnvVars = append(finalEnvVars, fmt.Sprintf("%s=%s", key, val))
 	}
 
-	runner := models.NewShellCommandRunner(command, finalEnvVars, path, streamOutput, r.ProjectCmdOutputHandler)
+	runner := models.NewShellCommandRunner(shell, command, finalEnvVars, path, streamOutput, r.ProjectCmdOutputHandler)
 	output, err := runner.Run(ctx)
 
 	if postProcessOutput == valid.PostProcessRunOutputStripRefreshing {

--- a/server/core/terraform/terraform_client.go
+++ b/server/core/terraform/terraform_client.go
@@ -466,7 +466,7 @@ func (c *DefaultClient) RunCommandAsync(ctx command.ProjectContext, path string,
 		envVars = append(envVars, fmt.Sprintf("%s=%s", key, val))
 	}
 
-	runner := models.NewShellCommandRunner(cmd, envVars, path, true, c.projectCmdOutputHandler)
+	runner := models.NewShellCommandRunner("sh", cmd, envVars, path, true, c.projectCmdOutputHandler)
 	inCh, outCh := runner.RunCommandAsync(ctx)
 	return inCh, outCh
 }

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -65,20 +65,42 @@ type StepRunner interface {
 // CustomStepRunner runs custom run steps.
 type CustomStepRunner interface {
 	// Run cmd in path.
-	Run(ctx command.ProjectContext, cmd string, path string, envs map[string]string, streamOutput bool, postProcessOutput valid.PostProcessRunOutputOption) (string, error)
+	Run(
+		ctx command.ProjectContext,
+		shell string,
+		cmd string,
+		path string,
+		envs map[string]string,
+		streamOutput bool,
+		postProcessOutput valid.PostProcessRunOutputOption,
+	) (string, error)
 }
 
 //go:generate pegomock generate --package mocks -o mocks/mock_env_step_runner.go EnvStepRunner
 
 // EnvStepRunner runs env steps.
 type EnvStepRunner interface {
-	Run(ctx command.ProjectContext, cmd string, value string, path string, envs map[string]string) (string, error)
+	Run(
+		ctx command.ProjectContext,
+		shell string,
+		cmd string,
+		value string,
+		path string,
+		envs map[string]string,
+	) (string, error)
 }
 
 // MultiEnvStepRunner runs multienv steps.
 type MultiEnvStepRunner interface {
 	// Run cmd in path.
-	Run(ctx command.ProjectContext, cmd string, path string, envs map[string]string, postProcessOutput valid.PostProcessRunOutputOption) (string, error)
+	Run(
+		ctx command.ProjectContext,
+		shell string,
+		cmd string,
+		path string,
+		envs map[string]string,
+		postProcessOutput valid.PostProcessRunOutputOption,
+	) (string, error)
 }
 
 //go:generate pegomock generate --package mocks -o mocks/mock_webhooks_sender.go WebhooksSender
@@ -790,15 +812,15 @@ func (p *DefaultProjectCommandRunner) runSteps(steps []valid.Step, ctx command.P
 		case "state_rm":
 			out, err = p.StateRmStepRunner.Run(ctx, step.ExtraArgs, absPath, envs)
 		case "run":
-			out, err = p.RunStepRunner.Run(ctx, step.RunCommand, absPath, envs, true, step.Output)
+			out, err = p.RunStepRunner.Run(ctx, step.RunShell, step.RunCommand, absPath, envs, true, step.Output)
 		case "env":
-			out, err = p.EnvStepRunner.Run(ctx, step.RunCommand, step.EnvVarValue, absPath, envs)
+			out, err = p.EnvStepRunner.Run(ctx, step.RunShell, step.RunCommand, step.EnvVarValue, absPath, envs)
 			envs[step.EnvVarName] = out
 			// We reset out to the empty string because we don't want it to
 			// be printed to the PR, it's solely to set the environment variable.
 			out = ""
 		case "multienv":
-			out, err = p.MultiEnvStepRunner.Run(ctx, step.RunCommand, absPath, envs, step.Output)
+			out, err = p.MultiEnvStepRunner.Run(ctx, step.RunShell, step.RunCommand, absPath, envs, step.Output)
 		}
 
 		if out != "" {


### PR DESCRIPTION
## what

Added an option to define the shell for the custom workflow steps with the `command` filed, like `run`, `env`, and `multienv`.

## why

- This change simplifies writing more elaborate shell logic.
- The same functionality is achievable by running `command: bash -c "my inline shell script"`, but dealing with double quote escaping within the shell script is quite cumbersome.
- The default busybox shell is limited and having "native" access to bash will improve user experience.

## tests

- I run the unit tests.
- I verified manually tested this functionality on a local setup.

## references

- `closes: #1417`
