### PR TITLE
feat: add --skip-working-dir-deletion-on-unlock flag

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -143,6 +143,7 @@ const (
 	SilenceVCSStatusNoProjectsFlag   = "silence-vcs-status-no-projects"
 	SilenceAllowlistErrorsFlag       = "silence-allowlist-errors"
 	SkipCloneNoChanges               = "skip-clone-no-changes"
+	SkipWorkingDirDeletionOnUnlock   = "skip-working-dir-deletion-on-unlock"
 	SlackTokenFlag                   = "slack-token"
 	SSLCertFileFlag                  = "ssl-cert-file"
 	SSLKeyFileFlag                   = "ssl-key-file"
@@ -624,6 +625,12 @@ var boolFlags = map[string]boolFlag{
 	},
 	SkipCloneNoChanges: {
 		description:  "Skips cloning the PR repo if there are no projects were changed in the PR.",
+		defaultValue: false,
+	},
+	SkipWorkingDirDeletionOnUnlock: {
+		description: "Skip deleting the working directory when running `atlantis unlock`. " +
+			"By default, unlocking a project will delete its working directory in addition to removing the lock. " +
+			"Set this to true to preserve working directories on unlock, only deleting plan files.",
 		defaultValue: false,
 	},
 	TFDownloadFlag: {

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -141,6 +141,7 @@ var testFlags = map[string]any{
 	SilenceAllowlistErrorsFlag:       true,
 	SilenceVCSStatusNoPlans:          true,
 	SkipCloneNoChanges:               true,
+	SkipWorkingDirDeletionOnUnlock:   true,
 	SlackTokenFlag:                   "slack-token",
 	SSLCertFileFlag:                  "cert-file",
 	SSLKeyFileFlag:                   "key-file",

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -1364,6 +1364,16 @@ ATLANTIS_SKIP_CLONE_NO_CHANGES=true
 
 `--skip-clone-no-changes` will skip cloning the repo during autoplan if there are no changes to Terraform projects. This will only apply for GitHub and GitLab and only for repos that have `atlantis.yaml` file. Defaults to `false`.
 
+### `--skip-working-dir-deletion-on-unlock`
+
+```bash
+atlantis server --skip-working-dir-deletion-on-unlock
+# or
+ATLANTIS_SKIP_WORKING_DIR_DELETION_ON_UNLOCK=true
+```
+
+When set, `atlantis unlock` will only delete plan files and preserve the cloned working directory. By default (`false`), unlocking a project deletes the full workspace directory to prevent lock and filesystem state from diverging. Set to `true` if you want to preserve working directories on unlock for faster re-planning. Defaults to `false`.
+
 ### `--slack-token` <Badge text="v0.43.0+" type="info"/>
 
 ```bash

--- a/server/server.go
+++ b/server/server.go
@@ -567,10 +567,11 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		VCSClient:  vcsClient,
 	}
 	deleteLockCommand := &events.DefaultDeleteLockCommand{
-		Locker:           lockingClient,
-		WorkingDir:       workingDir,
-		WorkingDirLocker: workingDirLocker,
-		Database:         database,
+		Locker:                         lockingClient,
+		WorkingDir:                     workingDir,
+		WorkingDirLocker:               workingDirLocker,
+		Database:                       database,
+		SkipWorkingDirDeletionOnUnlock: userConfig.SkipWorkingDirDeletionOnUnlock,
 	}
 
 	pullClosedExecutor := events.NewInstrumentedPullClosedExecutor(

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -112,31 +112,32 @@ type UserConfig struct {
 	SilenceVCSStatusNoPlans bool `mapstructure:"silence-vcs-status-no-plans"`
 	// SilenceVCSStatusNoProjects is whether autoplan should set commit status if no projects
 	// are found.
-	SilenceVCSStatusNoProjects bool            `mapstructure:"silence-vcs-status-no-projects"`
-	SilenceAllowlistErrors     bool            `mapstructure:"silence-allowlist-errors"`
-	SkipCloneNoChanges         bool            `mapstructure:"skip-clone-no-changes"`
-	SlackToken                 string          `mapstructure:"slack-token"`
-	SSLCertFile                string          `mapstructure:"ssl-cert-file"`
-	SSLKeyFile                 string          `mapstructure:"ssl-key-file"`
-	RestrictFileList           bool            `mapstructure:"restrict-file-list"`
-	TFDistribution             string          `mapstructure:"tf-distribution"` // deprecated in favor of DefaultTFDistribution
-	TFDownload                 bool            `mapstructure:"tf-download"`
-	TFDownloadURL              string          `mapstructure:"tf-download-url"`
-	TFEHostname                string          `mapstructure:"tfe-hostname"`
-	TFELocalExecutionMode      bool            `mapstructure:"tfe-local-execution-mode"`
-	TFEToken                   string          `mapstructure:"tfe-token"`
-	VarFileAllowlist           string          `mapstructure:"var-file-allowlist"`
-	VCSStatusName              string          `mapstructure:"vcs-status-name"`
-	DefaultTFDistribution      string          `mapstructure:"default-tf-distribution"`
-	DefaultTFVersion           string          `mapstructure:"default-tf-version"`
-	Webhooks                   []WebhookConfig `mapstructure:"webhooks" flag:"false"`
-	WebhookHttpHeaders         string          `mapstructure:"webhook-http-headers"`
-	WebBasicAuth               bool            `mapstructure:"web-basic-auth"`
-	WebUsername                string          `mapstructure:"web-username"`
-	WebPassword                string          `mapstructure:"web-password"`
-	WriteGitCreds              bool            `mapstructure:"write-git-creds"`
-	WebsocketCheckOrigin       bool            `mapstructure:"websocket-check-origin"`
-	UseTFPluginCache           bool            `mapstructure:"use-tf-plugin-cache"`
+	SilenceVCSStatusNoProjects     bool            `mapstructure:"silence-vcs-status-no-projects"`
+	SilenceAllowlistErrors         bool            `mapstructure:"silence-allowlist-errors"`
+	SkipCloneNoChanges             bool            `mapstructure:"skip-clone-no-changes"`
+	SkipWorkingDirDeletionOnUnlock bool            `mapstructure:"skip-working-dir-deletion-on-unlock"`
+	SlackToken                     string          `mapstructure:"slack-token"`
+	SSLCertFile                    string          `mapstructure:"ssl-cert-file"`
+	SSLKeyFile                     string          `mapstructure:"ssl-key-file"`
+	RestrictFileList               bool            `mapstructure:"restrict-file-list"`
+	TFDistribution                 string          `mapstructure:"tf-distribution"` // deprecated in favor of DefaultTFDistribution
+	TFDownload                     bool            `mapstructure:"tf-download"`
+	TFDownloadURL                  string          `mapstructure:"tf-download-url"`
+	TFEHostname                    string          `mapstructure:"tfe-hostname"`
+	TFELocalExecutionMode          bool            `mapstructure:"tfe-local-execution-mode"`
+	TFEToken                       string          `mapstructure:"tfe-token"`
+	VarFileAllowlist               string          `mapstructure:"var-file-allowlist"`
+	VCSStatusName                  string          `mapstructure:"vcs-status-name"`
+	DefaultTFDistribution          string          `mapstructure:"default-tf-distribution"`
+	DefaultTFVersion               string          `mapstructure:"default-tf-version"`
+	Webhooks                       []WebhookConfig `mapstructure:"webhooks" flag:"false"`
+	WebhookHttpHeaders             string          `mapstructure:"webhook-http-headers"`
+	WebBasicAuth                   bool            `mapstructure:"web-basic-auth"`
+	WebUsername                    string          `mapstructure:"web-username"`
+	WebPassword                    string          `mapstructure:"web-password"`
+	WriteGitCreds                  bool            `mapstructure:"write-git-creds"`
+	WebsocketCheckOrigin           bool            `mapstructure:"websocket-check-origin"`
+	UseTFPluginCache               bool            `mapstructure:"use-tf-plugin-cache"`
 }
 
 // ToAllowCommandNames parse AllowCommands into a slice of CommandName


### PR DESCRIPTION
## what

- Restore the original behavior of deleting working directories on `atlantis unlock`
- Add `--skip-working-dir-deletion-on-unlock` server flag to opt in to the post-#3751 behavior of only deleting plan files

## why

- #3751 changed `atlantis unlock` to only delete plan files, but this creates a failure mode where BoltDB lock state and filesystem state can diverge
- If a working directory is deleted or corrupted externally, `atlantis unlock` no longer provides a reliable way to fully reset project state
- The new default restores the original behavior; users who want to preserve working directories for faster re-planning can set `--skip-working-dir-deletion-on-unlock`

## tests

- [x] Updated existing `DeleteLock` and `DeleteLocksByPull` tests to verify `DeleteForWorkspace` is called by default
- [x] Added tests for `SkipWorkingDirDeletionOnUnlock=true` verifying only `DeletePlan` is called
- [x] `TestUserConfigAllTested` passes
- [x] `TestAllFlagsDocumented` passes

## references

- Closes #6256
- #3750 — Original issue requesting the behavior change
- #3751 — PR that changed unlock to only delete plan files