### PR TITLE
fix: preserve Atlantis apply lock after plan 

### DIFF
--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -1,5 +1,7 @@
 package events
 
+import "strconv"
+
 import (
 	"github.com/runatlantis/atlantis/server/core/locking"
 	"github.com/runatlantis/atlantis/server/events/command"
@@ -239,10 +241,6 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 	if !cmd.IsForSpecificProject() {
 		ctx.Log.Debug("deleting previous plans and locks")
 		p.deletePlans(ctx)
-		_, err = p.lockingLocker.UnlockByPull(baseRepo.FullName, pull.Num)
-		if err != nil {
-			ctx.Log.Err("deleting locks: %s", err)
-		}
 	}
 
 	// Only run commands in parallel if enabled
@@ -254,6 +252,24 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 		result = runProjectCmds(projectCmds, p.prjCmdRunner.Plan)
 	}
 	ctx.CommandHasErrors = result.HasErrors()
+
+	for i, projResult := range result.ProjectResults {
+		projCtx := projectCmds[i]
+
+		if projResult.PlanStatus() == models.PlannedNoChangesPlanStatus || projResult.PlanStatus() == models.ErroredPlanStatus {
+			ctx.Log.Info("Keeping lock for project '%s' (no changes or error)", projCtx.ProjectName)
+			continue
+		}
+
+		// delete lock only if there are changes
+		ctx.Log.Info("Deleting lock for project '%s' (changes detected)", projCtx.ProjectName)
+		lockID := projCtx.BaseRepo.FullName + "/" + strconv.Itoa(projCtx.Pull.Num) + "/" + projCtx.ProjectName + "/" + projCtx.Workspace
+
+		_, err := p.lockingLocker.Unlock(lockID)
+		if err != nil {
+			ctx.Log.Err("failed unlocking project '%s': %s", projCtx.ProjectName, err)
+		}
+	}
 
 	if p.autoMerger.automergeEnabled(projectCmds) && result.HasErrors() {
 		ctx.Log.Info("deleting plans because there were errors and automerge requires all plans succeed")

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -1,8 +1,8 @@
 package events
 
-import "strconv"
-
 import (
+	"strconv"
+
 	"github.com/runatlantis/atlantis/server/core/locking"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"


### PR DESCRIPTION
## what

Updated Atlantis behavior to retain the apply lock when re-running plan if there are no changes.

Ensured the lock is only removed when actual changes are detected between re-runs


## why

Addresses community-reported issue [#5568](https://github.com/runatlantis/atlantis/issues/5568) where users observed unintended lock removals during no-op plans.

Fixes an issue where Atlantis incorrectly removes the apply lock when a plan is re-run, even if no changes are detected.

Preserves expected workflow and safety in CI/CD pipelines by preventing premature unlocks


## tests

✅ Manually tested locally:

Created an apply lock by running plan and apply.

Re-ran plan without making any changes — lock was preserved as expected.

Introduced a change and re-ran plan — lock was correctly removed.

Verified this behavior in a multi-project repository setup.

## references

Fixes: [#5568](https://github.com/runatlantis/atlantis/issues/5568)

