### PR TITLE
feat: add configuration reload API endpoint

### DIFF
--- a/server/controllers/config_controller.go
+++ b/server/controllers/config_controller.go
@@ -1,0 +1,164 @@
+package controllers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+
+	"github.com/go-playground/validator/v10"
+	cfg "github.com/runatlantis/atlantis/server/core/config"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/events"
+	"github.com/runatlantis/atlantis/server/logging"
+	tally "github.com/uber-go/tally/v4"
+)
+
+const atlantisConfigTokenHeader = "X-Atlantis-Token"
+
+// ConfigReloadRequest represents the request structure for config reload
+type ConfigReloadRequest struct {
+	// Force reload even if config hasn't changed
+	Force bool `json:"force,omitempty"`
+}
+
+// ConfigReloadResponse represents the response structure for config reload
+type ConfigReloadResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+	Error   string `json:"error,omitempty"`
+}
+
+// ConfigController handles configuration management API endpoints
+type ConfigController struct {
+	APISecret          []byte
+	Logger             logging.SimpleLogging        `validate:"required"`
+	CommandRunner      *events.DefaultCommandRunner `validate:"required"`
+	RepoConfig         string                       // Path to repo config file
+	RepoConfigJSON     string                       // JSON config string
+	PolicyCheckEnabled bool                         // Whether policy checks are enabled
+	ParserValidator    *cfg.ParserValidator         `validate:"required"`
+	Scope              tally.Scope                  `validate:"required"`
+
+	// Mutex to ensure thread-safe config updates
+	configMutex sync.RWMutex
+}
+
+// ReloadConfig handles POST /api/config/reload
+func (c *ConfigController) ReloadConfig(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	// Validate API secret (same as other API endpoints)
+	if len(c.APISecret) == 0 {
+		c.respondError(w, http.StatusBadRequest, "API is disabled - no api-secret configured")
+		return
+	}
+
+	secret := r.Header.Get(atlantisConfigTokenHeader)
+	if secret != string(c.APISecret) {
+		c.respondError(w, http.StatusUnauthorized, fmt.Sprintf("header %s did not match expected secret", atlantisConfigTokenHeader))
+		return
+	}
+
+	// Parse request body
+	bytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		c.respondError(w, http.StatusBadRequest, "failed to read request body")
+		return
+	}
+
+	var request ConfigReloadRequest
+	if len(bytes) > 0 {
+		if err = json.Unmarshal(bytes, &request); err != nil {
+			c.respondError(w, http.StatusBadRequest, fmt.Sprintf("failed to parse request: %v", err.Error()))
+			return
+		}
+		if err = validator.New().Struct(request); err != nil {
+			c.respondError(w, http.StatusBadRequest, fmt.Sprintf("request validation failed: %v", err.Error()))
+			return
+		}
+	}
+
+	// Perform the configuration reload
+	err = c.reloadConfiguration()
+	if err != nil {
+		c.respondError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	response := ConfigReloadResponse{
+		Success: true,
+		Message: "Configuration reloaded successfully",
+	}
+
+	responseJSON, err := json.Marshal(response)
+	if err != nil {
+		c.respondError(w, http.StatusInternalServerError, "failed to marshal response")
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(responseJSON)
+	c.Logger.Info("Configuration reloaded successfully via API")
+}
+
+// reloadConfiguration performs the actual configuration reload
+func (c *ConfigController) reloadConfiguration() error {
+	c.configMutex.Lock()
+	defer c.configMutex.Unlock()
+
+	c.Logger.Info("Starting configuration reload")
+
+	// Create default global config
+	globalCfgArgs := valid.GlobalCfgArgs{
+		PolicyCheckEnabled: c.PolicyCheckEnabled,
+	}
+	globalCfg := valid.NewGlobalCfgFromArgs(globalCfgArgs)
+
+	// Parse the configuration using the same logic as server startup
+	parserValidator := &cfg.ParserValidator{}
+	var err error
+
+	if c.RepoConfig != "" {
+		c.Logger.Info("Reloading configuration from file: %s", c.RepoConfig)
+		globalCfg, err = parserValidator.ParseGlobalCfg(c.RepoConfig, globalCfg)
+		if err != nil {
+			return fmt.Errorf("parsing %s file: %w", c.RepoConfig, err)
+		}
+	} else if c.RepoConfigJSON != "" {
+		c.Logger.Info("Reloading configuration from JSON")
+		globalCfg, err = parserValidator.ParseGlobalCfgJSON(c.RepoConfigJSON, globalCfg)
+		if err != nil {
+			return fmt.Errorf("parsing repo-config-json: %w", err)
+		}
+	} else {
+		c.Logger.Info("No server-side configuration specified, using defaults")
+	}
+
+	// Update the global configuration in the command runner
+	// This is the critical part - we need to atomically update the configuration
+	c.CommandRunner.UpdateGlobalCfg(globalCfg)
+
+	c.Logger.Info("Configuration reload completed successfully")
+	return nil
+}
+
+// respondError sends an error response
+func (c *ConfigController) respondError(w http.ResponseWriter, statusCode int, message string) {
+	c.Logger.Warn("Config reload API error: %s", message)
+
+	response := ConfigReloadResponse{
+		Success: false,
+		Error:   message,
+	}
+
+	responseJSON, err := json.Marshal(response)
+	if err != nil {
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(statusCode)
+	w.Write(responseJSON)
+}

--- a/server/controllers/config_controller_test.go
+++ b/server/controllers/config_controller_test.go
@@ -1,0 +1,140 @@
+package controllers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/controllers"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/events"
+	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tally "github.com/uber-go/tally/v4"
+)
+
+func TestConfigController_ReloadConfig_Success(t *testing.T) {
+	// Setup
+	logger := logging.NewNoopLogger(t)
+	scope := tally.NoopScope
+	apiSecret := "test-secret"
+
+	// Create a mock command runner with initial config
+	commandRunner := &events.DefaultCommandRunner{
+		GlobalCfg: valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{}),
+	}
+
+	configController := &controllers.ConfigController{
+		APISecret:          []byte(apiSecret),
+		Logger:             logger,
+		CommandRunner:      commandRunner,
+		RepoConfig:         "",
+		RepoConfigJSON:     "",
+		PolicyCheckEnabled: false,
+		Scope:              scope,
+	}
+
+	// Create test request
+	reqBody := controllers.ConfigReloadRequest{}
+	jsonBody, err := json.Marshal(reqBody)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("POST", "/api/config/reload", bytes.NewBuffer(jsonBody))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Atlantis-Token", apiSecret)
+
+	rr := httptest.NewRecorder()
+
+	// Execute
+	configController.ReloadConfig(rr, req)
+
+	// Verify
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var response controllers.ConfigReloadResponse
+	err = json.Unmarshal(rr.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.True(t, response.Success)
+	assert.Contains(t, response.Message, "Configuration reloaded successfully")
+}
+
+func TestConfigController_ReloadConfig_InvalidAuth(t *testing.T) {
+	// Setup
+	logger := logging.NewNoopLogger(t)
+	scope := tally.NoopScope
+	apiSecret := "test-secret"
+
+	commandRunner := &events.DefaultCommandRunner{
+		GlobalCfg: valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{}),
+	}
+
+	configController := &controllers.ConfigController{
+		APISecret:          []byte(apiSecret),
+		Logger:             logger,
+		CommandRunner:      commandRunner,
+		RepoConfig:         "",
+		RepoConfigJSON:     "",
+		PolicyCheckEnabled: false,
+		Scope:              scope,
+	}
+
+	// Create test request with wrong token
+	reqBody := controllers.ConfigReloadRequest{}
+	jsonBody, err := json.Marshal(reqBody)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("POST", "/api/config/reload", bytes.NewBuffer(jsonBody))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Atlantis-Token", "wrong-secret")
+
+	rr := httptest.NewRecorder()
+
+	// Execute
+	configController.ReloadConfig(rr, req)
+
+	// Verify
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestConfigController_ReloadConfig_NoAuth(t *testing.T) {
+	// Setup
+	logger := logging.NewNoopLogger(t)
+	scope := tally.NoopScope
+	apiSecret := "test-secret"
+
+	commandRunner := &events.DefaultCommandRunner{
+		GlobalCfg: valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{}),
+	}
+
+	configController := &controllers.ConfigController{
+		APISecret:          []byte(apiSecret),
+		Logger:             logger,
+		CommandRunner:      commandRunner,
+		RepoConfig:         "",
+		RepoConfigJSON:     "",
+		PolicyCheckEnabled: false,
+		Scope:              scope,
+	}
+
+	// Create test request without token
+	reqBody := controllers.ConfigReloadRequest{}
+	jsonBody, err := json.Marshal(reqBody)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("POST", "/api/config/reload", bytes.NewBuffer(jsonBody))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+
+	// Execute
+	configController.ReloadConfig(rr, req)
+
+	// Verify
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}

--- a/server/controllers/config_controller_test.go
+++ b/server/controllers/config_controller_test.go
@@ -28,13 +28,12 @@ func TestConfigController_ReloadConfig_Success(t *testing.T) {
 	}
 
 	configController := &controllers.ConfigController{
-		APISecret:          []byte(apiSecret),
-		Logger:             logger,
-		CommandRunner:      commandRunner,
-		RepoConfig:         "",
-		RepoConfigJSON:     "",
-		PolicyCheckEnabled: false,
-		Scope:              scope,
+		APISecret:      []byte(apiSecret),
+		Logger:         logger,
+		CommandRunner:  commandRunner,
+		RepoConfig:     "",
+		RepoConfigJSON: "",
+		Scope:          scope,
 	}
 
 	// Create test request
@@ -73,13 +72,12 @@ func TestConfigController_ReloadConfig_InvalidAuth(t *testing.T) {
 	}
 
 	configController := &controllers.ConfigController{
-		APISecret:          []byte(apiSecret),
-		Logger:             logger,
-		CommandRunner:      commandRunner,
-		RepoConfig:         "",
-		RepoConfigJSON:     "",
-		PolicyCheckEnabled: false,
-		Scope:              scope,
+		APISecret:      []byte(apiSecret),
+		Logger:         logger,
+		CommandRunner:  commandRunner,
+		RepoConfig:     "",
+		RepoConfigJSON: "",
+		Scope:          scope,
 	}
 
 	// Create test request with wrong token
@@ -112,13 +110,12 @@ func TestConfigController_ReloadConfig_NoAuth(t *testing.T) {
 	}
 
 	configController := &controllers.ConfigController{
-		APISecret:          []byte(apiSecret),
-		Logger:             logger,
-		CommandRunner:      commandRunner,
-		RepoConfig:         "",
-		RepoConfigJSON:     "",
-		PolicyCheckEnabled: false,
-		Scope:              scope,
+		APISecret:      []byte(apiSecret),
+		Logger:         logger,
+		CommandRunner:  commandRunner,
+		RepoConfig:     "",
+		RepoConfigJSON: "",
+		Scope:          scope,
 	}
 
 	// Create test request without token

--- a/server/server.go
+++ b/server/server.go
@@ -111,6 +111,7 @@ type Server struct {
 	StatusController               *controllers.StatusController
 	JobsController                 *controllers.JobsController
 	APIController                  *controllers.APIController
+	ConfigController               *controllers.ConfigController
 	IndexTemplate                  web_templates.TemplateWriter
 	LockDetailTemplate             web_templates.TemplateWriter
 	ProjectJobsTemplate            web_templates.TemplateWriter
@@ -996,6 +997,17 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		GithubOrg:           userConfig.GithubOrg,
 	}
 
+	configController := &controllers.ConfigController{
+		APISecret:          []byte(userConfig.APISecret),
+		Logger:             logger,
+		CommandRunner:      commandRunner,
+		RepoConfig:         userConfig.RepoConfig,
+		RepoConfigJSON:     userConfig.RepoConfigJSON,
+		PolicyCheckEnabled: policyChecksEnabled,
+		ParserValidator:    parserValidator,
+		Scope:              statsScope,
+	}
+
 	server := &Server{
 		AtlantisVersion:                config.AtlantisVersion,
 		AtlantisURL:                    parsedURL,
@@ -1016,6 +1028,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		JobsController:                 jobsController,
 		StatusController:               statusController,
 		APIController:                  apiController,
+		ConfigController:               configController,
 		IndexTemplate:                  web_templates.IndexTemplate,
 		LockDetailTemplate:             web_templates.LockTemplate,
 		ProjectJobsTemplate:            web_templates.ProjectJobsTemplate,
@@ -1054,6 +1067,7 @@ func (s *Server) Start() error {
 	s.Router.HandleFunc("/api/plan", s.APIController.Plan).Methods("POST")
 	s.Router.HandleFunc("/api/apply", s.APIController.Apply).Methods("POST")
 	s.Router.HandleFunc("/api/locks", s.APIController.ListLocks).Methods("GET")
+	s.Router.HandleFunc("/api/config/reload", s.ConfigController.ReloadConfig).Methods("POST")
 	s.Router.HandleFunc("/github-app/exchange-code", s.GithubAppController.ExchangeCode).Methods("GET")
 	s.Router.HandleFunc("/github-app/setup", s.GithubAppController.New).Methods("GET")
 	s.Router.HandleFunc("/locks", s.LocksController.DeleteLock).Methods("DELETE").Queries("id", "{id:.*}")

--- a/server/server.go
+++ b/server/server.go
@@ -38,7 +38,7 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/mitchellh/go-homedir"
 	tally "github.com/uber-go/tally/v4"
-	prometheus "github.com/uber-go/tally/v4/prometheus"
+	"github.com/uber-go/tally/v4/prometheus"
 	"github.com/urfave/negroni/v3"
 
 	cfg "github.com/runatlantis/atlantis/server/core/config"
@@ -998,14 +998,16 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	}
 
 	configController := &controllers.ConfigController{
-		APISecret:          []byte(userConfig.APISecret),
-		Logger:             logger,
-		CommandRunner:      commandRunner,
-		RepoConfig:         userConfig.RepoConfig,
-		RepoConfigJSON:     userConfig.RepoConfigJSON,
-		PolicyCheckEnabled: policyChecksEnabled,
-		ParserValidator:    parserValidator,
-		Scope:              statsScope,
+		APISecret:       []byte(userConfig.APISecret),
+		Logger:          logger,
+		CommandRunner:   commandRunner,
+		RepoConfig:      userConfig.RepoConfig,
+		RepoConfigJSON:  userConfig.RepoConfigJSON,
+		ParserValidator: parserValidator,
+		Scope:           statsScope,
+		GlobalCfgArgs: valid.GlobalCfgArgs{
+			PolicyCheckEnabled: userConfig.EnablePolicyChecksFlag,
+		},
 	}
 
 	server := &Server{


### PR DESCRIPTION
Add support for reloading server-side repo configuration without requiring a full server restart. Enabling zero-downtime configuration updates for operational flexibility.