### PR TITLE
docs: Add alpha API notice to API endpoints documentation

### DIFF
--- a/runatlantis.io/docs/api-endpoints.md
+++ b/runatlantis.io/docs/api-endpoints.md
@@ -5,7 +5,7 @@ Aside from interacting via pull request comments, Atlantis could respond to a li
 :::warning ALPHA API - SUBJECT TO CHANGE
 The API endpoints documented on this page are currently in **alpha state** and are **not considered stable**. The request and response schemas may change at any time without prior notice or deprecation period.
 
-If you build integrations against these endpoints, be prepared to update your code when upgrading Atlantis versions.
+If you build integrations against these endpoints, when upgrading Atlantis you should review the release notes carefully and be prepared to update your code.
 :::
 
 ## Main Endpoints


### PR DESCRIPTION
## Summary

- Add a visible warning banner to the API endpoints documentation page
- Informs users that the API is in **alpha state** and **not considered stable**
- Sets expectations that schemas may change without prior notice

## Context

This change is related to ongoing discussions about API stability (see PR #6093). Adding this notice allows the API to evolve without breaking user expectations.

## Preview

The warning will render as a prominent notice at the top of the API endpoints page:

> ⚠️ **ALPHA API - SUBJECT TO CHANGE**
>
> The API endpoints documented on this page are in **alpha state** and are **not considered stable**. The request and response schemas may change at any time without prior notice or deprecation period.
>
> If you build integrations against these endpoints, be prepared to update your code when upgrading Atlantis versions.

## Test plan

- [ ] Verify the warning renders correctly on the docs site