### PR TITLE
feat: add HTTP pprof endpoints

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -86,7 +86,7 @@ const (
 	EnableDiffMarkdownFormat         = "enable-diff-markdown-format"
 	EnablePolicyChecksFlag           = "enable-policy-checks"
 	EnableRegExpCmdFlag              = "enable-regexp-cmd"
-	EnableProfilingRoutes            = "enable-profiling-routes"
+	EnableProfilingAPI               = "enable-profiling-api"
 	ExecutableName                   = "executable-name"
 	FailOnPreWorkflowHookError       = "fail-on-pre-workflow-hook-error"
 	HideUnchangedPlanComments        = "hide-unchanged-plan-comments"
@@ -530,7 +530,7 @@ var boolFlags = map[string]boolFlag{
 		description:  "Enable Atlantis to use regular expressions on plan/apply commands when \"-p\" flag is passed with it.",
 		defaultValue: false,
 	},
-	EnableProfilingRoutes: {
+	EnableProfilingAPI: {
 		description:  "Enable net/http/pprof routes in server for continuous profiling.",
 		defaultValue: false,
 	},

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -86,6 +86,7 @@ const (
 	EnableDiffMarkdownFormat         = "enable-diff-markdown-format"
 	EnablePolicyChecksFlag           = "enable-policy-checks"
 	EnableRegExpCmdFlag              = "enable-regexp-cmd"
+	EnableProfilingRoutes            = "enable-profiling-routes"
 	ExecutableName                   = "executable-name"
 	FailOnPreWorkflowHookError       = "fail-on-pre-workflow-hook-error"
 	HideUnchangedPlanComments        = "hide-unchanged-plan-comments"
@@ -527,6 +528,10 @@ var boolFlags = map[string]boolFlag{
 	},
 	EnableRegExpCmdFlag: {
 		description:  "Enable Atlantis to use regular expressions on plan/apply commands when \"-p\" flag is passed with it.",
+		defaultValue: false,
+	},
+	EnableProfilingRoutes: {
+		description:  "Enable net/http/pprof routes in server for continuous profiling.",
 		defaultValue: false,
 	},
 	EnableDiffMarkdownFormat: {

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -164,7 +164,7 @@ var testFlags = map[string]interface{}{
 	EnablePolicyChecksFlag:           false,
 	EnableRegExpCmdFlag:              false,
 	EnableDiffMarkdownFormat:         false,
-	EnableProfilingRoutes:            false,
+	EnableProfilingAPI:               false,
 }
 
 func TestExecute_Defaults(t *testing.T) {

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -164,6 +164,7 @@ var testFlags = map[string]interface{}{
 	EnablePolicyChecksFlag:           false,
 	EnableRegExpCmdFlag:              false,
 	EnableDiffMarkdownFormat:         false,
+	EnableProfilingRoutes:            false,
 }
 
 func TestExecute_Defaults(t *testing.T) {

--- a/runatlantis.io/docs/api-endpoints.md
+++ b/runatlantis.io/docs/api-endpoints.md
@@ -234,3 +234,7 @@ curl --request GET 'https://<ATLANTIS_HOST_NAME>/healthz'
   "status": "ok"
 }
 ```
+
+### GET /debug/pprof
+
+If `--enable-profiling-api` is set to true, it adds endpoints under this path to expose server's profiling data. See [profiling Go programs](https://go.dev/blog/pprof) for more information.

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -532,6 +532,16 @@ and set `--autoplan-modules` to `false`.
 
   Enables atlantis to run server side policies on the result of a terraform plan. Policies are defined in [server side repo config](server-side-repo-config.md#reference).
 
+### `--enable-profiling-api`
+
+  ```bash
+  atlantis server --enable-profiling-api
+  # or
+  ATLANTIS_ENABLE_PROFILING_API=true
+  ```
+
+  Enable [`net/http/pprof`](https://pkg.go.dev/net/http/pprof) endpoints for [continuous profiling](https://grafana.com/docs/pyroscope/latest/introduction/continuous-profiling/) of resources used by the server. See [profiling Go programs](https://go.dev/blog/pprof) for more information.
+
 ### `--enable-regexp-cmd`
 
   ```bash

--- a/server/server.go
+++ b/server/server.go
@@ -127,7 +127,7 @@ type Server struct {
 	ProjectCmdOutputHandler        jobs.ProjectCommandOutputHandler
 	ScheduledExecutorService       *scheduled.ExecutorService
 	DisableGlobalApplyLock         bool
-	EnableProfilingRoutes          bool
+	EnableProfilingAPI             bool
 }
 
 // Config holds config for server that isn't passed in by the user.
@@ -1029,7 +1029,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		WebUsername:                    userConfig.WebUsername,
 		WebPassword:                    userConfig.WebPassword,
 		ScheduledExecutorService:       scheduledExecutorService,
-		EnableProfilingRoutes:          userConfig.EnableProfilingRoutes,
+		EnableProfilingAPI:             userConfig.EnableProfilingAPI,
 	}
 
 	validate := validator.New(validator.WithRequiredStructEnabled())
@@ -1071,7 +1071,7 @@ func (s *Server) Start() error {
 		s.Router.HandleFunc("/apply/unlock", s.LocksController.UnlockApply).Methods("DELETE").Queries()
 	}
 
-	if s.EnableProfilingRoutes {
+	if s.EnableProfilingAPI {
 		for p, h := range map[string]http.HandlerFunc{
 			"/":        pprof.Index,
 			"/cmdline": pprof.Cmdline,

--- a/server/server.go
+++ b/server/server.go
@@ -126,6 +126,7 @@ type Server struct {
 	ProjectCmdOutputHandler        jobs.ProjectCommandOutputHandler
 	ScheduledExecutorService       *scheduled.ExecutorService
 	DisableGlobalApplyLock         bool
+	EnableProfilingRoutes          bool
 }
 
 // Config holds config for server that isn't passed in by the user.
@@ -1027,6 +1028,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		WebUsername:                    userConfig.WebUsername,
 		WebPassword:                    userConfig.WebPassword,
 		ScheduledExecutorService:       scheduledExecutorService,
+		EnableProfilingRoutes:          userConfig.EnableProfilingRoutes,
 	}
 
 	validate := validator.New(validator.WithRequiredStructEnabled())

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -45,6 +45,7 @@ type UserConfig struct {
 	EmojiReaction               string `mapstructure:"emoji-reaction"`
 	EnablePolicyChecksFlag      bool   `mapstructure:"enable-policy-checks"`
 	EnableRegExpCmd             bool   `mapstructure:"enable-regexp-cmd"`
+	EnableProfilingRoutes       bool   `mapstructure:"enable-profiling-routes"`
 	EnableDiffMarkdownFormat    bool   `mapstructure:"enable-diff-markdown-format"`
 	ExecutableName              string `mapstructure:"executable-name"`
 	// Fail and do not run the Atlantis command request if any of the pre workflow hooks error.

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -45,7 +45,7 @@ type UserConfig struct {
 	EmojiReaction               string `mapstructure:"emoji-reaction"`
 	EnablePolicyChecksFlag      bool   `mapstructure:"enable-policy-checks"`
 	EnableRegExpCmd             bool   `mapstructure:"enable-regexp-cmd"`
-	EnableProfilingRoutes       bool   `mapstructure:"enable-profiling-routes"`
+	EnableProfilingAPI          bool   `mapstructure:"enable-profiling-api"`
 	EnableDiffMarkdownFormat    bool   `mapstructure:"enable-diff-markdown-format"`
 	ExecutableName              string `mapstructure:"executable-name"`
 	// Fail and do not run the Atlantis command request if any of the pre workflow hooks error.


### PR DESCRIPTION
## what

This PR adds a new `--enable-profiling-routes` flag that when true will mount the `net/http/pprof` endpoints, allowing to perform [continuous profiling] on the running server. This will allow a deeper inspection on how the application behaves, where the most CPU and memory is consumed, and so on. See [profiling Go programs] for additional information.

## why

At Grafana Labs we use Atlantis with a large number of environments (740+) and when making a change that affects too many environments we have experienced slowness or OOM kills. We would like to make use of [Grafana Pyroscope](https://grafana.com/oss/pyroscope/) to investigate why this happens and hopefully contribute back.

## tests

Added flag test.

[continuous profiling]: https://grafana.com/docs/pyroscope/latest/introduction/continuous-profiling/
[profiling Go programs]: https://go.dev/blog/pprof