### PR TITLE
fix: GitHub - Support Token File for Git Commands

### DIFF
--- a/server/events/event_parser.go
+++ b/server/events/event_parser.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
 	"path"
 	"strings"
 
@@ -357,6 +358,7 @@ type EventParsing interface {
 type EventParser struct {
 	GithubUser         string
 	GithubToken        string
+	GithubTokenFile    string
 	GitlabUser         string
 	GitlabToken        string
 	GiteaUser          string
@@ -372,7 +374,15 @@ type EventParser struct {
 func (e *EventParser) ParseAPIPlanRequest(vcsHostType models.VCSHostType, repoFullName string, cloneURL string) (models.Repo, error) {
 	switch vcsHostType {
 	case models.Github:
-		return models.NewRepo(vcsHostType, repoFullName, cloneURL, e.GithubUser, e.GithubToken)
+		token := e.GithubToken
+		if e.GithubTokenFile != "" {
+			content, err := os.ReadFile(e.GithubTokenFile)
+			if err != nil {
+				return models.Repo{}, fmt.Errorf("failed reading github token file: %w", err)
+			}
+			token = string(content)
+		}
+		return models.NewRepo(vcsHostType, repoFullName, cloneURL, e.GithubUser, token)
 	case models.Gitea:
 		return models.NewRepo(vcsHostType, repoFullName, cloneURL, e.GiteaUser, e.GiteaToken)
 	case models.Gitlab:
@@ -626,7 +636,16 @@ func (e *EventParser) ParseGithubPull(logger logging.SimpleLogging, pull *github
 // returns a repo into the Atlantis model.
 // See EventParsing for return value docs.
 func (e *EventParser) ParseGithubRepo(ghRepo *github.Repository) (models.Repo, error) {
-	return models.NewRepo(models.Github, ghRepo.GetFullName(), ghRepo.GetCloneURL(), e.GithubUser, e.GithubToken)
+	token := e.GithubToken
+	if e.GithubTokenFile != "" {
+		content, err := os.ReadFile(e.GithubTokenFile)
+		if err != nil {
+			return models.Repo{}, fmt.Errorf("failed reading github token file: %w", err)
+		}
+		token = string(content)
+	}
+
+	return models.NewRepo(models.Github, ghRepo.GetFullName(), ghRepo.GetCloneURL(), e.GithubUser, token)
 }
 
 // ParseGiteaRepo parses the response from the Gitea API endpoint that

--- a/server/events/event_parser_test.go
+++ b/server/events/event_parser_test.go
@@ -36,6 +36,7 @@ import (
 var parser = events.EventParser{
 	GithubUser:         "github-user",
 	GithubToken:        "github-token",
+	GithubTokenFile:    "",
 	GitlabUser:         "gitlab-user",
 	GitlabToken:        "gitlab-token",
 	AllowDraftPRs:      false,

--- a/server/server.go
+++ b/server/server.go
@@ -560,6 +560,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	eventParser := &events.EventParser{
 		GithubUser:         userConfig.GithubUser,
 		GithubToken:        userConfig.GithubToken,
+		GithubTokenFile:    userConfig.GithubTokenFile,
 		GitlabUser:         userConfig.GitlabUser,
 		GitlabToken:        userConfig.GitlabToken,
 		GiteaUser:          userConfig.GiteaUser,


### PR DESCRIPTION
## what

Quick follow up to #3208.

I noticed during testing that we need to also set the token file here. I believe I must have been testing by running against a PR with a commit that was already checked out on the persistent volume. Atlantis detected that it didn't need to perform a `git clone` command.

I've updated my testing to include testing with a new PR and new commit, forcing a clean checkout.

## why

The GitHub client credentials are separate to the git client credentials, so we must set the token file here too when configuring Atlantis for a token file rather than the token directly.

## tests

Tested this with a clean clone in my environment.

## references

#3208

