### PR TITLE
docs: update example for policy checks against terraform files

### DIFF
--- a/runatlantis.io/.vitepress/sidebars.ts
+++ b/runatlantis.io/.vitepress/sidebars.ts
@@ -36,6 +36,7 @@ const en = [
           { text: "Pre Workflow Hooks", link: "/docs/pre-workflow-hooks" },
           { text: "Post Workflow Hooks", link: "/docs/post-workflow-hooks" },
           { text: "Conftest Policy Checking", link: "/docs/policy-checking" },
+          { text: "Custom Policicy Checking", link: "/docs/custom-policy-checks" },
           { text: "Custom Workflows", link: "/docs/custom-workflows" },
           { text: "Repo and Project Permissions", link: "/docs/repo-and-project-permissions" },
           { text: "Repo Level atlantis.yaml", link: "/docs/repo-level-atlantis-yaml" },

--- a/runatlantis.io/docs/policy-checking.md
+++ b/runatlantis.io/docs/policy-checking.md
@@ -164,16 +164,18 @@ Note that authentication may need to be configured separately if pulling policie
 
 ### Running policy check against Terraform source code
 
-By default, Atlantis runs the policy check against the [`SHOWFILE`](custom-workflows.md#custom-run-command). In order to run the policy test against Terraform files directly, override the default `conftest` command used and pass in `*.tf` as one of the inputs to `conftest`. The `show` step is required so that Atlantis will generate the `SHOWFILE`.
+By default, Atlantis runs the policy check against the [`SHOWFILE`](custom-workflows.md#custom-run-command). In order to run the policy test against Terraform files directly, pass `*.tf` file pattern to `extra_args` in policy check configuration.
 
 ```yaml
 workflows:
   custom:
     policy_check:
       steps:
-        - show
-        - run: conftest test $SHOWFILE *.tf --no-fail
+        - policy_check:
+            extra_args: ["*.tf"]
 ```
+
+To fully customize and override the policy check command, refer to [`custom policy checks`](custom-policy-checking.md).
 
 ### Quiet policy checks
 


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

- update example for policy checks againts source files with code that works
- include custom policy checks in the navbar

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

Suggested example to run conftest againts source files by patching `run:` does not really work because of the following issues:

- https://github.com/runatlantis/atlantis/issues/4308

With custom policy checks enabled, output is parsed but it's not evaluated correctly as described here.

- https://github.com/runatlantis/atlantis/issues/4952