### PR TITLE
chore: Remove known issues from copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,10 +13,8 @@
 **Build:** `make build-service` → creates `./atlantis` binary (~51MB, 30-60s first run, 10s subsequent). Clean: `make clean`
 
 **Test:** `make test` (unit, ~60s) • `make test-all` (includes integration, ~5min) • `make docker/test-all` (CI environment)
-⚠️ **Known failing test:** `TestNewServer_GitHubUser` in server/server_test.go - pre-existing, ignore it
 
 **Lint/Format:** `make check-fmt` (ALWAYS works) • `make fmt` (auto-format)
-⚠️ **Known issue:** `make lint` and `make check-lint` fail with Go 1.25+ version mismatch. Use `make check-fmt` locally, CI handles linting.
 
 **Mocks:** `make go-generate` (regenerate after interface changes) • `make regen-mocks` (delete & regenerate all)
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ IMAGE_NAME := runatlantis/atlantis
 .DEFAULT_GOAL := help
 
 # renovate: datasource=github-releases depName=golangci/golangci-lint
-GOLANGCI_LINT_VERSION := v1.64.4
+GOLANGCI_LINT_VERSION := v2.7.2
 
 .PHONY: help
 help: ## List targets & descriptions


### PR DESCRIPTION
## what

Remove known issues from copilot instructions

## why

- `make test-all` and `make lint` work fine for me locally (see below). If anyone does have a problem w these commands, we should figure out why, not tell LLMs to ignore it.
- `make check-lint` was in fact broken; the fix was to update the version of golangci-lint to match the one used in CI

## tests

```
atlantis % go test server/server_test.go -run TestNewServer_GitHubUser
ok  	command-line-arguments	0.802s
atlantis % make test-all
?   	github.com/runatlantis/atlantis	[no test files]
ok  	github.com/runatlantis/atlantis/cmd	0.421s
ok  	github.com/runatlantis/atlantis/server	1.495s
ok  	github.com/runatlantis/atlantis/server/controllers	0.547s
ok  	github.com/runatlantis/atlantis/server/controllers/events	217.920s
ok  	github.com/runatlantis/atlantis/server/controllers/web_templates	1.850s
ok  	github.com/runatlantis/atlantis/server/controllers/websocket	1.535s
ok  	github.com/runatlantis/atlantis/server/core/boltdb	2.084s
ok  	github.com/runatlantis/atlantis/server/core/config	0.733s
ok  	github.com/runatlantis/atlantis/server/core/config/raw	0.565s
ok  	github.com/runatlantis/atlantis/server/core/config/valid	1.761s
?   	github.com/runatlantis/atlantis/server/core/db	[no test files]
ok  	github.com/runatlantis/atlantis/server/core/locking	1.595s
ok  	github.com/runatlantis/atlantis/server/core/redis	1.524s
ok  	github.com/runatlantis/atlantis/server/core/runtime	2.072s
ok  	github.com/runatlantis/atlantis/server/core/runtime/cache	1.652s
ok  	github.com/runatlantis/atlantis/server/core/runtime/common	1.200s
ok  	github.com/runatlantis/atlantis/server/core/runtime/models	1.109s
ok  	github.com/runatlantis/atlantis/server/core/runtime/policy	1.029s
ok  	github.com/runatlantis/atlantis/server/core/terraform	15.543s
ok  	github.com/runatlantis/atlantis/server/core/terraform/ansi	1.081s
ok  	github.com/runatlantis/atlantis/server/core/terraform/tfclient	13.770s
ok  	github.com/runatlantis/atlantis/server/events	11.019s
ok  	github.com/runatlantis/atlantis/server/events/command	1.249s
ok  	github.com/runatlantis/atlantis/server/events/models	1.221s
ok  	github.com/runatlantis/atlantis/server/events/vcs	1.343s [no tests to run]
ok  	github.com/runatlantis/atlantis/server/events/vcs/azuredevops	1.483s
ok  	github.com/runatlantis/atlantis/server/events/vcs/bitbucketcloud	1.526s
ok  	github.com/runatlantis/atlantis/server/events/vcs/bitbucketserver	1.402s
ok  	github.com/runatlantis/atlantis/server/events/vcs/common	1.660s
?   	github.com/runatlantis/atlantis/server/events/vcs/gitea	[no test files]
ok  	github.com/runatlantis/atlantis/server/events/vcs/github	11.127s
ok  	github.com/runatlantis/atlantis/server/events/vcs/gitlab	22.901s
ok  	github.com/runatlantis/atlantis/server/events/webhooks	1.461s
ok  	github.com/runatlantis/atlantis/server/jobs	1.555s
ok  	github.com/runatlantis/atlantis/server/logging	1.653s
ok  	github.com/runatlantis/atlantis/server/metrics	0.877s
?   	github.com/runatlantis/atlantis/server/metrics/metricstest	[no test files]
ok  	github.com/runatlantis/atlantis/server/recovery	0.847s
ok  	github.com/runatlantis/atlantis/server/scheduled	1.792s
ok  	github.com/runatlantis/atlantis/server/utils	0.682s
?   	github.com/runatlantis/atlantis/testdrive	[no test files]
atlantis % make lint
golangci-lint run
0 issues.
atlantis % make check-lint
curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin v2.7.2
golangci/golangci-lint info checking GitHub for tag 'v2.7.2'
golangci/golangci-lint info found version: 2.7.2 for v2.7.2/darwin/arm64
golangci/golangci-lint info installed ./bin/golangci-lint
./bin/golangci-lint run -j 4 --timeout 5m
0 issues.
```

## references

Cleans up file added by #6124
