### PR TITLE
docs: supported emojis

### DIFF
--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -478,6 +478,8 @@ and set `--autoplan-modules` to `false`.
 
   The emoji reaction to use for marking processed comments. Currently supported on Azure DevOps, GitHub and GitLab. If not specified, Atlantis will not use an emoji reaction.
   Defaults to "" (empty string).
+  
+  Supports the options: "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes".
 
 ### `--enable-diff-markdown-format`
 


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

I went to add the emoji reaction functionality with :eye: and got the following error:
```
422 Invalid request.\n\neye is not a member of [\"+1\", \"-1\", \"laugh\", \"confused\", \"heart\", \"hooray\", \"rocket\", \"eyes\"].
```

So this PR just documents the emojis that are supported :)

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

Reduces the potential need for multiple deployments

## tests

<!--
- [ ] I have tested my changes by ...
-->

N/A

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

N/A

