### PR TITLE
ci(renovate): reduce noise by grouping by confidence

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,6 +32,12 @@
     ],
   },
   packageRules: [
+    // This group should reduce a lot of renovate PRs
+    {
+      "groupName": "Mend: high confidence minor and patch dependency updates",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchConfidence": ["very high", "high"]
+    },
     {
       matchFileNames: [
         'package.json',


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- ci(renovate): reduce noise by grouping by confidence

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- Mend, owner of renovatebot, uses analytics across all orgs that use renovate to figure out confidence is upgrading to a specific package version
- This change utilizes these analytics and groups PRs by the confidence rating to upgrade multiple very high and high rated deps in thr same PR
- Nevermind, this option matchConfidence is only available in a closed beta and requires a proprietary key. See reference.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- https://docs.mend.io/wsk/common-practices-for-renovate-configuration
- https://docs.renovatebot.com/configuration-options/#matchconfidence