### PR TITLE
chore: Create ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -3,7 +3,7 @@ As the Atlantis Community grows, we'd like to keep track of our users and adopte
 
 ## Updating this list
 
-1. Open a PR to directly update this list, or edit this file directly in Github
+1. Open a PR to directly update this list, or edit this file directly in GitHub
 
 ## Atlantis Adopters
 


### PR DESCRIPTION
## what

Adds an ADOPTERS.md file to encourage community contributions.

## why

The CNCF requires a public document listing adopters as part of growth for Incubation. 

## references

https://github.com/cncf/toc/blob/main/.github/ISSUE_TEMPLATE/template-incubation-application.md#required-5

