### PR TITLE
fix: show output if the custom policy check errors

### DIFF
--- a/server/core/runtime/run_step_runner.go
+++ b/server/core/runtime/run_step_runner.go
@@ -98,7 +98,7 @@ func (r *RunStepRunner) Run(
 		} else {
 			ctx.Log.Debug("Treating custom policy tool error exit code as a policy failure.  Error output: %s", err)
 		}
-		return "", err
+		return output, err
 	}
 
 	switch postProcessOutput {

--- a/server/core/runtime/run_step_runner_test.go
+++ b/server/core/runtime/run_step_runner_test.go
@@ -53,6 +53,7 @@ func TestRunStepRunner_Run(t *testing.T) {
 		},
 		{
 			Command: "echo 'a",
+			ExpOut:  "sh: -c: line 0: unexpected EOF while looking for matching `''\nsh: -c: line 1: syntax error: unexpected end of file\n",
 			ExpErr:  "exit status 2: running \"echo 'a\" in",
 		},
 		{
@@ -61,6 +62,7 @@ func TestRunStepRunner_Run(t *testing.T) {
 		},
 		{
 			Command: "lkjlkj",
+			ExpOut:  "sh: lkjlkj: command not found\n",
 			ExpErr:  "exit status 127: running \"lkjlkj\" in",
 		},
 		{
@@ -169,16 +171,18 @@ func TestRunStepRunner_Run(t *testing.T) {
 					CustomPolicyCheck:     customPolicyCheck,
 				}
 				out, err := r.Run(ctx, nil, c.Command, tmpDir, map[string]string{"test": "var"}, true, valid.PostProcessRunOutputShow)
-				if c.ExpErr != "" {
-					ErrContains(t, c.ExpErr, err)
-					return
-				}
-				Ok(t, err)
+
 				// Replace $DIR in the exp with the actual temp dir. We do this
 				// here because when constructing the cases we don't yet know the
 				// temp dir.
 				expOut := strings.Replace(c.ExpOut, "$DIR", tmpDir, -1)
 				Equals(t, expOut, out)
+
+				if c.ExpErr != "" {
+					ErrContains(t, c.ExpErr, err)
+					return
+				}
+				Ok(t, err)
 
 				terraform.VerifyWasCalledOnce().EnsureVersion(Eq(logger), NotEq(defaultDistribution), Eq(projVersion))
 				terraform.VerifyWasCalled(Never()).EnsureVersion(Eq(logger), Eq(defaultDistribution), Eq(defaultVersion))


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

The custom policy check output is now visible as PR comment even if the check exits with non-zero status.

Example:
```bash
# custom-policy-check.sh
echo "some test output for policy check"
echo "another line"
exit 1
```

Old:
<img width="847" height="190" alt="Screenshot 2025-08-21 at 11 36 04" src="https://github.com/user-attachments/assets/86953d90-424b-4d20-b611-5bd788dd7860" />

New - policy error:
<img width="862" height="455" alt="Screenshot 2025-08-21 at 13 16 00" src="https://github.com/user-attachments/assets/ef09f917-eaf6-4205-8a2d-64d904bd6576" />
(vs policy failure):
<img width="850" height="347" alt="Screenshot 2025-08-21 at 13 25 55" src="https://github.com/user-attachments/assets/0786d4bd-5fa3-4249-9d77-4bcc8a97e3f8" />


## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

- Some tools are using non-zero exit code to indicate policy failure - previously we had to always `|| true` to see the output and to let users `approve_policies`.
- Also if a custom script has a bug, there are no logs from the script execution available anywhere (unless you enable debug logging which is not really feasible in production environment) to help debugging. 
- This change also lets users to proceed with apply (by `approve_policies`) even if there is an issue with the policy check script itself.

## tests

<!--
- [ ] I have tested my changes by ...
-->

* tested manually (see screenshots above)...
* ... and added tests for running custom policy check

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

- closes #5725

