### PR TITLE
fix: ensure base branch is cloneable

### DIFF
--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -241,6 +241,13 @@ func (w *FileWorkspace) HasDiverged(logger logging.SimpleLogging, cloneDir strin
 
 func (w *FileWorkspace) updateToRef(logger logging.SimpleLogging, c wrappedGitContext, targetRef string) error {
 
+	// If we originally cloned using `--single-branch` and later changed the base branch of the PR,
+	// `git fetch --all` will not fetch the base branch from the original remote, so we update the config
+	// to ensure the current base branch is fetched.
+	if err := w.wrappedGit(logger, c, "config", "--local", "remote.origin.fetch", fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", c.pr.BaseBranch, c.pr.BaseBranch)); err != nil {
+		return err
+	}
+
 	// We use both `head` and `origin` remotes, update them both
 	if err := w.wrappedGit(logger, c, "fetch", "--all"); err != nil {
 		return err


### PR DESCRIPTION
## what

update `updateToRef` to ensure that the `remote.origin.fetch` refspec includes the current base branch of the PR.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

After updating from 0.36.0 to 0.37.1, we started seeing a bug where if a user changed the base branch of their MR, all atlantis plans would fail on the pre-workflow step with:

```
Error: Pre-workflow hook failed: running git reset --hard origin/branch: fatal: ambiguous argument 'origin/branch': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
: exit status 128
```

The root cause turned out to be `git clone --single-branch` setting the refspec to _only_ the original base branch, which prevents `git fetch --all` from fetching the new base branch we merge into later in `updateToRef`.

## tests

<!--
- [ ] I have tested my changes by ...
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

https://github.com/runatlantis/atlantis/pull/5895
