### PR TITLE
fix: Remove GitHub rate-limit client total sleep limit

### DIFF
--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -125,11 +125,7 @@ func NewGithubClient(hostname string, credentials GithubCredentials, config Gith
 		return nil, errors.Wrap(err, "error initializing github authentication transport")
 	}
 
-	transportWithRateLimit, err := github_ratelimit.NewRateLimitWaiterClient(
-		transport.Transport,
-		github_ratelimit.WithTotalSleepLimit(time.Minute, func(callbackContext *github_ratelimit.CallbackContext) {
-			logger.Warn("github rate limit exceeded total sleep time, requests will fail to avoid penalties from github")
-		}))
+	transportWithRateLimit, err := github_ratelimit.NewRateLimitWaiterClient(transport.Transport)
 	if err != nil {
 		return nil, errors.Wrap(err, "error initializing github rate limit transport")
 	}


### PR DESCRIPTION
## what

- GitHub client-side rate-limiting was introduced in v0.33.0.
- It was done so with the use of a hard-coded (i.e. not admin-configurable) "total sleep limit" client option, which allows developers to set a maximum total amount of time the rate-limiting client shall spend sleeping between requests. There is no documentation as to why that decision was made, that I was able to find.
- When the total amount of time sleeping exceeds this limit, further requests are not rate-limited, defeating the rate-limiting mechanism altogether and causing GitHub secondary rate limits.
- This means that, in a big enough deployment of Atlantis (one that would cause GitHub API request bursts big enough to exceed 1 minute of total sleep), the client-side rate-limiting mechanism is disabled, which is contradictory given that's precisely the kind of deployment that needs this sort of rate-limiting.

## why

-  This PR removes such "total sleep limit" option so that the Atlantis GitHub rate-limiting clients sleeps as much as it needs in order to avoid GitHub secondary rate limiting. There is a risk of deadlock that needs to be evaluated before merging this PR, which could explain why this option was added in the first place, but we don't know.
- Secondary rate-limiting is particularly annoying because it lasts for 1h, period during which Atlantis can't issue any further requests to the GitHub API (regardless of rate), blocking Atlantis end users from getting their work done.

## tests

- I am raising this PR and will immediately start using this fork in our production instance to mitigate this problem, I'll report back on how that goes.

## references

- Issue introduced in https://github.com/runatlantis/atlantis/pull/5226
- Original PR https://github.com/runatlantis/atlantis/pull/4926