### PR TITLE
chore(goreleaser): update for deprecated attributes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,8 @@ builds:
 archives:
   - id: zip
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
-    format: zip
+    formats:
+      - zip
     files:
       - none*
 


### PR DESCRIPTION
`archives.format` is deprecated see https://goreleaser.com/deprecations/#archivesformat

```
    • DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
```