### PR TITLE
fix(runatlantis.io): Fix header margin causing gap.

### DIFF
--- a/runatlantis.io/.vitepress/components/Banner.vue
+++ b/runatlantis.io/.vitepress/components/Banner.vue
@@ -39,25 +39,6 @@ const dismiss = () => {
   </div> -->
 </template>
 
-<style>
-.banner-dismissed {
-  --vp-layout-top-height: 0px !important;
-}
-html {
-  --vp-layout-top-height: 88px;
-}
-@media (min-width: 375px) {
-  html {
-    --vp-layout-top-height: 64px;
-  }
-}
-@media (min-width: 768px) {
-  html {
-    --vp-layout-top-height: 40px;
-  }
-}
-</style>
-
 <style scoped>
 .banner-dismissed .banner {
   display: none;


### PR DESCRIPTION
:

## what
Fixed a margin issue caused by the CSS variable --vp-layout-top-height.
Ensures consistent spacing across all devices.

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

## why
Variable was being set because of commented out dismiss banner dismiss functionality
```ts
<template>
  <!-- <div ref="el" class="banner">
    <div class="text">
    </div>

    <button type="button" @click="dismiss">
      <svg
        xmlns="http://www.w3.org/2000/svg"
        viewBox="0 0 20 20"
        fill="currentColor"
      >
        <path
          d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z"
        />
      </svg>
    </button>
  </div> -->
</template>

<style scoped>

```
Extra gap reduced readability on mobile and small screens.
Adjusting the variable improves overall layout and user experience.
<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## tests
Verified in development mode; no other core layout changes occurred.
Checked responsiveness on multiple screen widths to confirm readability.
<!--
- [ ] I have tested my changes by ...
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

N/A