### PR TITLE
fix: backport Alpine and Debian package version fixes to release-0.34

### DIFF
--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -92,10 +92,6 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
-      # https://github.com/docker/build-push-action/issues/761#issuecomment-1575006515
-      with:
-        driver-opts: |
-          image=moby/buildkit:v0.14.0
 
     - name: "Install cosign"
       uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
@@ -217,10 +213,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
-        # https://github.com/docker/build-push-action/issues/761#issuecomment-1575006515
-        with:
-          driver-opts: |
-            image=moby/buildkit:v0.14.0
 
       - name: "Build and load into Docker"
         if: contains(fromJson('["push", "pull_request"]'), github.event_name)

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,10 @@ WORKDIR /app
 # This is needed to download transitive dependencies instead of compiling them
 # https://github.com/montanaflynn/golang-docker-cache
 # https://github.com/golang/go/issues/27719
+# renovate: datasource=repology depName=alpine_3_21/bash versioning=loose
+ENV BUILDER_BASH_VERSION="5.2.37-r0"
 RUN apk add --no-cache \
-        bash~=5.2
+        bash=${BUILDER_BASH_VERSION}
 COPY go.mod go.sum ./
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN --mount=type=cache,target=/go/pkg/mod \
@@ -50,21 +52,36 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 FROM debian:${DEBIAN_TAG} AS debian-base
 
+# Define package versions for Debian
+# renovate: datasource=repology depName=debian_12/ca-certificates versioning=loose
+ENV DEBIAN_CA_CERTIFICATES_VERSION="20230311+deb12u1"
+# renovate: datasource=repology depName=debian_12/curl versioning=loose
+ENV DEBIAN_CURL_VERSION="7.88.1-10+deb12u12"
+# renovate: datasource=repology depName=debian_12/git versioning=loose
+ENV DEBIAN_GIT_VERSION="1:2.39.5-0+deb12u2"
+# renovate: datasource=repology depName=debian_12/unzip versioning=loose
+ENV DEBIAN_UNZIP_VERSION="6.0-28"
+# renovate: datasource=repology depName=debian_12/openssh-server versioning=loose
+ENV DEBIAN_OPENSSH_SERVER_VERSION="1:9.2p1-2+deb12u7"
+# renovate: datasource=repology depName=debian_12/dumb-init versioning=loose
+ENV DEBIAN_DUMB_INIT_VERSION="1.2.5-2"
+# renovate: datasource=repology depName=debian_12/gnupg versioning=loose
+ENV DEBIAN_GNUPG_VERSION="2.2.40-1.1"
+# renovate: datasource=repology depName=debian_12/openssl versioning=loose
+ENV DEBIAN_OPENSSL_VERSION="3.0.17-1~deb12u2"
+
 # Install packages needed to run Atlantis.
 # We place this last as it will bust less docker layer caches when packages update
-# hadolint ignore explanation
-# DL3008 (pin versions using "=") - Ignored to avoid failing the build
-# hadolint ignore=DL3008
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        ca-certificates \
-        curl \
-        git \
-        unzip \
-        openssh-server \
-        dumb-init \
-        gnupg \
-        openssl && \
+        ca-certificates=${DEBIAN_CA_CERTIFICATES_VERSION} \
+        curl=${DEBIAN_CURL_VERSION} \
+        git=${DEBIAN_GIT_VERSION} \
+        unzip=${DEBIAN_UNZIP_VERSION} \
+        openssh-server=${DEBIAN_OPENSSH_SERVER_VERSION} \
+        dumb-init=${DEBIAN_DUMB_INIT_VERSION} \
+        gnupg=${DEBIAN_GNUPG_VERSION} \
+        openssl=${DEBIAN_OPENSSL_VERSION} && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -159,20 +176,36 @@ COPY --from=deps /usr/bin/git-lfs /usr/bin/git-lfs
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 # renovate: datasource=repology depName=alpine_3_21/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20241121-r1"
+ENV CA_CERTIFICATES_VERSION="20250619-r0"
+# renovate: datasource=repology depName=alpine_3_21/curl versioning=loose
+ENV CURL_VERSION="8.12.1-r1"
+# renovate: datasource=repology depName=alpine_3_21/git versioning=loose  
+ENV GIT_VERSION="2.47.3-r0"
+# renovate: datasource=repology depName=alpine_3_21/unzip versioning=loose
+ENV UNZIP_VERSION="6.0-r15"
+# renovate: datasource=repology depName=alpine_3_21/bash versioning=loose
+ENV BASH_VERSION="5.2.37-r0"
+# renovate: datasource=repology depName=alpine_3_21/openssh versioning=loose
+ENV OPENSSH_VERSION="9.9_p2-r0"
+# renovate: datasource=repology depName=alpine_3_21/dumb-init versioning=loose
+ENV DUMB_INIT_VERSION="1.2.5-r3"
+# renovate: datasource=repology depName=alpine_3_21/gcompat versioning=loose
+ENV GCOMPAT_VERSION="1.1.0-r4"
+# renovate: datasource=repology depName=alpine_3_21/coreutils versioning=loose
+ENV COREUTILS_ENV_VERSION="9.5-r2"
 
 # Install packages needed to run Atlantis.
 # We place this last as it will bust less docker layer caches when packages update
 RUN apk add --no-cache \
-        ca-certificates~=${CA_CERTIFICATES_VERSION} \
-        curl~=8 \
-        git~=2 \
-        unzip~=6 \
-        bash~=5 \
-        openssh~=9 \
-        dumb-init~=1 \
-        gcompat~=1 \
-        coreutils-env~=9
+        ca-certificates=${CA_CERTIFICATES_VERSION} \
+        curl=${CURL_VERSION} \
+        git=${GIT_VERSION} \
+        unzip=${UNZIP_VERSION} \
+        bash=${BASH_VERSION} \
+        openssh=${OPENSSH_VERSION} \
+        dumb-init=${DUMB_INIT_VERSION} \
+        gcompat=${GCOMPAT_VERSION} \
+        coreutils-env=${COREUTILS_ENV_VERSION}
 
 # Set the entry point to the atlantis user and run the atlantis command
 USER atlantis


### PR DESCRIPTION
## Summary
Backport of PR #5760 to fix Docker build failures in the release-0.34 branch.

## Problem
All PRs targeting the release-0.34 branch will fail with Docker build errors due to outdated Alpine and Debian package versions, similar to the issue seen in release-0.35.

## Solution
This PR backports the package version fixes from main branch:

### Alpine Packages Updated:
- ca-certificates: 20241121-r1 → 20250619-r0
- curl: 8.12.1-r1
- git: 2.47.3-r0
- unzip: 6.0-r15
- bash: 5.2.37-r0 (also in builder stage)
- openssh: 9.9_p2-r0
- dumb-init: 1.2.5-r3
- gcompat: 1.1.0-r4
- coreutils-env: 9.5-r2

### Debian Packages Updated (now with version pinning):
- ca-certificates: 20230311+deb12u1
- curl: 7.88.1-10+deb12u12
- git: 1:2.39.5-0+deb12u2
- unzip: 6.0-28
- openssh-server: 1:9.2p1-2+deb12u7
- dumb-init: 1.2.5-2
- gnupg: 2.2.40-1.1
- openssl: 3.0.17-1~deb12u2

### Key Changes:
1. **Alpine**: Changed from fuzzy version matching (~=) to exact (=) for reproducibility
2. **Debian**: Added version pinning (was previously unpinned)
3. **Both**: Added renovate annotations for automatic updates

## Test Plan
- [x] Docker build tested locally for Alpine target
- [x] Docker build tested locally for Debian target
- [ ] CI/CD pipeline should pass after this fix

## Impact
This fix will unblock all PRs targeting the release-0.34 branch, including critical security updates.

## Related PRs
- #5760 - Original fix for main branch (merged)
- #5761 - Backport to release-0.35 branch