### PR TITLE
fix: correct unlock key format to match lock key format

### DIFF
--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -17,7 +17,6 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -961,13 +960,9 @@ func TestRunGenericPlanCommand_DeletePlans(t *testing.T) {
 	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
 	testdata.Pull.BaseRepo = testdata.GithubRepo
 	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan})
-	lockingLocker.VerifyWasCalledOnce().Unlock(fmt.Sprintf("%s/%d/%s/%s", testdata.Pull.BaseRepo.FullName, testdata.Pull.Num, projectCtx.ProjectName, projectCtx.Workspace))
-
-	lockingLocker.VerifyWasCalledOnce().
-		Unlock(testdata.Pull.BaseRepo.FullName + "/" +
-			strconv.Itoa(testdata.Pull.Num) + "/" +
-			projectCtx.ProjectName + "/" +
-			projectCtx.Workspace)
+	// The lock key should be repo/path/workspace format, not repo/pullnum/project/workspace
+	// Since RepoRelDir is not set in projectCtx, it defaults to empty string ""
+	lockingLocker.VerifyWasCalledOnce().Unlock(fmt.Sprintf("%s/%s/%s", testdata.Pull.BaseRepo.FullName, "", projectCtx.Workspace))
 }
 
 func TestRunSpecificPlanCommandDoesnt_DeletePlans(t *testing.T) {

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -1,7 +1,7 @@
 package events
 
 import (
-	"strconv"
+	"fmt"
 
 	"github.com/runatlantis/atlantis/server/core/locking"
 	"github.com/runatlantis/atlantis/server/events/command"
@@ -269,7 +269,7 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 
 		// delete lock only if there are changes
 		ctx.Log.Info("Deleting lock for project '%s' (changes detected)", projCtx.ProjectName)
-		lockID := projCtx.BaseRepo.FullName + "/" + strconv.Itoa(projCtx.Pull.Num) + "/" + projCtx.ProjectName + "/" + projCtx.Workspace
+		lockID := fmt.Sprintf("%s/%s/%s", projCtx.BaseRepo.FullName, projCtx.RepoRelDir, projCtx.Workspace)
 
 		_, err := p.lockingLocker.Unlock(lockID)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Fixes the unlock key format bug introduced in PR #5570
- Changes unlock key from `repo/pullnum/projectname/workspace` to `repo/path/workspace` to match the lock key format
- Updates test to expect the correct format

## Problem
PR #5570 added logic to preserve apply locks after plan when no changes are detected. However, it introduced a bug where the unlock key format didn't match the lock key format:
- Lock key: `repo/path/workspace`
- Unlock key (buggy): `repo/pullnum/projectname/workspace`

This mismatch caused locks to never be released, blocking subsequent operations on projects in the same directory.

## Solution
This PR corrects the unlock key to use the same format as the lock key, ensuring locks can be properly released when changes are detected.

## Test plan
- [x] Updated existing test to expect the correct lock format
- [ ] Manual testing with multiple projects in same directory
- [ ] Verify locks are released when changes are detected
- [ ] Verify locks are preserved when no changes are detected

Fixes #5722

🤖 Generated with [Claude Code](https://claude.ai/code)