### PR TITLE
chore(docs): Fix formatting on provider-credentials.md

### DIFF
--- a/runatlantis.io/docs/provider-credentials.md
+++ b/runatlantis.io/docs/provider-credentials.md
@@ -58,6 +58,7 @@ provider "aws" {
 ```
 
 Atlantis runs `terraform` with the following variables:
+
 | `-var` Argument                      | Description                                                                                                                            |
 |--------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
 | `atlantis_user=lkysow`               | The VCS username of who is running the plan command.                                                                                   |


### PR DESCRIPTION
## what

Fix the markdown formatting on `provider-credentials.md`

## why

```
Error: runatlantis.io/docs/provider-credentials.md:61 MD058/blanks-around-tables Tables should be surrounded by blank lines 
https://github.com/DavidAnson/markdownlint/blob/v0.35.0/doc/md058.md
```