### PR TITLE
fix: use the official ngrok image

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Docker compose is set up to start an atlantis container and ngrok container in t
 e.g.
 
 ```sh
-NGROK_AUTH=1234567890
+NGROK_AUTHTOKEN=1234567890
 
 ATLANTIS_GH_APP_ID=123
 ATLANTIS_GH_APP_KEY_FILE="/.ssh/somekey.pem"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,12 @@
 # Note: This file is only used for Atlantis local development
 services:
   ngrok:
-    image: wernight/ngrok:latest@sha256:d211f29ebcfe5f4e72df4fa8bdd9a667886e127d7fcb1be4a1af5ad83a8a1b77
+    image: ngrok/ngrok:latest@sha256:0dbf30ec036f2369d3b9018a8287aa2414deb90ccf44536cb2fcfd238b3d4f70
     ports:
       - 4040:4040
-    environment:
-      # https://dashboard.ngrok.com/get-started/your-authtoken
-      # NGROK_AUTH: REPLACE-WITH-YOUR-TOKEN // set this in atlantis.env
-      NGROK_PROTOCOL: http
-      NGROK_PORT: atlantis:4141
+    command:
+      - "http"
+      - "atlantis:4141"
     env_file:
       - atlantis.env
     depends_on:


### PR DESCRIPTION
Closes #5680

See https://ngrok.com/docs/using-ngrok-with/docker/ for additional usage information on ngrok & Docker.