### PR TITLE
chore(workflow): Fix Website GitHub Workflow link-check Job Filter

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           filters: |
             src:
-              - '**.js'
+              - 'runatlantis.io/**'
               - 'package-lock.json'
               - 'package.json'
               - '.github/workflows/website.yml'


### PR DESCRIPTION
## what

Replace `**.js` with `runatlantis.io/**` in the website GitHub workflow link-check job filter.


## why

So that any changes to website files in PRs will trigger the link-check job.
