### PR TITLE
docs: fix naming of directory in example

### DIFF
--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -180,7 +180,7 @@ Examples:
 - Autoplan when any `*.tf` file is modified except in `project2/` directory
   - `--autoplan-file-list='**/*.tf,!project2'`
 - Autoplan when any `*.tf` files or `.yml` files in subfolder of `project1` is modified.
-  - `--autoplan-file-list='**/*.tf,project2/**/*.yml'`
+  - `--autoplan-file-list='**/*.tf,project1/**/*.yml'`
 
 ::: warning NOTE
 By default, changes to modules will not trigger autoplanning. See the flags below.


### PR DESCRIPTION
## what
fixed an inconsistency in the server configuration markdown file so the name of the directory in an example matches up

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->


## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

the  example had the wrong directory name

## tests

<!--
- [ x] I have tested my changes by ...
-->
previewing the markdown

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

