### PR TITLE
feat: add error handling for unmatched branch in command execution

### DIFF
--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -713,8 +713,6 @@ func (c *DefaultCommandRunner) validateCtxAndComment(ctx *command.Context, comma
 		if err := c.VCSClient.CreateComment(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull.Num, errMsg, ""); err != nil {
 			ctx.Log.Err("unable to comment: %s", err)
 		}
-
-		// just ignore it to allow us to use any git workflows without malicious intentions.
 		return false
 	}
 	return true

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -707,7 +707,13 @@ func (c *DefaultCommandRunner) validateCtxAndComment(ctx *command.Context, comma
 
 	repo := c.GlobalCfg.MatchingRepo(ctx.Pull.BaseRepo.ID())
 	if !repo.BranchMatches(ctx.Pull.BaseBranch) {
-		ctx.Log.Info("command was run on a pull request which doesn't match base branches")
+		ctx.Log.Info("Destination branch %s is not compatible with allowed branches %v. Command will be aborted.", ctx.Pull.BaseBranch, repo.BranchRegex.String())
+
+		errMsg := fmt.Sprintf("Commands are not enabled for branch `%s`. Destination branch does not match the required pattern: `%s`", ctx.Pull.BaseBranch, repo.BranchRegex.String())
+		if err := c.VCSClient.CreateComment(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull.Num, errMsg, ""); err != nil {
+			ctx.Log.Err("unable to comment: %s", err)
+		}
+
 		// just ignore it to allow us to use any git workflows without malicious intentions.
 		return false
 	}

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -2041,6 +2041,26 @@ func TestRunCommentCommand_UnmatchedBranch(t *testing.T) {
 	vcsClient.VerifyWasCalled(Never()).CreateComment(Any[logging.SimpleLogging](), Any[models.Repo](), Any[int](), Any[string](), Any[string]())
 }
 
+func TestRunCommentCommand_UnmatchedBranch_CommentError(t *testing.T) {
+	t.Log("if a command is run on a pull request which doesn't match base branches, a comment with error message should be created")
+	vcsClient := setup(t)
+
+	ch.GlobalCfg.Repos = append(ch.GlobalCfg.Repos, valid.Repo{
+		IDRegex:     regexp.MustCompile(".*"),
+		BranchRegex: regexp.MustCompile("^main$"),
+	})
+	var pull github.PullRequest
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, BaseBranch: "develop"}
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(&pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(&pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+
+	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan})
+
+	expectedMsg := "Commands are not enabled for branch `develop`. Destination branch does not match the required pattern: `^main$`"
+	vcsClient.VerifyWasCalledOnce().CreateComment(
+		Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull.Num), Eq(expectedMsg), Eq(""))
+}
+
 func TestRunUnlockCommand_VCSComment(t *testing.T) {
 	testCases := []struct {
 		name    string

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -2025,23 +2025,6 @@ func TestRunCommentCommand_MatchedBranch(t *testing.T) {
 }
 
 func TestRunCommentCommand_UnmatchedBranch(t *testing.T) {
-	t.Log("if a command is run on a pull request which doesn't match base branches do not comment with error")
-	vcsClient := setup(t)
-
-	ch.GlobalCfg.Repos = append(ch.GlobalCfg.Repos, valid.Repo{
-		IDRegex:     regexp.MustCompile(".*"),
-		BranchRegex: regexp.MustCompile("^main$"),
-	})
-	var pull github.PullRequest
-	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, BaseBranch: "foo"}
-	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(&pull, nil)
-	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(&pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
-
-	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan})
-	vcsClient.VerifyWasCalled(Never()).CreateComment(Any[logging.SimpleLogging](), Any[models.Repo](), Any[int](), Any[string](), Any[string]())
-}
-
-func TestRunCommentCommand_UnmatchedBranch_CommentError(t *testing.T) {
 	t.Log("if a command is run on a pull request which doesn't match base branches, a comment with error message should be created")
 	vcsClient := setup(t)
 

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -1142,6 +1142,7 @@ func TestRunCommentCommand_IgnoredTargetedDirValidatesPullBeforeIgnoreCheck(t *t
 			setup: func() {
 				ch.GlobalCfg.Repos[0].BranchRegex = regexp.MustCompile("^main$")
 			},
+			wantComment: "Commands are not enabled for branch `release`. Destination branch does not match the required pattern: `^main$`",
 		},
 	}
 


### PR DESCRIPTION
## what

Displays a comment in the MR when the branch destination does not match the pattern defined in `repos.branch`, preventing Atlantis commands from executing.

Currently, Atlantis interrupts execution without providing clear feedback to the user about the reason for the failure.


## why

- Improve user experience by providing clear and immediate feedback
- Reduce confusion when a MR is blocked due to branch incompatibility
- Facilitate quick diagnosis of the problem without needing to consult server logs
- Increase understanding of branch restrictions configured in the repository

## tests

1. Set the repository's default branch to `main` or `master`.
2. Open a new MR targeting a branch other than `main` or `master`.
3. Atlantis starts execution but stops it after validating that the target branch does not match the default configured in `repos.branch`.

<details><summary>repos.yaml</summary>

```yaml
# https://www.runatlantis.io/docs/server-side-repo-config.html
repos:
  - id: /.*/
    workflow: terragrunt
    branch: /^main$/
    apply_requirements:
      - approved
      - mergeable

workflows:
  terragrunt:
    plan:
      steps:
        - env:
            name: TERRAGRUNT_TFPATH
            command: 'echo $(which terraform)'
        - env:
            name: TF_IN_AUTOMATION
            value: "true"
        - run:
            command: terragrunt plan -input=false $(printf '%s' $COMMENT_ARGS | sed 's/,/ /g' | tr -d '\\') -no-color -out $PLANFILE
            output: hide
        - run: |
            terragrunt show $PLANFILE
    apply:
      steps:
        - env:
            name: TERRAGRUNT_TFPATH
            command: 'echo $(which terraform)'
        - env:
            name: TF_IN_AUTOMATION
            value: "true"
        - run: terragrunt apply -input=false $PLANFILE
```
</details>


## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

