### PR TITLE
feat(api): pass flags to plan and apply endpoints

### DIFF
--- a/runatlantis.io/docs/api-endpoints.md
+++ b/runatlantis.io/docs/api-endpoints.md
@@ -39,6 +39,7 @@ At least one of `Directory` or `Workspace` should be specified.
 |-----------|--------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Directory | string | No       | Which directory to run plan in relative to root of repo                                                                                                   |
 | Workspace | string | No       | [Terraform workspace](https://developer.hashicorp.com/terraform/language/state/workspaces) of the plan. Use `default` if Terraform workspaces are unused. |
+| ExtraArgs | []string | No       | [Additional Terraform flags](https://www.runatlantis.io/docs/using-atlantis.html#additional-terraform-flags) |
 
 #### Sample Request
 

--- a/server/controllers/api_controller.go
+++ b/server/controllers/api_controller.go
@@ -48,6 +48,7 @@ type APIRequest struct {
 	Paths      []struct {
 		Directory string
 		Workspace string
+		ExtraArgs []string
 	}
 }
 
@@ -63,6 +64,7 @@ func (a *APIRequest) getCommands(ctx *command.Context, cmdBuilder func(*command.
 		cc = append(cc, &events.CommentCommand{
 			RepoRelDir: strings.TrimRight(path.Directory, "/"),
 			Workspace:  path.Workspace,
+			Flags:      path.ExtraArgs,
 		})
 	}
 


### PR DESCRIPTION
## what

- Support adding ExtraArgs per-directory via API endpoints

## why

- API should support all the same options as the PR integration

## tests

[x] `make test`

## references

- Re-implementation of the work done by @igaskin in https://github.com/runatlantis/atlantis/pull/3287
- Closes https://github.com/runatlantis/atlantis/issues/3256
