### PR TITLE
chore(docs): Fix Using Atlantis Merge Method Link

### DIFF
--- a/runatlantis.io/docs/using-atlantis.md
+++ b/runatlantis.io/docs/using-atlantis.md
@@ -149,7 +149,7 @@ atlantis apply -w staging
 * `-p project` Apply the plan for this project. Refers to the name of the project configured in the repo's [`atlantis.yaml` file](repo-level-atlantis-yaml.md). Cannot be used at same time as `-d` or `-w`.
 * `-w workspace` Apply the plan for this [Terraform workspace](https://developer.hashicorp.com/terraform/language/state/workspaces). Ignore this if Terraform workspaces are unused.
 * `--auto-merge-disabled` Disable [automerge](automerging.md) for this apply command.
-* `--auto-merge-method method` Specify which [merge method](automerging.md#how-to-set-merge-method-for-automerge) use for the apply command if [automerge](automerging.md) is enabled. Implemented only for GitHub.
+* `--auto-merge-method method` Specify which [merge method](automerging.md#how-to-set-the-merge-method-for-automerge) use for the apply command if [automerge](automerging.md) is enabled. Implemented only for GitHub.
 * `--verbose` Append Atlantis log to comment.
 
 ### Additional Terraform flags


### PR DESCRIPTION
## what

Fix the auto-merge merge method link in the 'Using Atlantis' docs.

```
http://localhost:8080/docs/using-atlantis.html
	id #how-to-set-merge-method-for-automerge not found	http://localhost:8080/docs/automerging.html#how-to-set-merge-method-for-automerge
```