### PR TITLE
chore: Use newer golanglint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -65,7 +65,7 @@ jobs:
           go-version-file: go.mod
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
         with:
           # renovate: datasource=github-releases depName=golangci/golangci-lint
           version: v2.5.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -68,7 +68,7 @@ jobs:
         uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
         with:
           # renovate: datasource=github-releases depName=golangci/golangci-lint
-          version: v1.64.4
+          version: v2.5.0
 
   skip-lint:
     needs: [changes]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,32 +1,37 @@
-linters-settings:
-  misspell:
-    # Correct spellings using locale preferences for US or UK.
-    # Default is to use a neutral variety of English.
-    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
-    # locale: US
-    ignore-words:
-      # for gitlab notes api
-      - noteable
-  revive:
-    rules:
-      - name: dot-imports
-        disabled: true
-
+version: "2"
 linters:
   enable:
-    - errcheck
     - gochecknoinits
-    - gofmt
     - gosec
-    - gosimple
-    - govet
-    - ineffassign
     - misspell
     - revive
-    - staticcheck
     - testifylint
-    - typecheck
     - unconvert
-    - unused
-run:
-  timeout: 10m
+  settings:
+    misspell:
+      ignore-rules:
+        - noteable
+    revive:
+      rules:
+        - name: dot-imports
+          disabled: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1708,7 +1708,7 @@ func GitHubPullRequestOpenedEvent(t *testing.T, headSHA string) *http.Request {
 	requestJSON, err := os.ReadFile(filepath.Join("testdata", "githubPullRequestOpenedEvent.json"))
 	Ok(t, err)
 	// Replace sha with expected sha.
-	requestJSONStr := strings.Replace(string(requestJSON), "c31fd9ea6f557ad2ea659944c3844a059b83bc5d", headSHA, -1)
+	requestJSONStr := strings.ReplaceAll(string(requestJSON), "c31fd9ea6f557ad2ea659944c3844a059b83bc5d", headSHA)
 	req, err := http.NewRequest("POST", "/events", bytes.NewBuffer([]byte(requestJSONStr)))
 	Ok(t, err)
 	req.Header.Set("Content-Type", "application/json")

--- a/server/controllers/events/events_controller_test.go
+++ b/server/controllers/events/events_controller_test.go
@@ -886,7 +886,7 @@ func TestPost_BBServerPullClosed(t *testing.T) {
 			// Build HTTP request.
 			requestBytes, err := os.ReadFile(filepath.Join("testdata", "bb-server-pull-deleted-event.json"))
 			// Replace the eventKey field with our event type.
-			requestJSON := strings.Replace(string(requestBytes), `"eventKey":"pr:deleted",`, fmt.Sprintf(`"eventKey":"%s",`, c.header), -1)
+			requestJSON := strings.ReplaceAll(string(requestBytes), `"eventKey":"pr:deleted",`, fmt.Sprintf(`"eventKey":"%s",`, c.header))
 			Ok(t, err)
 			req, err := http.NewRequest("POST", "/events", bytes.NewBuffer([]byte(requestJSON)))
 			Ok(t, err)

--- a/server/core/config/parser_validator_test.go
+++ b/server/core/config/parser_validator_test.go
@@ -1692,7 +1692,7 @@ workflows:
 			act, err := r.ParseGlobalCfg(path, valid.NewGlobalCfgFromArgs(globalCfgArgs))
 
 			if c.expErr != "" {
-				expErr := strings.Replace(c.expErr, "<tmp>", path, -1)
+				expErr := strings.ReplaceAll(c.expErr, "<tmp>", path)
 				ErrEquals(t, expErr, err)
 				return
 			}

--- a/server/core/config/raw/project.go
+++ b/server/core/config/raw/project.go
@@ -177,7 +177,7 @@ func (p Project) ToValid() valid.Project {
 // support any characters that must be url escaped *except* for '/' because
 // users like to name their projects to match the directory it's in.
 func validProjectName(name string) bool {
-	nameWithoutSlashes := strings.Replace(name, "/", "-", -1)
+	nameWithoutSlashes := strings.ReplaceAll(name, "/", "-")
 	return nameWithoutSlashes == url.QueryEscape(nameWithoutSlashes)
 }
 

--- a/server/core/config/raw/step.go
+++ b/server/core/config/raw/step.go
@@ -211,12 +211,12 @@ func (s Step) Validate() error {
 		case []interface{}:
 			for _, e := range t {
 				if _, ok := e.(string); !ok {
-					return fmt.Errorf("%q step %q option must contain only strings, found %v\n",
+					return fmt.Errorf("%q step %q option must contain only strings, found %v",
 						stepName, ShellArgsArgKey, e)
 				}
 			}
 		default:
-			return fmt.Errorf("%q step %q option must be a string or a list of strings, found %v\n",
+			return fmt.Errorf("%q step %q option must be a string or a list of strings, found %v",
 				stepName, ShellArgsArgKey, t)
 		}
 		delete(argMap, ShellArgsArgKey)
@@ -251,13 +251,13 @@ func (s Step) Validate() error {
 			}
 			delete(argMap, CommandArgKey)
 			if v, ok := argMap[OutputArgKey].(string); ok {
-				if stepName == RunStepName && !(v == valid.PostProcessRunOutputShow ||
-					v == valid.PostProcessRunOutputHide || v == valid.PostProcessRunOutputStripRefreshing) {
+				if stepName == RunStepName && (v != valid.PostProcessRunOutputShow &&
+					v != valid.PostProcessRunOutputHide && v != valid.PostProcessRunOutputStripRefreshing) {
 					return fmt.Errorf("run step %q option must be one of %q, %q, or %q",
 						OutputArgKey, valid.PostProcessRunOutputShow, valid.PostProcessRunOutputHide,
 						valid.PostProcessRunOutputStripRefreshing)
-				} else if stepName == MultiEnvStepName && !(v == valid.PostProcessRunOutputShow ||
-					v == valid.PostProcessRunOutputHide) {
+				} else if stepName == MultiEnvStepName && (v != valid.PostProcessRunOutputShow &&
+					v != valid.PostProcessRunOutputHide) {
 					return fmt.Errorf("multienv step %q option must be %q or %q",
 						OutputArgKey, valid.PostProcessRunOutputShow, valid.PostProcessRunOutputHide)
 				}
@@ -295,7 +295,7 @@ func (s Step) Validate() error {
 				len(keys), strings.Join(keys, ","))
 		}
 		for stepName := range elem {
-			if !(stepName == RunStepName || stepName == MultiEnvStepName) {
+			if stepName != RunStepName && stepName != MultiEnvStepName {
 				return fmt.Errorf("%q is not a valid step type", stepName)
 			}
 		}

--- a/server/core/config/raw/step_test.go
+++ b/server/core/config/raw/step_test.go
@@ -463,7 +463,7 @@ func TestStep_Validate(t *testing.T) {
 					},
 				},
 			},
-			expErr: "\"run\" step \"shellArgs\" option must be a string or a list of strings, found [42 42]\n",
+			expErr: "\"run\" step \"shellArgs\" option must be a string or a list of strings, found [42 42]",
 		},
 		{
 			description: "run step with shellArgs contain not strings",
@@ -477,7 +477,7 @@ func TestStep_Validate(t *testing.T) {
 					},
 				},
 			},
-			expErr: "\"run\" step \"shellArgs\" option must contain only strings, found 42\n",
+			expErr: "\"run\" step \"shellArgs\" option must contain only strings, found 42",
 		},
 		{
 			// For atlantis.yaml v2, this wouldn't parse, but now there should

--- a/server/core/runtime/apply_step_runner.go
+++ b/server/core/runtime/apply_step_runner.go
@@ -216,7 +216,7 @@ func (a *ApplyStepRunner) remotePlanChanged(planfileContents string, applyOut st
 	// Strip plan output after the prompt to execute the plan.
 	planEndIdx := strings.Index(output, "Do you want to perform these actions in workspace \"")
 	if planEndIdx < 0 {
-		return fmt.Errorf("Couldn't find plan end when parsing apply output:\n%q", applyOut)
+		return fmt.Errorf("couldn't find plan end when parsing apply output:\n%q", applyOut)
 	}
 	currPlan := strings.TrimSpace(output[:planEndIdx])
 

--- a/server/core/runtime/multienv_step_runner.go
+++ b/server/core/runtime/multienv_step_runner.go
@@ -37,7 +37,7 @@ func (r *MultiEnvStepRunner) Run(
 
 		vars, err := parseMultienvLine(res)
 		if err != nil {
-			return "", fmt.Errorf("Invalid environment variable definition: %s (%w)", res, err)
+			return "", fmt.Errorf("invalid environment variable definition: %s (%w)", res, err)
 		}
 
 		for i := 0; i < len(vars); i += 2 {

--- a/server/core/runtime/multienv_step_runner_test.go
+++ b/server/core/runtime/multienv_step_runner_test.go
@@ -45,7 +45,7 @@ func TestMultiEnvStepRunner_Run(t *testing.T) {
 		{
 			Command: `echo 'TF_VAR_REPODEFINEDVARIABLE_NO_VALUE'`,
 			Output:  valid.PostProcessRunOutputShow,
-			ExpErr:  "Invalid environment variable definition: TF_VAR_REPODEFINEDVARIABLE_NO_VALUE",
+			ExpErr:  "invalid environment variable definition: TF_VAR_REPODEFINEDVARIABLE_NO_VALUE",
 			ExpEnv:  map[string]string{},
 		},
 		{

--- a/server/core/runtime/policy/conftest_client.go
+++ b/server/core/runtime/policy/conftest_client.go
@@ -257,7 +257,7 @@ func (c *ConfTestExecutorWorkflow) Run(ctx command.ProjectContext, executablePat
 }
 
 func (c *ConfTestExecutorWorkflow) sanitizeOutput(inputFile string, output string) string {
-	return strings.Replace(output, inputFile, "<redacted plan file>", -1)
+	return strings.ReplaceAll(output, inputFile, "<redacted plan file>")
 }
 
 func (c *ConfTestExecutorWorkflow) EnsureExecutorVersion(log logging.SimpleLogging, v *version.Version) (string, error) {

--- a/server/core/runtime/post_workflow_hook_runner_test.go
+++ b/server/core/runtime/post_workflow_hook_runner_test.go
@@ -197,7 +197,7 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 			// here because when constructing the cases we don't yet know the
 			// temp dir.
 			Equals(t, c.ExpDescription, desc)
-			expOut := strings.Replace(c.ExpOut, "$DIR", tmpDir, -1)
+			expOut := strings.ReplaceAll(c.ExpOut, "$DIR", tmpDir)
 			projectCmdOutputHandler.VerifyWasCalledOnce().SendWorkflowHook(
 				Any[models.WorkflowHookCommandContext](), Eq(expOut), Eq(false))
 		})

--- a/server/core/runtime/pre_workflow_hook_runner_test.go
+++ b/server/core/runtime/pre_workflow_hook_runner_test.go
@@ -208,7 +208,7 @@ func TestPreWorkflowHookRunner_Run(t *testing.T) {
 			// here because when constructing the cases we don't yet know the
 			// temp dir.
 			Equals(t, c.ExpDescription, desc)
-			expOut := strings.Replace(c.ExpOut, "$DIR", tmpDir, -1)
+			expOut := strings.ReplaceAll(c.ExpOut, "$DIR", tmpDir)
 			projectCmdOutputHandler.VerifyWasCalledOnce().SendWorkflowHook(
 				Any[models.WorkflowHookCommandContext](), Eq(expOut), Eq(false))
 		})

--- a/server/core/runtime/run_step_runner_test.go
+++ b/server/core/runtime/run_step_runner_test.go
@@ -177,7 +177,7 @@ func TestRunStepRunner_Run(t *testing.T) {
 				// Replace $DIR in the exp with the actual temp dir. We do this
 				// here because when constructing the cases we don't yet know the
 				// temp dir.
-				expOut := strings.Replace(c.ExpOut, "$DIR", tmpDir, -1)
+				expOut := strings.ReplaceAll(c.ExpOut, "$DIR", tmpDir)
 				Equals(t, expOut, out)
 
 				terraform.VerifyWasCalledOnce().EnsureVersion(Eq(logger), NotEq(defaultDistribution), Eq(projVersion))

--- a/server/core/runtime/runtime.go
+++ b/server/core/runtime/runtime.go
@@ -93,7 +93,7 @@ func GetPlanFilename(workspace string, projName string) string {
 	if projName == "" {
 		return fmt.Sprintf("%s.tfplan", workspace)
 	}
-	projName = strings.Replace(projName, "/", planfileSlashReplace, -1)
+	projName = strings.ReplaceAll(projName, "/", planfileSlashReplace)
 	return fmt.Sprintf("%s-%s.tfplan", projName, workspace)
 }
 
@@ -119,5 +119,5 @@ func ProjectNameFromPlanfile(workspace string, filename string) (string, error) 
 		return "", nil
 	}
 	rawProjName := projMatch[0][1]
-	return strings.Replace(rawProjName, planfileSlashReplace, "/", -1), nil
+	return strings.ReplaceAll(rawProjName, planfileSlashReplace, "/"), nil
 }

--- a/server/core/terraform/ansi/strip_test.go
+++ b/server/core/terraform/ansi/strip_test.go
@@ -10,6 +10,7 @@ func TestStrip(t *testing.T) {
 	}{
 		{
 			name: "strip ansi",
+			//nolint:staticcheck // keep literal ANSI escape chars to match actual output
 			str: `
 [32m+[0m create
 [0m[1mPlan:[0m 3 to add, 0 to change, 0 to destroy.

--- a/server/core/terraform/tfclient/terraform_client_test.go
+++ b/server/core/terraform/tfclient/terraform_client_test.go
@@ -481,7 +481,7 @@ terraform {
 				"main.tf": fmt.Sprintf(baseVersionConfig, "= 0.12.8"),
 			},
 			"project2": map[string]interface{}{
-				"main.tf": strings.Replace(fmt.Sprintf(baseVersionConfig, "= 0.12.8"), "0.12.8", "0.12.9", -1),
+				"main.tf": strings.ReplaceAll(fmt.Sprintf(baseVersionConfig, "= 0.12.8"), "0.12.8", "0.12.9"),
 			},
 		},
 		Exp: map[string]string{

--- a/server/events/command/project_context.go
+++ b/server/events/command/project_context.go
@@ -159,7 +159,7 @@ func (p ProjectContext) GetShowResultFileName() string {
 	if p.ProjectName == "" {
 		return fmt.Sprintf("%s.json", p.Workspace)
 	}
-	projName := strings.Replace(p.ProjectName, "/", planfileSlashReplace, -1)
+	projName := strings.ReplaceAll(p.ProjectName, "/", planfileSlashReplace)
 	return fmt.Sprintf("%s-%s.json", projName, p.Workspace)
 }
 
@@ -168,7 +168,7 @@ func (p ProjectContext) GetPolicyCheckResultFileName() string {
 	if p.ProjectName == "" {
 		return fmt.Sprintf("%s-policyout.json", p.Workspace)
 	}
-	projName := strings.Replace(p.ProjectName, "/", planfileSlashReplace, -1)
+	projName := strings.ReplaceAll(p.ProjectName, "/", planfileSlashReplace)
 	return fmt.Sprintf("%s-%s-policyout.json", projName, p.Workspace)
 }
 

--- a/server/events/event_parser_test.go
+++ b/server/events/event_parser_test.go
@@ -842,7 +842,7 @@ func TestParseBitbucketCloudCommentEvent_CommitHashMissing(t *testing.T) {
 	path := filepath.Join("testdata", "bitbucket-cloud-comment-event.json")
 	bytes, err := os.ReadFile(path)
 	Ok(t, err)
-	emptyCommitHash := strings.Replace(string(bytes), `        "hash": "e0624da46d3a",`, "", -1)
+	emptyCommitHash := strings.ReplaceAll(string(bytes), `        "hash": "e0624da46d3a",`, "")
 	_, _, _, _, _, err = parser.ParseBitbucketCloudPullCommentEvent([]byte(emptyCommitHash))
 	ErrContains(t, "Key: 'CommentEvent.CommonEventData.PullRequest.Source.Commit.Hash' Error:Field validation for 'Hash' failed on the 'required' tag", err)
 }
@@ -923,7 +923,7 @@ func TestParseBitbucketCloudCommentEvent_MultipleStates(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.pullState, func(t *testing.T) {
-			withState := strings.Replace(string(bytes), `"state": "MERGED"`, fmt.Sprintf(`"state": "%s"`, c.pullState), -1)
+			withState := strings.ReplaceAll(string(bytes), `"state": "MERGED"`, fmt.Sprintf(`"state": "%s"`, c.pullState))
 			pull, _, _, _, _, err := parser.ParseBitbucketCloudPullCommentEvent([]byte(withState))
 			Ok(t, err)
 			Equals(t, c.exp, pull.State)
@@ -1094,7 +1094,7 @@ func TestParseBitbucketServerCommentEvent_CommitHashMissing(t *testing.T) {
 	if err != nil {
 		Ok(t, err)
 	}
-	emptyCommitHash := strings.Replace(string(bytes), `"latestCommit": "bfb1af1ba9c2a2fa84cd61af67e6e1b60a22e060",`, "", -1)
+	emptyCommitHash := strings.ReplaceAll(string(bytes), `"latestCommit": "bfb1af1ba9c2a2fa84cd61af67e6e1b60a22e060",`, "")
 	_, _, _, _, _, err = parser.ParseBitbucketServerPullCommentEvent([]byte(emptyCommitHash))
 	ErrContains(t, "Key: 'CommentEvent.CommonEventData.PullRequest.FromRef.LatestCommit' Error:Field validation for 'LatestCommit' failed on the 'required' tag", err)
 }
@@ -1173,7 +1173,7 @@ func TestParseBitbucketServerCommentEvent_MultipleStates(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.pullState, func(t *testing.T) {
-			withState := strings.Replace(string(bytes), `"state": "OPEN"`, fmt.Sprintf(`"state": "%s"`, c.pullState), -1)
+			withState := strings.ReplaceAll(string(bytes), `"state": "OPEN"`, fmt.Sprintf(`"state": "%s"`, c.pullState))
 			pull, _, _, _, _, err := parser.ParseBitbucketServerPullCommentEvent([]byte(withState))
 			Ok(t, err)
 			Equals(t, c.exp, pull.State)

--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -177,7 +177,7 @@ func NewMarkdownRenderer(
 // Render formats the data into a markdown string.
 // nolint: interfacer
 func (m *MarkdownRenderer) Render(ctx *command.Context, res command.Result, cmd PullCommand) string {
-	commandStr := cases.Title(language.English).String(strings.Replace(cmd.CommandName().String(), "_", " ", -1))
+	commandStr := cases.Title(language.English).String(strings.ReplaceAll(cmd.CommandName().String(), "_", " "))
 	var vcsRequestType string
 	if ctx.Pull.BaseRepo.VCSHost.Type == models.Gitlab {
 		vcsRequestType = "Merge Request"
@@ -324,7 +324,7 @@ func (m *MarkdownRenderer) renderProjectResults(ctx *command.Context, results []
 			}
 			// Error out if no template was found, only if there are no errors or failures.
 			// This is because some errors and failures rely on additional context rendered by templates, but not all errors or failures.
-		} else if !(result.Error != nil || result.Failure != "") {
+		} else if result.Error == nil && result.Failure == "" {
 			resultData.Rendered = "Found no template. This is a bug!"
 		}
 		// Render error or failure templates. Done outside of previous block so that other context can be rendered for use here.
@@ -402,11 +402,11 @@ func (m *MarkdownRenderer) renderProjectResults(ctx *command.Context, results []
 		return fmt.Sprintf("no template matched–this is a bug: command=%s", common.Command)
 	}
 
-	switch {
-	case common.Command == planCommandTitle:
+	switch common.Command {
+	case planCommandTitle:
 		numPlanFailures := len(results) - numPlanSuccesses
 		return m.renderTemplateTrimSpace(tmpl, planResultData{resultsTmplData, common, numPlansWithChanges, numPlansWithNoChanges, numPlanFailures})
-	case common.Command == applyCommandTitle:
+	case applyCommandTitle:
 		return m.renderTemplateTrimSpace(tmpl, applyResultData{resultsTmplData, common, numApplySuccesses, numApplyFailures, numApplyErrors})
 	}
 	return m.renderTemplateTrimSpace(tmpl, resultData{resultsTmplData, common})

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -105,7 +105,7 @@ func NewRepo(vcsHostType VCSHostType, repoFullName string, cloneURL string, vcsU
 
 	// We url encode because we're using them in a URL and weird characters can
 	// mess up git.
-	cloneURL = strings.Replace(cloneURL, " ", "%20", -1)
+	cloneURL = strings.ReplaceAll(cloneURL, " ", "%20")
 	escapedVCSUser := url.QueryEscape(vcsUser)
 	escapedVCSToken := url.QueryEscape(vcsToken)
 	auth := fmt.Sprintf("%s:%s@", escapedVCSUser, escapedVCSToken)
@@ -113,10 +113,10 @@ func NewRepo(vcsHostType VCSHostType, repoFullName string, cloneURL string, vcsU
 
 	// Construct clone urls with http and https auth. Need to do both
 	// because Bitbucket supports http.
-	authedCloneURL := strings.Replace(cloneURL, "https://", "https://"+auth, -1)
-	authedCloneURL = strings.Replace(authedCloneURL, "http://", "http://"+auth, -1)
-	sanitizedCloneURL := strings.Replace(cloneURL, "https://", "https://"+redactedAuth, -1)
-	sanitizedCloneURL = strings.Replace(sanitizedCloneURL, "http://", "http://"+redactedAuth, -1)
+	authedCloneURL := strings.ReplaceAll(cloneURL, "https://", "https://"+auth)
+	authedCloneURL = strings.ReplaceAll(authedCloneURL, "http://", "http://"+auth)
+	sanitizedCloneURL := strings.ReplaceAll(cloneURL, "https://", "https://"+redactedAuth)
+	sanitizedCloneURL = strings.ReplaceAll(sanitizedCloneURL, "http://", "http://"+redactedAuth)
 
 	// Get the owner and repo names from the full name.
 	owner, repo := SplitRepoFullName(repoFullName)

--- a/server/events/pending_plan_finder_test.go
+++ b/server/events/pending_plan_finder_test.go
@@ -224,7 +224,7 @@ func TestPendingPlanFinder_Find(t *testing.T) {
 			// Replace the actual dir with ??? to allow for comparison.
 			var actPlansComparable []events.PendingPlan
 			for _, p := range actPlans {
-				p.RepoDir = strings.Replace(p.RepoDir, tmpDir, "???", -1)
+				p.RepoDir = strings.ReplaceAll(p.RepoDir, tmpDir, "???")
 				actPlansComparable = append(actPlansComparable, p)
 			}
 			Equals(t, c.expPlans, actPlansComparable)

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -1562,7 +1562,7 @@ projects:
 				"main.tf": baseVersionConfig,
 			},
 			"project2": map[string]interface{}{
-				"main.tf": strings.Replace(baseVersionConfig, "0.12.8", "0.12.9", -1),
+				"main.tf": strings.ReplaceAll(baseVersionConfig, "0.12.8", "0.12.9"),
 			},
 		},
 		ModifiedFiles: []string{"project1/main.tf", "project2/main.tf"},

--- a/server/events/vcs/azuredevops_client.go
+++ b/server/events/vcs/azuredevops_client.go
@@ -172,7 +172,7 @@ func (g *AzureDevopsClient) PullIsApproved(logger logging.SimpleLogging, repo mo
 			continue
 		}
 
-		if review.IdentityRef.GetUniqueName() == adPull.GetCreatedBy().GetUniqueName() {
+		if review.GetUniqueName() == adPull.GetCreatedBy().GetUniqueName() {
 			continue
 		}
 
@@ -302,7 +302,7 @@ func (g *AzureDevopsClient) UpdateStatus(logger logging.SimpleLogging, repo mode
 			}
 		}
 		if iterationID := status.IterationID; iterationID != nil {
-			if !(*iterationID >= 1) {
+			if *iterationID < 1 {
 				return errors.New("supportsIterations was true but got invalid iteration ID or no matching iteration commit SHA was found")
 			}
 		}

--- a/server/events/vcs/bitbucketserver/client_test.go
+++ b/server/events/vcs/bitbucketserver/client_test.go
@@ -103,8 +103,8 @@ func TestClient_GetModifiedFilesPagination(t *testing.T) {
 		switch r.RequestURI {
 		// The first request should hit this URL.
 		case "/rest/api/1.0/projects/ow/repos/repo/pull-requests/1/changes?start=0":
-			resp := strings.Replace(firstResp, `"isLastPage": true`, `"isLastPage": false`, -1)
-			resp = strings.Replace(resp, `"nextPageStart": null`, `"nextPageStart": 3`, -1)
+			resp := strings.ReplaceAll(firstResp, `"isLastPage": true`, `"isLastPage": false`)
+			resp = strings.ReplaceAll(resp, `"nextPageStart": null`, `"nextPageStart": 3`)
 			w.Write([]byte(resp)) // nolint: errcheck
 			return
 			// The second should hit this URL.

--- a/server/events/vcs/gitea/client.go
+++ b/server/events/vcs/gitea/client.go
@@ -111,7 +111,7 @@ func (c *GiteaClient) GetModifiedFiles(logger logging.SimpleLogging, repo models
 
 	for page < nextPage {
 		page = +1
-		listOptions.ListOptions.Page = page
+		listOptions.Page = page
 		files, resp, err := c.giteaClient.ListPullRequestFiles(repo.Owner, repo.Name, int64(pull.Num), listOptions)
 		if err != nil {
 			logger.Debug("[page %d] GET /repos/%v/%v/pulls/%d/files returned: %v", page, repo.Owner, repo.Name, pull.Num, resp.StatusCode)
@@ -253,7 +253,7 @@ func (c *GiteaClient) PullIsApproved(logger logging.SimpleLogging, repo models.R
 
 	for page < nextPage {
 		page = +1
-		listOptions.ListOptions.Page = page
+		listOptions.Page = page
 		pullReviews, resp, err := c.giteaClient.ListPullReviews(repo.Owner, repo.Name, int64(pull.Num), listOptions)
 
 		if err != nil {
@@ -354,7 +354,7 @@ func (c *GiteaClient) DiscardReviews(_ logging.SimpleLogging, repo models.Repo, 
 
 	for page < nextPage {
 		page = +1
-		listOptions.ListOptions.Page = page
+		listOptions.Page = page
 		pullReviews, resp, err := c.giteaClient.ListPullReviews(repo.Owner, repo.Name, int64(pull.Num), listOptions)
 
 		if err != nil {
@@ -480,7 +480,7 @@ func (c *GiteaClient) GetPullLabels(logger logging.SimpleLogging, repo models.Re
 
 	for page < nextPage {
 		page = +1
-		opts.ListOptions.Page = page
+		opts.Page = page
 
 		labels, resp, err := c.giteaClient.GetIssueLabels(repo.Owner, repo.Name, int64(pull.Num), opts)
 

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -564,7 +564,7 @@ func (g *GithubClient) WorkflowRunMatchesWorkflowFileReference(workflowRun Workf
 		return false, err
 	}
 
-	if !(repoId == workflowFileReference.RepositoryId && workflowRun.File.Path == workflowFileReference.Path) {
+	if repoId != workflowFileReference.RepositoryId || workflowRun.File.Path != workflowFileReference.Path {
 		return false, nil
 	} else if workflowFileReference.Sha != nil {
 		return strings.Contains(string(workflowRun.File.RepositoryFileUrl), string(*workflowFileReference.Sha)), nil
@@ -966,11 +966,11 @@ func (g *GithubClient) MergePull(logger logging.SimpleLogging, pull models.PullR
 
 		isMethodAllowed, isMethodExist := mergeMethodsAllow[method]
 		if !isMethodExist {
-			return fmt.Errorf("Merge method '%s' is unknown. Specify one of the valid values: '%s'", method, strings.Join(mergeMethodsName, ", "))
+			return fmt.Errorf("merge method '%s' is unknown. Specify one of the valid values: '%s'", method, strings.Join(mergeMethodsName, ", "))
 		}
 
 		if !isMethodAllowed() {
-			return fmt.Errorf("Merge method '%s' is not allowed by the repository Pull Request settings", method)
+			return fmt.Errorf("merge method '%s' is not allowed by the repository Pull Request settings", method)
 		}
 	} else {
 		method = defaultMergeMethod

--- a/server/events/vcs/github_client_test.go
+++ b/server/events/vcs/github_client_test.go
@@ -1067,7 +1067,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 			allowSquash:       true,
 			mergeMethodOption: "merge",
 			expMethod:         "",
-			expErr:            "Merge method 'merge' is not allowed by the repository Pull Request settings",
+			expErr:            "merge method 'merge' is not allowed by the repository Pull Request settings",
 		},
 		"merge with rebase: overridden by command: rebase not allowed": {
 			allowMerge:        true,
@@ -1075,7 +1075,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 			allowSquash:       true,
 			mergeMethodOption: "rebase",
 			expMethod:         "",
-			expErr:            "Merge method 'rebase' is not allowed by the repository Pull Request settings",
+			expErr:            "merge method 'rebase' is not allowed by the repository Pull Request settings",
 		},
 		"merge with squash: overridden by command: squash not allowed": {
 			allowMerge:        true,
@@ -1083,7 +1083,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 			allowSquash:       false,
 			mergeMethodOption: "squash",
 			expMethod:         "",
-			expErr:            "Merge method 'squash' is not allowed by the repository Pull Request settings",
+			expErr:            "merge method 'squash' is not allowed by the repository Pull Request settings",
 		},
 		"merge with unknown: overridden by command: unknown doesn't exist": {
 			allowMerge:        true,
@@ -1091,7 +1091,7 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 			allowSquash:       true,
 			mergeMethodOption: "unknown",
 			expMethod:         "",
-			expErr:            "Merge method 'unknown' is unknown. Specify one of the valid values: 'merge, rebase, squash'",
+			expErr:            "merge method 'unknown' is unknown. Specify one of the valid values: 'merge, rebase, squash'",
 		},
 	}
 

--- a/server/events/vcs/github_client_test.go
+++ b/server/events/vcs/github_client_test.go
@@ -1102,18 +1102,18 @@ func TestGithubClient_MergePullCorrectMethod(t *testing.T) {
 			jsBytes, err := os.ReadFile("testdata/github-repo.json")
 			Ok(t, err)
 			resp := string(jsBytes)
-			resp = strings.Replace(resp,
+			resp = strings.ReplaceAll(resp,
 				`"allow_squash_merge": true`,
 				fmt.Sprintf(`"allow_squash_merge": %t`, c.allowSquash),
-				-1)
-			resp = strings.Replace(resp,
+			)
+			resp = strings.ReplaceAll(resp,
 				`"allow_merge_commit": true`,
 				fmt.Sprintf(`"allow_merge_commit": %t`, c.allowMerge),
-				-1)
-			resp = strings.Replace(resp,
+			)
+			resp = strings.ReplaceAll(resp,
 				`"allow_rebase_merge": true`,
 				fmt.Sprintf(`"allow_rebase_merge": %t`, c.allowRebase),
-				-1)
+			)
 
 			testServer := httptest.NewTLSServer(
 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -435,8 +435,8 @@ func (w *FileWorkspace) cloneDir(r models.Repo, p models.PullRequest, workspace 
 // sanitizeGitCredentials replaces any git clone urls that contain credentials
 // in s with the sanitized versions.
 func (w *FileWorkspace) sanitizeGitCredentials(s string, base models.Repo, head models.Repo) string {
-	baseReplaced := strings.Replace(s, base.CloneURL, base.SanitizedCloneURL, -1)
-	return strings.Replace(baseReplaced, head.CloneURL, head.SanitizedCloneURL, -1)
+	baseReplaced := strings.ReplaceAll(s, base.CloneURL, base.SanitizedCloneURL)
+	return strings.ReplaceAll(baseReplaced, head.CloneURL, head.SanitizedCloneURL)
 }
 
 // Set the flag that indicates we need to check for upstream changes (if using merge checkout strategy)

--- a/server/jobs/project_command_output_handler_test.go
+++ b/server/jobs/project_command_output_handler_test.go
@@ -129,7 +129,7 @@ func TestProjectCommandOutputHandler(t *testing.T) {
 		close(ch)
 
 		expectedMsgs := []string{Msg, Msg}
-		assert.Equal(t, len(expectedMsgs), len(receivedMsgs))
+		assert.Len(t, receivedMsgs, len(expectedMsgs))
 		for i := range expectedMsgs {
 			assert.Equal(t, expectedMsgs[i], receivedMsgs[i])
 		}

--- a/server/recovery/recovery.go
+++ b/server/recovery/recovery.go
@@ -92,6 +92,6 @@ func function(pc uintptr) []byte {
 	if period := bytes.Index(name, dot); period >= 0 {
 		name = name[period+1:]
 	}
-	name = bytes.Replace(name, centerDot, dot, -1)
+	name = bytes.ReplaceAll(name, centerDot, dot)
 	return name
 }

--- a/server/server.go
+++ b/server/server.go
@@ -514,10 +514,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	} else {
 		lockingClient = locking.NewClient(backend)
 	}
-	disableGlobalApplyLock := false
-	if userConfig.DisableGlobalApplyLock {
-		disableGlobalApplyLock = true
-	}
+	disableGlobalApplyLock := userConfig.DisableGlobalApplyLock
 
 	applyLockingClient = locking.NewApplyClient(backend, disableApply, disableGlobalApplyLock)
 	workingDirLocker := events.NewDefaultWorkingDirLocker()
@@ -1301,7 +1298,7 @@ func ParseAtlantisURL(u string) (*url.URL, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !(parsed.Scheme == "http" || parsed.Scheme == "https") {
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
 		return nil, errors.New("http or https must be specified")
 	}
 	// We want the path to end without a trailing slash so we know how to

--- a/testdrive/testdrive.go
+++ b/testdrive/testdrive.go
@@ -48,7 +48,7 @@ This mode sets up Atlantis on a test repo so you can try it out. We will
 
 [bold]Press Ctrl-c at any time to exit
 `
-var pullRequestBody = strings.Replace(`
+var pullRequestBody = strings.ReplaceAll(`
 In this pull request we will learn how to use Atlantis.
 
 1. In a couple of seconds you should see the output of Atlantis automatically running $terraform plan$.
@@ -82,7 +82,7 @@ In this pull request we will learn how to use Atlantis.
 
 1. Finally, merge the pull request to unlock this directory.
 
-Thank you for trying out Atlantis! Next, try using Atlantis on your own repositories: [www.runatlantis.io/guide/getting-started.html](https://www.runatlantis.io/guide/getting-started.html).`, "$", "`", -1)
+Thank you for trying out Atlantis! Next, try using Atlantis on your own repositories: [www.runatlantis.io/guide/getting-started.html](https://www.runatlantis.io/guide/getting-started.html).`, "$", "`")
 
 // Start begins the testdrive process.
 // nolint: errcheck


### PR DESCRIPTION
## what

Use a newer version of golang lint

## why

Keeping things up-to-date.

Specifically I'd like to upgrade to golang 1.25, but it looks like our golanglint isn't supported.

I used the `golangci-lint migrate` followed by `golangci-lint run --fix` to do most of the work here, the rest was mostly making error values conform to golang conventions.

## tests

Just running tests.

## references

N/A

