### PR TITLE
Update pin_ci_terraform_providers.sh

### DIFF
--- a/scripts/pin_ci_terraform_providers.sh
+++ b/scripts/pin_ci_terraform_providers.sh
@@ -3,7 +3,7 @@
 # Script to pin terraform providers in e2e tests
 
 RANDOM_PROVIDER_VERSION="3.6.1"
-NULL_PROVIDER_VERSION="3.2.3"
+NULL_PROVIDER_VERSION="3.2.4"
 
 TEST_REPOS_DIR="server/controllers/events/testdata/test-repos"
 


### PR DESCRIPTION
This pull request makes a small update to the `scripts/pin_ci_terraform_providers.sh` script, incrementing the version of the `NULL_PROVIDER_VERSION` from `3.2.3` to `3.2.4`.