### PR TITLE
feat: use hcl syntax highlighting for error output (#6149)

### DIFF
--- a/server/events/templates/wrapped_err.tmpl
+++ b/server/events/templates/wrapped_err.tmpl
@@ -2,7 +2,7 @@
 **{{ .Command }} Error**
 <details><summary>Show Output</summary>
 
-```
+```hcl
 {{ .Error }}
 ```
 {{- if ne .RenderedContext "" }}


### PR DESCRIPTION
## what

- Update `wrapped_err.tmpl` to use `hcl` syntax highlighting for error blocks instead of plain text.

## why

- Current error output renders as plain text (monochrome) on GitHub/GitLab.
- Terraform errors contain HCL structures; using `hcl` significantly improves readability (DX) by coloring keys, strings, and attributes.

## tests

- [x] I have tested my changes by verifying the rendered markdown output on both GitHub and GitLab.

## references

- Closes #6149