### PR TITLE
fix: update cncf invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 * How to get started: [www.runatlantis.io/guide](https://www.runatlantis.io/guide)
 * Full documentation: [www.runatlantis.io/docs](https://www.runatlantis.io/docs)
 * Download the latest release: [github.com/runatlantis/atlantis/releases/latest](https://github.com/runatlantis/atlantis/releases/latest)
-* Get help in our [Slack channel](https://slack.cncf.io/f) in channel #atlantis and development in #atlantis-contributors
+* Get help in our [Slack channel](https://slack.cncf.io/) in channel #atlantis and development in #atlantis-contributors
 * Start Contributing: [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## What is Atlantis?


### PR DESCRIPTION
## what

relates to https://github.com/runatlantis/atlantis/pull/5336