### PR TITLE
fix(workflows/testing-env-image): add `packages: write` for ghcr image push

### DIFF
--- a/.github/workflows/testing-env-image.yml
+++ b/.github/workflows/testing-env-image.yml
@@ -47,6 +47,8 @@ jobs:
     if: needs.changes.outputs.should-run-build == 'true'
     name: Build Testing Env Image
     runs-on: ubuntu-24.04
+    permissions:
+      packages: write # for ghcr.io push
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4


### PR DESCRIPTION
## what

fix testing-image push flow issue

```
ERROR: failed to solve: failed to push ghcr.io/runatlantis/testing-env:2025.03.04: unexpected status from POST request to https://ghcr.io/v2/runatlantis/testing-env/blobs/uploads/: 403 Forbidden
```

https://github.com/runatlantis/atlantis/actions/runs/13644220126/job/38140024300#step:9:595

relates to #5271