### PR TITLE
fix: Separate user and email for bitbucket

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -67,6 +67,7 @@ const (
 	BitbucketBaseURLFlag             = "bitbucket-base-url"
 	BitbucketTokenFlag               = "bitbucket-token"
 	BitbucketUserFlag                = "bitbucket-user"
+	BitbucketEmailFlag               = "bitbucket-email"
 	BitbucketWebhookSecretFlag       = "bitbucket-webhook-secret"
 	CheckoutDepthFlag                = "checkout-depth"
 	CheckoutStrategyFlag             = "checkout-strategy"
@@ -251,6 +252,9 @@ var stringFlags = map[string]stringFlag{
 		defaultValue: DefaultAutoplanFileList,
 	},
 	BitbucketUserFlag: {
+		description: "Bitbucket username for git operations.",
+	},
+	BitbucketEmailFlag: {
 		description: "Bitbucket username of API user.",
 	},
 	BitbucketTokenFlag: {
@@ -1037,6 +1041,10 @@ func (s *ServerCmd) validate(userConfig server.UserConfig) error {
 	}
 	if strings.Contains(userConfig.RepoAllowlist, "://") {
 		return fmt.Errorf("--%s cannot contain ://, should be hostnames only", RepoAllowlistFlag)
+	}
+	if (userConfig.BitbucketUser != "" && userConfig.BitbucketEmail == "") ||
+		(userConfig.BitbucketUser == "" && userConfig.BitbucketEmail != "") {
+		return fmt.Errorf("--%s must be specified alongside --%s", BitbucketEmailFlag, BitbucketUserFlag)
 	}
 
 	parsed, err := url.Parse(userConfig.BitbucketBaseURL)

--- a/server/events/vcs/bitbucketcloud/client.go
+++ b/server/events/vcs/bitbucketcloud/client.go
@@ -18,6 +18,7 @@ import (
 type Client struct {
 	HTTPClient  *http.Client
 	Username    string
+	Email       string
 	Password    string
 	BaseURL     string
 	AtlantisURL string
@@ -27,13 +28,14 @@ type Client struct {
 // URL for Atlantis that will be linked to from the build status icons. This
 // linking is annoying because we don't have anywhere good to link but a URL is
 // required.
-func NewClient(httpClient *http.Client, username string, password string, atlantisURL string) *Client {
+func NewClient(httpClient *http.Client, username, email, password, atlantisURL string) *Client {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
 	return &Client{
 		HTTPClient:  httpClient,
 		Username:    username,
+		Email:       email,
 		Password:    password,
 		BaseURL:     BaseURL,
 		AtlantisURL: atlantisURL,
@@ -316,7 +318,7 @@ func (b *Client) prepRequest(method string, path string, body io.Reader) (*http.
 	if err != nil {
 		return nil, err
 	}
-	req.SetBasicAuth(b.Username, b.Password)
+	req.SetBasicAuth(b.Email, b.Password)
 	if body != nil {
 		req.Header.Add("Content-Type", "application/json")
 	}

--- a/server/events/vcs/bitbucketcloud/client_test.go
+++ b/server/events/vcs/bitbucketcloud/client_test.go
@@ -75,7 +75,7 @@ func TestClient_GetModifiedFilesPagination(t *testing.T) {
 	defer testServer.Close()
 
 	serverURL = testServer.URL
-	client := bitbucketcloud.NewClient(http.DefaultClient, "user", "pass", "runatlantis.io")
+	client := bitbucketcloud.NewClient(http.DefaultClient, "user", "email", "pass", "runatlantis.io")
 	client.BaseURL = testServer.URL
 
 	files, err := client.GetModifiedFiles(
@@ -139,7 +139,7 @@ func TestClient_GetModifiedFilesOldNil(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	client := bitbucketcloud.NewClient(http.DefaultClient, "user", "pass", "runatlantis.io")
+	client := bitbucketcloud.NewClient(http.DefaultClient, "user", "email", "pass", "runatlantis.io")
 	client.BaseURL = testServer.URL
 
 	files, err := client.GetModifiedFiles(
@@ -208,7 +208,7 @@ func TestClient_PullIsApproved(t *testing.T) {
 			}))
 			defer testServer.Close()
 
-			client := bitbucketcloud.NewClient(http.DefaultClient, "user", "pass", "runatlantis.io")
+			client := bitbucketcloud.NewClient(http.DefaultClient, "user", "email", "pass", "runatlantis.io")
 			client.BaseURL = testServer.URL
 
 			repo, err := models.NewRepo(models.BitbucketServer, "owner/repo", "https://bitbucket.org/owner/repo.git", "user", "token")
@@ -342,7 +342,7 @@ func TestClient_PullIsMergeable(t *testing.T) {
 			}))
 			defer testServer.Close()
 
-			client := bitbucketcloud.NewClient(http.DefaultClient, "user", "pass", "runatlantis.io")
+			client := bitbucketcloud.NewClient(http.DefaultClient, "user", "email", "pass", "runatlantis.io")
 			client.BaseURL = testServer.URL
 
 			actMergeable, err := client.PullIsMergeable(
@@ -368,7 +368,7 @@ func TestClient_PullIsMergeable(t *testing.T) {
 }
 
 func TestClient_MarkdownPullLink(t *testing.T) {
-	client := bitbucketcloud.NewClient(http.DefaultClient, "user", "pass", "runatlantis.io")
+	client := bitbucketcloud.NewClient(http.DefaultClient, "user", "email", "pass", "runatlantis.io")
 	pull := models.PullRequest{Num: 1}
 	s, _ := client.MarkdownPullLink(pull)
 	exp := "#1"
@@ -392,7 +392,7 @@ func TestClient_GetMyUUID(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	client := bitbucketcloud.NewClient(http.DefaultClient, "user", "pass", "runatlantis.io")
+	client := bitbucketcloud.NewClient(http.DefaultClient, "user", "email", "pass", "runatlantis.io")
 	client.BaseURL = testServer.URL
 	v, _ := client.GetMyUUID()
 	Equals(t, v, "{00000000-0000-0000-0000-000000000001}")
@@ -415,7 +415,7 @@ func TestClient_GetComment(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	client := bitbucketcloud.NewClient(http.DefaultClient, "user", "pass", "runatlantis.io")
+	client := bitbucketcloud.NewClient(http.DefaultClient, "user", "email", "pass", "runatlantis.io")
 	client.BaseURL = testServer.URL
 	v, _ := client.GetPullRequestComments(
 		models.Repo{
@@ -451,7 +451,7 @@ func TestClient_DeleteComment(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	client := bitbucketcloud.NewClient(http.DefaultClient, "user", "pass", "runatlantis.io")
+	client := bitbucketcloud.NewClient(http.DefaultClient, "user", "email", "pass", "runatlantis.io")
 	client.BaseURL = testServer.URL
 	err := client.DeletePullRequestComment(
 		models.Repo{
@@ -513,7 +513,7 @@ func TestClient_HidePRComments(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	client := bitbucketcloud.NewClient(http.DefaultClient, "user", "pass", "runatlantis.io")
+	client := bitbucketcloud.NewClient(http.DefaultClient, "user", "email", "pass", "runatlantis.io")
 	client.BaseURL = testServer.URL
 	err = client.HidePrevCommandComments(logger,
 		models.Repo{

--- a/server/server.go
+++ b/server/server.go
@@ -299,6 +299,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 			bitbucketCloudClient = bitbucketcloud.NewClient(
 				http.DefaultClient,
 				userConfig.BitbucketUser,
+				userConfig.BitbucketEmail,
 				userConfig.BitbucketToken,
 				userConfig.AtlantisURL)
 		} else {

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -30,6 +30,7 @@ type UserConfig struct {
 	BitbucketBaseURL            string `mapstructure:"bitbucket-base-url"`
 	BitbucketToken              string `mapstructure:"bitbucket-token"`
 	BitbucketUser               string `mapstructure:"bitbucket-user"`
+	BitbucketEmail              string `mapstructure:"bitbucket-email"`
 	BitbucketWebhookSecret      string `mapstructure:"bitbucket-webhook-secret"`
 	CheckoutDepth               int    `mapstructure:"checkout-depth"`
 	CheckoutStrategy            string `mapstructure:"checkout-strategy"`


### PR DESCRIPTION
## what

Separates out `email` from `user` for bitbucket.


## why

My understanding of #5696 is that there has to be a separate "username" from "email" address in the new bitbucket authentication scheme, so I added a flag to tease that out:

```
atlantis % go run main.go server --bitbucket-user foo --bitbucket-token bar --repo-allowlist='hi'                            
Error: --bitbucket-email must be specified alongside --bitbucket-user
exit status 1
atlantis % go run main.go server --bitbucket-user foo --bitbucket-token bar --repo-allowlist='hi' --bitbucket-email=foo@bar
{"level":"info","ts":"2025-10-30T23:06:24.009-0400","caller":"server/server.go:345","msg":"Supported VCS Hosts: BitbucketCloud","json":{}}
```

DISCLAIMER: I've never used bitbucket before, and am just going off the description of a problem in #5696 to try to help out.

## tests

TODO: add tests

Also need to update documentation

## references

closes: #5696
