### PR TITLE
feat: allow markdown templates to be reloaded without server restart.

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -120,6 +120,7 @@ const (
 	LockingDBType                    = "locking-db-type"
 	LogLevelFlag                     = "log-level"
 	MarkdownTemplateOverridesDirFlag = "markdown-template-overrides-dir"
+	MarkdownTemplateLiveReloadFlag   = "markdown-template-live-reload"
 	MaxCommentsPerCommand            = "max-comments-per-command"
 	ParallelPoolSize                 = "parallel-pool-size"
 	StatsNamespace                   = "stats-namespace"
@@ -403,6 +404,10 @@ var stringFlags = map[string]stringFlag{
 	MarkdownTemplateOverridesDirFlag: {
 		description:  "Directory for custom overrides to the markdown templates used for comments.",
 		defaultValue: DefaultMarkdownTemplateOverridesDir,
+	},
+	MarkdownTemplateLiveReloadFlag: {
+		description:  "Enable live reloading of markdown templates from the override directory on each render call.",
+		defaultValue: "false",
 	},
 	StatsNamespace: {
 		description:  "Namespace for aggregating stats.",

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1523,6 +1523,7 @@ func setupE2E(t *testing.T, repoDir string, opt setupOption) (events_controllers
 			"atlantis",                       // executableName
 			false,                            // hideUnchangedPlanComments
 			opt.userConfig.QuietPolicyChecks, // quietPolicyChecks
+			false,                            // liveReloadEnabled
 		),
 	}
 

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -129,7 +129,7 @@ func setup(t *testing.T, options ...func(testConfig *TestConfig)) *vcsmocks.Mock
 	pullUpdater = &events.PullUpdater{
 		HidePrevPlanComments: false,
 		VCSClient:            vcsClient,
-		MarkdownRenderer:     events.NewMarkdownRenderer(false, false, false, false, false, false, "", "atlantis", false, false),
+		MarkdownRenderer:     events.NewMarkdownRenderer(false, false, false, false, false, false, "", "atlantis", false, false, false),
 	}
 
 	autoMerger = &events.AutoMerger{

--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -58,6 +58,10 @@ type MarkdownRenderer struct {
 	executableName            string
 	hideUnchangedPlanComments bool
 	quietPolicyChecks         bool
+	// markdownTemplateOverridesDir is the directory containing template overrides for live editing.
+	markdownTemplateOverridesDir string
+	// liveReloadEnabled is true if templates should be reloaded on each render call.
+	liveReloadEnabled bool
 }
 
 // commonData is data that all responses have.
@@ -153,30 +157,48 @@ func NewMarkdownRenderer(
 	executableName string,
 	hideUnchangedPlanComments bool,
 	quietPolicyChecks bool,
+	liveReloadEnabled bool,
 ) *MarkdownRenderer {
-	var templates *template.Template
-	templates, _ = template.New("").Funcs(sprig.TxtFuncMap()).ParseFS(templatesFS, "templates/*.tmpl")
+	templates := loadTemplates(markdownTemplateOverridesDir)
+	return &MarkdownRenderer{
+		gitlabSupportsCommonMark:     gitlabSupportsCommonMark,
+		disableApplyAll:              disableApplyAll,
+		disableMarkdownFolding:       disableMarkdownFolding,
+		disableApply:                 disableApply,
+		disableRepoLocking:           disableRepoLocking,
+		enableDiffMarkdownFormat:     enableDiffMarkdownFormat,
+		markdownTemplates:            templates,
+		executableName:               executableName,
+		hideUnchangedPlanComments:    hideUnchangedPlanComments,
+		quietPolicyChecks:            quietPolicyChecks,
+		markdownTemplateOverridesDir: markdownTemplateOverridesDir,
+		liveReloadEnabled:            liveReloadEnabled,
+	}
+}
+
+// loadTemplates loads templates from embedded FS and optionally from override directory.
+func loadTemplates(markdownTemplateOverridesDir string) *template.Template {
+	templates, _ := template.New("").Funcs(sprig.TxtFuncMap()).ParseFS(templatesFS, "templates/*.tmpl")
 	if overrides, err := templates.ParseGlob(fmt.Sprintf("%s/*.tmpl", markdownTemplateOverridesDir)); err == nil {
 		// doesn't override if templates directory doesn't exist
 		templates = overrides
 	}
-	return &MarkdownRenderer{
-		gitlabSupportsCommonMark:  gitlabSupportsCommonMark,
-		disableApplyAll:           disableApplyAll,
-		disableMarkdownFolding:    disableMarkdownFolding,
-		disableApply:              disableApply,
-		disableRepoLocking:        disableRepoLocking,
-		enableDiffMarkdownFormat:  enableDiffMarkdownFormat,
-		markdownTemplates:         templates,
-		executableName:            executableName,
-		hideUnchangedPlanComments: hideUnchangedPlanComments,
-		quietPolicyChecks:         quietPolicyChecks,
+	return templates
+}
+
+// reloadTemplates reloads templates if live reload is enabled.
+func (m *MarkdownRenderer) reloadTemplates() {
+	if m.liveReloadEnabled {
+		m.markdownTemplates = loadTemplates(m.markdownTemplateOverridesDir)
 	}
 }
 
 // Render formats the data into a markdown string.
 // nolint: interfacer
 func (m *MarkdownRenderer) Render(ctx *command.Context, res command.Result, cmd PullCommand) string {
+	// Reload templates if live reload is enabled
+	m.reloadTemplates()
+
 	commandStr := cases.Title(language.English).String(strings.Replace(cmd.CommandName().String(), "_", " ", -1))
 	var vcsRequestType string
 	if ctx.Pull.BaseRepo.VCSHost.Type == models.Gitlab {

--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -71,6 +71,7 @@ func TestRenderErr(t *testing.T) {
 		"atlantis", // executableName
 		false,      // hideUnchangedPlanComments
 		false,      // quietPolicyChecks
+		false,      // liveReloadEnabled
 	)
 	logger := logging.NewNoopLogger(t).WithHistory()
 	logText := "log"
@@ -146,6 +147,7 @@ func TestRenderFailure(t *testing.T) {
 		"atlantis", // executableName
 		false,      // hideUnchangedPlanComments
 		false,      // quietPolicyChecks
+		false,      // liveReloadEnabled
 	)
 	logger := logging.NewNoopLogger(t).WithHistory()
 	logText := "log"
@@ -196,6 +198,7 @@ func TestRenderErrAndFailure(t *testing.T) {
 		"atlantis", // executableName
 		false,      // hideUnchangedPlanComments
 		false,      // quietPolicyChecks
+		false,      // liveReloadEnabled
 	)
 	logger := logging.NewNoopLogger(t).WithHistory()
 	ctx := &command.Context{
@@ -1203,6 +1206,7 @@ $$$
 		"atlantis", // executableName
 		false,      // hideUnchangedPlanComments
 		false,      // quietPolicyChecks
+		false,      // liveReloadEnabled
 	)
 	logger := logging.NewNoopLogger(t).WithHistory()
 	logText := "log"
@@ -1577,6 +1581,7 @@ $$$
 		"atlantis", // executableName
 		false,      // hideUnchangedPlanComments
 		true,       // quietPolicyChecks
+		false,      // liveReloadEnabled
 	)
 	logger := logging.NewNoopLogger(t).WithHistory()
 	logText := "log"
@@ -1778,6 +1783,7 @@ $$$
 		"atlantis", // executableName
 		false,      // hideUnchangedPlanComments
 		false,      // quietPolicyChecks
+		false,      // liveReloadEnabled
 	)
 	logger := logging.NewNoopLogger(t).WithHistory()
 	logText := "log"
@@ -1963,6 +1969,7 @@ $$$
 		"atlantis", // executableName
 		false,      // hideUnchangedPlanComments
 		false,      // quietPolicyChecks
+		false,      // liveReloadEnabled
 	)
 	logger := logging.NewNoopLogger(t).WithHistory()
 	logText := "log"
@@ -2022,6 +2029,7 @@ func TestRenderCustomPolicyCheckTemplate_DisableApplyAll(t *testing.T) {
 		"atlantis", // executableName
 		false,      // hideUnchangedPlanComments
 		false,      // quietPolicyChecks
+		false,      // liveReloadEnabled
 	)
 	logger := logging.NewNoopLogger(t).WithHistory()
 	logText := "log"
@@ -2097,6 +2105,7 @@ func TestRenderProjectResults_DisableFolding(t *testing.T) {
 		"atlantis", // executableName
 		false,      // hideUnchangedPlanComments
 		false,      // quietPolicyChecks
+		false,      // liveReloadEnabled
 	)
 	logger := logging.NewNoopLogger(t).WithHistory()
 	logText := "log"
@@ -2207,6 +2216,7 @@ func TestRenderProjectResults_WrappedErr(t *testing.T) {
 					"atlantis",                // executableName
 					false,                     // hideUnchangedPlanComments
 					false,                     // quietPolicyChecks
+					false,                     // liveReloadEnabled
 				)
 				logger := logging.NewNoopLogger(t).WithHistory()
 				logText := "log"
@@ -2353,6 +2363,7 @@ func TestRenderProjectResults_WrapSingleProject(t *testing.T) {
 						"atlantis",                // executableName
 						false,                     // hideUnchangedPlanComments
 						false,                     // quietPolicyChecks
+						false,                     // liveReloadEnabled
 					)
 					logger := logging.NewNoopLogger(t).WithHistory()
 					logText := "log"
@@ -2504,6 +2515,7 @@ func TestRenderProjectResults_MultiProjectApplyWrapped(t *testing.T) {
 		"atlantis", // executableName
 		false,      // hideUnchangedPlanComments
 		false,      // quietPolicyChecks
+		false,      // liveReloadEnabled
 	)
 	logger := logging.NewNoopLogger(t).WithHistory()
 	logText := "log"
@@ -2584,6 +2596,7 @@ func TestRenderProjectResults_MultiProjectPlanWrapped(t *testing.T) {
 		"atlantis", // executableName
 		false,      // hideUnchangedPlanComments
 		false,      // quietPolicyChecks
+		false,      // liveReloadEnabled
 	)
 	logger := logging.NewNoopLogger(t).WithHistory()
 	logText := "log"
@@ -2811,6 +2824,7 @@ This plan was not saved because one or more projects failed and automerge requir
 				"atlantis", // executableName
 				false,      // hideUnchangedPlanComments
 				false,      // quietPolicyChecks
+				false,      // liveReloadEnabled
 			)
 			logger := logging.NewNoopLogger(t).WithHistory()
 			logText := "log"
@@ -3368,6 +3382,7 @@ $$$
 		"atlantis", // executableName
 		false,      // hideUnchangedPlanComments
 		false,      // quietPolicyChecks
+		false,      // liveReloadEnabled
 	)
 	logger := logging.NewNoopLogger(t).WithHistory()
 	logText := "log"
@@ -3506,6 +3521,7 @@ $$$
 		"atlantis", // executableName
 		false,      // hideUnchangedPlanComments
 		false,      // quietPolicyChecks
+		false,      // liveReloadEnabled
 	)
 	logger := logging.NewNoopLogger(t).WithHistory()
 	logText := "log"
@@ -3966,6 +3982,7 @@ func TestRenderProjectResultsWithEnableDiffMarkdownFormat(t *testing.T) {
 		"atlantis", // executableName
 		false,      // hideUnchangedPlanComments
 		false,      // quietPolicyChecks
+		false,      // liveReloadEnabled
 	)
 	logger := logging.NewNoopLogger(t).WithHistory()
 	logText := "log"
@@ -4022,6 +4039,7 @@ func BenchmarkRenderProjectResultsWithEnableDiffMarkdownFormat(b *testing.B) {
 		"atlantis", // executableName
 		false,      // hideUnchangedPlanComments
 		false,      // quietPolicyChecks
+		false,      // liveReloadEnabled
 	)
 	logger := logging.NewNoopLogger(b).WithHistory()
 	logText := "log"
@@ -4235,6 +4253,7 @@ Ran Plan for 3 projects:
 		"atlantis", // executableName
 		true,       // hideUnchangedPlanComments
 		false,      // quietPolicyChecks
+		false,      // liveReloadEnabled
 	)
 	logger := logging.NewNoopLogger(t).WithHistory()
 	logText := "log"
@@ -4271,6 +4290,119 @@ Ran Plan for 3 projects:
 							fmt.Sprintf("\n<details><summary>Log</summary>\n<p>\n\n```\n%s\n```\n</p></details>", log), normalize(s))
 					}
 				})
+			}
+		})
+	}
+}
+
+// TestLiveReload tests that templates are reloaded when live reload is enabled
+func TestLiveReload(t *testing.T) {
+	tests := []struct {
+		name              string
+		liveReloadEnabled bool
+		expectReload      bool
+	}{
+		{
+			name:              "live reload enabled",
+			liveReloadEnabled: true,
+			expectReload:      true,
+		},
+		{
+			name:              "live reload disabled",
+			liveReloadEnabled: false,
+			expectReload:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a temporary directory for template overrides
+			tmpDir := t.TempDir()
+
+			// Create initial template override
+			initialTemplate := `{{ define "planSuccessWrapped" -}}
+<details><summary>Initial Template</summary>
+{{ .TerraformOutput }}
+</details>
+{{ end -}}`
+
+			initialTemplatePath := fmt.Sprintf("%s/plan_success_wrapped.tmpl", tmpDir)
+			err := os.WriteFile(initialTemplatePath, []byte(initialTemplate), 0600)
+			Ok(t, err)
+
+			// Create markdown renderer with live reload setting
+			renderer := events.NewMarkdownRenderer(
+				false,                // gitlabSupportsCommonMark
+				false,                // disableApplyAll
+				false,                // disableApply
+				false,                // disableMarkdownFolding
+				false,                // disableRepoLocking
+				false,                // enableDiffMarkdownFormat
+				tmpDir,               // markdownTemplateOverridesDir
+				"atlantis",           // executableName
+				false,                // hideUnchangedPlanComments
+				false,                // quietPolicyChecks
+				tt.liveReloadEnabled, // liveReloadEnabled
+			)
+
+			// Create test context and result
+			ctx := &command.Context{
+				Log: logging.NewNoopLogger(t).WithHistory(),
+				Pull: models.PullRequest{
+					BaseRepo: models.Repo{
+						VCSHost: models.VCSHost{
+							Type: models.Github,
+						},
+					},
+				},
+			}
+
+			planSuccess := &models.PlanSuccess{
+				TerraformOutput: strings.Repeat("test output line\n", 15), // Make it long enough to use wrapped template
+				LockURL:         "https://example.com/lock",
+				RePlanCmd:       "atlantis plan",
+				ApplyCmd:        "atlantis apply",
+			}
+
+			res := command.Result{
+				ProjectResults: []command.ProjectResult{
+					{
+						Workspace:   "default",
+						RepoRelDir:  ".",
+						ProjectName: "test",
+						PlanSuccess: planSuccess,
+					},
+				},
+			}
+
+			cmd := &events.CommentCommand{
+				Name:    command.Plan,
+				Verbose: false,
+			}
+
+			// Test initial template
+			rendered := renderer.Render(ctx, res, cmd)
+			Assert(t, strings.Contains(rendered, "Initial Template"), "Expected 'Initial Template' in rendered output, got: %s", rendered)
+			Assert(t, !strings.Contains(rendered, "Updated Template"), "Expected 'Updated Template' to NOT be in rendered output, got: %s", rendered)
+
+			// Update the template file
+			updatedTemplate := `{{ define "planSuccessWrapped" -}}
+<details><summary>Updated Template</summary>
+{{ .TerraformOutput }}
+</details>
+{{ end -}}`
+
+			err = os.WriteFile(initialTemplatePath, []byte(updatedTemplate), 0600)
+			Ok(t, err)
+
+			// Test that the template is updated or not based on live reload setting
+			rendered = renderer.Render(ctx, res, cmd)
+			if tt.expectReload {
+				Assert(t, strings.Contains(rendered, "Updated Template"), "Expected 'Updated Template' in rendered output, got: %s", rendered)
+				Assert(t, !strings.Contains(rendered, "Initial Template"), "Expected 'Initial Template' to NOT be in rendered output, got: %s", rendered)
+			} else {
+				Assert(t, strings.Contains(rendered, "Initial Template"), "Expected 'Initial Template' to still be in rendered output (live reload disabled), got: %s", rendered)
+				Assert(t, !strings.Contains(rendered, "Updated Template"), "Expected 'Updated Template' to NOT be in rendered output (live reload disabled), got: %s", rendered)
 			}
 		})
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -486,6 +486,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		userConfig.ExecutableName,
 		userConfig.HideUnchangedPlanComments,
 		userConfig.QuietPolicyChecks,
+		userConfig.MarkdownTemplateLiveReload,
 	)
 
 	var lockingClient locking.Locker

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -80,6 +80,7 @@ type UserConfig struct {
 	LockingDBType                   string `mapstructure:"locking-db-type"`
 	LogLevel                        string `mapstructure:"log-level"`
 	MarkdownTemplateOverridesDir    string `mapstructure:"markdown-template-overrides-dir"`
+	MarkdownTemplateLiveReload      bool   `mapstructure:"markdown-template-live-reload"`
 	MaxCommentsPerCommand           int    `mapstructure:"max-comments-per-command"`
 	IgnoreVCSStatusNames            string `mapstructure:"ignore-vcs-status-names"`
 	ParallelPoolSize                int    `mapstructure:"parallel-pool-size"`


### PR DESCRIPTION
## what

Allow markdown templates to be re-loaded without server restart. Feature is behind a flag.

## why

Changing templates shouldn't require a full restart.

## tests

Added tests to validate functionality

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

