### PR TITLE
Update gitlab.go

### DIFF
--- a/e2e/gitlab.go
+++ b/e2e/gitlab.go
@@ -46,7 +46,7 @@ func NewGitlabClient() *GitlabClient {
 	}
 	ownerName := os.Getenv("GITLAB_REPO_OWNER_NAME")
 	if ownerName == "" {
-		ownerName = "run-atlantis"
+		ownerName = "runatlantis"
 	}
 	repoName := os.Getenv("GITLAB_REPO_NAME")
 	if repoName == "" {


### PR DESCRIPTION
This pull request includes a small change to the `e2e/gitlab.go` file. The change updates the default value for the `GITLAB_REPO_OWNER_NAME` environment variable to "runatlantis" instead of "run-atlantis".

* [`e2e/gitlab.go`](diffhunk://#diff-a7a1655db9d4851901e4df545850850c3e31c121f3b77c8a7d2d32c98940b3a8L49-R49): Changed default `GITLAB_REPO_OWNER_NAME` from "run-atlantis" to "runatlantis".
