### PR TITLE
fix: correct plan/apply divergent error message

### DIFF
--- a/server/events/command_requirement_handler.go
+++ b/server/events/command_requirement_handler.go
@@ -34,7 +34,7 @@ func (a *DefaultCommandRequirementHandler) ValidatePlanProject(repoDir string, c
 			}
 		case raw.UnDivergedRequirement:
 			if a.WorkingDir.HasDiverged(ctx.Log, repoDir) {
-				return "Default branch must be rebased onto pull request before running plan.", nil
+				return "Pull request branch must be rebased onto default branch before running plan.", nil
 			}
 		}
 	}
@@ -61,7 +61,7 @@ func (a *DefaultCommandRequirementHandler) ValidateApplyProject(repoDir string, 
 			}
 		case raw.UnDivergedRequirement:
 			if a.WorkingDir.HasDiverged(ctx.Log, repoDir) {
-				return "Default branch must be rebased onto pull request before running apply.", nil
+				return "Pull request branch must be rebased onto default branch before running apply.", nil
 			}
 		}
 	}

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -311,7 +311,7 @@ func TestDefaultProjectCommandRunner_ApplyDiverged(t *testing.T) {
 	When(mockWorkingDir.HasDiverged(ctx.Log, tmp)).ThenReturn(true)
 
 	res := runner.Apply(ctx)
-	Equals(t, "Default branch must be rebased onto pull request before running apply.", res.Failure)
+	Equals(t, "Pull request branch must be rebased onto default branch before running apply.", res.Failure)
 }
 
 // Test that it runs the expected apply steps.


### PR DESCRIPTION
## what

Change the wording of the error message that gets displayed as comment on PRs where the default branch has diverged from the PR's branch. It switches both mentioned branches to be inline with rebase terminology in git.

Let me know if this is correct or not.


## why

The error message is wrong I think and could lead to confusion.

## tests

- [x] I have tested my changes by adapting one necessary test

Also this is only printed string change.
