### PR TITLE
chore: Remove usage of errors.Cause

### DIFF
--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -825,7 +825,7 @@ func (p *DefaultProjectCommandBuilder) buildProjectCommand(ctx *command.Context,
 	// use the default repository workspace because it is the only one guaranteed to have an atlantis.yaml,
 	// other workspaces will not have the file if they are using pre_workflow_hooks to generate it dynamically
 	repoDir, err := p.WorkingDir.GetWorkingDir(ctx.Pull.BaseRepo, ctx.Pull, DefaultWorkspace)
-	if os.IsNotExist(errors.Cause(err)) {
+	if errors.Is(err, os.ErrNotExist) {
 		return projCtx, errors.New("no working directory found–did you run plan?")
 	} else if err != nil {
 		return projCtx, err


### PR DESCRIPTION
## what

Remove all usages of `errors.Cause()`

## why

We are replacing `pkg/errors` with the standard library `errors` (#5269). One method the standard library does not have is Cause(). It *does* have errors.Is, which is in fact just a thin wrapper around the std library's (https://github.com/pkg/errors/blob/master/go113.go#L16), so even though this package is importing and using pkg/errors, when it is changed to import and use std library, this new line will be a no-op.

## tests

Ran unit tests.

## references

- Partially addresses: #5269 

