### PR TITLE
docs: #5734 - Update notes for GH App webhooks

### DIFF
--- a/runatlantis.io/docs/access-credentials.md
+++ b/runatlantis.io/docs/access-credentials.md
@@ -63,7 +63,9 @@ Only a single installation per GitHub App is supported at the moment.
 :::
 
 ::: tip NOTE
-GitHub App handles the webhook calls by itself, hence there is no need to create webhooks separately. If webhooks were created manually, those should be removed when using GitHub App. Otherwise, there would be 2 calls to Atlantis resulting in locking errors on path/workspace.
+GitHub App handles the webhook calls by itself, hence there is no need to create webhooks separately. If webhooks were created manually, those can be removed when using GitHub App. Otherwise, there would be 2 calls to Atlantis resulting in locking errors on path/workspace.
+
+Webhooks can either be created manually or managed by the GitHub App for repositories that trigger Atlantis. If manually creating (see the [section below](access-credentials.md#manually-creating-the-github-app)), do not specify webhook details in the GitHub app configuration settings. In both cases it is strongly recommended to protect the webhooks using a secret. See [Webhook Secrets](webhook-secrets.md#webhook-secrets)
 :::
 
 #### Manually Creating the GitHub app
@@ -82,10 +84,6 @@ Manually installing the GitHub app means that the credentials can be shared by m
 
 ::: tip NOTE
 Repositories must be manually registered with the created GitHub app to allow Atlantis to interact with Pull Requests.
-:::
-
-::: tip NOTE
-Webhooks must be created manually for repositories that trigger Atlantis.
 :::
 
 ::: tip NOTE


### PR DESCRIPTION
## what

The webhook configuration notes are confusing on the documentation page that instructs users how to configure a GitHub App for source control integration. There are two somewhat conflicting statements that could be combined into a single note and given a bit more explanation. This will prevent questions like the one I asked in Slack specifically about being confused by this documentation.
  
## why

I have time to help and I think clear documentation is extremely helpful in providing a smooth adoption/on-boarding experience for new users while also helping "advanced" users move faster.

If there are suggestions on wording, grammar, etc. please comment. I am happy to make whatever changes are requested/required. I am by no means emotionally attached to the actual verbiage I proposed in this PR as long as it is clear and concise.


## tests

I have not tested because this is just a doc change. I am not sure how to build or test that the docs render correctly. Happy to do that if someone would like to point me in that direction.

## references

closes #5734
