### PR TITLE
feat: implement --ignore-vcs-status-names for GitLab

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -472,7 +472,7 @@ var stringFlags = map[string]stringFlag{
 	IgnoreVCSStatusNames: {
 		description: "Comma separated list of VCS status names from other atlantis services." +
 			" When `gh-allow-mergeable-bypass-apply` is true, will ignore status checks (e.g. `status1/plan`, `status1/apply`, `status2/plan`, `status2/apply`) from other Atlantis services when checking if the PR is mergeable." +
-			" Currently only implemented for GitHub.",
+			" Currently only implemented for GitHub and GitLab.",
 		defaultValue: DefaultIgnoreVCSStatusNames,
 	},
 	VCSStatusName: {

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -977,7 +977,7 @@ Comma separated list of VCS status names from other atlantis services.
 When `gh-allow-mergeable-bypass-apply` is true, will ignore status checks
 (e.g. `status1/plan`, `status1/apply`, `status2/plan`, `status2/apply`)
 from other Atlantis services when checking if the PR is mergeable.
-Currently only implemented for GitHub.
+Currently only implemented for GitHub or GitLab.
 
 ### `--include-git-untracked-files` <Badge text="v0.27.0+" type="info"/>
 


### PR DESCRIPTION
## what

Implement the `--ignore-vcs-status-names` flag for the GitLab provider. Similar to #4978, this consults an ignore list when for commit status names when determining mergeability. If a commit status name can be parsed as `{vcsstatusname}/...` and that parsed `vcsstatusname` is present in the configured ignore list then it is skipped.

## why

Similar reasoning as expressed in #2848 for the existing GitHub-only feature - when multiple atlantis servers with different `vcs-status-names` operate on a single repo with a `mergeable` requirement they see pending pipeline statuses set by the other atlantis instances and report that the MR is not mergeable.

## tests

- [x] I have tested my changes by adding unit test coverage. `go test ./server/events/vcs` passes, however an existing, unrelated, test failure at main/HEAD causes `make test` to fail.
- [x] Tested locally with and without ignored status names.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
https://github.com/runatlantis/atlantis/issues/2848
https://github.com/runatlantis/atlantis/pull/4978
