### PR TITLE
revert: "fix: Missing image signature for v0.36.0 release"

### DIFF
--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -181,18 +181,15 @@ jobs:
       if: env.PUSH == 'true' && github.event_name != 'pull_request'
       run: |
         # Sign dev tags, version tags, and latest tags
-        for tag in ${TAGS}; do
-          echo "Signing $tag"
-          cosign sign \
-            --yes \
-            -a actor=${{ github.actor}} \
-            -a ref_name=${{ github.ref_name}} \
-            -a ref=${{ github.sha }} \
-            "$tag"
-        done
- 
+        echo "${TAGS}" | xargs -I {} cosign sign \
+          --yes \
+          -a actor=${{ github.actor}} \
+          -a ref_name=${{ github.ref_name}} \
+          -a ref=${{ github.sha }} \
+          {}@${DIGEST}
       env:
         TAGS: ${{ steps.meta.outputs.tags }}
+        DIGEST: ${{ steps.build.outputs.digest }}
 
   test:
     needs: [changes]


### PR DESCRIPTION
Reverts runatlantis/atlantis#5875

After additional investigations we learned that it's actually not related to the workflow but the fact a past action was cancelled for the v0.36.0 alpine build: https://github.com/runatlantis/atlantis/actions/runs/17834439178/job/50712175546 

Please merge this PR to revert the changes and re-run the action for alpine to make sure we have a signed version for v0.36.0.