### PR TITLE
chore: update gitlab repo ref

### DIFF
--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -37,7 +37,7 @@ function cleanupPid() {
 ./atlantis server \
   --data-dir="/tmp" \
   --log-level="debug" \
-  --repo-allowlist="github.com/runatlantis/atlantis-tests,gitlab.com/run-atlantis/atlantis-tests" \
+  --repo-allowlist="github.com/runatlantis/atlantis-tests,gitlab.com/runatlantis/atlantis-tests" \
   --repo-config-json='{"repos":[{"id":"/.*/", "allowed_overrides":["apply_requirements","workflow"], "allow_custom_workflows":true}]}' \
   &> /tmp/atlantis-server.log &
 ATLANTIS_PID=$!


### PR DESCRIPTION
## what

we used to have `runatlantis` and `run-atlantis` orgs, both have the `atlantis-tests` repo, which is a big confusing. after I setup the repo sync from `github.com/runatlantis/atlantis-tests` to `gitlab.com/runatlantis/atlantis-tests`, @jamengual has deleted `run-atlantis/atlantis-tests` repo. So converging the refs in here. 

cc @lukemassa 