### PR TITLE
fix: code scanning alert no. 12: Reflected cross-site scripting

### DIFF
--- a/server/controllers/events/events_controller.go
+++ b/server/controllers/events/events_controller.go
@@ -16,6 +16,7 @@ package events
 import (
 	"encoding/json"
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"strings"
@@ -178,7 +179,7 @@ func (e *VCSEventsController) handleGithubPost(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	githubReqID := "X-Github-Delivery=" + r.Header.Get("X-Github-Delivery")
+	githubReqID := "X-Github-Delivery=" + html.EscapeString(r.Header.Get("X-Github-Delivery"))
 	logger := e.Logger.With("gh-request-id", githubReqID)
 	scope := e.Scope.SubScope("github_event")
 


### PR DESCRIPTION
Fixes [https://github.com/runatlantis/atlantis/security/code-scanning/12](https://github.com/runatlantis/atlantis/security/code-scanning/12)

To fix the reflected cross-site scripting vulnerability, we need to ensure that any user-controlled input is properly sanitized or escaped before being included in the HTTP response. In this case, we can use the `html.EscapeString` function from the `html` package to escape any potentially dangerous characters in the `githubReqID` before including it in the `resp.body`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
