### PR TITLE
feat: add disable-did-you-mean config

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -77,6 +77,7 @@ const (
 	DisableApplyAllFlag              = "disable-apply-all"
 	DisableAutoplanFlag              = "disable-autoplan"
 	DisableAutoplanLabelFlag         = "disable-autoplan-label"
+	DisableDidYouMeanPromptFlag      = "disable-did-you-mean-prompt"
 	DisableMarkdownFoldingFlag       = "disable-markdown-folding"
 	DisableRepoLockingFlag           = "disable-repo-locking"
 	DisableGlobalApplyLockFlag       = "disable-global-apply-lock"
@@ -512,6 +513,9 @@ var boolFlags = map[string]boolFlag{
 		defaultValue: false,
 	},
 
+	DisableDidYouMeanPromptFlag: {
+		description: "Disable the 'Did you mean atlantis?' comment when users type 'terraform' instead of 'atlantis'",
+	},
 	DisableRepoLockingFlag: {
 		description: "Disable atlantis locking repos",
 	},

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -82,6 +82,7 @@ var testFlags = map[string]interface{}{
 	DisableMarkdownFoldingFlag:       true,
 	DisableRepoLockingFlag:           true,
 	DisableGlobalApplyLockFlag:       false,
+	DisableDidYouMeanPromptFlag:      true,
 	DiscardApprovalOnPlanFlag:        true,
 	EmojiReaction:                    "eyes",
 	ExecutableName:                   "atlantis",
@@ -249,14 +250,12 @@ func getUserConfigKeysWithFlags() []string {
 
 	}
 	return ret
-
 }
 
 func TestUserConfigAllTested(t *testing.T) {
 	t.Log("All settings in userConfig should be tested.")
 
 	for _, userConfigKey := range getUserConfigKeysWithFlags() {
-
 		t.Run(userConfigKey, func(t *testing.T) {
 			// If a setting is configured in server.UserConfig, it should be tested here. If there is no corresponding const
 			// for specifying the flag, that probably means one *also* needs to be added to server.go
@@ -264,13 +263,10 @@ func TestUserConfigAllTested(t *testing.T) {
 				t.Errorf("server.UserConfig has field with mapstructure %s that is not tested, and potentially also not configured as a flag. Either add it to testFlags (and potentially as a const in cmd/server), or remove it from server.UserConfig", userConfigKey)
 			}
 		})
-
 	}
-
 }
 
 func getDocumentedFlags(t *testing.T) []string {
-
 	var ret []string
 	docFile := "../runatlantis.io/docs/server-configuration.md"
 
@@ -354,7 +350,6 @@ func TestAllFlagsDocumented(t *testing.T) {
 			t.Errorf("Found documentation for flag that doesn't exist: %s", documentedFlag)
 		}
 	}
-
 }
 
 func TestExecute_ConfigFile(t *testing.T) {

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -439,6 +439,16 @@ and set `--autoplan-modules` to `false`.
 
   If `disable-autoplan` property is `true`, this flag has no effect.
 
+### `--disable-did-you-mean-prompt`
+
+  ```bash
+  atlantis server --disable-did-you-mean-prompt
+  # or
+  ATLANTIS_DISABLE_DID_YOU_MEAN_PROMPT=true
+  ```
+
+  Disable the "Did you mean atlantis?" comment when users type 'terraform' instead of 'atlantis'.
+
 ### `--disable-global-apply-lock`
 
   ```bash

--- a/server/server.go
+++ b/server/server.go
@@ -610,6 +610,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		userConfig.AzureDevopsUser,
 		userConfig.ExecutableName,
 		allowCommands,
+		userConfig.DisableDidYouMeanPrompt,
 	)
 	defaultTfDistribution := terraformClient.DefaultDistribution()
 	defaultTfVersion := terraformClient.DefaultVersion()

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -37,6 +37,7 @@ type UserConfig struct {
 	DisableApplyAll             bool   `mapstructure:"disable-apply-all"`
 	DisableAutoplan             bool   `mapstructure:"disable-autoplan"`
 	DisableAutoplanLabel        string `mapstructure:"disable-autoplan-label"`
+	DisableDidYouMeanPrompt     bool   `mapstructure:"disable-did-you-mean-prompt"`
 	DisableMarkdownFolding      bool   `mapstructure:"disable-markdown-folding"`
 	DisableRepoLocking          bool   `mapstructure:"disable-repo-locking"`
 	DisableGlobalApplyLock      bool   `mapstructure:"disable-global-apply-lock"`


### PR DESCRIPTION
## what

Adds configuration to disable the "did you mean" feature.

## why

The "did you mean" feature can cause problems when naming the atlantis executable something that can be within a small Levenshtein distance of words users add as part of comments. See the issue linked below for a couple of examples, including one that results in a particularly unfortunate infinite loop.

## tests

I mirrored the existing "did you mean" test and verified that with the feature disabled via this new configuration, those comments are all ignored.

## references

Closes https://github.com/runatlantis/atlantis/issues/5011.

I haven't contributed to this repo before, so please excuse if I missed updating some documentation or violated a norm. Happy to tweak things as needed.