### PR TITLE
Update extra_args documentation about workflow variables

### DIFF
--- a/runatlantis.io/docs/custom-workflows.md
+++ b/runatlantis.io/docs/custom-workflows.md
@@ -141,6 +141,21 @@ workflows:
           extra_args: ["--all-namespaces"]
 ```
 
+Please note: It is not possible to use workflow variables like `$PROJECT_NAME` in `extra_args` arguments directly, due to the way variable expansion is implemented. Instead, you have to create a local variable first and use that:
+
+```yaml
+workflows:
+  myworkflow:
+    plan:
+      steps:
+        - env: # Allow PROJECT_NAME to be used in extra_args:
+            name: LOCAL_PROJECT_NAME
+            command: echo ${PROJECT_NAME}
+        - init:
+            extra_args:
+              - "-backend-config=\"address=${MY_GITLAB_PROJECT_URL}/terraform/state/${LOCAL_PROJECT_NAME}\""
+```
+
 ### Custom init/plan/apply Commands
 
 If you want to customize `terraform init`, `plan` or `apply` in ways that


### PR DESCRIPTION
## what

Update documentation of `extra_args` to explicitly state that workflow variables cannot be used there.

## why

It's non-intuitive that expansion of workflow variables (like `$PROCECT_NAME`) does work in workflow step commands, but not inside `extra_args` arguments. As this creates hard to debug errors, because not expanded variables are silently dropped, this PR updates the documentation and provides an example for a workaround.


## references

- Issue #659 already discusses this issue and proposes several solutions, one of which this PR adds to the documentation to make it easier to find.  
