### PR TITLE
chore: Revert "chore: Fix build CI mismatch"

### DIFF
--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -252,7 +252,6 @@ jobs:
     strategy:
       matrix:
         image_type: [alpine, debian]
-        platform: [linux/arm64/v8, linux/amd64, linux/arm/v7]
     runs-on: ubuntu-24.04
     steps:
       - name: Harden Runner


### PR DESCRIPTION
Reverts runatlantis/atlantis#5253

This needs reverting following on from https://github.com/runatlantis/atlantis/pull/5257 as it is no longer correct, and is blocking the CI of PRs that don't build images, e.g.: https://github.com/runatlantis/atlantis/pull/5276