### PR TITLE
feat: set TF_APPEND_USER_AGENT env var for terraform steps

### DIFF
--- a/runatlantis.io/docs/custom-workflows.md
+++ b/runatlantis.io/docs/custom-workflows.md
@@ -665,6 +665,11 @@ Full example, filtering output and masking matching text (`mySecret: "foo"` -> `
       every character is escaped, ex. `atlantis plan -- arg1 arg2` will result in `COMMENT_ARGS=\a\r\g\1,\a\r\g\2`.
   * `ATLANTIS_PR_APPROVED` - "true" if the PR is approved
   * `ATLANTIS_PR_MERGEABLE` - "true" if the PR is mergeable
+  * `TF_APPEND_USER_AGENT` - Most Terraform providers inject this environment variable into the `User-Agent` header when performing HTTP requests.
+      The default value contains the [`--vcs-status-name`](/docs/server-configuration.html#vcs-status-name) (defaults to `atlantis`), the Atlantis version, user who executed the Atlantis command, the command name, directory, workspace, HEAD commit SHA, and the PR URL.
+      Example: `atlantis/1.2.3 (user; apply; default; project1; f3bbbd66a63d4bf1747940578ec3d0103530e21d; +https://github.com/runatlantis/atlantis/pull/5588)`.
+      This makes it easier to correlate actions in provider audit logs (ex: AWS CloudTrail) with the related PR/commit that caused the resource to be accessed/modified.
+      If you wish to override this environment variable to be a different format or include other fields (ex: the PR Author), you can add a custom `env` step as shown in [#2651](https://github.com/runatlantis/atlantis/issues/2651).
 
 * A custom command will only terminate if all output file descriptors are closed.
 Therefore a custom command can only be sent to the background (e.g. for an SSH tunnel during

--- a/runatlantis.io/docs/custom-workflows.md
+++ b/runatlantis.io/docs/custom-workflows.md
@@ -669,6 +669,7 @@ Full example, filtering output and masking matching text (`mySecret: "foo"` -> `
       The default value contains the [`--vcs-status-name`](/docs/server-configuration.html#vcs-status-name) (defaults to `atlantis`), the Atlantis version, user who executed the Atlantis command, the command name, directory, workspace, HEAD commit SHA, and the PR URL.
       Example: `atlantis/1.2.3 (user; apply; default; project1; f3bbbd66a63d4bf1747940578ec3d0103530e21d; +https://github.com/runatlantis/atlantis/pull/5588)`.
       This makes it easier to correlate actions in provider audit logs (ex: AWS CloudTrail) with the related PR/commit that caused the resource to be accessed/modified.
+      If `TF_APPEND_USER_AGENT` is already set in the Atlantis process environment, Atlantis appends the operator-supplied value after its own so the final HTTP `User-Agent` becomes `Terraform/x.y.z <atlantis-built-value> <operator-value>` rather than overwriting it.
       If you wish to override this environment variable to be a different format or include other fields (ex: the PR Author), you can add a custom `env` step as shown in [#2651](https://github.com/runatlantis/atlantis/issues/2651).
 
 * A custom command will only terminate if all output file descriptors are closed.

--- a/server/core/runtime/run_step_runner_test.go
+++ b/server/core/runtime/run_step_runner_test.go
@@ -108,6 +108,10 @@ func TestRunStepRunner_Run(t *testing.T) {
 			ExpOut:  "args=-target=resource1,-target=resource2\n",
 		},
 		{
+			Command: "echo tf_append_user_agent=$TF_APPEND_USER_AGENT",
+			ExpOut:  "tf_append_user_agent=passthrough\n",
+		},
+		{
 			Command: `echo mySecret: \"foo\"`,
 			ExpOut:  "mySecret: \"<redacted>\"\n",
 			PostProcessOutput: []valid.PostProcessRunOutputOption{
@@ -186,7 +190,7 @@ func TestRunStepRunner_Run(t *testing.T) {
 					EscapedCommentArgs:    []string{"-target=resource1", "-target=resource2"},
 					CustomPolicyCheck:     customPolicyCheck,
 				}
-				out, err := r.Run(ctx, nil, c.Command, tmpDir, map[string]string{"test": "var"}, true, c.PostProcessOutput, c.PostProcessFilterRegexes)
+				out, err := r.Run(ctx, nil, c.Command, tmpDir, map[string]string{"TF_APPEND_USER_AGENT": "passthrough"}, true, c.PostProcessOutput, c.PostProcessFilterRegexes)
 				if c.ExpErr != "" {
 					ErrContains(t, c.ExpErr, err)
 					return

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -319,6 +319,8 @@ func errorWithStepOutput(err error, outputs []string) error {
 
 // DefaultProjectCommandRunner implements ProjectCommandRunner.
 type DefaultProjectCommandRunner struct {
+	AtlantisVersion           string
+	VCSStatusName             string
 	VcsClient                 vcs.Client
 	Locker                    ProjectLocker
 	LockURLGenerator          LockURLGenerator
@@ -1098,7 +1100,28 @@ func (p *DefaultProjectCommandRunner) runSteps(steps []valid.Step, ctx command.P
 	unlock := p.WorkingDir.GitReadLock(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)
 	defer unlock()
 
-	envs := make(map[string]string)
+	// Truncate the verbose atlantis version (ex: 'dev (commit: none) (build date: unknown)' -> 'dev').
+	atlantisVersion, _, _ := strings.Cut(p.AtlantisVersion, " ")
+
+	vcsStatusName := p.VCSStatusName
+	if vcsStatusName == "" {
+		vcsStatusName = "atlantis"
+	}
+
+	envs := map[string]string{
+		"TF_APPEND_USER_AGENT": fmt.Sprintf(
+			"%s/%s (%s; %s; %s; %s; %s; +%s)",
+			vcsStatusName,
+			atlantisVersion,
+			ctx.User.Username,
+			ctx.CommandName,
+			ctx.RepoRelDir,
+			ctx.Workspace,
+			ctx.Pull.HeadCommit,
+			ctx.Pull.URL,
+		),
+	}
+
 	for _, step := range steps {
 		var out string
 		var err error

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -1108,18 +1108,27 @@ func (p *DefaultProjectCommandRunner) runSteps(steps []valid.Step, ctx command.P
 		vcsStatusName = "atlantis"
 	}
 
+	tfAppendUserAgent := fmt.Sprintf(
+		"%s/%s (%s; %s; %s; %s; %s; +%s)",
+		vcsStatusName,
+		atlantisVersion,
+		ctx.User.Username,
+		ctx.CommandName,
+		ctx.RepoRelDir,
+		ctx.Workspace,
+		ctx.Pull.HeadCommit,
+		ctx.Pull.URL,
+	)
+	// If the operator already set TF_APPEND_USER_AGENT on the Atlantis
+	// process, preserve their value by appending it after ours. The
+	// resulting HTTP User-Agent sent by Terraform providers will be:
+	//   Terraform/x.y.z <atlantis-built-value> <operator-value>
+	if existing := os.Getenv("TF_APPEND_USER_AGENT"); existing != "" {
+		tfAppendUserAgent = tfAppendUserAgent + " " + existing
+	}
+
 	envs := map[string]string{
-		"TF_APPEND_USER_AGENT": fmt.Sprintf(
-			"%s/%s (%s; %s; %s; %s; %s; +%s)",
-			vcsStatusName,
-			atlantisVersion,
-			ctx.User.Username,
-			ctx.CommandName,
-			ctx.RepoRelDir,
-			ctx.Workspace,
-			ctx.Pull.HeadCommit,
-			ctx.Pull.URL,
-		),
+		"TF_APPEND_USER_AGENT": tfAppendUserAgent,
 	}
 
 	for _, step := range steps {

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -70,10 +70,6 @@ func TestDefaultProjectCommandRunner_Plan(t *testing.T) {
 	When(mockLocker.TryLock(Any[logging.SimpleLogging](), Any[models.PullRequest](), Any[models.User](), Any[string](),
 		Any[models.Project](), AnyBool())).ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key"}, nil)
 
-	expEnvs := map[string]string{
-		"name": "value",
-	}
-
 	ctx := command.ProjectContext{
 		Log: logging.NewNoopLogger(t),
 		Steps: []valid.Step{
@@ -97,6 +93,11 @@ func TestDefaultProjectCommandRunner_Plan(t *testing.T) {
 		},
 		Workspace:  "default",
 		RepoRelDir: ".",
+	}
+
+	expEnvs := map[string]string{
+		"name":                 "value",
+		"TF_APPEND_USER_AGENT": fmt.Sprintf("atlantis/ (; %s; .; default; ; +)", ctx.CommandName),
 	}
 
 	// Each step will output its step name.
@@ -2973,14 +2974,19 @@ func TestDefaultProjectCommandRunner_Apply(t *testing.T) {
 					MergeableStatus: models.MergeableStatus{IsMergeable: false},
 				},
 			}
+			tfAppendUA := fmt.Sprintf("atlantis/ (; %s; .; default; ; +)", ctx.CommandName)
 			expEnvs := map[string]string{
-				"key": "value",
+				"key":                  "value",
+				"TF_APPEND_USER_AGENT": tfAppendUA,
+			}
+			envStepEnvs := map[string]string{
+				"TF_APPEND_USER_AGENT": tfAppendUA,
 			}
 			When(mockInit.Run(ctx, nil, repoDir, expEnvs)).ThenReturn("init", nil)
 			When(mockPlan.Run(ctx, nil, repoDir, expEnvs)).ThenReturn("plan", nil)
 			When(mockApply.Run(ctx, nil, repoDir, expEnvs)).ThenReturn("apply", nil)
 			When(mockRun.Run(ctx, nil, "", repoDir, expEnvs, true, nil, nil)).ThenReturn("run", nil)
-			When(mockEnv.Run(ctx, nil, "", "value", repoDir, make(map[string]string))).ThenReturn("value", nil)
+			When(mockEnv.Run(ctx, nil, "", "value", repoDir, envStepEnvs)).ThenReturn("value", nil)
 
 			res := runner.Apply(ctx)
 			Equals(t, c.expOut, res.ApplySuccess)
@@ -3054,7 +3060,9 @@ func TestDefaultProjectCommandRunner_ApplyRunStepFailure(t *testing.T) {
 		ApplyRequirements: []string{},
 		RepoRelDir:        ".",
 	}
-	expEnvs := map[string]string{}
+	expEnvs := map[string]string{
+		"TF_APPEND_USER_AGENT": fmt.Sprintf("atlantis/ (; %s; .; default; ; +)", ctx.CommandName),
+	}
 	When(mockApply.Run(ctx, nil, repoDir, expEnvs)).ThenReturn("apply", fmt.Errorf("something went wrong"))
 
 	res := runner.Apply(ctx)
@@ -3199,7 +3207,9 @@ func TestDefaultProjectCommandRunner_RunEnvSteps(t *testing.T) {
 
 // Test that it runs the expected import steps.
 func TestDefaultProjectCommandRunner_Import(t *testing.T) {
-	expEnvs := map[string]string{}
+	expEnvs := map[string]string{
+		"TF_APPEND_USER_AGENT": "atlantis/ (; apply; .; default; ; +)",
+	}
 	cases := []struct {
 		description   string
 		steps         []valid.Step

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -5115,3 +5115,117 @@ func TestDefaultProjectCommandRunner_PathTraversal(t *testing.T) {
 		}
 	}
 }
+
+// TestDefaultProjectCommandRunner_TFAppendUserAgent verifies that
+// TF_APPEND_USER_AGENT is composed from AtlantisVersion (truncated at the
+// first space), VCSStatusName (falling back to "atlantis"), and PR context.
+// It also verifies that an operator-supplied TF_APPEND_USER_AGENT in the
+// Atlantis process environment is preserved by appending it after the
+// Atlantis-built value rather than being silently overwritten.
+func TestDefaultProjectCommandRunner_TFAppendUserAgent(t *testing.T) {
+	cases := []struct {
+		description     string
+		atlantisVersion string
+		vcsStatusName   string
+		existingEnv     string
+		expEnv          string
+	}{
+		{
+			description:     "non-empty version is truncated at first space and custom vcs status name is used",
+			atlantisVersion: "1.2.3 (commit: abc) (build date: 2024-01-01)",
+			vcsStatusName:   "myatlantis",
+			existingEnv:     "",
+			expEnv:          "myatlantis/1.2.3 (alice; apply; project1; default; deadbeef; +https://github.com/owner/repo/pull/42)",
+		},
+		{
+			description:     "empty vcs status name falls back to atlantis",
+			atlantisVersion: "1.2.3",
+			vcsStatusName:   "",
+			existingEnv:     "",
+			expEnv:          "atlantis/1.2.3 (alice; apply; project1; default; deadbeef; +https://github.com/owner/repo/pull/42)",
+		},
+		{
+			description:     "operator-supplied TF_APPEND_USER_AGENT is appended after the atlantis-built value",
+			atlantisVersion: "1.2.3",
+			vcsStatusName:   "atlantis",
+			existingEnv:     "my-org/1.0 (custom)",
+			expEnv:          "atlantis/1.2.3 (alice; apply; project1; default; deadbeef; +https://github.com/owner/repo/pull/42) my-org/1.0 (custom)",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			RegisterMockTestingT(t)
+			if c.existingEnv != "" {
+				t.Setenv("TF_APPEND_USER_AGENT", c.existingEnv)
+			} else {
+				_ = os.Unsetenv("TF_APPEND_USER_AGENT")
+			}
+
+			mockApply := mocks.NewMockStepRunner()
+			mockWorkingDir := mocks.NewMockWorkingDir()
+			mockLocker := mocks.NewMockProjectLocker()
+			mockSender := mocks.NewMockWebhooksSender()
+			applyReqHandler := &events.DefaultCommandRequirementHandler{
+				WorkingDir: mockWorkingDir,
+			}
+
+			runner := events.DefaultProjectCommandRunner{
+				Locker:                    mockLocker,
+				LockURLGenerator:          mockURLGenerator{},
+				ApplyStepRunner:           mockApply,
+				WorkingDir:                mockWorkingDir,
+				Webhooks:                  mockSender,
+				WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+				CommandRequirementHandler: applyReqHandler,
+				AtlantisVersion:           c.atlantisVersion,
+				VCSStatusName:             c.vcsStatusName,
+			}
+
+			repoDir := t.TempDir()
+			projectDir := filepath.Join(repoDir, "project1")
+			Ok(t, os.Mkdir(projectDir, 0700))
+
+			When(mockWorkingDir.GetWorkingDir(
+				Any[models.Repo](),
+				Any[models.PullRequest](),
+				Any[string](),
+			)).ThenReturn(repoDir, nil)
+			When(mockWorkingDir.GitReadLock(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).ThenReturn(func() {})
+			When(mockLocker.TryLock(
+				Any[logging.SimpleLogging](),
+				Any[models.PullRequest](),
+				Any[models.User](),
+				Any[string](),
+				Any[models.Project](),
+				AnyBool(),
+			)).ThenReturn(&events.TryLockResponse{
+				LockAcquired: true,
+				LockKey:      "lock-key",
+			}, nil)
+
+			ctx := command.ProjectContext{
+				Log: logging.NewNoopLogger(t),
+				Steps: []valid.Step{
+					{StepName: "apply"},
+				},
+				Workspace:         "default",
+				ApplyRequirements: []string{},
+				RepoRelDir:        "project1",
+				User:              models.User{Username: "alice"},
+				Pull: models.PullRequest{
+					HeadCommit: "deadbeef",
+					URL:        "https://github.com/owner/repo/pull/42",
+				},
+			}
+			expEnvs := map[string]string{
+				"TF_APPEND_USER_AGENT": c.expEnv,
+			}
+			When(mockApply.Run(ctx, nil, projectDir, expEnvs)).ThenReturn("apply", nil)
+
+			res := runner.Apply(ctx)
+			Equals(t, "apply", res.ApplySuccess)
+			mockApply.VerifyWasCalledOnce().Run(ctx, nil, projectDir, expEnvs)
+		})
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -743,6 +743,8 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	cancellationTracker := events.NewCancellationTracker()
 
 	projectCommandRunner := &events.DefaultProjectCommandRunner{
+		AtlantisVersion:  config.AtlantisVersion,
+		VCSStatusName:    userConfig.VCSStatusName,
 		VcsClient:        vcsClient,
 		Locker:           projectLocker,
 		LockURLGenerator: router,


### PR DESCRIPTION
Note: this was originally implemented in #5588. I tried to implement this with a merge commit, plus my standalone fixes, plus addressing the feedback from @nitrocode (on the original PR), but I couldn't get it to apply cleanly. So this PR implements the same functionality squashed into a single commit, with the original PR's author added as a co-author.

## what

Set `TF_APPEND_USER_AGENT` before all terraform step executions so that providers include Atlantis context in their User-Agent headers. This makes it easier to correlate actions in provider audit logs (e.g. AWS CloudTrail) with the PR/commit that triggered them.

The value uses the `--vcs-status-name` (defaults to 'atlantis') as the product token, allowing operators running multiple Atlantis instances to differentiate between them.

Format: `<vcs-status-name>/<version> (<user>; <command>; <dir>; <workspace>; <commit>; +<pr-url>)`

## why

It's useful to have this information in logs (ex: CloudTrail) to identify exactly which PR modified a resource.

## tests

Updated tests to pass with these changes

## references

- #5588
- closes #2651
