### PR TITLE
chore: Fix build CI mismatch

### DIFF
--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -241,6 +241,7 @@ jobs:
     strategy:
       matrix:
         image_type: [alpine, debian]
+        platform: [linux/arm64/v8, linux/amd64, linux/arm/v7]
     runs-on: ubuntu-24.04
     steps:
       - run: 'echo "No build required"'

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/runatlantis/atlantis/badge)](https://scorecard.dev/viewer/?uri=github.com/runatlantis/atlantis)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9428/badge)](https://www.bestpractices.dev/projects/9428)
 
+
 <p align="center">
   <img src="./runatlantis.io/public/hero.png" alt="Atlantis Logo"/><br><br>
   <b>Terraform Pull Request Automation</b>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/runatlantis/atlantis/badge)](https://scorecard.dev/viewer/?uri=github.com/runatlantis/atlantis)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9428/badge)](https://www.bestpractices.dev/projects/9428)
 
-
 <p align="center">
   <img src="./runatlantis.io/public/hero.png" alt="Atlantis Logo"/><br><br>
   <b>Terraform Pull Request Automation</b>


### PR DESCRIPTION
## what

Fix strategy so "skip build" has same matrix as "test" for build.


## why

Otherwise these checks are never satisfied in situations where the build doesn't occur

## tests

This PR is not a good test of itself, since it changes the github CI file, thus triggering the builds explicitly :). After this is merged, I'll try another PR that shouldn't trigger a build and we'll confirm they are "skipped"

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

