### PR TITLE
fix: Unintentional nil errors in azuredevops client

### DIFF
--- a/server/events/vcs/azuredevops_client.go
+++ b/server/events/vcs/azuredevops_client.go
@@ -267,7 +267,7 @@ func (g *AzureDevopsClient) UpdateStatus(logger logging.SimpleLogging, repo mode
 		return errors.Wrap(err, "getting pull request")
 	}
 	if resp.StatusCode != http.StatusOK {
-		return errors.Wrapf(err, "http response code %d getting pull request", resp.StatusCode)
+		return errors.Errorf("http response code %d getting pull request", resp.StatusCode)
 	}
 	if source.GetSupportsIterations() {
 		opts := azuredevops.PullRequestIterationsListOptions{}
@@ -276,7 +276,7 @@ func (g *AzureDevopsClient) UpdateStatus(logger logging.SimpleLogging, repo mode
 			return errors.Wrap(err, "listing pull request iterations")
 		}
 		if resp.StatusCode != http.StatusOK {
-			return errors.Wrapf(err, "http response code %d listing pull request iterations", resp.StatusCode)
+			return errors.Errorf("http response code %d listing pull request iterations", resp.StatusCode)
 		}
 		for _, iteration := range iterations {
 			if sourceRef := iteration.GetSourceRefCommit(); sourceRef != nil {
@@ -297,7 +297,7 @@ func (g *AzureDevopsClient) UpdateStatus(logger logging.SimpleLogging, repo mode
 		return errors.Wrap(err, "creating pull request status")
 	}
 	if resp.StatusCode != http.StatusOK {
-		return errors.Wrapf(err, "http response code %d creating pull request status", resp.StatusCode)
+		return errors.Errorf("http response code %d creating pull request status", resp.StatusCode)
 	}
 	return err
 }


### PR DESCRIPTION
## what

Fix some errors in azuredevops that are unintentionally returning nil.

## why

Each of these call sites is proceeded by `if err != nil { return }`, so if we reach these lines of code, we know that `err` is `nil`. However, `errors.Wrap` is documented to return nil if err is nil. https://pkg.go.dev/github.com/pkg/errors#Wrap. This means we are actually returning a `nil` error in these cases, which is not intentional

## tests

Unit tests.

## references

Found while working on #5269.
Similar issue to #5294.

