### PR TITLE
chore(deps): bump ngrok to 3.19.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Setup ngrok
         run: |
-          wget -q -O ngrok.tar.gz https://bin.equinox.io/a/4no1PS1PoRF/ngrok-v3-3.13.0-linux-amd64.tar.gz
+          wget -q -O ngrok.tar.gz https://bin.equinox.io/a/9VU6NY9RyvK/ngrok-v3-3.19.1-linux-amd64.tar.gz
           tar -xzf ngrok.tar.gz
           chmod +x ngrok
           ./ngrok version


### PR DESCRIPTION
## what
bump ngrok to 3.19.1 

need to figure out a way to have renovate to update it, there is some discussions on archlinux about it, https://aur.archlinux.org/packages/ngrok