### PR TITLE
fix: add env variable DEFAULT_CONFTEST_VERSION to dockerfile so it's available at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -208,6 +208,9 @@ RUN apk add --no-cache \
         gcompat=${GCOMPAT_VERSION} \
         coreutils-env=${COREUTILS_ENV_VERSION}
 
+ARG DEFAULT_CONFTEST_VERSION
+ENV DEFAULT_CONFTEST_VERSION=${DEFAULT_CONFTEST_VERSION}
+
 # Set the entry point to the atlantis user and run the atlantis command
 USER atlantis
 ENTRYPOINT ["docker-entrypoint.sh"]


### PR DESCRIPTION
## what
Add environment variable `DEFAULT_CONFTEST_VERSION` available to runtime without explicitly defining it.


## why
Prevent annoying log message related to conftest version not being defined.

## tests
I have tested my changes by build atlantis and running it with docker run.

## references
closes #5996 

