### PR TITLE
fix: ensure multi-image builds succeed

### DIFF
--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -200,7 +200,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3
         # https://github.com/docker/build-push-action/issues/761#issuecomment-1575006515
@@ -217,7 +216,8 @@ jobs:
           context: .
           build-args: |
             ATLANTIS_BASE_TAG_TYPE=${{ matrix.image_type }}
-          push: true
+          push: false
+          load: true
           tags: "${{ env.DOCKER_REPO }}:goss-test"
           target: ${{ matrix.image_type }}
 

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -172,13 +172,11 @@ jobs:
 
     - name: "Sign images with environment annotations"
       # no key needed, we're using the GitHub OIDC flow
-      # Only run on alpine/amd64 build to avoid signing multiple times
       if: env.PUSH == 'true' && github.event_name != 'pull_request'
       run: |
         # Sign dev tags, version tags, and latest tags
         echo "${TAGS}" | xargs -I {} cosign sign \
           --yes \
-          --recursive=true \
           -a actor=${{ github.actor}} \
           -a ref_name=${{ github.ref_name}} \
           -a ref=${{ github.sha }} \

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -220,8 +220,7 @@ jobs:
           context: .
           build-args: |
             ATLANTIS_BASE_TAG_TYPE=${{ matrix.image_type }}
-          push: false
-          load: true
+          push: true
           tags: "${{ env.DOCKER_REPO }}:goss-test"
           target: ${{ matrix.image_type }}
 

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -53,7 +53,6 @@ jobs:
     strategy:
       matrix:
         image_type: [alpine, debian]
-        platform: [linux/arm64/v8, linux/amd64, linux/arm/v7]
     runs-on: ubuntu-24.04
     env:
       # Set docker repo to either the fork or the main repo where the branch exists
@@ -156,7 +155,7 @@ jobs:
           ATLANTIS_VERSION=${{ env.RELEASE_VERSION }}
           ATLANTIS_COMMIT=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
           ATLANTIS_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
-        platforms: ${{ matrix.platform }}
+        platforms: linux/arm64/v8, linux/amd64, linux/arm/v7
         push: ${{ env.PUSH }}
         tags: ${{ steps.meta.outputs.tags }}
         target: ${{ matrix.image_type }}

--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -173,7 +173,7 @@ jobs:
     - name: "Sign images with environment annotations"
       # no key needed, we're using the GitHub OIDC flow
       # Only run on alpine/amd64 build to avoid signing multiple times
-      if: env.PUSH == 'true' && github.event_name != 'pull_request' && matrix.image_type == 'alpine' && matrix.platform == 'linux/amd64'
+      if: env.PUSH == 'true' && github.event_name != 'pull_request'
       run: |
         # Sign dev tags, version tags, and latest tags
         echo "${TAGS}" | xargs -I {} cosign sign \


### PR DESCRIPTION
## what

we implemented image signing in #5185. unfortunately a logic flaw was introduced in this change which broke multi-architecture builds. the change modified the build steps to use a matrix build. however, the matrix was incorrectly configured, which caused the last arch in the build sequence (linux/arm/v7) to overwrite the other 2 tags. effectively, we steamrolled ourselves.

this change corrects the error by simplifying the matrix. instead of using six parallel build steps, we use a single build step which pushes a multi-arch manifest in one shot. this has the added benefit of speeding builds up. 


## why

atlantis guarantees the availability of images for multiple CPU architectures. this promise must be kept.
## tests

tested by building images in my fork.

* debian: https://github.com/notdurson/atlantis/pkgs/container/atlantis/340182754?tag=dev-debian
* alpine: https://github.com/notdurson/atlantis/pkgs/container/atlantis/340182683?tag=dev-alpine 
## references

closes #5222 