### PR TITLE
feat: implement atlantis reset command

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -168,7 +168,7 @@ const (
 	DefaultADHostname                   = "dev.azure.com"
 	DefaultAutoDiscoverMode             = "auto"
 	DefaultAutoplanFileList             = "**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl"
-	DefaultAllowCommands                = "version,plan,apply,unlock,approve_policies"
+	DefaultAllowCommands                = "version,plan,apply,unlock,approve_policies,reset"
 	DefaultCheckoutStrategy             = CheckoutStrategyBranch
 	DefaultCheckoutDepth                = 0
 	DefaultBitbucketBaseURL             = bitbucketcloud.BaseURL

--- a/server/events/command/name.go
+++ b/server/events/command/name.go
@@ -30,6 +30,8 @@ const (
 	Import
 	// State is a command to run terraform state rm
 	State
+	// Reset is a command to reset PR state by clearing locks and triggering replan
+	Reset
 	// Adding more? Don't forget to update String() below
 )
 
@@ -47,6 +49,7 @@ var AllCommentCommands = []Name{
 	ApprovePolicies,
 	Import,
 	State,
+	Reset,
 }
 
 // TitleString returns the string representation in title form.
@@ -74,6 +77,8 @@ func (c Name) String() string {
 		return "import"
 	case State:
 		return "state"
+	case Reset:
+		return "reset"
 	}
 	return ""
 }
@@ -149,6 +154,8 @@ func ParseCommandName(name string) (Name, error) {
 		return Import, nil
 	case "state":
 		return State, nil
+	case "reset":
+		return Reset, nil
 	}
 	return -1, fmt.Errorf("unknown command name: %s", name)
 }

--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -292,6 +292,11 @@ func (e *CommentParser) Parse(rawComment string, vcsHost models.VCSHostType) Com
 		flagSet.StringVarP(&dir, dirFlagLong, dirFlagShort, "", "Which directory to run state command in relative to root of repo, ex. 'child/dir'.")
 		flagSet.StringVarP(&project, projectFlagLong, projectFlagShort, "", "Which project to run state command for. Refers to the name of the project configured in a repo config file. Cannot be used at same time as workspace or dir flags.")
 		flagSet.BoolVarP(&verbose, verboseFlagLong, verboseFlagShort, false, "Append Atlantis log to comment.")
+	case command.Reset.String():
+		name = command.Reset
+		flagSet = pflag.NewFlagSet(command.Reset.String(), pflag.ContinueOnError)
+		flagSet.SetOutput(io.Discard)
+		flagSet.BoolVarP(&verbose, verboseFlagLong, verboseFlagShort, false, "Append Atlantis log to comment.")
 	default:
 		return CommentParseResult{CommentResponse: fmt.Sprintf("Error: unknown command %q – this is a bug", cmd)}
 	}
@@ -517,6 +522,7 @@ func (e *CommentParser) HelpComment() string {
 		AllowApprovePolicies bool
 		AllowImport          bool
 		AllowState           bool
+		AllowReset           bool
 	}{
 		ExecutableName:       e.ExecutableName,
 		AllowVersion:         e.isAllowedCommand(command.Version.String()),
@@ -526,6 +532,7 @@ func (e *CommentParser) HelpComment() string {
 		AllowApprovePolicies: e.isAllowedCommand(command.ApprovePolicies.String()),
 		AllowImport:          e.isAllowedCommand(command.Import.String()),
 		AllowState:           e.isAllowedCommand(command.State.String()),
+		AllowReset:           e.isAllowedCommand(command.Reset.String()),
 	}); err != nil {
 		return fmt.Sprintf("Failed to render template, this is a bug: %v", err)
 	}
@@ -585,6 +592,10 @@ Commands:
   state rm ADDRESS...
            Runs 'terraform state rm' for the passed address resource.
            To remove a specific project resource, use the -d, -w and -p flags.
+{{- end }}
+{{- if .AllowReset }}
+  reset    Resets PR state by clearing all locks and triggering replan.
+           Useful when PR structure changes and Atlantis gets confused about projects.
 {{- end }}
   help     View help.
 

--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -925,6 +925,8 @@ Commands:
   state rm ADDRESS...
            Runs 'terraform state rm' for the passed address resource.
            To remove a specific project resource, use the -d, -w and -p flags.
+  reset    Resets PR state by clearing all locks and triggering replan.
+           Useful when PR structure changes and Atlantis gets confused about projects.
   help     View help.
 
 Flags:

--- a/server/events/reset_command_runner.go
+++ b/server/events/reset_command_runner.go
@@ -1,0 +1,52 @@
+package events
+
+import (
+	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/events/vcs"
+)
+
+func NewResetCommandRunner(
+	pullCleaner PullCleaner,
+	vcsClient vcs.Client,
+) *ResetCommandRunner {
+	return &ResetCommandRunner{
+		pullCleaner: pullCleaner,
+		vcsClient:   vcsClient,
+	}
+}
+
+type ResetCommandRunner struct {
+	pullCleaner  PullCleaner
+	commandRunner CommandRunner // Set later to avoid circular dependency
+	vcsClient     vcs.Client
+}
+
+func (r *ResetCommandRunner) SetCommandRunner(commandRunner CommandRunner) {
+	r.commandRunner = commandRunner
+}
+
+func (r *ResetCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
+	baseRepo := ctx.Pull.BaseRepo
+	headRepo := ctx.HeadRepo
+	pull := ctx.Pull
+	user := ctx.User
+
+	ctx.Log.Info("Resetting PR state by clearing locks and triggering replan")
+
+	// First, clean up the pull like it was closed
+	if err := r.pullCleaner.CleanUpPull(ctx.Log, baseRepo, pull); err != nil {
+		ctx.Log.Err("failed to clean up pull during reset: %s", err)
+		if commentErr := r.vcsClient.CreateComment(ctx.Log, baseRepo, pull.Num, "Failed to reset PR state", command.Reset.String()); commentErr != nil {
+			ctx.Log.Err("unable to comment on reset failure: %s", commentErr)
+		}
+		return
+	}
+
+	// Now trigger autoplan to replan all projects
+	r.commandRunner.RunAutoplanCommand(baseRepo, headRepo, pull, user)
+
+	// Comment on success
+	if commentErr := r.vcsClient.CreateComment(ctx.Log, baseRepo, pull.Num, "PR state has been reset. All locks cleared and replanning triggered.", command.Reset.String()); commentErr != nil {
+		ctx.Log.Err("unable to comment on reset success: %s", commentErr)
+	}
+}

--- a/server/events/reset_command_runner_test.go
+++ b/server/events/reset_command_runner_test.go
@@ -1,0 +1,303 @@
+package events_test
+
+import (
+	"errors"
+	"testing"
+
+	. "github.com/petergtz/pegomock/v4"
+	"github.com/runatlantis/atlantis/server/events"
+	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/events/mocks"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/events/models/testdata"
+	vcsmocks "github.com/runatlantis/atlantis/server/events/vcs/mocks"
+	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/runatlantis/atlantis/server/metrics"
+	. "github.com/runatlantis/atlantis/testing"
+)
+
+func TestResetCommandRunner_Run(t *testing.T) {
+	logger := logging.NewNoopLogger(t)
+	RegisterMockTestingT(t)
+
+	tests := []struct {
+		name           string
+		cleanUpErr     error
+		expComment     string
+		expAutoplan    bool
+		expCleanUpCall bool
+	}{
+		{
+			name:           "success - clears locks and triggers replan",
+			cleanUpErr:     nil,
+			expComment:     "PR state has been reset. All locks cleared and replanning triggered.",
+			expAutoplan:    true,
+			expCleanUpCall: true,
+		},
+		{
+			name:           "failure - cleanup fails",
+			cleanUpErr:     errors.New("cleanup failed"),
+			expComment:     "Failed to reset PR state",
+			expAutoplan:    false,
+			expCleanUpCall: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup mocks
+			pullCleaner := mocks.NewMockPullCleaner()
+			vcsClient := vcsmocks.NewMockClient()
+			commandRunner := mocks.NewMockCommandRunner()
+
+			// Create the reset command runner
+			resetRunner := events.NewResetCommandRunner(pullCleaner, vcsClient)
+			resetRunner.SetCommandRunner(commandRunner)
+
+			// Setup test data
+			scopeNull, _, _ := metrics.NewLoggingScope(logger, "atlantis")
+			modelPull := models.PullRequest{
+				BaseRepo: testdata.GithubRepo,
+				State:    models.OpenPullState,
+				Num:      testdata.Pull.Num,
+			}
+			ctx := &command.Context{
+				User:     testdata.User,
+				Log:      logger,
+				Scope:    scopeNull,
+				Pull:     modelPull,
+				HeadRepo: testdata.GithubRepo,
+				Trigger:  command.CommentTrigger,
+			}
+			cmd := &events.CommentCommand{Name: command.Reset}
+
+			// Setup mock behavior
+			When(pullCleaner.CleanUpPull(
+				Any[logging.SimpleLogging](),
+				Eq(testdata.GithubRepo),
+				Eq(modelPull),
+			)).ThenReturn(tt.cleanUpErr)
+
+			// Run the reset command
+			resetRunner.Run(ctx, cmd)
+
+			// Verify CleanUpPull was called
+			if tt.expCleanUpCall {
+				pullCleaner.VerifyWasCalledOnce().CleanUpPull(
+					Any[logging.SimpleLogging](),
+					Eq(testdata.GithubRepo),
+					Eq(modelPull),
+				)
+			}
+
+			// Verify autoplan was triggered (only on success)
+			if tt.expAutoplan {
+				commandRunner.VerifyWasCalledOnce().RunAutoplanCommand(
+					Eq(testdata.GithubRepo),
+					Eq(testdata.GithubRepo),
+					Eq(modelPull),
+					Eq(testdata.User),
+				)
+			} else {
+				commandRunner.VerifyWasCalled(Never()).RunAutoplanCommand(
+					Any[models.Repo](),
+					Any[models.Repo](),
+					Any[models.PullRequest](),
+					Any[models.User](),
+				)
+			}
+
+			// Verify comment was created
+			vcsClient.VerifyWasCalledOnce().CreateComment(
+				Any[logging.SimpleLogging](),
+				Eq(testdata.GithubRepo),
+				Eq(modelPull.Num),
+				Eq(tt.expComment),
+				Eq("reset"),
+			)
+		})
+	}
+}
+
+func TestResetCommandRunner_SetCommandRunner(t *testing.T) {
+	RegisterMockTestingT(t)
+
+	pullCleaner := mocks.NewMockPullCleaner()
+	vcsClient := vcsmocks.NewMockClient()
+	commandRunner := mocks.NewMockCommandRunner()
+
+	resetRunner := events.NewResetCommandRunner(pullCleaner, vcsClient)
+
+	// Initially commandRunner should be nil, so SetCommandRunner should set it
+	resetRunner.SetCommandRunner(commandRunner)
+
+	// The commandRunner is now set - we can verify this by running the reset
+	// command and checking that RunAutoplanCommand is called
+	logger := logging.NewNoopLogger(t)
+	scopeNull, _, _ := metrics.NewLoggingScope(logger, "atlantis")
+	modelPull := models.PullRequest{
+		BaseRepo: testdata.GithubRepo,
+		State:    models.OpenPullState,
+		Num:      testdata.Pull.Num,
+	}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logger,
+		Scope:    scopeNull,
+		Pull:     modelPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	cmd := &events.CommentCommand{Name: command.Reset}
+
+	When(pullCleaner.CleanUpPull(
+		Any[logging.SimpleLogging](),
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+	)).ThenReturn(nil)
+
+	resetRunner.Run(ctx, cmd)
+
+	// If SetCommandRunner worked, RunAutoplanCommand should have been called
+	commandRunner.VerifyWasCalledOnce().RunAutoplanCommand(
+		Any[models.Repo](),
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Any[models.User](),
+	)
+}
+
+func TestResetCommandRunner_CommentCreationFails(t *testing.T) {
+	logger := logging.NewNoopLogger(t)
+	RegisterMockTestingT(t)
+
+	pullCleaner := mocks.NewMockPullCleaner()
+	vcsClient := vcsmocks.NewMockClient()
+	commandRunner := mocks.NewMockCommandRunner()
+
+	resetRunner := events.NewResetCommandRunner(pullCleaner, vcsClient)
+	resetRunner.SetCommandRunner(commandRunner)
+
+	scopeNull, _, _ := metrics.NewLoggingScope(logger, "atlantis")
+	modelPull := models.PullRequest{
+		BaseRepo: testdata.GithubRepo,
+		State:    models.OpenPullState,
+		Num:      testdata.Pull.Num,
+	}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logger,
+		Scope:    scopeNull,
+		Pull:     modelPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	cmd := &events.CommentCommand{Name: command.Reset}
+
+	// Setup: cleanup succeeds but comment creation fails
+	When(pullCleaner.CleanUpPull(
+		Any[logging.SimpleLogging](),
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+	)).ThenReturn(nil)
+
+	When(vcsClient.CreateComment(
+		Any[logging.SimpleLogging](),
+		Any[models.Repo](),
+		Any[int](),
+		Any[string](),
+		Any[string](),
+	)).ThenReturn(errors.New("comment creation failed"))
+
+	// Run should not panic even if comment creation fails
+	Assert(t, func() bool {
+		resetRunner.Run(ctx, cmd)
+		return true
+	}(), "Run should not panic when comment creation fails")
+
+	// Verify cleanup and autoplan were still called
+	pullCleaner.VerifyWasCalledOnce().CleanUpPull(
+		Any[logging.SimpleLogging](),
+		Eq(testdata.GithubRepo),
+		Eq(modelPull),
+	)
+	commandRunner.VerifyWasCalledOnce().RunAutoplanCommand(
+		Any[models.Repo](),
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Any[models.User](),
+	)
+}
+
+func TestResetCommandRunner_CleanupFailsCommentFails(t *testing.T) {
+	logger := logging.NewNoopLogger(t)
+	RegisterMockTestingT(t)
+
+	pullCleaner := mocks.NewMockPullCleaner()
+	vcsClient := vcsmocks.NewMockClient()
+	commandRunner := mocks.NewMockCommandRunner()
+
+	resetRunner := events.NewResetCommandRunner(pullCleaner, vcsClient)
+	resetRunner.SetCommandRunner(commandRunner)
+
+	scopeNull, _, _ := metrics.NewLoggingScope(logger, "atlantis")
+	modelPull := models.PullRequest{
+		BaseRepo: testdata.GithubRepo,
+		State:    models.OpenPullState,
+		Num:      testdata.Pull.Num,
+	}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logger,
+		Scope:    scopeNull,
+		Pull:     modelPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	cmd := &events.CommentCommand{Name: command.Reset}
+
+	// Setup: both cleanup and comment creation fail
+	When(pullCleaner.CleanUpPull(
+		Any[logging.SimpleLogging](),
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+	)).ThenReturn(errors.New("cleanup failed"))
+
+	When(vcsClient.CreateComment(
+		Any[logging.SimpleLogging](),
+		Any[models.Repo](),
+		Any[int](),
+		Any[string](),
+		Any[string](),
+	)).ThenReturn(errors.New("comment creation failed"))
+
+	// Run should not panic even when both operations fail
+	Assert(t, func() bool {
+		resetRunner.Run(ctx, cmd)
+		return true
+	}(), "Run should not panic when both cleanup and comment creation fail")
+
+	// Verify cleanup was called
+	pullCleaner.VerifyWasCalledOnce().CleanUpPull(
+		Any[logging.SimpleLogging](),
+		Eq(testdata.GithubRepo),
+		Eq(modelPull),
+	)
+
+	// Verify autoplan was NOT called since cleanup failed
+	commandRunner.VerifyWasCalled(Never()).RunAutoplanCommand(
+		Any[models.Repo](),
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Any[models.User](),
+	)
+
+	// Verify error comment was attempted
+	vcsClient.VerifyWasCalledOnce().CreateComment(
+		Any[logging.SimpleLogging](),
+		Eq(testdata.GithubRepo),
+		Eq(modelPull.Num),
+		Eq("Failed to reset PR state"),
+		Eq("reset"),
+	)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -849,6 +849,11 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		instrumentedProjectCmdRunner,
 	)
 
+	resetCommandRunner := events.NewResetCommandRunner(
+		pullClosedExecutor,
+		vcsClient,
+	)
+
 	commentCommandRunnerByCmd := map[command.Name]events.CommentCommandRunner{
 		command.Plan:            planCommandRunner,
 		command.Apply:           applyCommandRunner,
@@ -857,6 +862,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		command.Version:         versionCommandRunner,
 		command.Import:          importCommandRunner,
 		command.State:           stateCommandRunner,
+		command.Reset:           resetCommandRunner,
 	}
 
 	var teamAllowlistChecker command.TeamAllowlistChecker
@@ -910,6 +916,9 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		VarFileAllowlistChecker:        varFileAllowlistChecker,
 		CommitStatusUpdater:            commitStatusUpdater,
 	}
+	// Set the command runner on the reset command runner to avoid circular dependency
+	resetCommandRunner.SetCommandRunner(commandRunner)
+
 	repoAllowlist, err := events.NewRepoAllowlistChecker(userConfig.RepoAllowlist)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

This PR implements a new `atlantis reset` command that addresses issue #1944 by providing a way to clear PR state when Atlantis gets confused about which projects to plan after PR modifications.

### Problem
When a PR starts with many projects and then gets reworked with some removed, Atlantis may continue trying to plan projects that no longer exist. The only workaround was to close and reopen the PR.

### Solution
The new `atlantis reset` command simulates closing and reopening a PR by:
1. Cleaning up the PR state (clearing locks, workspaces, and database entries) - same as when a PR is closed
2. Triggering autoplan on all currently modified projects - same as when a PR is opened/updated

## Changes

- **server/events/command/name.go**: Add `Reset` to the `Name` enum and `AllCommentCommands`
- **server/events/comment_parser.go**: Add help text for the reset command
- **server/events/reset_command_runner.go**: New `ResetCommandRunner` that:
  - Uses `PullCleaner.CleanUpPull()` to clear PR state
  - Calls `RunAutoplanCommand()` to trigger replanning
  - Comments on success/failure
- **server/server.go**: Register the reset command runner
- **cmd/server.go**: Add `reset` to default allowed commands

## Test Plan

- [x] Unit tests for `ResetCommandRunner` covering:
  - Successful reset flow
  - Cleanup failure handling
  - Comment creation failure handling
  - Combined failure scenarios
- [x] Tests verify proper interaction with `PullCleaner` and `CommandRunner`
- [x] All existing tests pass

## Usage

```
atlantis reset
```

When commented on a PR, this will:
1. Delete all locks and workspaces for the PR
2. Re-run autoplan to detect current projects
3. Post a comment confirming the reset

Fixes #1944

🤖 Generated with [Claude Code](https://claude.com/claude-code)