### PR TITLE
chore: Remove some references to pkg/errors

### DIFF
--- a/server/core/config/parser_validator.go
+++ b/server/core/config/parser_validator.go
@@ -111,7 +111,7 @@ func (p *ParserValidator) ParseRepoCfgData(repoCfgData []byte, globalCfg valid.G
 func (p *ParserValidator) ParseGlobalCfg(configFile string, defaultCfg valid.GlobalCfg) (valid.GlobalCfg, error) {
 	configData, err := os.ReadFile(configFile) // nolint: gosec
 	if err != nil {
-		return valid.GlobalCfg{}, fmt.Errorf("unable to read %s file: %v", configFile, err)
+		return valid.GlobalCfg{}, fmt.Errorf("unable to read %s file: %w", configFile, err)
 	}
 	if len(configData) == 0 {
 		return valid.GlobalCfg{}, fmt.Errorf("file %s was empty", configFile)
@@ -200,7 +200,7 @@ func (p *ParserValidator) applyLegacyShellParsing(cfg *valid.RepoCfg) error {
 		if s.StepName == "run" {
 			split, err := shlex.Split(s.RunCommand)
 			if err != nil {
-				return fmt.Errorf("unable to parse %q: %v", s.RunCommand, err)
+				return fmt.Errorf("unable to parse %q: %w", s.RunCommand, err)
 			}
 			s.RunCommand = strings.Join(split, " ")
 		}

--- a/server/core/config/parser_validator.go
+++ b/server/core/config/parser_validator.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -11,7 +12,7 @@ import (
 
 	validation "github.com/go-ozzo/ozzo-validation"
 	shlex "github.com/google/shlex"
-	"github.com/pkg/errors"
+
 	"github.com/runatlantis/atlantis/server/core/config/raw"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	yaml "gopkg.in/yaml.v3"
@@ -29,11 +30,11 @@ func (p *ParserValidator) HasRepoCfg(absRepoDir, repoConfigFile string) (bool, e
 	const invalidExtensionFilename = "atlantis.yml"
 	_, err := os.Stat(p.repoCfgPath(absRepoDir, invalidExtensionFilename))
 	if err == nil {
-		return false, errors.Errorf("found %q as config file; rename using the .yaml extension", invalidExtensionFilename)
+		return false, fmt.Errorf("found %q as config file; rename using the .yaml extension", invalidExtensionFilename)
 	}
 
 	_, err = os.Stat(p.repoCfgPath(absRepoDir, repoConfigFile))
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		return false, nil
 	}
 	return err == nil, err
@@ -48,12 +49,7 @@ func (p *ParserValidator) ParseRepoCfg(absRepoDir string, globalCfg valid.Global
 	configData, err := os.ReadFile(configFile) // nolint: gosec
 
 	if err != nil {
-		if !os.IsNotExist(err) {
-			return valid.RepoCfg{}, errors.Wrapf(err, "unable to read %s file", repoConfigFile)
-		}
-		// Don't wrap os.IsNotExist errors because we want our callers to be
-		// able to detect if it's a NotExist err.
-		return valid.RepoCfg{}, err
+		return valid.RepoCfg{}, fmt.Errorf("unable to read %s file: %w", repoConfigFile, err)
 	}
 	return p.ParseRepoCfgData(configData, globalCfg, repoID, branch)
 }
@@ -115,7 +111,7 @@ func (p *ParserValidator) ParseRepoCfgData(repoCfgData []byte, globalCfg valid.G
 func (p *ParserValidator) ParseGlobalCfg(configFile string, defaultCfg valid.GlobalCfg) (valid.GlobalCfg, error) {
 	configData, err := os.ReadFile(configFile) // nolint: gosec
 	if err != nil {
-		return valid.GlobalCfg{}, errors.Wrapf(err, "unable to read %s file", configFile)
+		return valid.GlobalCfg{}, fmt.Errorf("unable to read %s file: %v", configFile, err)
 	}
 	if len(configData) == 0 {
 		return valid.GlobalCfg{}, fmt.Errorf("file %s was empty", configFile)
@@ -204,7 +200,7 @@ func (p *ParserValidator) applyLegacyShellParsing(cfg *valid.RepoCfg) error {
 		if s.StepName == "run" {
 			split, err := shlex.Split(s.RunCommand)
 			if err != nil {
-				return errors.Wrapf(err, "unable to parse %q", s.RunCommand)
+				return fmt.Errorf("unable to parse %q: %v", s.RunCommand, err)
 			}
 			s.RunCommand = strings.Join(split, " ")
 		}

--- a/server/core/config/parser_validator_test.go
+++ b/server/core/config/parser_validator_test.go
@@ -1,7 +1,9 @@
 package config_test
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -50,14 +52,14 @@ func TestHasRepoCfg_InvalidFileExtension(t *testing.T) {
 func TestParseRepoCfg_DirDoesNotExist(t *testing.T) {
 	r := config.ParserValidator{}
 	_, err := r.ParseRepoCfg("/not/exist", globalCfg, "", "")
-	Assert(t, os.IsNotExist(err), "exp not exist err")
+	Assert(t, errors.Is(err, fs.ErrNotExist), "exp not exist err")
 }
 
 func TestParseRepoCfg_FileDoesNotExist(t *testing.T) {
 	tmpDir := t.TempDir()
 	r := config.ParserValidator{}
 	_, err := r.ParseRepoCfg(tmpDir, globalCfg, "", "")
-	Assert(t, os.IsNotExist(err), "exp not exist err")
+	Assert(t, errors.Is(err, fs.ErrNotExist), "exp not exist err")
 }
 
 func TestParseRepoCfg_BadPermissions(t *testing.T) {

--- a/server/core/config/raw/autodiscover.go
+++ b/server/core/config/raw/autodiscover.go
@@ -1,6 +1,7 @@
 package raw
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 

--- a/server/core/config/raw/autodiscover.go
+++ b/server/core/config/raw/autodiscover.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/bmatcuk/doublestar/v4"
 	validation "github.com/go-ozzo/ozzo-validation"
-	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 )
 

--- a/server/core/config/raw/global_cfg.go
+++ b/server/core/config/raw/global_cfg.go
@@ -185,7 +185,7 @@ func (r Repo) Validate() error {
 		}
 		_, err := regexp.Compile(id[1 : len(id)-1])
 		if err != nil {
-			return fmt.Errorf("parsing: %s: %v", id, err)
+			return fmt.Errorf("parsing: %s: %w", id, err)
 		}
 		return nil
 	}
@@ -201,7 +201,7 @@ func (r Repo) Validate() error {
 		withoutSlashes := branch[1 : len(branch)-1]
 		_, err := regexp.Compile(withoutSlashes)
 		if err != nil {
-			return fmt.Errorf("parsing: %s: %v", branch, err)
+			return fmt.Errorf("parsing: %s: %w", branch, err)
 		}
 		return nil
 	}

--- a/server/core/config/raw/global_cfg.go
+++ b/server/core/config/raw/global_cfg.go
@@ -1,12 +1,12 @@
 package raw
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
 
 	validation "github.com/go-ozzo/ozzo-validation"
-	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/utils"
 )
@@ -184,7 +184,10 @@ func (r Repo) Validate() error {
 			return nil
 		}
 		_, err := regexp.Compile(id[1 : len(id)-1])
-		return errors.Wrapf(err, "parsing: %s", id)
+		if err != nil {
+			return fmt.Errorf("parsing: %s: %v", id, err)
+		}
+		return nil
 	}
 
 	branchValid := func(value interface{}) error {
@@ -197,7 +200,10 @@ func (r Repo) Validate() error {
 		}
 		withoutSlashes := branch[1 : len(branch)-1]
 		_, err := regexp.Compile(withoutSlashes)
-		return errors.Wrapf(err, "parsing: %s", branch)
+		if err != nil {
+			return fmt.Errorf("parsing: %s: %v", branch, err)
+		}
+		return nil
 	}
 
 	repoConfigFileValid := func(value interface{}) error {

--- a/server/core/config/raw/project.go
+++ b/server/core/config/raw/project.go
@@ -76,7 +76,7 @@ func (p Project) Validate() error {
 		withoutSlashes := branch[1 : len(branch)-1]
 		_, err := regexp.Compile(withoutSlashes)
 		if err != nil {
-			return fmt.Errorf("parsing: %s: %v", branch, err)
+			return fmt.Errorf("parsing: %s: %w", branch, err)
 		}
 		return nil
 	}

--- a/server/core/config/raw/project.go
+++ b/server/core/config/raw/project.go
@@ -1,6 +1,7 @@
 package raw
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"path/filepath"
@@ -9,7 +10,6 @@ import (
 
 	validation "github.com/go-ozzo/ozzo-validation"
 	version "github.com/hashicorp/go-version"
-	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 )
 
@@ -75,7 +75,10 @@ func (p Project) Validate() error {
 		}
 		withoutSlashes := branch[1 : len(branch)-1]
 		_, err := regexp.Compile(withoutSlashes)
-		return errors.Wrapf(err, "parsing: %s", branch)
+		if err != nil {
+			return fmt.Errorf("parsing: %s: %v", branch, err)
+		}
+		return nil
 	}
 
 	DependsOn := func(value interface{}) error {

--- a/server/core/config/raw/raw.go
+++ b/server/core/config/raw/raw.go
@@ -4,8 +4,9 @@
 package raw
 
 import (
+	"fmt"
+
 	version "github.com/hashicorp/go-version"
-	"github.com/pkg/errors"
 )
 
 // VersionValidator helper function to validate binary version.
@@ -16,5 +17,5 @@ func VersionValidator(value interface{}) error {
 		return nil
 	}
 	_, err := version.NewVersion(*strPtr)
-	return errors.Wrapf(err, "version %q could not be parsed", *strPtr)
+	return fmt.Errorf("version %q could not be parsed: %w", *strPtr, err)
 }

--- a/server/core/config/raw/raw.go
+++ b/server/core/config/raw/raw.go
@@ -17,5 +17,8 @@ func VersionValidator(value interface{}) error {
 		return nil
 	}
 	_, err := version.NewVersion(*strPtr)
-	return fmt.Errorf("version %q could not be parsed: %w", *strPtr, err)
+	if err != nil {
+		return fmt.Errorf("version %q could not be parsed: %w", *strPtr, err)
+	}
+	return nil
 }

--- a/server/core/config/raw/raw_test.go
+++ b/server/core/config/raw/raw_test.go
@@ -4,7 +4,8 @@ import (
 	"io"
 	"strings"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"gopkg.in/yaml.v3"
 )
 


### PR DESCRIPTION
## what

Remove references to `pkg/errors` from server/core/config packages.

## why

Per #5269 we should be removing this dependency. I picked this package first because it has a somewhat complicated use of the pkg/errors and I wanted to make sure it worked as expected.

## tests

Running unit tests

## references

- Partially addresses: #5269

