### PR TITLE
chore(deps): drop 0.31 release line support

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,8 +9,8 @@
   automerge: true,
   baseBranches: [
     'main',
-    'release-0.31',
     'release-0.32',
+    'release-0.33',
   ],
   platformAutomerge: true,
   labels: [


### PR DESCRIPTION
## what

drop 0.31 release line support (we only support latest two release lines)

closes #5399
closes #5400
closes #5404
closes #5406