### PR TITLE
chore: Upgrade katex to 0.16.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3070,9 +3070,9 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.16.15",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.15.tgz",
-      "integrity": "sha512-yE9YJIEAk2aZ+FL/G8r+UGw0CTUzEA8ZFy6E+8tc3spHUKq3qBnzCkI1CQwGoI9atJhVyFPEypQsTY7mJ1Pi9w==",
+      "version": "0.16.21",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.21.tgz",
+      "integrity": "sha512-XvqR7FgOHtWupfMiigNzmh+MgUVmDGU2kXZm899ZkPfcuoPuFxyHmXsgATDpFZDAXCI8tvinaVcDo8PIIJSo4A==",
       "dev": true,
       "funding": [
         "https://opencollective.com/katex",


### PR DESCRIPTION
## what

Ran `npm upgrade katex`

## why

Address vulnerability https://www.cve.org/CVERecord?id=CVE-2025-23207.

This should also fix failing CI

## tests

I ran `npm run website:dev` and poked around, seemed fine.

## references

https://www.cve.org/CVERecord?id=CVE-2025-23207
CI failing on main: https://app.fossa.com/projects/git%2Bgithub.com%2Frunatlantis%2Fatlantis/refs/branch/main/cfe9df7ea61de8cf72a812b4d61a4fd95dc86d2e/preview

