### PR TITLE
fix: add explicit TLS validation and logging for startup and cert reload

### DIFF
--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -1386,6 +1386,14 @@ File containing x509 Certificate used for serving HTTPS.
 If the cert is signed by a CA, the file should be the concatenation
 of the server's certificate, any intermediates, and the CA's certificate.
 
+When both `--ssl-cert-file` and `--ssl-key-file` are set, Atlantis validates
+TLS material at startup and on certificate reload:
+- Startup fails fast for invalid certificate/key pairs and encrypted private keys.
+- Expired certificates and cert hostname mismatches (checked against the
+  `--atlantis-url` hostname) are logged as warnings.
+- On the next TLS handshake after certificate/key files change, invalid
+  replacements are logged as errors and TLS handshakes fail until fixed.
+
 ### `--ssl-key-file` <Badge text="v0.2.4+" type="info"/>
 
 ```bash
@@ -1395,6 +1403,8 @@ ATLANTIS_SSL_KEY_FILE="/etc/ssl/private/my-cert.key"
 ```
 
 File containing x509 private key matching `--ssl-cert-file`.
+Encrypted private keys are not supported because Atlantis cannot be configured
+with a passphrase.
 
 ### `--stats-namespace` <Badge text="v0.43.0+" type="info"/>
 

--- a/server/server.go
+++ b/server/server.go
@@ -1111,6 +1111,19 @@ func (s *Server) Start() error {
 
 	defer s.Logger.Flush()
 
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+	if s.SSLCertFile != "" && s.SSLKeyFile != "" {
+		cert, certLastRefreshTime, keyLastRefreshTime, warnings, err := s.loadAndValidateSSLCertificate()
+		if err != nil {
+			return fmt.Errorf("invalid tls configuration cert=%q key=%q: %w", s.SSLCertFile, s.SSLKeyFile, err)
+		}
+		s.logTLSWarnings(warnings)
+		s.SSLCert = cert
+		s.CertLastRefreshTime = certLastRefreshTime
+		s.KeyLastRefreshTime = keyLastRefreshTime
+		tlsConfig.GetCertificate = s.GetSSLCertificate
+	}
+
 	// Ensure server gracefully drains connections when stopped.
 	stop := make(chan os.Signal, 1)
 	// Stop on SIGINTs and SIGTERMs.
@@ -1122,9 +1135,13 @@ func (s *Server) Start() error {
 		s.ProjectCmdOutputHandler.Handle()
 	}()
 
-	tlsConfig := &tls.Config{GetCertificate: s.GetSSLCertificate, MinVersion: tls.VersionTLS12}
-
-	server := &http.Server{Addr: fmt.Sprintf(":%d", s.Port), Handler: n, TLSConfig: tlsConfig, ReadHeaderTimeout: 10 * time.Second}
+	server := &http.Server{
+		Addr:              fmt.Sprintf(":%d", s.Port),
+		Handler:           n,
+		TLSConfig:         tlsConfig,
+		ReadHeaderTimeout: 10 * time.Second,
+		ErrorLog:          log.New(&stdlibServerErrorLogWriter{logger: s.Logger}, "", 0),
+	}
 	go func() {
 		s.Logger.Info("Atlantis started - listening on port %v", s.Port)
 
@@ -1318,12 +1335,13 @@ func (s *Server) GetSSLCertificate(*tls.ClientHelloInfo) (*tls.Certificate, erro
 	}
 
 	if s.SSLCert == nil || certStat.ModTime() != s.CertLastRefreshTime || keyStat.ModTime() != s.KeyLastRefreshTime {
-		cert, err := tls.LoadX509KeyPair(s.SSLCertFile, s.SSLKeyFile)
+		validationResult, err := validateTLSCertificate(s.SSLCertFile, s.SSLKeyFile, s.tlsValidationHostname(), time.Now())
 		if err != nil {
 			return nil, fmt.Errorf("while loading tls cert: %w", err)
 		}
+		s.logTLSWarnings(validationResult.Warnings)
 
-		s.SSLCert = &cert
+		s.SSLCert = &validationResult.Certificate
 		s.CertLastRefreshTime = certStat.ModTime()
 		s.KeyLastRefreshTime = keyStat.ModTime()
 	}

--- a/server/tls_validation.go
+++ b/server/tls_validation.go
@@ -1,0 +1,177 @@
+// Copyright 2026 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/runatlantis/atlantis/server/logging"
+)
+
+type tlsValidationResult struct {
+	Certificate tls.Certificate
+	Warnings    []string
+}
+
+func (s *Server) loadAndValidateSSLCertificate() (*tls.Certificate, time.Time, time.Time, []string, error) {
+	certStat, err := os.Stat(s.SSLCertFile)
+	if err != nil {
+		return nil, time.Time{}, time.Time{}, nil, fmt.Errorf("while getting cert file modification time: %w", err)
+	}
+
+	keyStat, err := os.Stat(s.SSLKeyFile)
+	if err != nil {
+		return nil, time.Time{}, time.Time{}, nil, fmt.Errorf("while getting key file modification time: %w", err)
+	}
+
+	validationResult, err := validateTLSCertificate(s.SSLCertFile, s.SSLKeyFile, s.tlsValidationHostname(), time.Now())
+	if err != nil {
+		return nil, time.Time{}, time.Time{}, nil, err
+	}
+
+	return &validationResult.Certificate, certStat.ModTime(), keyStat.ModTime(), validationResult.Warnings, nil
+}
+
+func (s *Server) logTLSWarnings(warnings []string) {
+	if s.Logger == nil {
+		return
+	}
+	for _, warning := range warnings {
+		s.Logger.Warn("tls certificate warning, %s", warning)
+	}
+}
+
+func (s *Server) tlsValidationHostname() string {
+	if s.AtlantisURL == nil {
+		return ""
+	}
+	return s.AtlantisURL.Hostname()
+}
+
+func validateTLSCertificate(certFile string, keyFile string, hostname string, now time.Time) (*tlsValidationResult, error) {
+	keyPEMBytes, err := os.ReadFile(keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("reading tls key file: %w", err)
+	}
+
+	if isEncryptedPrivateKeyPEM(keyPEMBytes) {
+		return nil, fmt.Errorf("tls private key is encrypted, atlantis does not support encrypted keys because no passphrase can be configured")
+	}
+
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("loading tls cert and key pair: %w", err)
+	}
+
+	if len(cert.Certificate) == 0 {
+		return nil, fmt.Errorf("tls certificate did not include a leaf certificate")
+	}
+
+	leafCertificate, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return nil, fmt.Errorf("parsing tls leaf certificate: %w", err)
+	}
+
+	var warnings []string
+	if now.Before(leafCertificate.NotBefore) {
+		warnings = append(warnings, fmt.Sprintf("certificate %q is not yet valid, not_before=%s", certFile, leafCertificate.NotBefore.UTC().Format(time.RFC3339)))
+	}
+	if now.After(leafCertificate.NotAfter) {
+		warnings = append(warnings, fmt.Sprintf("certificate %q is expired, not_after=%s", certFile, leafCertificate.NotAfter.UTC().Format(time.RFC3339)))
+	}
+
+	if hostnameWarning := validateCertificateHostname(leafCertificate, hostname, certFile); hostnameWarning != "" {
+		warnings = append(warnings, hostnameWarning)
+	}
+
+	return &tlsValidationResult{
+		Certificate: cert,
+		Warnings:    warnings,
+	}, nil
+}
+
+func isEncryptedPrivateKeyPEM(keyPEMBytes []byte) bool {
+	remaining := keyPEMBytes
+	for {
+		block, rest := pem.Decode(remaining)
+		if block == nil {
+			return false
+		}
+		remaining = rest
+
+		blockType := strings.ToUpper(strings.TrimSpace(block.Type))
+		if blockType == "ENCRYPTED PRIVATE KEY" {
+			return true
+		}
+		if strings.Contains(blockType, "PRIVATE KEY") && x509.IsEncryptedPEMBlock(block) {
+			return true
+		}
+	}
+}
+
+func validateCertificateHostname(certificate *x509.Certificate, hostname string, certFile string) string {
+	hostname = strings.TrimSuffix(strings.TrimSpace(hostname), ".")
+	if hostname == "" {
+		return ""
+	}
+
+	if len(certificate.DNSNames) > 0 || len(certificate.IPAddresses) > 0 {
+		if err := certificate.VerifyHostname(hostname); err != nil {
+			return fmt.Sprintf("certificate %q san entries do not match atlantis hostname %q", certFile, hostname)
+		}
+		return ""
+	}
+
+	commonName := strings.TrimSuffix(strings.TrimSpace(certificate.Subject.CommonName), ".")
+	if commonName == "" {
+		return fmt.Sprintf("certificate %q has no san entries and no common name, so it cannot be matched against atlantis hostname %q", certFile, hostname)
+	}
+	if commonNameMatchesHostname(commonName, hostname) {
+		return ""
+	}
+
+	return fmt.Sprintf("certificate %q common name %q does not match atlantis hostname %q", certFile, commonName, hostname)
+}
+
+func commonNameMatchesHostname(commonName string, hostname string) bool {
+	commonName = strings.ToLower(commonName)
+	hostname = strings.ToLower(hostname)
+
+	if commonName == hostname {
+		return true
+	}
+
+	if net.ParseIP(hostname) != nil {
+		return false
+	}
+
+	if strings.HasPrefix(commonName, "*.") {
+		suffix := strings.TrimPrefix(commonName, "*")
+		if !strings.HasSuffix(hostname, suffix) {
+			return false
+		}
+		// Wildcard only matches a single left-most label.
+		return strings.Count(hostname, ".") == strings.Count(strings.TrimPrefix(suffix, "."), ".")+1
+	}
+	return false
+}
+
+type stdlibServerErrorLogWriter struct {
+	logger logging.SimpleLogging
+}
+
+func (w *stdlibServerErrorLogWriter) Write(p []byte) (int, error) {
+	message := strings.TrimSpace(string(p))
+	if message != "" && w.logger != nil {
+		w.logger.Err("http server error, %q", message)
+	}
+	return len(p), nil
+}

--- a/server/tls_validation_internal_test.go
+++ b/server/tls_validation_internal_test.go
@@ -1,0 +1,352 @@
+// Copyright 2026 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/runatlantis/atlantis/server/logging"
+	. "github.com/runatlantis/atlantis/testing"
+)
+
+type testCertificateOptions struct {
+	commonName string
+	dnsNames   []string
+	notBefore  time.Time
+	notAfter   time.Time
+}
+
+func TestValidateTLSCertificate(t *testing.T) {
+	now := time.Date(2026, 3, 12, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name            string
+		hostname        string
+		createFiles     func(t *testing.T, dir string) (string, string)
+		expectedErr     string
+		expectedWarning []string
+	}{
+		{
+			name:     "valid cert and key with matching SAN",
+			hostname: "atlantis.example.com",
+			createFiles: func(t *testing.T, dir string) (string, string) {
+				certPEM, keyPEM, _ := newSelfSignedCertificatePEM(t, testCertificateOptions{
+					commonName: "ignored-cn.example.com",
+					dnsNames:   []string{"atlantis.example.com"},
+					notBefore:  now.Add(-time.Hour),
+					notAfter:   now.Add(24 * time.Hour),
+				})
+				return writeCertificateFiles(t, dir, "valid", certPEM, keyPEM)
+			},
+		},
+		{
+			name:     "expired cert returns warning",
+			hostname: "atlantis.example.com",
+			createFiles: func(t *testing.T, dir string) (string, string) {
+				certPEM, keyPEM, _ := newSelfSignedCertificatePEM(t, testCertificateOptions{
+					commonName: "atlantis.example.com",
+					dnsNames:   []string{"atlantis.example.com"},
+					notBefore:  now.Add(-48 * time.Hour),
+					notAfter:   now.Add(-24 * time.Hour),
+				})
+				return writeCertificateFiles(t, dir, "expired", certPEM, keyPEM)
+			},
+			expectedWarning: []string{"expired"},
+		},
+		{
+			name:     "not yet valid cert returns warning",
+			hostname: "atlantis.example.com",
+			createFiles: func(t *testing.T, dir string) (string, string) {
+				certPEM, keyPEM, _ := newSelfSignedCertificatePEM(t, testCertificateOptions{
+					commonName: "atlantis.example.com",
+					dnsNames:   []string{"atlantis.example.com"},
+					notBefore:  now.Add(24 * time.Hour),
+					notAfter:   now.Add(48 * time.Hour),
+				})
+				return writeCertificateFiles(t, dir, "not-yet-valid", certPEM, keyPEM)
+			},
+			expectedWarning: []string{"not yet valid", "not_before="},
+		},
+		{
+			name:     "cert and key mismatch returns error",
+			hostname: "atlantis.example.com",
+			createFiles: func(t *testing.T, dir string) (string, string) {
+				certPEM, _, _ := newSelfSignedCertificatePEM(t, testCertificateOptions{
+					commonName: "atlantis.example.com",
+					dnsNames:   []string{"atlantis.example.com"},
+					notBefore:  now.Add(-time.Hour),
+					notAfter:   now.Add(24 * time.Hour),
+				})
+				_, wrongKeyPEM, _ := newSelfSignedCertificatePEM(t, testCertificateOptions{
+					commonName: "different.example.com",
+					dnsNames:   []string{"different.example.com"},
+					notBefore:  now.Add(-time.Hour),
+					notAfter:   now.Add(24 * time.Hour),
+				})
+				return writeCertificateFiles(t, dir, "mismatch", certPEM, wrongKeyPEM)
+			},
+			expectedErr: "loading tls cert and key pair",
+		},
+		{
+			name:     "encrypted key returns error",
+			hostname: "atlantis.example.com",
+			createFiles: func(t *testing.T, dir string) (string, string) {
+				certPEM, _, keyDER := newSelfSignedCertificatePEM(t, testCertificateOptions{
+					commonName: "atlantis.example.com",
+					dnsNames:   []string{"atlantis.example.com"},
+					notBefore:  now.Add(-time.Hour),
+					notAfter:   now.Add(24 * time.Hour),
+				})
+				encryptedBlock, err := x509.EncryptPEMBlock(rand.Reader, "PRIVATE KEY", keyDER, []byte("passphrase"), x509.PEMCipherAES256)
+				Ok(t, err)
+				encryptedKey := pem.EncodeToMemory(encryptedBlock)
+				return writeCertificateFiles(t, dir, "encrypted", certPEM, encryptedKey)
+			},
+			expectedErr: "does not support encrypted keys",
+		},
+		{
+			name:     "hostname mismatch warns and SAN is preferred over CN",
+			hostname: "atlantis.example.com",
+			createFiles: func(t *testing.T, dir string) (string, string) {
+				certPEM, keyPEM, _ := newSelfSignedCertificatePEM(t, testCertificateOptions{
+					commonName: "atlantis.example.com",
+					dnsNames:   []string{"other.example.com"},
+					notBefore:  now.Add(-time.Hour),
+					notAfter:   now.Add(24 * time.Hour),
+				})
+				return writeCertificateFiles(t, dir, "hostname-mismatch", certPEM, keyPEM)
+			},
+			expectedWarning: []string{"san entries do not match atlantis hostname"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			certFile, keyFile := tc.createFiles(t, t.TempDir())
+			validationResult, err := validateTLSCertificate(certFile, keyFile, tc.hostname, now)
+
+			if tc.expectedErr != "" {
+				ErrContains(t, tc.expectedErr, err)
+				return
+			}
+
+			Ok(t, err)
+
+			Assert(t, len(tc.expectedWarning) != 0 || len(validationResult.Warnings) == 0, "expected no warnings, got %v", validationResult.Warnings)
+			for _, expectedWarningSubstring := range tc.expectedWarning {
+				Assert(t, containsSubstring(validationResult.Warnings, expectedWarningSubstring), "expected warning containing %q, got %v", expectedWarningSubstring, validationResult.Warnings)
+			}
+		})
+	}
+}
+
+func TestGetSSLCertificate_ReloadErrorIsReturned(t *testing.T) {
+	now := time.Date(2026, 3, 12, 0, 0, 0, 0, time.UTC)
+	initialCert, initialKey, _ := newSelfSignedCertificatePEM(t, testCertificateOptions{
+		commonName: "atlantis.example.com",
+		dnsNames:   []string{"atlantis.example.com"},
+		notBefore:  now.Add(-time.Hour),
+		notAfter:   now.Add(24 * time.Hour),
+	})
+	rotatedCert, _, _ := newSelfSignedCertificatePEM(t, testCertificateOptions{
+		commonName: "atlantis.example.com",
+		dnsNames:   []string{"atlantis.example.com"},
+		notBefore:  now.Add(-time.Hour),
+		notAfter:   now.Add(48 * time.Hour),
+	})
+	_, mismatchedKey, _ := newSelfSignedCertificatePEM(t, testCertificateOptions{
+		commonName: "different.example.com",
+		dnsNames:   []string{"different.example.com"},
+		notBefore:  now.Add(-time.Hour),
+		notAfter:   now.Add(48 * time.Hour),
+	})
+
+	dir := t.TempDir()
+	certFile, keyFile := writeCertificateFiles(t, dir, "reload", initialCert, initialKey)
+
+	logger := logging.NewNoopLogger(t).WithHistory()
+	atlantisURL := mustParseURL(t, "https://atlantis.example.com")
+	s := &Server{
+		AtlantisURL: atlantisURL,
+		SSLCertFile: certFile,
+		SSLKeyFile:  keyFile,
+		Logger:      logger,
+	}
+
+	_, err := s.GetSSLCertificate(nil)
+	Ok(t, err)
+
+	Ok(t, os.WriteFile(certFile, rotatedCert, 0600))
+	Ok(t, os.WriteFile(keyFile, mismatchedKey, 0600))
+	s.CertLastRefreshTime = s.CertLastRefreshTime.Add(-time.Second)
+	s.KeyLastRefreshTime = s.KeyLastRefreshTime.Add(-time.Second)
+
+	_, err = s.GetSSLCertificate(nil)
+	Assert(t, err != nil, "expected reload error, got nil")
+	ErrContains(t, "while loading tls cert", err)
+
+	history := logger.GetHistory()
+	Assert(t, !strings.Contains(history, "tls certificate reload"), "unexpected explicit reload error log in history, got: %s", history)
+}
+
+func TestGetSSLCertificate_ReloadWarningIsLogged(t *testing.T) {
+	now := time.Date(2026, 3, 12, 0, 0, 0, 0, time.UTC)
+	initialCert, initialKey, _ := newSelfSignedCertificatePEM(t, testCertificateOptions{
+		commonName: "atlantis.example.com",
+		dnsNames:   []string{"atlantis.example.com"},
+		notBefore:  now.Add(-time.Hour),
+		notAfter:   now.Add(24 * time.Hour),
+	})
+	expiredCert, expiredKey, _ := newSelfSignedCertificatePEM(t, testCertificateOptions{
+		commonName: "atlantis.example.com",
+		dnsNames:   []string{"atlantis.example.com"},
+		notBefore:  now.Add(-48 * time.Hour),
+		notAfter:   now.Add(-24 * time.Hour),
+	})
+
+	dir := t.TempDir()
+	certFile, keyFile := writeCertificateFiles(t, dir, "reload-warning", initialCert, initialKey)
+
+	logger := logging.NewNoopLogger(t).WithHistory()
+	s := &Server{
+		AtlantisURL: mustParseURL(t, "https://atlantis.example.com"),
+		SSLCertFile: certFile,
+		SSLKeyFile:  keyFile,
+		Logger:      logger,
+	}
+
+	_, err := s.GetSSLCertificate(nil)
+	Ok(t, err)
+
+	Ok(t, os.WriteFile(certFile, expiredCert, 0600))
+	Ok(t, os.WriteFile(keyFile, expiredKey, 0600))
+	s.CertLastRefreshTime = s.CertLastRefreshTime.Add(-time.Second)
+	s.KeyLastRefreshTime = s.KeyLastRefreshTime.Add(-time.Second)
+
+	_, err = s.GetSSLCertificate(nil)
+	Ok(t, err)
+
+	history := logger.GetHistory()
+	Assert(t, strings.Contains(history, "tls certificate warning,") && strings.Contains(history, "expired"), "expected expiry warning in log history, got: %s", history)
+}
+
+func TestStart_InvalidTLSConfigFailsFast(t *testing.T) {
+	now := time.Date(2026, 3, 12, 0, 0, 0, 0, time.UTC)
+	certPEM, _, _ := newSelfSignedCertificatePEM(t, testCertificateOptions{
+		commonName: "atlantis.example.com",
+		dnsNames:   []string{"atlantis.example.com"},
+		notBefore:  now.Add(-time.Hour),
+		notAfter:   now.Add(24 * time.Hour),
+	})
+	_, wrongKeyPEM, _ := newSelfSignedCertificatePEM(t, testCertificateOptions{
+		commonName: "different.example.com",
+		dnsNames:   []string{"different.example.com"},
+		notBefore:  now.Add(-time.Hour),
+		notAfter:   now.Add(24 * time.Hour),
+	})
+	certFile, keyFile := writeCertificateFiles(t, t.TempDir(), "startup-fail-fast", certPEM, wrongKeyPEM)
+
+	logger := logging.NewNoopLogger(t).WithHistory()
+	s := &Server{
+		AtlantisURL:            mustParseURL(t, "https://atlantis.example.com"),
+		Router:                 mux.NewRouter(),
+		Port:                   4141,
+		SSLCertFile:            certFile,
+		SSLKeyFile:             keyFile,
+		Logger:                 logger,
+		DisableGlobalApplyLock: true,
+		EnableProfilingAPI:     false,
+		WebAuthentication:      false,
+	}
+
+	err := s.Start()
+	Assert(t, err != nil, "expected tls startup validation error, got nil")
+	ErrContains(t, "invalid tls configuration", err)
+}
+
+func TestStdlibServerErrorLogWriter_Write(t *testing.T) {
+	logger := logging.NewNoopLogger(t).WithHistory()
+	writer := &stdlibServerErrorLogWriter{logger: logger}
+
+	message := "http: TLS handshake error from 127.0.0.1:12345: remote error: tls: bad certificate\n"
+	n, err := writer.Write([]byte(message))
+	Ok(t, err)
+	Equals(t, len(message), n)
+
+	history := logger.GetHistory()
+	Assert(t, strings.Contains(history, "http server error"), "expected bridged stdlib server error in history, got: %s", history)
+}
+
+func newSelfSignedCertificatePEM(t *testing.T, options testCertificateOptions) ([]byte, []byte, []byte) {
+	t.Helper()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	Ok(t, err)
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	Ok(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	Ok(t, err)
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Atlantis TLS test suite"},
+			CommonName:   options.commonName,
+		},
+		NotBefore:   options.notBefore,
+		NotAfter:    options.notAfter,
+		DNSNames:    options.dnsNames,
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	Ok(t, err)
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+
+	return certPEM, keyPEM, keyDER
+}
+
+func writeCertificateFiles(t *testing.T, dir string, prefix string, certPEM []byte, keyPEM []byte) (string, string) {
+	t.Helper()
+
+	certFile := filepath.Join(dir, fmt.Sprintf("%s-cert.pem", prefix))
+	keyFile := filepath.Join(dir, fmt.Sprintf("%s-key.pem", prefix))
+
+	Ok(t, os.WriteFile(certFile, certPEM, 0600))
+	Ok(t, os.WriteFile(keyFile, keyPEM, 0600))
+	return certFile, keyFile
+}
+
+func mustParseURL(t *testing.T, rawURL string) *url.URL {
+	t.Helper()
+	parsed, err := ParseAtlantisURL(rawURL)
+	Ok(t, err)
+	return parsed
+}
+
+func containsSubstring(messages []string, substring string) bool {
+	for _, message := range messages {
+		if strings.Contains(message, substring) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Improves Atlantis server TLS diagnostics and validation so invalid TLS material is no longer silent/confusing.

## what

- Added shared TLS validation logic (`server/tls_validation.go`) used by startup and reload paths.
- Startup now performs TLS preflight validation and **fails fast** on fatal issues.
- Added TLS warning classification for non-fatal issues:
  - expired certificate -> warning
  - CN/SAN hostname mismatch vs `--atlantis-url` hostname -> warning
- Fatal TLS validation errors:
  - cert/key mismatch
  - encrypted private key (passphrase unsupported)
  - cert/key parse/read issues
- Reuse same validation on cert reload in `GetSSLCertificate`.
  - Existing runtime behavior is preserved: invalid reloaded certs still cause handshake failure (no fallback), but with clearer surfacing.
- Wired `http.Server.ErrorLog` to Atlantis logger so stdlib HTTP/TLS errors are visible.
- Updated TLS server configuration docs to describe startup/reload behavior and encrypted-key limitation.



## why

- TLS misconfiguration previously failed late (during handshake), making root cause hard to identify.
- Stdlib HTTP/TLS errors were effectively hidden due to default logger suppression.
- Operators need immediate, actionable feedback when cert/key material is invalid.
- Some TLS issues should not block startup (expired cert, hostname mismatch), but should still be visible as warnings.
- Startup fail-fast for fatal TLS errors reduces debugging time and prevents ambiguous runtime behavior.

## tests

Added/updated tests in `server/tls_validation_internal_test.go`:
- validation matrix:
  - valid cert/key
  - expired cert warning
  - cert/key mismatch error
  - encrypted key error
  - hostname mismatch warning (SAN precedence over CN fallback)
- reload error path returns expected error
- reload warning path logs warning
- startup fail-fast on invalid TLS
- stdlib `ErrorLog` bridge writer behavior


