### PR TITLE
fix: UI Jobs streams are not cleaned up after PR is closed

### DIFF
--- a/server/events/pull_closed_executor.go
+++ b/server/events/pull_closed_executor.go
@@ -87,10 +87,12 @@ func (p *PullClosedExecutor) CleanUpPull(logger logging.SimpleLogging, repo mode
 	if pullStatus != nil {
 		for _, project := range pullStatus.Projects {
 			jobContext := jobs.PullInfo{
-				PullNum:     pull.Num,
-				Repo:        pull.BaseRepo.Name,
-				Workspace:   project.Workspace,
-				ProjectName: project.ProjectName,
+				PullNum:      pull.Num,
+				Repo:         pull.BaseRepo.Name,
+				RepoFullName: pull.BaseRepo.FullName,
+				ProjectName:  project.ProjectName,
+				Path:         project.RepoRelDir,
+				Workspace:    project.Workspace,
 			}
 			p.LogStreamResourceCleaner.CleanUp(jobContext)
 		}


### PR DESCRIPTION
## what

- Update `func (p *PullClosedExecutor) CleanUpPull` to use the updated definition of `PullInfo

## why

- see related [issue](https://github.com/runatlantis/atlantis/issues/5348)
- [this commit](https://github.com/runatlantis/atlantis/commit/ce95f8ee0512806112b62d5febac006ce09f1e36#diff-d92fd2afa5f428fc1511e75c598f74095fafd22671cb944c3b144fe48bb94a5a) updated the definition of `PullInfo`
- `PullInfo` wasn't updated in function used to cleanup job info, so matches were not found in the mapping

## tests

- tested in my local environment with PRs from Azure Devops

## references

- see [issue](https://github.com/runatlantis/atlantis/issues/5348)
