### PR TITLE
feat: Trim backticks from MR comments (for Gitlab)

### DIFF
--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -145,6 +145,7 @@ type CommentParseResult struct {
 // - atlantis import ADDRESS ID
 func (e *CommentParser) Parse(rawComment string, vcsHost models.VCSHostType) CommentParseResult {
 	comment := strings.TrimSpace(rawComment)
+	comment = strings.Trim(comment, "`")
 
 	if multiLineRegex.MatchString(comment) {
 		return CommentParseResult{Ignore: true}

--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -144,6 +144,33 @@ func TestParse_HelpResponse(t *testing.T) {
 	}
 }
 
+func TestParse_TrimCommandString(t *testing.T) {
+	t.Log("commands should be trimmed of whitespace and backtick (helps with Gitlab copy/paste issues)")
+	allowCommandsCases := [][]command.Name{
+		command.AllCommentCommands,
+		{}, // empty case
+	}
+	helpComments := []string{
+		"`atlantis help`",
+		"`  atlantis help  `",
+		"`atlantis help`  ",
+		"  `atlantis help",
+	}
+	for _, allowCommandCase := range allowCommandsCases {
+		for _, c := range helpComments {
+			t.Run(fmt.Sprintf("%s with allow commands %v", c, allowCommandCase), func(t *testing.T) {
+				commentParser := events.CommentParser{
+					GithubUser:     "github-user",
+					ExecutableName: "atlantis",
+					AllowCommands:  allowCommandCase,
+				}
+				r := commentParser.Parse(c, models.Github)
+				Equals(t, commentParser.HelpComment(), r.CommentResponse)
+			})
+		}
+	}
+}
+
 func TestParse_UnusedArguments(t *testing.T) {
 	t.Log("if there are unused flags we return an error")
 	cases := []struct {


### PR DESCRIPTION
## what

Small change to trim backticks (`` ` ``) from MR comments to help with copy pasting atlantis commands from Gitlab. This is in addition to trimming whitespace.

## why

Gitlab adds backticks when copy pasting code, which currently fails with atlantis and requires having to remove them before submitting the comment.

For example, copying this pre-populated code

<img width="1018" alt="image" src="https://github.com/user-attachments/assets/a975b61b-c9f5-46e9-8b1f-c9af138f5643" />

Becomes 

<img width="1114" alt="image" src="https://github.com/user-attachments/assets/2fcc0356-ee3a-45d4-8fc9-a5a4a70c78e5" />

## tests

Added a unit test

