### PR TITLE
ci(image): remove buildkit pin

### DIFF
--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -92,10 +92,6 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
-      # https://github.com/docker/build-push-action/issues/761#issuecomment-1575006515
-      with:
-        driver-opts: |
-          image=moby/buildkit:v0.14.0
 
     - name: "Install cosign"
       uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
@@ -217,10 +213,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
-        # https://github.com/docker/build-push-action/issues/761#issuecomment-1575006515
-        with:
-          driver-opts: |
-            image=moby/buildkit:v0.14.0
 
       - name: "Build and load into Docker"
         if: contains(fromJson('["push", "pull_request"]'), github.event_name)


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- ci(image): remove buildkit pin

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- Previous reason to pin is no longer an issue
- New problems pop up due to this old version such as the failing build when buildkit's cache throws an error

## tests

<!--
- [ ] I have tested my changes by ...
-->
See PR checks

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Old issue which required the v0.14.0 pin https://github.com/docker/build-push-action/issues/761#issuecomment-1575006515
- This issue https://github.com/moby/buildkit/issues/2492 is the reason for dropping the pin
- Latest version https://github.com/moby/buildkit/releases/tag/v0.20.2
