### PR TITLE
feat: add disable cloneurl check flag

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -76,6 +76,7 @@ const (
 	DisableApplyAllFlag              = "disable-apply-all"
 	DisableAutoplanFlag              = "disable-autoplan"
 	DisableAutoplanLabelFlag         = "disable-autoplan-label"
+	DisableCloneURLCheckFlag         = "disable-cloneurl-check"
 	DisableMarkdownFoldingFlag       = "disable-markdown-folding"
 	DisableRepoLockingFlag           = "disable-repo-locking"
 	DisableGlobalApplyLockFlag       = "disable-global-apply-lock"
@@ -610,6 +611,10 @@ var boolFlags = map[string]boolFlag{
 	UseTFPluginCache: {
 		description:  "Enable the use of the Terraform plugin cache",
 		defaultValue: true,
+	},
+	DisableCloneURLCheckFlag: {
+		description:  "Disable the clone URL path check that verifies the clone URL matches the repo name.",
+		defaultValue: false,
 	},
 }
 var intFlags = map[string]intFlag{

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -158,6 +158,7 @@ var testFlags = map[string]interface{}{
 	EnablePolicyChecksFlag:           false,
 	EnableRegExpCmdFlag:              false,
 	EnableDiffMarkdownFormat:         false,
+	DisableCloneURLCheckFlag:         true,
 }
 
 func TestExecute_Defaults(t *testing.T) {

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -158,7 +158,7 @@ var testFlags = map[string]interface{}{
 	EnablePolicyChecksFlag:           false,
 	EnableRegExpCmdFlag:              false,
 	EnableDiffMarkdownFormat:         false,
-	DisableCloneURLCheckFlag:         true,
+	DisableCloneURLCheckFlag:         false,
 }
 
 func TestExecute_Defaults(t *testing.T) {

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -430,6 +430,16 @@ and set `--autoplan-modules` to `false`.
 
   If `disable-autoplan` property is `true`, this flag has no effect.
 
+### `--disable-cloneurl-check`
+
+  ```bash
+  atlantis server --disable-cloneurl-check
+  # or
+  ATLANTIS_DISABLE_CLONEURL_CHECK=true
+  ```
+
+  Disable the clone URL path check that verifies the clone URL matches the repo name. By default, Atlantis verifies that the clone URL path matches the repo name to avoid malicious URLs. This flag disables that check.
+
 ### `--disable-markdown-folding`
 
   ```bash

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -32,6 +32,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// DisableCloneURLCheck controls whether to skip the clone URL path check.
+var DisableCloneURLCheck bool
+
 type PullReqStatus struct {
 	ApprovalStatus ApprovalStatus
 	Mergeable      bool
@@ -96,7 +99,8 @@ func NewRepo(vcsHostType VCSHostType, repoFullName string, cloneURL string, vcsU
 	// and because the caller in that case actually constructs the clone url
 	// from the repo name and so there's no point checking if they match.
 	// Azure DevOps also does not require .git at the end of clone urls.
-	if vcsHostType != BitbucketServer && vcsHostType != AzureDevops {
+	// We also skip this check if DisableCloneURLCheck is true.
+	if vcsHostType != BitbucketServer && vcsHostType != AzureDevops && !DisableCloneURLCheck {
 		expClonePath := fmt.Sprintf("/%s.git", repoFullName)
 		if expClonePath != cloneURLParsed.Path {
 			return Repo{}, fmt.Errorf("expected clone url to have path %q but had %q", expClonePath, cloneURLParsed.Path)

--- a/server/server.go
+++ b/server/server.go
@@ -168,6 +168,9 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		return nil, err
 	}
 
+	// Set the clone URL check flag based on user config
+	models.DisableCloneURLCheck = userConfig.DisableCloneURLCheck
+
 	var supportedVCSHosts []models.VCSHostType
 	var githubClient vcs.IGithubClient
 	var githubAppEnabled bool

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -34,6 +34,7 @@ type UserConfig struct {
 	DisableApplyAll             bool   `mapstructure:"disable-apply-all"`
 	DisableAutoplan             bool   `mapstructure:"disable-autoplan"`
 	DisableAutoplanLabel        string `mapstructure:"disable-autoplan-label"`
+	DisableCloneURLCheck        bool   `mapstructure:"disable-cloneurl-check"`
 	DisableMarkdownFolding      bool   `mapstructure:"disable-markdown-folding"`
 	DisableRepoLocking          bool   `mapstructure:"disable-repo-locking"`
 	DisableGlobalApplyLock      bool   `mapstructure:"disable-global-apply-lock"`


### PR DESCRIPTION
## what

Adding a new flag to optionally disable the clone URL path check that verifies the clone URL matches the repo name


## why

In one of my projects github enterprise unfortunately was setup with a basepath (like `git.acme.com/gitlab`). Setting `ATLANTIS_GITLAB_HOSTNAME` to `git.acme.com/gitlab` results in an error like:
`expected clone url to have path "/path/to/repo.git" but had "/gitlab/path/to/repo.git"`

Setting the new flag to `true` disables this check

## tests

- [X] I have tested my changes by building atlantis and running it with the new flag


## references

closes #1450


