### PR TITLE
fix: check for githubApp should only affect GitHub repos

### DIFF
--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -99,9 +99,10 @@ type FileWorkspace struct {
 	// TestingOverrideBaseCloneURL can be used during testing to override the
 	// URL of the base repo to be cloned. If it's empty then we clone normally.
 	TestingOverrideBaseCloneURL string
-	// GithubAppEnabled is true and a PR number is supplied, we should fetch
-	// the ref "pull/PR_NUMBER/head" from the "origin" remote. If this is false,
-	// we fetch "+refs/heads/$HEAD_BRANCH" from the "<prSourceRemote>" remote.
+	// GithubAppEnabled enables GitHub App-specific PR fetching for GitHub repos.
+	// When this is true for a GitHub PR with a pull number, merge checkouts fetch
+	// "pull/PR_NUMBER/head" from "origin". Other VCS hosts still fetch
+	// "+refs/heads/$HEAD_BRANCH" from the "<prSourceRemote>" remote.
 	GithubAppEnabled bool
 	// use the global setting without overriding
 	GpgNoSigningEnabled bool
@@ -280,7 +281,7 @@ func (w *FileWorkspace) recheckDiverged(logger logging.SimpleLogging, p models.P
 			"git", "remote", "set-url", "origin", p.BaseRepo.CloneURL,
 		},
 	}
-	if w.usesPRSourceRemote(p) {
+	if w.usesPRSourceRemote(headRepo, p) {
 		cmds = append(cmds,
 			[]string{"git", "remote", "set-url", prSourceRemote, headRepo.CloneURL},
 			[]string{"git", "remote", "update"},
@@ -561,7 +562,7 @@ func (w *FileWorkspace) updateToRef(logger logging.SimpleLogging, c wrappedGitCo
 	// head (mergeToBaseBranch fetches pull/<n>/head from origin), so only update
 	// origin and avoid fetching a possibly inaccessible fork.
 	fetchArgs := []string{"fetch", "--all"}
-	if !w.usesPRSourceRemote(c.pr) {
+	if !w.usesPRSourceRemote(c.head, c.pr) {
 		fetchArgs = []string{"fetch", "origin"}
 	}
 	if err := w.wrappedGit(logger, c, fetchArgs...); err != nil {
@@ -641,8 +642,8 @@ func (w *FileWorkspace) isBranchAtTargetRef(logger logging.SimpleLogging, c wrap
 // skip creating/updating it. Fetching the head repo otherwise only slows down
 // "git remote update"/"git fetch --all" and, when the App installation can't
 // read the fork, fails and makes recheckDiverged spuriously assume divergence.
-func (w *FileWorkspace) usesPRSourceRemote(p models.PullRequest) bool {
-	return !w.GithubAppEnabled || p.Num <= 0
+func (w *FileWorkspace) usesPRSourceRemote(head models.Repo, p models.PullRequest) bool {
+	return head.VCSHost.Type != models.Github || !w.GithubAppEnabled || p.Num <= 0
 }
 
 func (w *FileWorkspace) forceClone(logger logging.SimpleLogging, c wrappedGitContext) error {
@@ -685,7 +686,7 @@ func (w *FileWorkspace) forceClone(logger logging.SimpleLogging, c wrappedGitCon
 		}
 	}
 
-	if w.usesPRSourceRemote(c.pr) {
+	if w.usesPRSourceRemote(c.head, c.pr) {
 		if err := w.wrappedGit(logger, c, "remote", "add", prSourceRemote, headCloneURL); err != nil {
 			return err
 		}
@@ -745,7 +746,7 @@ func (w *FileWorkspace) wrappedGit(logger logging.SimpleLogging, c wrappedGitCon
 func (w *FileWorkspace) mergeToBaseBranch(logger logging.SimpleLogging, c wrappedGitContext) error {
 	fetchRef := fmt.Sprintf("+refs/heads/%s:", c.pr.HeadBranch)
 	fetchRemote := prSourceRemote
-	if w.GithubAppEnabled && c.pr.Num > 0 {
+	if c.head.VCSHost.Type == models.Github && w.GithubAppEnabled && c.pr.Num > 0 {
 		fetchRef = fmt.Sprintf("pull/%d/head:", c.pr.Num)
 		fetchRemote = "origin"
 	}

--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -227,6 +227,60 @@ func TestClone_CheckoutMergeGithubAppNoSourceRemote(t *testing.T) {
 	Assert(t, strings.Contains(remotes, "origin"), "expected \"origin\" remote, got remotes: %q", remotes)
 }
 
+func TestClone_CheckoutMergeGithubAppNonGithubUsesSourceRemote(t *testing.T) {
+	// Initialize the git repo.
+	repoDir := initRepo(t)
+
+	// Add a commit to branch 'branch' that's not on main.
+	runCmd(t, repoDir, "git", "checkout", "branch")
+	runCmd(t, repoDir, "touch", "branch-file")
+	runCmd(t, repoDir, "git", "add", "branch-file")
+	runCmd(t, repoDir, "git", "commit", "-m", "branch-commit")
+	branchCommit := runCmd(t, repoDir, "git", "rev-parse", "HEAD")
+
+	// Now switch back to main and advance the main branch by another commit.
+	runCmd(t, repoDir, "git", "checkout", "main")
+	runCmd(t, repoDir, "touch", "main-file")
+	runCmd(t, repoDir, "git", "add", "main-file")
+	runCmd(t, repoDir, "git", "commit", "-m", "main-commit")
+	mainCommit := runCmd(t, repoDir, "git", "rev-parse", "HEAD")
+
+	logger := logging.NewNoopLogger(t)
+	dataDir := t.TempDir()
+
+	overrideURL := fmt.Sprintf("file://%s", repoDir)
+	wd := &events.FileWorkspace{
+		DataDir:                     dataDir,
+		CheckoutMerge:               true,
+		CheckoutDepth:               50,
+		TestingOverrideHeadCloneURL: overrideURL,
+		TestingOverrideBaseCloneURL: overrideURL,
+		GpgNoSigningEnabled:         true,
+		GithubAppEnabled:            true,
+	}
+
+	cloneDir, err := wd.Clone(logger, models.Repo{
+		VCSHost: models.VCSHost{Type: models.Gitlab},
+	}, models.PullRequest{
+		BaseRepo:   models.Repo{},
+		HeadBranch: "branch",
+		BaseBranch: "main",
+		Num:        1,
+	}, "default")
+	Ok(t, err)
+
+	// Non-GitHub repos do not have GitHub's pull/<n>/head ref, so the merge must
+	// still fetch the head branch from the source remote.
+	actBaseCommit := runCmd(t, cloneDir, "git", "rev-parse", "HEAD~1")
+	actHeadCommit := runCmd(t, cloneDir, "git", "rev-parse", "HEAD^2")
+	Equals(t, mainCommit, actBaseCommit)
+	Equals(t, branchCommit, actHeadCommit)
+
+	remotes := runCmd(t, cloneDir, "git", "remote")
+	Assert(t, strings.Contains(remotes, "source"), "expected \"source\" remote for non-GitHub repo, got remotes: %q", remotes)
+	Assert(t, strings.Contains(remotes, "origin"), "expected \"origin\" remote, got remotes: %q", remotes)
+}
+
 // Test that if we're using the merge method and the repo is already cloned at
 // the right commit, then we don't reclone.
 func TestClone_CheckoutMergeNoReclone(t *testing.T) {


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

Special fetchRef logic for Github App would only be applied if current repository is a Github repository 

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

When running with Github App and Gitlab enabled at the same time, Atlantis would fail planning MRs to Gitlab with error: `fatal:  couldn't find remote ref pull/2295/head`. I identified that Atlantis was trying to follow Github refs for pull-requests, instead of merge-requests for Gitlab. With Github App disabled the error would disappear.

This solution only enables special Github App logic if current repo is a Github repo. Previous check was server wide, but this one is focusing specifically on the current repository.

_I am not sure of the approach, maybe I should focus on making sure githubAppEnabled is always false when in GitLab repo_ 🤔 

## tests

<!--
- [ ] I have tested my changes by ...
-->
- [x] I have tested my changes by building locally ( make build )
- [x] I have tested my changes by running `make test`
- [x] I have tested my changes on my sandbox and production atlantis clusters and I am happily running with both Gitlab and Github App active

Unfortunately couldn't run tests in docker, seems like last version of test container needs a go update:
```
make docker/test
docker run -it -v /REDACTED/atlantis:/atlantis ghcr.io/runatlantis/testing-env:latest sh -c "cd /atlantis && make test"
go: go.mod requires go >= 1.25.4 (running go 1.25.3; GOTOOLCHAIN=local)
go: go.mod requires go >= 1.25.4 (running go 1.25.3; GOTOOLCHAIN=local)
go: go.mod requires go >= 1.25.4 (running go 1.25.3; GOTOOLCHAIN=local)
make: *** [Makefile:55: test] Error 1
make: *** [docker/test] Error 2
```

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
Introduced in https://github.com/runatlantis/atlantis/pull/2044


