### PR TITLE
ci(release): separate section for docs and deps

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -22,6 +22,9 @@ changelog:
       labels:
         - docs
         - website
+    - title: Dependencies
+      labels:
+        - dependencies
     - title: Other Changes 🔄
       labels:
         - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,7 +3,6 @@ changelog:
     labels:
       - ignore-for-release
       - github-actions
-      - website
     authors:
       - octocat
   categories:
@@ -19,6 +18,10 @@ changelog:
     - title: Bug fixes 🐛
       labels:
         - bug
+    - title: Documentation
+      labels:
+        - docs
+        - website
     - title: Other Changes 🔄
       labels:
         - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,9 +3,9 @@ changelog:
     labels:
       - ignore-for-release
       - github-actions
+      - website
     authors:
       - octocat
-      - renovate[bot]
   categories:
     - title: Breaking Changes 🛠
       labels:


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- ci(release): separate section for docs and deps

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- Generally people only care about changes to the binary than the website
- Let's keep website and docs as separate sections
- No reason to ignore renovatebot as users generally care about updates to dependencies. We can move that to a separate section too.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes?search-overlay-open=true
