### PR TITLE
chore: Add User Agent to Website Link GitHub Check Muffet Step

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -96,6 +96,7 @@ jobs:
             -e 'https://github.com/runatlantis/helm-charts#customization' \
             -e 'https://github.com/sethvargo/atlantis-on-gke/blob/master/terraform/tls.tf#L64-L84' \
             -e 'https://confluence.atlassian.com/*' \
+            --header 'User-Agent: Curl' \
             --header 'Accept-Encoding:deflate, gzip' \
             --buffer-size 8192 \
             http://localhost:8080/

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -96,7 +96,7 @@ jobs:
             -e 'https://github.com/runatlantis/helm-charts#customization' \
             -e 'https://github.com/sethvargo/atlantis-on-gke/blob/master/terraform/tls.tf#L64-L84' \
             -e 'https://confluence.atlassian.com/*' \
-            --header 'User-Agent: Curl' \
+            --header 'User-Agent: Mufffet' \
             --header 'Accept-Encoding:deflate, gzip' \
             --buffer-size 8192 \
             http://localhost:8080/

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -96,7 +96,7 @@ jobs:
             -e 'https://github.com/runatlantis/helm-charts#customization' \
             -e 'https://github.com/sethvargo/atlantis-on-gke/blob/master/terraform/tls.tf#L64-L84' \
             -e 'https://confluence.atlassian.com/*' \
-            --header 'User-Agent: Mufffet' \
+            --header 'User-Agent: Muffet' \
             --header 'Accept-Encoding:deflate, gzip' \
             --buffer-size 8192 \
             http://localhost:8080/


### PR DESCRIPTION
## what

Add a `User-Agent` header to the muffet step in the Website Link GitHub check.

## why

The `muffet` step is frequently failing with the following:

 ```
http://localhost:8080/contributing/glossary.html
	timeout	https://azure.microsoft.com/en-us/products/devops
```

There is an issue discussing this here: https://github.com/raviqqe/muffet/issues/306 and the solution is to add a `User-Agent` header to muffet.

Testing this locally, setting the User-Agent to `curl` fixed the Microsoft site, but then caused 429 errors on  https://developer.hashicorp.com/terraform/cdktf. Setting the User-Agent to `muffet` solved both issues.