### PR TITLE
feat(webhooks): add the apply result/error into webhooks

### DIFF
--- a/server/events/webhooks/webhooks.go
+++ b/server/events/webhooks/webhooks.go
@@ -37,13 +37,14 @@ type Sender interface {
 
 // ApplyResult is the result of a terraform apply.
 type ApplyResult struct {
-	Workspace   string
-	Repo        models.Repo
-	Pull        models.PullRequest
-	User        models.User
-	Success     bool
-	Directory   string
-	ProjectName string
+	Workspace     string
+	Repo          models.Repo
+	Pull          models.PullRequest
+	User          models.User
+	Success       bool
+	Directory     string
+	ProjectName   string
+	ResultMessage string
 }
 
 // MultiWebhookSender sends multiple webhooks for each one it's configured for.


### PR DESCRIPTION
## what

- Adds the 'stdout' of an apply operation to HTTP webhooks

## why

- This provides more context for downstream systems - allowing for better notifications and better automation, e.g. using AI to advise on the type of error encountered
- Specific example: You configure a hook that rebases a PR if it is out of date before allowing an apply to take place. Now, any `atlantis apply` attempts that lead to rebases show up as errors (webhook says `success = false`) on the webhook, which is misleading

## tests

Example outputs from listening to atlantis webhooks locally with netcat, first success then failure:

```
❯ nc -kl 8888
POST / HTTP/1.1
Host: localhost:8888
User-Agent: Go-http-client/1.1
Content-Length: 1410
Content-Type: application/json
Accept-Encoding: gzip

# redacted unnecessary lines
"Success":true,"Directory":".","ProjectName":"","ResultMessage":"random_integer.test: Creating...\nrandom_integer.test: Creation complete after 0s [id=26697]\n\nApply complete! Resources: 1 added, 0 changed, 0 destroyed.\n\nOutputs:\n\nint = {\n  \"id\" = \"26697\"\n  \"keepers\" = tomap(null) /* of string */\n  \"max\" = 50011\n  \"min\" = 1\n  \"result\" = 26697\n  \"seed\" = tostring(null)\n}\n"}



❯ nc -kl 8888
POST / HTTP/1.1
Host: localhost:8888
User-Agent: Go-http-client/1.1
Content-Length: 1843
Content-Type: application/json
Accept-Encoding: gzip

# redacted unnecessary lines
"Success":false,"Directory":".","ProjectName":"","ResultMessage":"running 'sh -c' '/usr/bin/terraform apply -input=false \"/home/antti/.atlantis/repos/Antvirf/tf-test-for-atlantis/2/default/default.tfplan\"' in '/home/antti/.atlantis/repos/Antvirf/tf-test-for-atlantis/2/default': exit status 1\nnull_resource.fail_test: Creating...\nrandom_integer.test: Creating...\nnull_resource.fail_test: Provisioning with 'local-exec'...\nnull_resource.fail_test (local-exec): Executing: [\"/bin/sh\" \"-c\" \"exit 1\"]\nrandom_integer.test: Creation complete after 0s [id=36118]\n╷\n│ Error: local-exec provisioner error\n│ \n│   with null_resource.fail_test,\n│   on main.tf line 8, in resource \"null_resource\" \"fail_test\":\n│    8:   provisioner \"local-exec\" {\n│ \n│ Error running command 'exit 1': exit status 1. Output: \n╵\n"}
```
