### PR TITLE
chore: Clarify logs in determining merged project configs

### DIFF
--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -504,6 +504,8 @@ func (p *DefaultProjectCommandBuilder) buildAllCommandsByCfg(ctx *command.Contex
 			return nil, errors.Wrapf(err, "parsing %s", repoCfgFile)
 		}
 		ctx.Log.Info("successfully parsed %s file", repoCfgFile)
+	} else {
+		ctx.Log.Info("repo config file %s is absent, using global defaults", repoCfg)
 	}
 
 	mergedProjectCfgs, err := p.getMergedProjectCfgs(ctx, repoDir, modifiedFiles, repoCfg)

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -379,7 +379,7 @@ func (p *DefaultProjectCommandBuilder) autoDiscoverModeEnabled(ctx *command.Cont
 }
 
 // getMergedProjectCfgs gets all merged project configs for building commands given a context and a clone repo
-func (p *DefaultProjectCommandBuilder) getMergedProjectCfgs(ctx *command.Context, repoDir string, modifiedFiles []string, repoCfg valid.RepoCfg, hasRepoCfg bool, repoCfgFile string) ([]valid.MergedProjectCfg, error) {
+func (p *DefaultProjectCommandBuilder) getMergedProjectCfgs(ctx *command.Context, repoDir string, modifiedFiles []string, repoCfg valid.RepoCfg) ([]valid.MergedProjectCfg, error) {
 	mergedCfgs := make([]valid.MergedProjectCfg, 0)
 
 	moduleInfo, err := FindModuleProjects(repoDir, p.AutoDetectModuleFiles)
@@ -403,17 +403,8 @@ func (p *DefaultProjectCommandBuilder) getMergedProjectCfgs(ctx *command.Context
 	}
 
 	if p.autoDiscoverModeEnabled(ctx, repoCfg) {
-		// If there is no config file or it specified no projects, then we'll plan each project that
-		// our algorithm determines was modified.
-		if hasRepoCfg {
-			if len(repoCfg.Projects) == 0 {
-				ctx.Log.Info("no projects are defined in %s. Will resume automatic detection", repoCfgFile)
-			} else {
-				ctx.Log.Info("automatic project discovery enabled. Will resume automatic detection")
-			}
-		} else {
-			ctx.Log.Info("found no %s file", repoCfgFile)
-		}
+		ctx.Log.Info("automatic project discovery enabled. Will run automatic detection")
+
 		// build a module index for projects that are explicitly included
 		allModifiedProjects := p.ProjectFinder.DetermineProjects(
 			ctx.Log, modifiedFiles, ctx.Pull.BaseRepo.FullName, repoDir, p.AutoplanFileList, moduleInfo)
@@ -515,7 +506,7 @@ func (p *DefaultProjectCommandBuilder) buildAllCommandsByCfg(ctx *command.Contex
 		ctx.Log.Info("successfully parsed %s file", repoCfgFile)
 	}
 
-	mergedProjectCfgs, err := p.getMergedProjectCfgs(ctx, repoDir, modifiedFiles, repoCfg, hasRepoCfg, repoCfgFile)
+	mergedProjectCfgs, err := p.getMergedProjectCfgs(ctx, repoDir, modifiedFiles, repoCfg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## what

Collapse and clarify logs in determining merged project configs.


## why

I didn't quite understand this when going through #5245, but the logs and comments under automatic detection made it seem like it was conditional on other projects not being found, however that's not the case. If automatic detection is enabled, we simply run it. Maybe that used to be the case, but now this log and comment is a bit misleading and redundant.

This also allowed fewer parameters to be passed into this function, which feels more correct to me; it's a detail that this function doesn't quite "know" that the reason hasRepoCfg is false is that it couldn't find the file. That logging can and should happen closer to when the parsing actually happens.

## tests

Normal CI

## references

