### PR TITLE
chore: Markdown Renderer Test Fix (release-0.27)

### DIFF
--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -387,7 +387,6 @@ $$$
 * :repeat: To re-run policies **plan** this project again by commenting:
     * $atlantis plan -d path -w workspace$
 </details>
-
 $$$
 policy set: policy1: 2 tests, 1 passed, 0 warnings, 1 failure, 0 exceptions
 $$$


### PR DESCRIPTION
## what

Fix the failing markdown renderer test in the `release-0.27` branch.

### References

- https://github.com/runatlantis/atlantis/pull/4389
