### PR TITLE
docs: update gitlab links

### DIFF
--- a/e2e/gitlab.go
+++ b/e2e/gitlab.go
@@ -166,7 +166,7 @@ func (g GitlabClient) DeleteBranch(ctx context.Context, branchName string) error
 }
 
 func (g GitlabClient) IsAtlantisInProgress(state string) bool {
-	// From https://docs.gitlab.com/ee/api/pipelines.html
+	// From https://docs.gitlab.com/api/pipelines/
 	// created, waiting_for_resource, preparing, pending, running, success, failed, canceled, skipped, manual, scheduled
 	for _, s := range []string{"success", "failed", "canceled", "skipped"} {
 		if state == s {

--- a/runatlantis.io/contributing/events-controller.md
+++ b/runatlantis.io/contributing/events-controller.md
@@ -85,7 +85,7 @@ documentation.
 - [Azure DevOps Pull Request Created](https://learn.microsoft.com/en-us/azure/devops/service-hooks/events?view=azure-devops#pull-request-created)
 - [BitBucket Pull Request](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Pull-request-events)
 - [GitHub Pull Request](https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request)
-- [GitLab Merge Request](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#merge-request-events)
+- [GitLab Merge Request](https://docs.gitlab.com/user/project/integrations/webhook_events/#merge-request-events)
 - [Gitea Webhooks](https://docs.gitea.com/next/usage/webhooks)
 
 </details>

--- a/runatlantis.io/docs/access-credentials.md
+++ b/runatlantis.io/docs/access-credentials.md
@@ -114,7 +114,7 @@ A new permission for `Actions` has been added, which is required for checking if
 
 ### GitLab
 
-* Follow: [GitLab: Create a personal access token](https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html#create-a-personal-access-token)
+* Follow: [GitLab: Create a personal access token](https://docs.gitlab.com/user/profile/personal_access_tokens/#create-a-personal-access-token)
 * Create a token with **api** scope
 * Record the access token
 

--- a/runatlantis.io/docs/command-requirements.md
+++ b/runatlantis.io/docs/command-requirements.md
@@ -57,7 +57,7 @@ The `approved` requirement by:
 Each VCS provider has different rules around who can approve:
 
 * **GitHub** – **Any user with read permissions** to the repo can approve a pull request
-* **GitLab** – The user who can approve can be set in the [repo settings](https://docs.gitlab.com/ee/user/project/merge_requests/approvals/)
+* **GitLab** – The user who can approve can be set in the [repo settings](https://docs.gitlab.com/user/project/merge_requests/approvals/)
 * **Bitbucket Cloud (bitbucket.org)** – A user can approve their own pull request but
   Atlantis does not count that as an approval and requires an approval from at least one user that
   is not the author of the pull request
@@ -303,6 +303,6 @@ request can run the actual `atlantis apply` command.
 ## Next Steps
 
 * For more information on GitHub pull request reviews and approvals see: [GitHub: About pull request reviews](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews)
-* For more information on GitLab merge request reviews and approvals (only supported on GitLab Enterprise) see: [GitLab: Merge request approvals](https://docs.gitlab.com/ee/user/project/merge_requests/approvals/).
+* For more information on GitLab merge request reviews and approvals (only supported on GitLab Enterprise) see: [GitLab: Merge request approvals](https://docs.gitlab.com/user/project/merge_requests/approvals/).
 * For more information on Bitbucket pull request reviews and approvals see: [BitBucket: Use pull requests for code review](https://confluence.atlassian.com/bitbucket/pull-requests-and-code-review-223220593.html)
 * For more information on Azure DevOps pull request reviews and approvals see: [Azure DevOps: Create pull requests](https://docs.microsoft.com/en-us/azure/devops/repos/git/pull-requests?view=azure-devops&tabs=browser)

--- a/runatlantis.io/guide/testing-locally.md
+++ b/runatlantis.io/guide/testing-locally.md
@@ -197,7 +197,7 @@ TOKEN="{YOUR_TOKEN}"
 
 ### GitLab or GitLab Enterprise Access Token
 
-- follow [GitLab: Create a personal access token](https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html#create-a-personal-access-token)
+- follow [GitLab: Create a personal access token](https://docs.gitlab.com/user/profile/personal_access_tokens/#create-a-personal-access-token)
 - create a token with **api** scope
 - set the token as an environment variable
 


### PR DESCRIPTION
## what

updated gitlab links (both ee and ce paths are no longer applicable, not sure when that happened, but there was [some discussion on reddit](https://www.reddit.com/r/gitlab/comments/18xkwlu/gitlabce_documentation/) one year ago).

updating the links to new one.


