### PR TITLE
fix(docs): Note is missing an end block in markdown

### DIFF
--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -830,6 +830,7 @@ based on the organization or user that triggered the webhook.
 
   ::: warning NOTE
   Atlantis needs to be able to view the listed group members, inaccessible or non-existent groups are silently ignored.
+  :::
 
 ### `--gitlab-hostname`
 


### PR DESCRIPTION
## what

Fix markdown issue where a "note" block wasn't ended.

## why

I noticed on the website this awkward formatting here: https://runatlantis.io/docs/server-configuration.html#gitlab-group-allowlist

<img width="921" alt="Screenshot 2025-05-11 at 4 22 15 PM" src="https://github.com/user-attachments/assets/37f7d890-22d3-48c5-9694-b44d6851c427" />

The "Note" ended after a subsequently correctly formatted note (I guess the trailing `:::` ends all the note "levels"?)

## tests

Ran locally, it's working now.

<img width="873" alt="Screenshot 2025-05-11 at 4 29 41 PM" src="https://github.com/user-attachments/assets/cd9468bf-b1e7-4cf5-928a-eee85d180fe2" />


## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

