### PR TITLE
fix: api 500er with policy, check getCommands index against commentCommand lenght

### DIFF
--- a/server/controllers/api_controller.go
+++ b/server/controllers/api_controller.go
@@ -243,6 +243,10 @@ func (a *APIController) apiPlan(request *APIRequest, ctx *command.Context) (*com
 
 	var projectResults []command.ProjectResult
 	for i, cmd := range cmds {
+                if i >= len(cc) {
+			ctx.Log.Warn("cmds (count %d) from getCommands are longer than commentCommand (len %d)", i, len(cc))
+                        break
+                }
 		err = a.PreWorkflowHooksCommandRunner.RunPreHooks(ctx, cc[i])
 		if err != nil {
 			if a.FailOnPreWorkflowHookError {


### PR DESCRIPTION
## what

If the api is called for plan and policies are activated, the commentCommand is shorter than the count of cmds. This leads to a 500. 
The check prevents a crash here and a warning is issued.
I could not find out why there is a discrepancy here.

## why

First of all to prevent the crash and thus prevent the 500. The warning can then help to recognize the cases when both counts deviate from each other.

## tests

Tests were carried out manually, after the change there were no more api/plan 500s with activated policies.
## references

It may alsocloses a GitHub issue `#4318`, but you cannot see whether policies are active.
