### PR TITLE
chore(renovate): only support most two recent releases 0.31 and 0.32

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,7 +9,8 @@
   automerge: true,
   baseBranches: [
     'main',
-    '/^release-.*/',
+    'release-0.31',
+    'release-0.32',
   ],
   platformAutomerge: true,
   labels: [


### PR DESCRIPTION
## what

per security policy doc, only supports 0.31 and 0.32, which are the most two recent releases. 

closes #5215
closes #5216
closes #5217
closes #5218
closes #5219

relates to https://github.com/runatlantis/atlantis/issues/2818