### PR TITLE
fix: Prevent any users from approving custom policy sets 

### DIFF
--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -518,8 +518,10 @@ func (p *DefaultProjectCommandRunner) doPolicyCheck(ctx command.ProjectContext) 
 	var postConftestOutput []string
 	var policySetResults []models.PolicySetResult
 
+	inputPolicySets := ctx.PolicySets.PolicySets
 	for i, output := range outputs {
 		index = i
+		policySetName := inputPolicySets[index].Name
 		if !ctx.CustomPolicyCheck {
 			err = json.Unmarshal([]byte(strings.Join([]string{output}, "\n")), &policySetResults)
 			if err == nil {
@@ -529,7 +531,7 @@ func (p *DefaultProjectCommandRunner) doPolicyCheck(ctx command.ProjectContext) 
 		} else {
 			// Using a policy tool other than Conftest, manually building result struct
 			passed := !strings.Contains(strings.ToLower(output), "fail")
-			policySetResults = append(policySetResults, models.PolicySetResult{PolicySetName: "Custom", PolicyOutput: output, Passed: passed, ReqApprovals: 1, CurApprovals: 0})
+			policySetResults = append(policySetResults, models.PolicySetResult{PolicySetName: policySetName, PolicyOutput: output, Passed: passed, ReqApprovals: 1, CurApprovals: 0})
 			preConftestOutput = append(preConftestOutput, "")
 		}
 	}


### PR DESCRIPTION
## what
<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
Currently, using custom policy tools with Atlantis inadvertently allows any user to successfully execute `atlantis approve_policies` on the policy check.  To prevent this we need to properly propagate the name of the policy set to custom sets as well.  Policy set naming is used to map user permissions for who can approve what, and as a result all users are able to approve the current default name "Custom" since there are no restrictions governing it.

## why
<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
For the small community of Atlantis folks leveraging Terraform policy tools other than the integrated Conftest, this change is extremely important.  Any user being able to bypass any custom policy set is a critical flaw in a controlled actuation workflow.

## tests

<!--
- [ ] I have tested my changes by ...
-->
I have tested these changes by reproducing the bug where any user can approve the policy set and then confirming it is not possible with this change added.  The scope of the code change is tiny so ramifications outside of the `doPolicyCheck` method are unlikely.

## references
<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
Exact bug: https://github.com/runatlantis/atlantis/issues/4243
Unfortunately this has been open for a year and I wish I'd seen it sooner
