### PR TITLE
fix: Improve error response from API Endpoints

### DIFF
--- a/server/events/command/project_result_test.go
+++ b/server/events/command/project_result_test.go
@@ -275,7 +275,7 @@ func TestPlanSuccess_Summary(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.expResult, func(t *testing.T) {
-			Equals(t, c.expResult, c.p.PlanSuccess.Summary())
+			Equals(t, c.expResult, c.p.ProjectCommandOutput.PlanSuccess.Summary())
 		})
 	}
 }

--- a/server/events/command/result.go
+++ b/server/events/command/result.go
@@ -3,6 +3,8 @@
 
 package command
 
+import "encoding/json"
+
 // Result is the result of running a Command.
 type Result struct {
 	Error          error
@@ -26,4 +28,21 @@ func (c Result) HasErrors() bool {
 		}
 	}
 	return false
+}
+
+// MarshalJSON implements custom JSON marshaling to properly serialize the Error field.
+func (c Result) MarshalJSON() ([]byte, error) {
+	type Alias Result
+	var errMsg *string
+	if c.Error != nil {
+		msg := c.Error.Error()
+		errMsg = &msg
+	}
+	return json.Marshal(&struct {
+		Error *string `json:"Error"`
+		*Alias
+	}{
+		Error: errMsg,
+		Alias: (*Alias)(&c),
+	})
 }

--- a/server/events/command/result_test.go
+++ b/server/events/command/result_test.go
@@ -4,6 +4,7 @@
 package command_test
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -122,6 +123,134 @@ func TestCommandResult_HasErrors(t *testing.T) {
 	for descrip, c := range cases {
 		t.Run(descrip, func(t *testing.T) {
 			Equals(t, c.exp, c.cr.HasErrors())
+		})
+	}
+}
+
+func TestCommandResult_MarshalJSON(t *testing.T) {
+	cases := map[string]struct {
+		cr          command.Result
+		expContains string
+	}{
+		"error is serialized": {
+			cr: command.Result{
+				Error: errors.New("test error message"),
+			},
+			expContains: `"Error":"test error message"`,
+		},
+		"nil error": {
+			cr: command.Result{
+				Error: nil,
+			},
+			expContains: `"Error":null`,
+		},
+		"project result with error": {
+			cr: command.Result{
+				ProjectResults: []command.ProjectResult{
+					{
+						ProjectCommandOutput: command.ProjectCommandOutput{
+							Error: errors.New("project error"),
+						},
+						RepoRelDir:  ".",
+						Workspace:   "default",
+						ProjectName: "myproject",
+						Command:     command.Plan,
+					},
+				},
+			},
+			expContains: `"Error":"project error"`,
+		},
+	}
+
+	for descrip, c := range cases {
+		t.Run(descrip, func(t *testing.T) {
+			jsonBytes, err := json.Marshal(c.cr)
+			Ok(t, err)
+			jsonStr := string(jsonBytes)
+			Assert(t, len(jsonStr) > 0, "JSON should not be empty")
+			Assert(t, jsonStr != "{}", "JSON should not be empty object")
+			// Check that the expected string is contained in the JSON
+			if c.expContains != "" {
+				Assert(t, len(jsonStr) > len(c.expContains), "JSON should contain expected string")
+				contains := false
+				for i := 0; i <= len(jsonStr)-len(c.expContains); i++ {
+					if jsonStr[i:i+len(c.expContains)] == c.expContains {
+						contains = true
+						break
+					}
+				}
+				Assert(t, contains, "JSON should contain: %s, got: %s", c.expContains, jsonStr)
+			}
+		})
+	}
+}
+
+func TestProjectResultMarshalJSON(t *testing.T) {
+	cases := map[string]struct {
+		pr          command.ProjectResult
+		expContains []string
+	}{
+		"all fields with error": {
+			pr: command.ProjectResult{
+				ProjectCommandOutput: command.ProjectCommandOutput{
+					Error:          errors.New("terraform error"),
+					Failure:        "",
+					ApplySuccess:   "",
+					VersionSuccess: "",
+				},
+				Command:     command.Plan,
+				SubCommand:  "",
+				RepoRelDir:  "terraform/infrastructure",
+				Workspace:   "default",
+				ProjectName: "myproject",
+			},
+			expContains: []string{
+				`"Error":"terraform error"`,
+				`"Command":1`,
+				`"RepoRelDir":"terraform/infrastructure"`,
+				`"Workspace":"default"`,
+				`"ProjectName":"myproject"`,
+			},
+		},
+		"nil error": {
+			pr: command.ProjectResult{
+				ProjectCommandOutput: command.ProjectCommandOutput{
+					Error: nil,
+				},
+				Command:     command.Apply,
+				RepoRelDir:  ".",
+				Workspace:   "staging",
+				ProjectName: "test-project",
+			},
+			expContains: []string{
+				`"Error":null`,
+				`"Command":0`,
+				`"RepoRelDir":"."`,
+				`"Workspace":"staging"`,
+				`"ProjectName":"test-project"`,
+			},
+		},
+	}
+
+	for descrip, c := range cases {
+		t.Run(descrip, func(t *testing.T) {
+			jsonBytes, err := json.Marshal(c.pr)
+			Ok(t, err)
+			jsonStr := string(jsonBytes)
+			Assert(t, len(jsonStr) > 0, "JSON should not be empty")
+			Assert(t, jsonStr != "{}", "JSON should not be empty object")
+			// Check that all expected strings are contained in the JSON
+			for _, expected := range c.expContains {
+				Assert(t, len(jsonStr) > len(expected), "JSON should contain expected string")
+				contains := false
+				for i := 0; i <= len(jsonStr)-len(expected); i++ {
+					if jsonStr[i:i+len(expected)] == expected {
+						contains = true
+						break
+					}
+				}
+				Assert(t, contains, "JSON should contain: %s, got: %s", expected, jsonStr)
+			}
 		})
 	}
 }

--- a/server/events/db_updater.go
+++ b/server/events/db_updater.go
@@ -19,7 +19,7 @@ func (c *DBUpdater) updateDB(ctx *command.Context, pull models.PullRequest, resu
 	// and so the pull request would always have errors.
 	var filtered []command.ProjectResult
 	for _, r := range results {
-		if _, ok := r.Error.(DirNotExistErr); ok {
+		if _, ok := r.ProjectCommandOutput.Error.(DirNotExistErr); ok {
 			ctx.Log.Debug("ignoring error result from project at dir %q workspace %q because it is dir not exist error", r.RepoRelDir, r.Workspace)
 			continue
 		}

--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -235,110 +235,110 @@ func (m *MarkdownRenderer) renderProjectResults(ctx *command.Context, results []
 			ProjectName:  result.ProjectName,
 			IsSuccessful: result.IsSuccessful(),
 		}
-		if result.PlanSuccess != nil {
-			result.PlanSuccess.TerraformOutput = strings.TrimSpace(result.PlanSuccess.TerraformOutput)
+		if result.ProjectCommandOutput.PlanSuccess != nil {
+			result.ProjectCommandOutput.PlanSuccess.TerraformOutput = strings.TrimSpace(result.ProjectCommandOutput.PlanSuccess.TerraformOutput)
 			data := planSuccessData{
-				PlanSuccess:              *result.PlanSuccess,
+				PlanSuccess:              *result.ProjectCommandOutput.PlanSuccess,
 				PlanWasDeleted:           common.PlansDeleted,
 				DisableApply:             common.DisableApply,
 				DisableRepoLocking:       common.DisableRepoLocking,
 				EnableDiffMarkdownFormat: common.EnableDiffMarkdownFormat,
-				PlanStats:                result.PlanSuccess.Stats(),
+				PlanStats:                result.ProjectCommandOutput.PlanSuccess.Stats(),
 			}
-			if m.shouldUseWrappedTmpl(vcsHost, result.PlanSuccess.TerraformOutput) {
-				data.PlanSummary = result.PlanSuccess.Summary()
+			if m.shouldUseWrappedTmpl(vcsHost, result.ProjectCommandOutput.PlanSuccess.TerraformOutput) {
+				data.PlanSummary = result.ProjectCommandOutput.PlanSuccess.Summary()
 				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("planSuccessWrapped"), data)
 			} else {
 				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("planSuccessUnwrapped"), data)
 			}
-			resultData.NoChanges = result.PlanSuccess.NoChanges()
-			if result.PlanSuccess.NoChanges() {
+			resultData.NoChanges = result.ProjectCommandOutput.PlanSuccess.NoChanges()
+			if result.ProjectCommandOutput.PlanSuccess.NoChanges() {
 				numPlansWithNoChanges++
 			} else {
 				numPlansWithChanges++
 			}
 			numPlanSuccesses++
-		} else if result.PolicyCheckResults != nil && common.Command == policyCheckCommandTitle {
+		} else if result.ProjectCommandOutput.PolicyCheckResults != nil && common.Command == policyCheckCommandTitle {
 			policyCheckResults := policyCheckResultsData{
-				PreConftestOutput:     result.PolicyCheckResults.PreConftestOutput,
-				PostConftestOutput:    result.PolicyCheckResults.PostConftestOutput,
-				PolicyCheckResults:    *result.PolicyCheckResults,
-				PolicyCheckSummary:    result.PolicyCheckResults.Summary(),
-				PolicyApprovalSummary: result.PolicyCheckResults.PolicySummary(),
-				PolicyCleared:         result.PolicyCheckResults.PolicyCleared(),
+				PreConftestOutput:     result.ProjectCommandOutput.PolicyCheckResults.PreConftestOutput,
+				PostConftestOutput:    result.ProjectCommandOutput.PolicyCheckResults.PostConftestOutput,
+				PolicyCheckResults:    *result.ProjectCommandOutput.PolicyCheckResults,
+				PolicyCheckSummary:    result.ProjectCommandOutput.PolicyCheckResults.Summary(),
+				PolicyApprovalSummary: result.ProjectCommandOutput.PolicyCheckResults.PolicySummary(),
+				PolicyCleared:         result.ProjectCommandOutput.PolicyCheckResults.PolicyCleared(),
 				commonData:            common,
 			}
-			if m.shouldUseWrappedTmpl(vcsHost, result.PolicyCheckResults.CombinedOutput()) {
+			if m.shouldUseWrappedTmpl(vcsHost, result.ProjectCommandOutput.PolicyCheckResults.CombinedOutput()) {
 				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("policyCheckResultsWrapped"), policyCheckResults)
 			} else {
 				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("policyCheckResultsUnwrapped"), policyCheckResults)
 			}
-			if result.Error == nil && result.Failure == "" {
+			if result.ProjectCommandOutput.Error == nil && result.ProjectCommandOutput.Failure == "" {
 				numPolicyCheckSuccesses++
 			}
-		} else if result.PolicyCheckResults != nil && common.Command == approvePoliciesCommandTitle {
+		} else if result.ProjectCommandOutput.PolicyCheckResults != nil && common.Command == approvePoliciesCommandTitle {
 			policyCheckResults := policyCheckResultsData{
-				PolicyCheckResults:    *result.PolicyCheckResults,
-				PolicyCheckSummary:    result.PolicyCheckResults.Summary(),
-				PolicyApprovalSummary: result.PolicyCheckResults.PolicySummary(),
-				PolicyCleared:         result.PolicyCheckResults.PolicyCleared(),
+				PolicyCheckResults:    *result.ProjectCommandOutput.PolicyCheckResults,
+				PolicyCheckSummary:    result.ProjectCommandOutput.PolicyCheckResults.Summary(),
+				PolicyApprovalSummary: result.ProjectCommandOutput.PolicyCheckResults.PolicySummary(),
+				PolicyCleared:         result.ProjectCommandOutput.PolicyCheckResults.PolicyCleared(),
 				commonData:            common,
 			}
-			if m.shouldUseWrappedTmpl(vcsHost, result.PolicyCheckResults.CombinedOutput()) {
+			if m.shouldUseWrappedTmpl(vcsHost, result.ProjectCommandOutput.PolicyCheckResults.CombinedOutput()) {
 				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("policyCheckResultsWrapped"), policyCheckResults)
 			} else {
 				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("policyCheckResultsUnwrapped"), policyCheckResults)
 			}
-			if result.Error == nil && result.Failure == "" {
+			if result.ProjectCommandOutput.Error == nil && result.ProjectCommandOutput.Failure == "" {
 				numPolicyApprovalSuccesses++
 			}
-		} else if result.ApplySuccess != "" {
-			output := strings.TrimSpace(result.ApplySuccess)
-			if m.shouldUseWrappedTmpl(vcsHost, result.ApplySuccess) {
+		} else if result.ProjectCommandOutput.ApplySuccess != "" {
+			output := strings.TrimSpace(result.ProjectCommandOutput.ApplySuccess)
+			if m.shouldUseWrappedTmpl(vcsHost, result.ProjectCommandOutput.ApplySuccess) {
 				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("applyWrappedSuccess"), struct{ Output string }{output})
 			} else {
 				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("applyUnwrappedSuccess"), struct{ Output string }{output})
 			}
 			numApplySuccesses++
-		} else if result.VersionSuccess != "" {
-			output := strings.TrimSpace(result.VersionSuccess)
+		} else if result.ProjectCommandOutput.VersionSuccess != "" {
+			output := strings.TrimSpace(result.ProjectCommandOutput.VersionSuccess)
 			if m.shouldUseWrappedTmpl(vcsHost, output) {
 				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("versionWrappedSuccess"), struct{ Output string }{output})
 			} else {
 				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("versionUnwrappedSuccess"), struct{ Output string }{output})
 			}
 			numVersionSuccesses++
-		} else if result.ImportSuccess != nil {
-			result.ImportSuccess.Output = strings.TrimSpace(result.ImportSuccess.Output)
-			if m.shouldUseWrappedTmpl(vcsHost, result.ImportSuccess.Output) {
-				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("importSuccessWrapped"), result.ImportSuccess)
+		} else if result.ProjectCommandOutput.ImportSuccess != nil {
+			result.ProjectCommandOutput.ImportSuccess.Output = strings.TrimSpace(result.ProjectCommandOutput.ImportSuccess.Output)
+			if m.shouldUseWrappedTmpl(vcsHost, result.ProjectCommandOutput.ImportSuccess.Output) {
+				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("importSuccessWrapped"), result.ProjectCommandOutput.ImportSuccess)
 			} else {
-				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("importSuccessUnwrapped"), result.ImportSuccess)
+				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("importSuccessUnwrapped"), result.ProjectCommandOutput.ImportSuccess)
 			}
-		} else if result.StateRmSuccess != nil {
-			result.StateRmSuccess.Output = strings.TrimSpace(result.StateRmSuccess.Output)
-			if m.shouldUseWrappedTmpl(vcsHost, result.StateRmSuccess.Output) {
-				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("stateRmSuccessWrapped"), result.StateRmSuccess)
+		} else if result.ProjectCommandOutput.StateRmSuccess != nil {
+			result.ProjectCommandOutput.StateRmSuccess.Output = strings.TrimSpace(result.ProjectCommandOutput.StateRmSuccess.Output)
+			if m.shouldUseWrappedTmpl(vcsHost, result.ProjectCommandOutput.StateRmSuccess.Output) {
+				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("stateRmSuccessWrapped"), result.ProjectCommandOutput.StateRmSuccess)
 			} else {
-				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("stateRmSuccessUnwrapped"), result.StateRmSuccess)
+				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("stateRmSuccessUnwrapped"), result.ProjectCommandOutput.StateRmSuccess)
 			}
 			// Error out if no template was found, only if there are no errors or failures.
 			// This is because some errors and failures rely on additional context rendered by templates, but not all errors or failures.
-		} else if result.Error == nil && result.Failure == "" {
+		} else if result.ProjectCommandOutput.Error == nil && result.ProjectCommandOutput.Failure == "" {
 			resultData.Rendered = "Found no template. This is a bug!"
 		}
 		// Render error or failure templates. Done outside of previous block so that other context can be rendered for use here.
-		if result.Error != nil {
+		if result.ProjectCommandOutput.Error != nil {
 			tmpl := templates.Lookup("unwrappedErr")
-			if m.shouldUseWrappedTmpl(vcsHost, result.Error.Error()) {
+			if m.shouldUseWrappedTmpl(vcsHost, result.ProjectCommandOutput.Error.Error()) {
 				tmpl = templates.Lookup("wrappedErr")
 			}
-			resultData.Rendered = m.renderTemplateTrimSpace(tmpl, errData{result.Error.Error(), resultData.Rendered, common})
+			resultData.Rendered = m.renderTemplateTrimSpace(tmpl, errData{result.ProjectCommandOutput.Error.Error(), resultData.Rendered, common})
 			if common.Command == applyCommandTitle {
 				numApplyErrors++
 			}
-		} else if result.Failure != "" {
-			resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("failure"), failureData{result.Failure, resultData.Rendered, common})
+		} else if result.ProjectCommandOutput.Failure != "" {
+			resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("failure"), failureData{result.ProjectCommandOutput.Failure, resultData.Rendered, common})
 			if common.Command == applyCommandTitle {
 				numApplyFailures++
 			}


### PR DESCRIPTION
Add MarshalJSON methods to Result and ProjectCommandOutput to properly serialize Go error types as strings in JSON responses. This fixes the issue where error fields were being returned as null instead of error messages in API endpoints.

## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

When you plan workflow has previous steps and one of them fails the error does not get "propagated" to the response, giving you responses like:

```json
{
      "Error": null,
      "Failure": "",
      "ProjectResults": [
          {
              "Error": {}, <--------
              "Failure": "",
              "PlanSuccess": null,
              "PolicyCheckResults": null,
              "ApplySuccess": "",
              "VersionSuccess": "",
              "ImportSuccess": null,
              "StateRmSuccess": null,
              "Command": 1,
              "SubCommand": "",
              "RepoRelDir": "terraform/myproject",
              "Workspace": "default",
              "ProjectName": "myproject",
              "SilencePRComments": null
          }
      ],
      "PlansDeleted": false
  }
```

And now:

```json
{
  "Error": null,
  "Failure": "",
  "ProjectResults": [
    {
      "Error": "cannot run \"plan\": the default workspace at path terraform/myproject is currently locked for this pull request by \"plan\".\nWait until the previous command is complete and try again", <---- or other kind of errors
      "Failure": "",
      "PlanSuccess": null,
      "PolicyCheckResults": null,
      "ApplySuccess": "",
      "VersionSuccess": "",
      "ImportSuccess": null,
      "StateRmSuccess": null,
      "Command": 1,
      "SubCommand": "",
      "RepoRelDir": "terraform/myproject",
      "Workspace": "default",
      "ProjectName": "myproject",
      "SilencePRComments": null
    }
  ],
  "PlansDeleted": false
}
```

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

We are exploring the use of Atlantis API to use drift check and report it, we use custom workflows so when init, terraform fmt or something else fails before the plan we don't see the error.

## tests

<!--
- [ ] I have tested my changes by ...
-->

I deployed this in our env and saw the expected results.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

[Slack Thread](https://cloud-native.slack.com/archives/C07T45G27EZ/p1768918161486109)


> This was solve using Claude Desktop