### PR TITLE
docs: Document automatic env/{workspace}.tfvars feature

### DIFF
--- a/runatlantis.io/docs/custom-workflows.md
+++ b/runatlantis.io/docs/custom-workflows.md
@@ -19,6 +19,10 @@ Custom workflows can be specified in the Server-Side Repo Config or in the Repo-
 
 ### .tfvars files
 
+::: tip
+Before creating custom workflows for `.tfvars` files, consider using Atlantis's automatic `env/{workspace}.tfvars` feature. If you structure your files as `env/staging.tfvars`, `env/production.tfvars`, etc., Atlantis will automatically include them based on the workspace without any configuration. See [Using Atlantis - Automatic Environment Variable Files](using-atlantis.md#automatic-environment-variable-files) for details.
+:::
+
 Given the structure:
 
 ```plain

--- a/runatlantis.io/docs/requirements.md
+++ b/runatlantis.io/docs/requirements.md
@@ -82,8 +82,31 @@ If you're using Terraform `>= 0.9.0`, Atlantis supports workspaces through an
 └── main.tf
 ```
 
-For Atlantis to be able to plan automatically with `.tfvars files`, you need to create
-an `atlantis.yaml` file to tell it to use `-var-file={YOUR_FILE}`.
+Atlantis supports `.tfvars` files in two ways:
+
+#### Automatic env/{workspace}.tfvars files
+Atlantis automatically includes workspace-specific variable files if they exist in an `env/` directory:
+
+```plain
+.
+├── main.tf
+├── variables.tf
+└── env/
+    ├── default.tfvars
+    ├── staging.tfvars
+    └── production.tfvars
+```
+
+When using this structure, Atlantis will automatically include the appropriate file based on the workspace:
+- `atlantis plan` includes `env/default.tfvars`
+- `atlantis plan -w staging` includes `env/staging.tfvars`  
+- `atlantis plan -w production` includes `env/production.tfvars`
+
+This requires no additional configuration and works automatically.
+
+#### Custom .tfvars files with atlantis.yaml
+For other `.tfvars` file locations or structures, you need to create
+an `atlantis.yaml` file to tell Atlantis to use `-var-file={YOUR_FILE}`.
 See [atlantis.yaml Use Cases](custom-workflows.md#tfvars-files) for more details.
 
 ### Multiple Repos

--- a/runatlantis.io/docs/using-atlantis.md
+++ b/runatlantis.io/docs/using-atlantis.md
@@ -94,6 +94,36 @@ atlantis plan -d dir -- -var foo='bar'
 
 If you always need to append a certain flag, see [Custom Workflow Use Cases](custom-workflows.md#adding-extra-arguments-to-terraform-commands).
 
+### Automatic Environment Variable Files
+
+Atlantis automatically includes workspace-specific variable files if they exist in your repository. This feature helps reduce duplication across different environments and workspaces.
+
+#### How it works
+
+When running `atlantis plan`, Atlantis automatically checks for a file at `env/{workspace}.tfvars` relative to the project directory. If this file exists, Atlantis will automatically include it using the `-var-file` flag.
+
+#### Examples
+
+```
+# Repository structure
+my-terraform-project/
+├── main.tf
+├── variables.tf
+└── env/
+    ├── default.tfvars
+    ├── staging.tfvars
+    └── production.tfvars
+```
+
+When you run:
+- `atlantis plan` (uses default workspace) automatically includes `env/default.tfvars`
+- `atlantis plan -w staging` automatically includes `env/staging.tfvars`
+- `atlantis plan -w production` automatically includes `env/production.tfvars`
+
+::: tip
+This feature works for any workspace name. If you have a custom workspace called `dev-team-1`, Atlantis will look for `env/dev-team-1.tfvars`.
+:::
+
 ### Using the -destroy Flag
 
 #### Example
@@ -162,6 +192,10 @@ Because Atlantis under the hood is running `terraform apply plan.tfplan`, any Te
 
 They're ignored because they can't be specified for an already generated planfile.
 If you would like to specify these flags, do it while running `atlantis plan`.
+
+::: tip
+The automatic `env/{workspace}.tfvars` file inclusion happens during the `atlantis plan` phase. Since `atlantis apply` uses the already-generated plan file, any environment-specific variables are already incorporated from when the plan was created.
+:::
 
 ---
 


### PR DESCRIPTION
Closes #5690

Add documentation for the previously undocumented automatic env/{workspace}.tfvars file inclusion feature that has existed in Atlantis for a long time.