### PR TITLE
fix: Missing image signature for v0.36.0 release

### DIFF
--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -181,15 +181,18 @@ jobs:
       if: env.PUSH == 'true' && github.event_name != 'pull_request'
       run: |
         # Sign dev tags, version tags, and latest tags
-        echo "${TAGS}" | xargs -I {} cosign sign \
-          --yes \
-          -a actor=${{ github.actor}} \
-          -a ref_name=${{ github.ref_name}} \
-          -a ref=${{ github.sha }} \
-          {}@${DIGEST}
+        for tag in ${TAGS}; do
+          echo "Signing $tag"
+          cosign sign \
+            --yes \
+            -a actor=${{ github.actor}} \
+            -a ref_name=${{ github.ref_name}} \
+            -a ref=${{ github.sha }} \
+            "$tag"
+        done
+ 
       env:
         TAGS: ${{ steps.meta.outputs.tags }}
-        DIGEST: ${{ steps.build.outputs.digest }}
 
   test:
     needs: [changes]


### PR DESCRIPTION
## what

The {}@${DIGEST} format is incorrect for cosign. When you append a digest to a tag like this, cosign interprets it as trying to sign a specific image digest, not the tag itself.

What's Actually Happening

The signing succeeds (you see "Successfully verified SCT...") But it's signing the wrong artifacts - it's creating signatures for the digest references, not the actual tags

The signatures end up as sha256-* entries in the registry instead of being associated with the tags users pull.

## why

Signatures are not shipped.

## tests

N/A

## references

N/A

