### PR TITLE
fix: rendering of merge emoji when upstream was modified

### DIFF
--- a/server/events/templates/plan_success_wrapped.tmpl
+++ b/server/events/templates/plan_success_wrapped.tmpl
@@ -23,6 +23,6 @@ This plan was not saved because one or more projects failed and automerge requir
   {{ .RePlanCmd }}
   ```
 {{ end -}}
-{{ .PlanSummary -}}
+{{ .PlanSummary }}
 {{ template "mergedAgain" . -}}
 {{ end -}}


### PR DESCRIPTION
## what

Without this, we would typically get

```
Plan: 3 to add, 0 to change, 0 to destroy.:twisted_rightwards_arrows: Upstream was modified, a new merge was performed.
```

With this, we should be getting whitespace before the `:twisted_rightwards_arrows` part.

## why

Without this, we would not have our beautiful :twisted_rightwards_arrows: rendered as an emoji.
