### PR TITLE
chore!: Update conftest and warn about breaking change in release notes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG DEFAULT_TERRAFORM_VERSION=1.11.4
 # renovate: datasource=github-releases depName=opentofu/opentofu versioning=hashicorp
 ARG DEFAULT_OPENTOFU_VERSION=1.10.1
 # renovate: datasource=github-releases depName=open-policy-agent/conftest
-ARG DEFAULT_CONFTEST_VERSION=0.59.0
+ARG DEFAULT_CONFTEST_VERSION=0.61.2
 
 # Stage 1: build artifact and download deps
 

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -16,7 +16,7 @@ RUN case $(uname -m) in x86_64|amd64) ARCH="amd64" ;; aarch64|arm64|armv7l) ARCH
 
 # Install conftest
 # renovate: datasource=github-releases depName=open-policy-agent/conftest
-ENV CONFTEST_VERSION=0.59.0
+ENV CONFTEST_VERSION=0.61.2
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN case $(uname -m) in x86_64|amd64) ARCH="x86_64" ;; aarch64|arm64|armv7l) ARCH="arm64" ;; esac && \
     curl -LOs https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_${ARCH}.tar.gz && \


### PR DESCRIPTION
## what

Update the version of conftest to the latest available.

## why

The next version has breaking changes that will likely affect some atlantis users: https://github.com/open-policy-agent/conftest/releases/tag/v0.59.0
Given the substantial backlog that renovate is pushing ahead of it due to rate limiting, this might happen unnoticed in any future release. For predictability, I’d suggest doing the update with the next release and mentioning it in the release notes.

## tests

NA

## references

- https://github.com/open-policy-agent/conftest/releases/tag/v0.59.0

## Release notes
Bundled conftest has breaking change: https://github.com/open-policy-agent/conftest/releases/tag/v0.59.0

> Bump hcl2json - This makes the behavior of the conversion more consistent by always using arrays for blocks that can be repeated.

Policies might need tweaking to keep working.

