### PR TITLE
fix: prevent checkout-depth bypass in recheckDiverged and updateToRef

### DIFF
--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -216,7 +216,7 @@ func (w *FileWorkspace) recheckDiverged(logger logging.SimpleLogging, p models.P
 			"git", "remote", "set-url", prSourceRemote, headRepo.CloneURL,
 		},
 		{
-			"git", "remote", "update",
+			"git", "fetch", "origin",
 		},
 	}
 
@@ -275,8 +275,8 @@ func (w *FileWorkspace) remoteHasBranch(logger logging.SimpleLogging, c wrappedG
 
 func (w *FileWorkspace) updateToRef(logger logging.SimpleLogging, c wrappedGitContext, targetRef string) error {
 
-	// We use both `<prSourceRemote>` and `origin` remotes, update them both
-	if err := w.wrappedGit(logger, c, "fetch", "--all"); err != nil {
+	// Fetch origin only; the source remote is handled by mergeToBaseBranch with proper depth
+	if err := w.wrappedGit(logger, c, "fetch", "origin"); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## what

- Fix `--checkout-depth` being bypassed by `recheckDiverged` and `updateToRef` in `working_dir.go`
- Replace `git remote update` with `git fetch origin` in `recheckDiverged` - avoids fetching all branches from all remotes (origin + source)
- Replace `git fetch --all` with `git fetch origin` in `updateToRef` - same issue
- The `source` remote is already fetched by `mergeToBaseBranch` with proper `--depth` handling

## why

When using `--checkout-strategy=merge --checkout-depth=N`, the initial clone correctly uses shallow cloning. However, `recheckDiverged` runs `git remote update` which fetches all branches from all remotes, and `updateToRef` runs `git fetch --all` which does the same.
IMO, only `origin` (cloned with `--single-branch`) needs to be fetched in these two places. The `source` remote fetch with depth is already handled downstream by `mergeToBaseBranch`.

Neither change should affect the branch checkout strategy: `recheckDiverged` returns when `CheckoutMerge` is off, and for branch strategy `origin` is the only remote so `fetch origin` == `fetch --all`

## tests

- [x] Added `TestMergeAgain_PreservesShallowDepth` - creates a repo with history, performs a shallow clone with `CheckoutDepth: 2`, advances main to trigger divergence, calls `MergeAgain` and checks if the repo remains shallow afterwards

## references

- [git remote update](https://git-scm.com/docs/git-remote) + https://stackoverflow.com/a/78908960
- `mergeToBaseBranch` in `working_dir.go` already calls `git fetch --depth N source +refs/heads/$branch`
