### PR TITLE
chore: Simplify use of the doublestar Match for ignore paths

### DIFF
--- a/server/core/config/valid/repo_cfg_test.go
+++ b/server/core/config/valid/repo_cfg_test.go
@@ -410,9 +410,8 @@ func TestConfig_IsPathIgnoredForAutoDiscover(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
 
-			enabled, err := c.repoCfg.IsPathIgnoredForAutoDiscover(c.path)
-			Ok(t, err)
-			Equals(t, c.expIgnored, enabled)
+			ignored := c.repoCfg.IsPathIgnoredForAutoDiscover(c.path)
+			Equals(t, c.expIgnored, ignored)
 		})
 	}
 }

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -421,11 +421,7 @@ func (p *DefaultProjectCommandBuilder) getMergedProjectCfgs(ctx *command.Context
 		}
 		for _, mp := range allModifiedProjects {
 			path := filepath.Clean(mp.Path)
-			ignore, err := repoCfg.IsPathIgnoredForAutoDiscover(path)
-			if err != nil {
-				return nil, err
-			}
-			if ignore {
+			if repoCfg.IsPathIgnoredForAutoDiscover(path) {
 				continue
 			}
 			_, dirExists := configuredProjDirs[path]


### PR DESCRIPTION
## what

 Simplify use of the doublestar Match for ignore paths by using MatchUnvalidated.


## why

We already explicitly validate all patterns when parsing the config, there's no reason to run Match(), which does additional validation and optionally returns an error.

I didn't quite understand how this package worked until a conversation with the maintainer (https://github.com/bmatcuk/doublestar/issues/85), and now I think this is the correct approach.

## tests

Running unit tests.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

