### PR TITLE
docs: Update API Endpoints params

### DIFF
--- a/runatlantis.io/docs/api-endpoints.md
+++ b/runatlantis.io/docs/api-endpoints.md
@@ -21,13 +21,18 @@ Execute [atlantis plan](using-atlantis.md#atlantis-plan) on the specified reposi
 
 #### Parameters
 
-| Name       | Type    | Required | Description                              |
-|------------|---------|----------|------------------------------------------|
-| Repository | string  | Yes      | Name of the Terraform repository         |
-| Ref        | string  | Yes      | Git reference, like a branch name        |
-| Type       | string  | Yes      | Type of the VCS provider (Github/Gitlab) |
-| Paths      | Path    | Yes      | Paths to the projects to run the plan    |
-| PR         | int     | No       | Pull Request number                      |
+| Name       | Type     | Required | Description                              |
+|------------|----------|----------|------------------------------------------|
+| Repository | string   | Yes      | Name of the Terraform repository         |
+| Ref        | string   | Yes      | Git reference, like a branch name        |
+| Type       | string   | Yes      | Type of the VCS provider (Github/Gitlab) |
+| Projects   | []string | No       | List of project names to run the plan    |
+| Paths      | []Path   | No       | Paths to the projects to run the plan    |
+| PR         | int      | No       | Pull Request number                      |
+
+::: tip NOTE
+At least one of `Projects` or `Paths` must be specified.
+:::
 
 #### Path
 
@@ -96,13 +101,18 @@ Execute [atlantis apply](using-atlantis.md#atlantis-apply) on the specified repo
 
 #### Parameters
 
-| Name       | Type   | Required | Description                              |
-|------------|--------|----------|------------------------------------------|
-| Repository | string | Yes      | Name of the Terraform repository         |
-| Ref        | string | Yes      | Git reference, like a branch name        |
-| Type       | string | Yes      | Type of the VCS provider (Github/Gitlab) |
-| Paths      | Path   | Yes      | Paths to the projects to run the apply   |
-| PR         | int    | No       | Pull Request number                      |
+| Name       | Type     | Required | Description                              |
+|------------|----------|----------|------------------------------------------|
+| Repository | string   | Yes      | Name of the Terraform repository         |
+| Ref        | string   | Yes      | Git reference, like a branch name        |
+| Type       | string   | Yes      | Type of the VCS provider (Github/Gitlab) |
+| Projects   | []string | No       | List of project names to run the apply   |
+| Paths      | []Path   | No       | Paths to the projects to run the apply   |
+| PR         | int      | No       | Pull Request number                      |
+
+::: tip NOTE
+At least one of `Projects` or `Paths` must be specified.
+:::
 
 #### Path
 


### PR DESCRIPTION
## what

This pull request updates the API documentation to clarify and improve the parameter definitions for the `/api/plan` and `/api/apply` endpoints. The main changes are the introduction of the `Projects` parameter, clarification of the `Paths` parameter, and a note about their usage requirements.

**API parameter improvements:**

* Added a `Projects` parameter (`[]string`) as an optional way to specify project names for both the `/api/plan` and `/api/apply` endpoints.
* Changed the `Paths` parameter to be optional and accept multiple values (`[]Path`) instead of a single required value.
* Added a documentation note stating that at least one of `Projects` or `Paths` must be specified for these endpoints.

## why

Docs were out-of-date

## tests

n/a

## references

- https://github.com/runatlantis/atlantis/blob/8fd24e7d52fa06eee58cbdccd9f713b245ff31b3/server/controllers/api_controller.go#L47-L57