### PR TITLE
fix(docs): generate release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -30,7 +30,7 @@ changelog:
     - title: Bug fixes 🐛
       labels:
         - bug
-    - title: Security changes :lock:
+    - title: Security changes
       labels:
         - security
     - title: Documentation


### PR DESCRIPTION
This pull request includes a minor update to the `.github/release.yml` file. The change removes the lock emoji from the "Security changes" section title for consistency with the other section titles.