### PR TITLE
chore: Add nil checks before returning wrapped error

### DIFF
--- a/server/controllers/events/events_controller.go
+++ b/server/controllers/events/events_controller.go
@@ -413,8 +413,8 @@ func (e *VCSEventsController) HandleGithubCommentEvent(event *github.IssueCommen
 
 	baseRepo, user, pullNum, err := e.Parser.ParseGithubIssueCommentEvent(logger, event)
 
-	wrapped := errors.Wrapf(err, "Failed parsing event: %s", githubReqID)
 	if err != nil {
+		wrapped := errors.Wrapf(err, "Failed parsing event: %s", githubReqID)
 		return HTTPResponse{
 			body: wrapped.Error(),
 			err: HTTPError{

--- a/server/controllers/websocket/mux.go
+++ b/server/controllers/websocket/mux.go
@@ -76,5 +76,9 @@ func (m *Multiplexor) Handle(w http.ResponseWriter, r *http.Request) error {
 	go m.registry.Register(key, buffer)
 	defer m.registry.Deregister(key, buffer)
 
-	return errors.Wrapf(m.writer.Write(w, r, buffer), "writing to ws %s", key)
+	err = m.writer.Write(w, r, buffer)
+	if err != nil {
+		return errors.Wrapf(err, "writing to ws %s", key)
+	}
+	return nil
 }

--- a/server/core/redis/redis.go
+++ b/server/core/redis/redis.go
@@ -200,7 +200,10 @@ func (r *RedisDB) LockCommand(cmdName command.Name, lockTime time.Time) (*comman
 	_, err := r.client.Get(ctx, cmdLockKey).Result()
 	if err == redis.Nil {
 		err = r.client.Set(ctx, cmdLockKey, newLockSerialized, 0).Err()
-		return &lock, errors.Wrap(err, "db transaction failed")
+		if err != nil {
+			return nil, errors.Wrap(err, "db transaction failed")
+		}
+		return &lock, nil
 	} else if err != nil {
 		return nil, errors.Wrap(err, "db transaction failed")
 	}

--- a/server/core/redis/redis.go
+++ b/server/core/redis/redis.go
@@ -267,7 +267,10 @@ func (r *RedisDB) UpdateProjectStatus(pull models.PullRequest, workspace string,
 	}
 
 	err = r.writePull(key, currStatus)
-	return errors.Wrap(err, "db transaction failed")
+	if err != nil {
+		errors.Wrap(err, "db transaction failed")
+	}
+	return nil
 }
 
 func (r *RedisDB) GetPullStatus(pull models.PullRequest) (*models.PullStatus, error) {
@@ -277,8 +280,10 @@ func (r *RedisDB) GetPullStatus(pull models.PullRequest) (*models.PullStatus, er
 	}
 
 	pullStatus, err := r.getPull(key)
-
-	return pullStatus, errors.Wrap(err, "db transaction failed")
+	if err != nil {
+		return nil, errors.Wrap(err, "db transaction failed")
+	}
+	return pullStatus, nil
 }
 
 func (r *RedisDB) DeletePullStatus(pull models.PullRequest) error {
@@ -286,7 +291,11 @@ func (r *RedisDB) DeletePullStatus(pull models.PullRequest) error {
 	if err != nil {
 		return err
 	}
-	return errors.Wrap(r.deletePull(key), "db transaction failed")
+	err = r.deletePull(key)
+	if err != nil {
+		return errors.Wrap(err, "db transaction failed")
+	}
+	return nil
 }
 
 func (r *RedisDB) UpdatePullWithResults(pull models.PullRequest, newResults []command.ProjectResult) (models.PullStatus, error) {
@@ -359,7 +368,11 @@ func (r *RedisDB) UpdatePullWithResults(pull models.PullRequest, newResults []co
 	}
 
 	// Now, we overwrite the key with our new status.
-	return newStatus, errors.Wrap(r.writePull(key, newStatus), "db transaction failed")
+	err = r.writePull(key, newStatus)
+	if err != nil {
+		return models.PullStatus{}, errors.Wrap(err, "db transaction failed")
+	}
+	return newStatus, nil
 }
 
 func (r *RedisDB) getPull(key string) (*models.PullStatus, error) {
@@ -383,12 +396,18 @@ func (r *RedisDB) writePull(key string, pull models.PullStatus) error {
 		return errors.Wrap(err, "serializing")
 	}
 	err = r.client.Set(ctx, key, serialized, 0).Err()
-	return errors.Wrap(err, "DB Transaction failed")
+	if err != nil {
+		return errors.Wrap(err, "DB Transaction failed")
+	}
+	return nil
 }
 
 func (r *RedisDB) deletePull(key string) error {
 	err := r.client.Del(ctx, key).Err()
-	return errors.Wrap(err, "DB Transaction failed")
+	if err != nil {
+		return errors.Wrap(err, "DB Transaction failed")
+	}
+	return nil
 }
 
 func (r *RedisDB) lockKey(p models.Project, workspace string) string {

--- a/server/core/redis/redis.go
+++ b/server/core/redis/redis.go
@@ -268,7 +268,7 @@ func (r *RedisDB) UpdateProjectStatus(pull models.PullRequest, workspace string,
 
 	err = r.writePull(key, currStatus)
 	if err != nil {
-		errors.Wrap(err, "db transaction failed")
+		return errors.Wrap(err, "db transaction failed")
 	}
 	return nil
 }

--- a/server/core/runtime/models/shell_command_runner.go
+++ b/server/core/runtime/models/shell_command_runner.go
@@ -127,7 +127,8 @@ func (s *ShellCommandRunner) RunCommandAsync(ctx command.ProjectContext) (chan<-
 				ctx.Log.Debug("writing %q to remote command's stdin", line)
 				_, err := io.WriteString(stdin, line)
 				if err != nil {
-					ctx.Log.Err(errors.Wrapf(err, "writing %q to process", line).Error())
+					err = errors.Wrapf(err, "writing %q to process", line)
+					ctx.Log.Err(err.Error())
 				}
 			}
 		}()

--- a/server/core/runtime/models/shell_command_runner.go
+++ b/server/core/runtime/models/shell_command_runner.go
@@ -173,8 +173,7 @@ func (s *ShellCommandRunner) RunCommandAsync(ctx command.ProjectContext) (chan<-
 
 		// We're done now. Send an error if there was one.
 		if err != nil {
-			err = errors.Wrapf(err, "running '%s' '%s' in '%s'",
-				s.shell.String(), s.command, s.workingDir)
+			err = errors.Wrapf(err, "running '%s' '%s' in '%s'", s.shell.String(), s.command, s.workingDir)
 			log.Err(err.Error())
 			outCh <- Line{Err: err}
 		} else {

--- a/server/events/pending_plan_finder.go
+++ b/server/events/pending_plan_finder.go
@@ -59,8 +59,7 @@ func (p *DefaultPendingPlanFinder) findWithAbsPaths(pullDir string) ([]PendingPl
 		lsCmd.Dir = repoDir
 		lsOut, err := lsCmd.CombinedOutput()
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "running 'git ls-files . --others' in '%s' directory: %s",
-				repoDir, string(lsOut))
+			return nil, nil, errors.Wrapf(err, "running 'git ls-files . --others' in '%s' directory: %s", repoDir, string(lsOut))
 		}
 		for _, file := range strings.Split(string(lsOut), "\n") {
 			if filepath.Ext(file) == ".tfplan" {

--- a/server/events/vcs/azuredevops_client.go
+++ b/server/events/vcs/azuredevops_client.go
@@ -69,6 +69,9 @@ func (g *AzureDevopsClient) GetModifiedFiles(logger logging.SimpleLogging, repo 
 	sourceRefName := strings.Replace(pullRequest.GetSourceRefName(), "refs/heads/", "", 1)
 
 	r, resp, err := g.Client.Git.GetDiffs(g.ctx, owner, project, repoName, targetRefName, sourceRefName)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting pull request")
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, errors.Wrapf(err, "http response code %d getting diff %s to %s", resp.StatusCode, sourceRefName, targetRefName)
 	}

--- a/server/events/vcs/gitlab_client.go
+++ b/server/events/vcs/gitlab_client.go
@@ -542,16 +542,14 @@ func (g *GitlabClient) MergePull(logger logging.SimpleLogging, pull models.PullR
 
 	mr, err := g.GetMergeRequest(logger, pull.BaseRepo.FullName, pull.Num)
 	if err != nil {
-		return errors.Wrap(
-			err, "unable to merge merge request, it was not possible to retrieve the merge request")
+		return errors.Wrap(err, "unable to merge merge request, it was not possible to retrieve the merge request")
 	}
 	project, resp, err := g.Client.Projects.GetProject(mr.ProjectID, nil)
 	if resp != nil {
 		logger.Debug("GET /projects/%d returned: %d", mr.ProjectID, resp.StatusCode)
 	}
 	if err != nil {
-		return errors.Wrap(
-			err, "unable to merge merge request, it was not possible to check the project requirements")
+		return errors.Wrap(err, "unable to merge merge request, it was not possible to check the project requirements")
 	}
 
 	if project != nil && project.OnlyAllowMergeIfPipelineSucceeds {

--- a/server/events/vcs/gitlab_client.go
+++ b/server/events/vcs/gitlab_client.go
@@ -566,7 +566,10 @@ func (g *GitlabClient) MergePull(logger logging.SimpleLogging, pull models.PullR
 	if resp != nil {
 		logger.Debug("PUT /projects/%s/merge_requests/%d/merge returned: %d", pull.BaseRepo.FullName, pull.Num, resp.StatusCode)
 	}
-	return errors.Wrap(err, "unable to merge merge request, it may not be in a mergeable state")
+	if err != nil {
+		return errors.Wrap(err, "unable to merge merge request, it may not be in a mergeable state")
+	}
+	return nil
 }
 
 // MarkdownPullLink specifies the string used in a pull request comment to reference another pull request.

--- a/server/server.go
+++ b/server/server.go
@@ -426,8 +426,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 
 	parsedURL, err := ParseAtlantisURL(userConfig.AtlantisURL)
 	if err != nil {
-		return nil, errors.Wrapf(err,
-			"parsing --%s flag %q", config.AtlantisURLFlag, userConfig.AtlantisURL)
+		return nil, errors.Wrapf(err, "parsing --%s flag %q", config.AtlantisURLFlag, userConfig.AtlantisURL)
 	}
 
 	underlyingRouter := mux.NewRouter()

--- a/testdrive/testdrive.go
+++ b/testdrive/testdrive.go
@@ -286,8 +286,14 @@ tunnels:
 		colorstring.Println("\n[green]Thank you for using atlantis :) \n[reset]For more information about how to use atlantis in production go to: https://www.runatlantis.io")
 		return nil
 	case err := <-ngrokErrors:
-		return errors.Wrap(err, "ngrok tunnel")
+		if err != nil {
+			err = errors.Wrap(err, "ngrok tunnel")
+		}
+		return err
 	case err := <-atlantisErrors:
-		return errors.Wrap(err, "atlantis server")
+		if err != nil {
+			err = errors.Wrap(err, "atlantis server")
+		}
+		return err
 	}
 }


### PR DESCRIPTION
## what

Add nil checks before returning wrapped errors.

## why

Partially in prep for #5269, since if we return `fmt.Errorf("... : %w", err)` when err is nil, it won't, as `errors.Wrap(err, "...")` does in this situation, return nil.

Additionally, I find that relying on `errors.Wrap(err, "...")` to return `nil` if err is nil a bit hard to read. It can also lead to subtle bugs like #5294 and #5312.

I also put a few errors that were split between lines onto one line, which is more specifically in prep for #5269 (which I am writing a script to do replacements for mechanically).

## tests

Just running unit tests.

## references

Cleaning up code to make #5269 a bit simpler (though I think this change is worth doing on its own).

