### PR TITLE
docs: Introducing Atlantis Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Slack](https://img.shields.io/badge/Join-Atlantis%20Community%20Slack-red)](https://communityinviter.com/apps/cloud-native/cncf)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/runatlantis/atlantis/badge)](https://scorecard.dev/viewer/?uri=github.com/runatlantis/atlantis)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9428/badge)](https://www.bestpractices.dev/projects/9428)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Atlantis%20Guru-006BFF)](https://gurubase.io/g/atlantis)
 
 <p align="center">
   <img src="./runatlantis.io/public/hero.png" alt="Atlantis Logo"/><br><br>


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Atlantis Guru](https://gurubase.io/g/atlantis) to Gurubase. Atlantis Guru uses the data from this repo and data from the [docs](https://www.runatlantis.io/docs) to answer questions by leveraging the LLM.

In this PR, I showcased the "Atlantis Guru", which highlights that Atlantis now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Atlantis Guru in Gurubase, just let me know that's totally fine.
