### PR TITLE
fix: Prevent errors when writing to broken websockets

### DIFF
--- a/server/controllers/websocket/writer.go
+++ b/server/controllers/websocket/writer.go
@@ -2,6 +2,7 @@ package websocket
 
 import (
 	"net/http"
+	"sync"
 
 	"github.com/gorilla/websocket"
 	"github.com/pkg/errors"
@@ -26,22 +27,45 @@ type Writer struct {
 
 func (w *Writer) Write(rw http.ResponseWriter, r *http.Request, input chan string) error {
 	conn, err := w.upgrader.Upgrade(rw, r, nil)
-
 	if err != nil {
 		return errors.Wrap(err, "upgrading websocket connection")
 	}
 
+	var connMu sync.Mutex
+	done := make(chan struct{})
+
+	// read from the socket to detect a disconnection
+	go func() {
+		defer close(done)
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+
 	// block on reading our input channel
-	for msg := range input {
-		if err := conn.WriteMessage(websocket.BinaryMessage, []byte("\r"+msg+"\n")); err != nil {
-			w.log.Warn("Failed to write ws message: %s", err)
-			return err
+	for {
+		select {
+		case msg, ok := <-input:
+			if !ok {
+				// input channel is closed, close the connection
+				if err := conn.Close(); err != nil {
+					w.log.Warn("Failed to close ws connection: %s", err)
+				}
+				return nil
+			}
+
+			connMu.Lock()
+			err := conn.WriteMessage(websocket.BinaryMessage, []byte("\r"+msg+"\n"))
+			connMu.Unlock()
+			if err != nil {
+				w.log.Warn("Failed to write ws message: %s", err)
+				return err
+			}
+		case <-done:
+			// client disconnected
+			return nil
 		}
 	}
-
-	// close ws conn after input channel is closed
-	if err = conn.Close(); err != nil {
-		w.log.Warn("Failed to close ws connection: %s", err)
-	}
-	return nil
 }

--- a/server/controllers/websocket/writer_test.go
+++ b/server/controllers/websocket/writer_test.go
@@ -1,0 +1,46 @@
+// Copyright 2025 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package websocket
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWriter_Write(t *testing.T) {
+	log := logging.NewNoopLogger(t)
+
+	t.Run("client disconnects", func(t *testing.T) {
+		writer := NewWriter(log, true)
+		input := make(chan string, 1)
+
+		// Test server that uses the writer
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			err := writer.Write(w, r, input)
+			assert.NoError(t, err, "writer.Write should not return an error on client disconnect")
+		}))
+		defer server.Close()
+
+		// Client connects to the server
+		wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+		ws, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+		assert.NoError(t, err, "failed to connect to websocket")
+
+		// Simulate client disconnect
+		ws.Close()
+
+		// Try to send a message, this should not block or panic
+		input <- "test"
+
+		// Give it some time to process
+		time.Sleep(100 * time.Millisecond)
+	})
+}


### PR DESCRIPTION

## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

This commit attempts to resolve the errors identified in #6180, by
adding a `sync.Mutex` around the websocket channels.

**Disclaimer:** This code was written by Gemini based on the exceptions
in #6180, and reviewed by myself.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

Resolves the errors logged when using UI :)

## tests

* Unit tests added

## references

Fixes #6180
