### PR TITLE
feat: add --parallelism flag for plan and apply

### DIFF
--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -1077,6 +1077,8 @@ ATLANTIS_PARALLEL_POOL_SIZE=100
 
 Max size of the wait group that runs parallel plans and applies (if enabled). Defaults to `15`
 
+This setting can be overridden on a per-command basis using the `--parallelism` flag in PR comments (e.g., `atlantis apply --parallelism 1`), but the per-command value cannot exceed this server maximum.
+
 ### `--pending-apply-status` <Badge text="v0.36.0+" type="info"/>
 
 ```bash

--- a/runatlantis.io/docs/using-atlantis.md
+++ b/runatlantis.io/docs/using-atlantis.md
@@ -77,6 +77,7 @@ atlantis plan -w staging
   * Ex. `atlantis plan -d child/dir`
 * `-p project` Which project to run plan for. Refers to the name of the project configured in the repo's [`atlantis.yaml` file](repo-level-atlantis-yaml.md). Cannot be used at same time as `-d` or `-w` because the project defines this already.
 * `-w workspace` Switch to this [Terraform workspace](https://developer.hashicorp.com/terraform/language/state/workspaces) before planning. Defaults to `default`. Ignore this if Terraform workspaces are unused.
+* `--parallelism number` Override the server's parallel pool size for this command. Use `1` to run projects sequentially. Value of `0` (default) uses the server's `--parallel-pool-size` setting. Cannot exceed the server's maximum.
 * `--verbose` Append Atlantis log to comment.
 
 ::: warning NOTE
@@ -180,6 +181,7 @@ atlantis apply -w staging
 * `-w workspace` Apply the plan for this [Terraform workspace](https://developer.hashicorp.com/terraform/language/state/workspaces). Ignore this if Terraform workspaces are unused.
 * `--auto-merge-disabled` Disable [automerge](automerging.md) for this apply command.
 * `--auto-merge-method method` Specify which [merge method](automerging.md#how-to-set-the-merge-method-for-automerge) use for the apply command if [automerge](automerging.md) is enabled. Implemented only for GitHub.
+* `--parallelism number` Override the server's parallel pool size for this command. Use `1` to run projects sequentially. Value of `0` (default) uses the server's `--parallel-pool-size` setting. Cannot exceed the server's maximum.
 * `--verbose` Append Atlantis log to comment.
 
 ### Additional Terraform flags

--- a/server/events/command/project_context.go
+++ b/server/events/command/project_context.go
@@ -47,6 +47,9 @@ type ProjectContext struct {
 	ParallelPlanEnabled bool
 	// ParallelPolicyCheckEnabled is true if parallel policy_check is enabled for this project.
 	ParallelPolicyCheckEnabled bool
+	// Parallelism is the max number of projects to run in parallel for this command.
+	// A value of 0 means use the server-configured default.
+	Parallelism int
 	// AutoplanEnabled is true if autoplanning is enabled for this project.
 	AutoplanEnabled bool
 	// BaseRepo is the repository that the pull request will be merged into.

--- a/server/events/event_parser.go
+++ b/server/events/event_parser.go
@@ -144,6 +144,9 @@ type CommentCommand struct {
 	PolicySet string
 	// ClearPolicyApproval is true if approvals should be cleared out for specified policies.
 	ClearPolicyApproval bool
+	// Parallelism is the max number of projects to run in parallel for this command.
+	// A value of 0 means use the default server parallelism.
+	Parallelism int
 }
 
 // IsForSpecificProject returns true if the command is for a specific dir, workspace
@@ -180,11 +183,11 @@ func (c CommentCommand) IsAutoplan() bool {
 
 // String returns a string representation of the command.
 func (c CommentCommand) String() string {
-	return fmt.Sprintf("command=%q, verbose=%t, dir=%q, workspace=%q, project=%q, policyset=%q, auto-merge-disabled=%t, auto-merge-method=%s, clear-policy-approval=%t, flags=%q", c.Name.String(), c.Verbose, c.RepoRelDir, c.Workspace, c.ProjectName, c.PolicySet, c.AutoMergeDisabled, c.AutoMergeMethod, c.ClearPolicyApproval, strings.Join(c.Flags, ","))
+	return fmt.Sprintf("command=%q, verbose=%t, dir=%q, workspace=%q, project=%q, policyset=%q, auto-merge-disabled=%t, auto-merge-method=%s, clear-policy-approval=%t, parallelism=%d, flags=%q", c.Name.String(), c.Verbose, c.RepoRelDir, c.Workspace, c.ProjectName, c.PolicySet, c.AutoMergeDisabled, c.AutoMergeMethod, c.ClearPolicyApproval, c.Parallelism, strings.Join(c.Flags, ","))
 }
 
 // NewCommentCommand constructs a CommentCommand, setting all missing fields to defaults.
-func NewCommentCommand(repoRelDir string, flags []string, name command.Name, subName string, verbose, autoMergeDisabled bool, autoMergeMethod string, workspace string, project string, policySet string, clearPolicyApproval bool) *CommentCommand {
+func NewCommentCommand(repoRelDir string, flags []string, name command.Name, subName string, verbose, autoMergeDisabled bool, autoMergeMethod string, workspace string, project string, policySet string, clearPolicyApproval bool, parallelism int) *CommentCommand {
 	// If repoRelDir was empty we want to keep it that way to indicate that it
 	// wasn't specified in the comment.
 	if repoRelDir != "" {
@@ -205,6 +208,7 @@ func NewCommentCommand(repoRelDir string, flags []string, name command.Name, sub
 		ProjectName:         project,
 		PolicySet:           policySet,
 		ClearPolicyApproval: clearPolicyApproval,
+		Parallelism:         parallelism,
 	}
 }
 

--- a/server/events/event_parser_test.go
+++ b/server/events/event_parser_test.go
@@ -752,14 +752,14 @@ func TestNewCommand_CleansDir(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.RepoRelDir, func(t *testing.T) {
-			cmd := events.NewCommentCommand(c.RepoRelDir, nil, command.Plan, "", false, false, "", "workspace", "", "", false)
+			cmd := events.NewCommentCommand(c.RepoRelDir, nil, command.Plan, "", false, false, "", "workspace", "", "", false, 0)
 			Equals(t, c.ExpDir, cmd.RepoRelDir)
 		})
 	}
 }
 
 func TestNewCommand_EmptyDirWorkspaceProject(t *testing.T) {
-	cmd := events.NewCommentCommand("", nil, command.Plan, "", false, false, "", "", "", "", false)
+	cmd := events.NewCommentCommand("", nil, command.Plan, "", false, false, "", "", "", "", false, 0)
 	Equals(t, events.CommentCommand{
 		RepoRelDir:  "",
 		Flags:       nil,
@@ -771,7 +771,7 @@ func TestNewCommand_EmptyDirWorkspaceProject(t *testing.T) {
 }
 
 func TestNewCommand_AllFieldsSet(t *testing.T) {
-	cmd := events.NewCommentCommand("dir", []string{"a", "b"}, command.Plan, "", true, false, "", "workspace", "project", "policyset", false)
+	cmd := events.NewCommentCommand("dir", []string{"a", "b"}, command.Plan, "", true, false, "", "workspace", "project", "policyset", false, 0)
 	Equals(t, events.CommentCommand{
 		Workspace:   "workspace",
 		RepoRelDir:  "dir",
@@ -818,7 +818,7 @@ func TestCommentCommand_IsAutoplan(t *testing.T) {
 }
 
 func TestCommentCommand_String(t *testing.T) {
-	exp := `command="plan", verbose=true, dir="mydir", workspace="myworkspace", project="myproject", policyset="", auto-merge-disabled=false, auto-merge-method=, clear-policy-approval=false, flags="flag1,flag2"`
+	exp := `command="plan", verbose=true, dir="mydir", workspace="myworkspace", project="myproject", policyset="", auto-merge-disabled=false, auto-merge-method=, clear-policy-approval=false, parallelism=0, flags="flag1,flag2"`
 	Equals(t, exp, (events.CommentCommand{
 		RepoRelDir:  "mydir",
 		Flags:       []string{"flag1", "flag2"},

--- a/server/events/project_command_builder_internal_test.go
+++ b/server/events/project_command_builder_internal_test.go
@@ -690,7 +690,7 @@ projects:
 						PullRequestStatus: models.PullReqStatus{
 							MergeableStatus: models.MergeableStatus{IsMergeable: true},
 						},
-					}, cmd, "", "", []string{"flag"}, tmp, "project1", "myworkspace", true)
+					}, cmd, "", "", []string{"flag"}, tmp, "project1", "myworkspace", true, 0)
 
 					if c.expErr != "" {
 						ErrEquals(t, c.expErr, err)
@@ -907,7 +907,7 @@ projects:
 						PullRequestStatus: models.PullReqStatus{
 							MergeableStatus: models.MergeableStatus{IsMergeable: true},
 						},
-					}, cmd, "", "myproject_[1-2]", []string{"flag"}, tmp, "project1", "myworkspace", true)
+					}, cmd, "", "myproject_[1-2]", []string{"flag"}, tmp, "project1", "myworkspace", true, 0)
 
 					if c.expErr != "" {
 						ErrEquals(t, c.expErr, err)
@@ -1153,7 +1153,7 @@ workflows:
 					PullRequestStatus: models.PullReqStatus{
 						MergeableStatus: models.MergeableStatus{IsMergeable: true},
 					},
-				}, command.Plan, "", "", []string{"flag"}, tmp, "project1", "myworkspace", true)
+				}, command.Plan, "", "", []string{"flag"}, tmp, "project1", "myworkspace", true, 0)
 
 				if c.expErr != "" {
 					ErrEquals(t, c.expErr, err)
@@ -1305,7 +1305,7 @@ projects:
 						PullRequestStatus: models.PullReqStatus{
 							MergeableStatus: models.MergeableStatus{IsMergeable: true},
 						},
-					}, cmd, "", "", []string{}, tmp, "project1", "myworkspace", true)
+					}, cmd, "", "", []string{}, tmp, "project1", "myworkspace", true, 0)
 					Equals(t, c.expLen, len(ctxs))
 					Ok(t, err)
 				})


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
Adds support for overriding the server's parallel pool size on a per-command basis. This is useful when a PR has race conditions between projects and needs to run sequentially, while other PRs can still use the server's default parallelism.

Changes:
- Added Parallelism field to CommentCommand and ProjectContext
- Updated command runners to use getEffectivePoolSize()
- Added flag parsing with validation (must be >= 0)
- Updated tests and documentation

Usage:
 ```  
atlantis plan --parallelism 1   # sequential execution
atlantis apply --parallelism 5  # limit to 5 parallel projects
atlantis plan                   # uses server default (15)
```
The server enforces a maximum cap - if a user specifies a value higher than the server's pool size, it gets capped with a warning logged.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

Fixes the problems described in #5627

## tests

<!--
- [ ] I have tested my changes by ...
-->

I have added unit tests for the newly added functions and behaviour

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

Closes #5627
