### PR TITLE
Add 2025 blog post to blog index page

### DIFF
--- a/runatlantis.io/blog.md
+++ b/runatlantis.io/blog.md
@@ -9,8 +9,9 @@ We are thrilled to have you here! Our blog is a collection of insightful article
 
 ### Explore Our Popular Posts
 
-We have a rich history of blog posts dating back to 2017-2019. Here are some of our popular posts:
+We have a rich history of blog posts dating back to 2017. Here are some of our popular posts:
 
+- [Atlantis on Google Cloud Run](blog/2025/atlantis-on-google-cloud-run.md)
 - [4 Reasons To Try HashiCorp's (New) Free Terraform Remote State Storage](blog/2019/4-reasons-to-try-hashicorps-new-free-terraform-remote-state-storage.md)
 - [I'm Joining HashiCorp!](blog/2018/joining-hashicorp.md)
 - [Putting The Dev Into DevOps: Why Your Developers Should Write Terraform Too](blog/2018/putting-the-dev-into-devops-why-your-developers-should-write-terraform-too.md)


### PR DESCRIPTION
## Summary
- Add "Atlantis on Google Cloud Run" blog post to the popular posts section in blog.md
- Update description to be more inclusive of newer posts (changed "2017-2019" to "2017")

## Problem
The 2025 blog post "Atlantis on Google Cloud Run" exists in the repository but wasn't appearing on the blog page because it wasn't listed in the hardcoded popular posts section of `blog.md`.

## Solution
Added the blog post to the top of the popular posts list so it's visible to users visiting the blog page.

🤖 Generated with [Claude Code](https://claude.ai/code)