### PR TITLE
fix: ignore policies-passed requirement when validating plan command

### DIFF
--- a/server/events/command_requirement_handler.go
+++ b/server/events/command_requirement_handler.go
@@ -36,7 +36,17 @@ func (a *DefaultCommandRequirementHandler) ValidateProjectDependencies(ctx comma
 }
 
 func (a *DefaultCommandRequirementHandler) ValidatePlanProject(repoDir string, ctx command.ProjectContext) (failure string, err error) {
-	return a.validateCommandRequirement(repoDir, ctx, command.Plan, ctx.PlanRequirements)
+	// Policy checks are only run after a plan.
+	// If they previously failed, we ignore the status to re-run the plan.
+	var planRequirements []string
+	for _, req := range ctx.PlanRequirements {
+		if req == valid.PoliciesPassedCommandReq {
+			continue
+		}
+		planRequirements = append(planRequirements, req)
+	}
+
+	return a.validateCommandRequirement(repoDir, ctx, command.Plan, planRequirements)
 }
 
 func (a *DefaultCommandRequirementHandler) ValidateApplyProject(repoDir string, ctx command.ProjectContext) (failure string, err error) {

--- a/server/events/command_requirement_handler_test.go
+++ b/server/events/command_requirement_handler_test.go
@@ -52,6 +52,21 @@ func TestAggregateApplyRequirements_ValidatePlanProject(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: "pass with previously failed policy checks",
+			ctx: command.ProjectContext{
+				PlanRequirements: fullRequirements, // valid.PoliciesPassedCommandReq is ignored
+				PullReqStatus: models.PullReqStatus{
+					ApprovalStatus:  models.ApprovalStatus{IsApproved: true},
+					MergeableStatus: models.MergeableStatus{IsMergeable: true},
+				},
+				ProjectPlanStatus: models.ErroredPolicyCheckStatus,
+			},
+			setup: func(workingDir *mocks.MockWorkingDir) {
+				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string]())).ThenReturn(false)
+			},
+			wantErr: assert.NoError,
+		},
+		{
 			name: "fail by no approved",
 			ctx: command.ProjectContext{
 				PlanRequirements: []string{raw.ApprovedRequirement},


### PR DESCRIPTION
## what

This PR updates the `plan` command's validator to ignore the `policies_passed` requirement when present in `ProjectContext.PlanRequirements`.

This resolves issue https://github.com/runatlantis/atlantis/issues/5993 introduced by https://github.com/runatlantis/atlantis/pull/5851: When a policy check fails, the subsequent plan _always_ fails. Plans run after this run as normal.

> It seems that after a failure, atlantis updates its internal state to a point _before_ the policy check - so any subsequent plan will succeed. An alternative solution could be to "pretend" the policy checks haven't run yet in the context of the plan.

Specifying `repos[*].plan_requirements: []` in the server-side `repos.yaml` does not successfully work around the issue - the value seems to be overwritten somewhere.

## why

This fixes an issue with the standard use case for policy checks. We want to upgrade to the latest atlantis version to make use of parallel plan & apply - but the additional friction caused by this (and potential contacts from teams not familiar with atlantis) means we cannot adopt this version.

I believe atlantis can only run policy checks _after_ a plan is completed, so this small-scoped solution makes the most sense to me. If this assumption is wrong, I'd be happy to look into an alternative solution that fits a broader set of use cases!

## tests

- I have updated the relevant unit tests to account for this new test case

## references

- caused by runatlantis/atlantis#5851
- closes runatlantis/atlantis#5993

