### PR TITLE
chore(deps): bump ca-certificates to `20241121-r1` (release-0.32)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -155,7 +155,7 @@ COPY --from=deps /usr/bin/git-lfs /usr/bin/git-lfs
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 # renovate: datasource=repology depName=alpine_3_21/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20241010"
+ENV CA_CERTIFICATES_VERSION="20241121-r1"
 
 # Install packages needed to run Atlantis.
 # We place this last as it will bust less docker layer caches when packages update


### PR DESCRIPTION
https://github.com/runatlantis/atlantis/pull/5235 for release 0.32