### PR TITLE
fix: Do not use name `head` for source remote

### DIFF
--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -552,7 +552,7 @@ func TestClone_ResetOnWrongCommitWithMergeStrategy(t *testing.T) {
 	runCmd(t, checkoutDir, "git", "config", "--local", "commit.gpgsign", "false")
 
 	runCmd(t, checkoutDir, "git", "checkout", "main")
-	runCmd(t, checkoutDir, "git", "remote", "add", "head", repoDir)
+	runCmd(t, checkoutDir, "git", "remote", "add", "source", repoDir)
 
 	// Simulate the merge strategy
 	runCmd(t, checkoutDir, "git", "checkout", "branch")
@@ -614,8 +614,8 @@ func TestClone_MasterHasDiverged(t *testing.T) {
 	firstPRDir := repoDir + "/first-pr"
 	runCmd(t, repoDir, "mkdir", "-p", "first-pr")
 	runCmd(t, firstPRDir, "git", "clone", "--branch", "main", "--single-branch", repoDir, ".")
-	runCmd(t, firstPRDir, "git", "remote", "add", "head", repoDir)
-	runCmd(t, firstPRDir, "git", "fetch", "head", "+refs/heads/first-pr")
+	runCmd(t, firstPRDir, "git", "remote", "add", "source", repoDir)
+	runCmd(t, firstPRDir, "git", "fetch", "source", "+refs/heads/first-pr")
 	runCmd(t, firstPRDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
 	runCmd(t, firstPRDir, "git", "config", "--local", "user.name", "atlantisbot")
 	runCmd(t, firstPRDir, "git", "config", "--local", "commit.gpgsign", "false")
@@ -632,8 +632,8 @@ func TestClone_MasterHasDiverged(t *testing.T) {
 	secondPRDir := repoDir + "/second-pr"
 	runCmd(t, repoDir, "mkdir", "-p", "second-pr")
 	runCmd(t, secondPRDir, "git", "clone", "--branch", "main", "--single-branch", repoDir, ".")
-	runCmd(t, secondPRDir, "git", "remote", "add", "head", repoDir)
-	runCmd(t, secondPRDir, "git", "fetch", "head", "+refs/heads/second-pr")
+	runCmd(t, secondPRDir, "git", "remote", "add", "source", repoDir)
+	runCmd(t, secondPRDir, "git", "fetch", "source", "+refs/heads/second-pr")
 	runCmd(t, secondPRDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
 	runCmd(t, secondPRDir, "git", "config", "--local", "user.name", "atlantisbot")
 	runCmd(t, secondPRDir, "git", "config", "--local", "commit.gpgsign", "false")
@@ -718,8 +718,8 @@ func TestHasDiverged_MasterHasDiverged(t *testing.T) {
 	firstPRDir := repoDir + "/first-pr"
 	runCmd(t, repoDir, "mkdir", "-p", "first-pr")
 	runCmd(t, firstPRDir, "git", "clone", "--branch", "main", "--single-branch", repoDir, ".")
-	runCmd(t, firstPRDir, "git", "remote", "add", "head", repoDir)
-	runCmd(t, firstPRDir, "git", "fetch", "head", "+refs/heads/first-pr")
+	runCmd(t, firstPRDir, "git", "remote", "add", "source", repoDir)
+	runCmd(t, firstPRDir, "git", "fetch", "source", "+refs/heads/first-pr")
 	runCmd(t, firstPRDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
 	runCmd(t, firstPRDir, "git", "config", "--local", "user.name", "atlantisbot")
 	runCmd(t, firstPRDir, "git", "config", "--local", "commit.gpgsign", "false")
@@ -736,8 +736,8 @@ func TestHasDiverged_MasterHasDiverged(t *testing.T) {
 	secondPRDir := repoDir + "/second-pr"
 	runCmd(t, repoDir, "mkdir", "-p", "second-pr")
 	runCmd(t, secondPRDir, "git", "clone", "--branch", "main", "--single-branch", repoDir, ".")
-	runCmd(t, secondPRDir, "git", "remote", "add", "head", repoDir)
-	runCmd(t, secondPRDir, "git", "fetch", "head", "+refs/heads/second-pr")
+	runCmd(t, secondPRDir, "git", "remote", "add", "source", repoDir)
+	runCmd(t, secondPRDir, "git", "fetch", "source", "+refs/heads/second-pr")
 	runCmd(t, secondPRDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
 	runCmd(t, secondPRDir, "git", "config", "--local", "user.name", "atlantisbot")
 	runCmd(t, secondPRDir, "git", "config", "--local", "commit.gpgsign", "false")


### PR DESCRIPTION
## what

Use `source` instead of `head` as name of remote corresponding to the source repo of the PR.

## why

It was originally called `head` because that's what github calls it. However, the term head is overloaded in git. Specifically, if you call a remote `head` it can lead to ambiguities where git can't determine the right ref for `HEAD`.

Note this has nothing to do w github or Atlantis, this is just a fact about the way git resolves short names.

```
~ % git clone https://github.com/lukemassa/atlantis-test.git test-head-as-remote
Cloning into 'test-head-as-remote'...
remote: Enumerating objects: 521, done.
remote: Counting objects: 100% (84/84), done.
remote: Compressing objects: 100% (56/56), done.
remote: Total 521 (delta 30), reused 32 (delta 22), pack-reused 437 (from 2)
Receiving objects: 100% (521/521), 67.37 KiB | 1.37 MiB/s, done.
Resolving deltas: 100% (253/253), done.
~ % cd test-head-as-remote 
test-head-as-remote % git remote add head https://github.com/lukemassa/atlantis-test.git
test-head-as-remote % git status
On branch main
Your branch is up to date with 'origin/main'.

nothing to commit, working tree clean
test-head-as-remote % git fetch head
From https://github.com/lukemassa/atlantis-test
 * [new branch]      add_a_project            -> head/add_a_project
...
 * [new branch]      update_run               -> head/update_run
 * [new branch]      updating_project         -> head/updating_project
warning: refname 'HEAD' is ambiguous.
test-head-as-remote % git status
warning: refname 'HEAD' is ambiguous.
warning: refname 'HEAD' is ambiguous.
On branch main
Your branch is up to date with 'origin/main'.

nothing to commit, working tree clean
```

This is because `rev-parse` attempts to resolve branches *and* remotes, and is *not* case sensitive.

We've used `head` for a while, but only recently #5895 did we start to rely on HEAD being correct *after* a fetch. It's perfectly legal to have a remote called head, and it doesn't cause a problem until you run `git fetch head` or `git fetch --all`. At that point, you have a `HEAD` ref in the `head` remote. Subsequently, calls to `git rev-parse HEAD` (which are needed by the new logic to determine if you're on the right branch or not) are ambiguous.

The specific place where this is biting us now is determining the current ref uses combined output, so it includes this warning. We should probably fix that separately.

```
{"level":"debug","ts":"2025-12-06T01:30:11.046-0500","caller":"events/working_dir.go:315","msg":"Comparing PR ref \"3f070dafe3a0bce68da6941bfb01f2578cbb7074\" to local ref \"warning: refname 'HEAD' is ambiguous.\\n3f070dafe3a0bce68da6941bfb01f2578cbb7074\"","json":{"repo":"lukemassa/atlantis-test","pull":"38"}}
```

## tests

Before:
```
{"level":"info","ts":"2025-12-06T01:30:09.939-0500","caller":"events/working_dir.go:124","msg":"repo was already cloned but branch is not at correct commit, updating to \"3f070dafe3a0bce68da6941bfb01f2578cbb7074\"","json":
{"level":"error","ts":"2025-12-06T01:30:11.046-0500","caller":"events/instrumented_project_command_builder.go:78","msg":"Error building auto plan commands: post-merge verification failed: HEAD^2 != 3f070dafe3a0bce68da6941bfb01f2578cbb7074","json":{},"stacktrace":"github.com/runatlantis/atlantis/server/events.(*InstrumentedProjectCommandBuilder).buildAndEmitStats\n\t/Users/lmassa/atlantis/server/events/instrumented_project_command_builder.go:78\ngithub.com/runatlantis/atlantis/server/events.(*InstrumentedProjectCommandBuilder).BuildAutoplanCommands\n\t/Users/lmassa/atlantis/server/events/instrumented_project_command_builder.go:29\ngithub.com/runatlantis/atlantis/server/events.(*PlanCommandRunner).runAutoplan\n\t/Users/lmassa/atlantis/server/events/plan_command_runner.go:101\ngithub.com/runatlantis/atlantis/server/events.(*PlanCommandRunner).Run\n\t/Users/lmassa/atlantis/server/events/plan_command_runner.go:326\ngithub.com/runatlantis/atlantis/server/events.(*DefaultCommandRunner).RunAutoplanCommand\n\t/Users/lmassa/atlantis/server/events/command_runner.go:251"}
```


After:
```
{"level":"info","ts":"2025-12-06T01:24:46.513-0500","caller":"events/working_dir.go:126","msg":"repo was already cloned but branch is not at correct commit, updating to \"28d527cae51ea5d94c5df1cb6d6a0d6e6137ef0e\"","json":{"repo":"lukemassa/atlantis-test","pull":"37"}}
{"level":"info","ts":"2025-12-06T01:24:47.698-0500","caller":"events/project_command_builder.go:530","msg":"successfully parsed atlantis.yaml file","json":{"repo":"lukemassa/atlantis-test","pull":"37"}}
```

## references

Closes: #6009
