### PR TITLE
feat: add configurable plan timeout to expire stale plans

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -125,6 +125,7 @@ const (
 	MaxCommentsPerCommand            = "max-comments-per-command"
 	ParallelPoolSize                 = "parallel-pool-size"
 	PendingApplyStatusFlag           = "pending-apply-status"
+	PlanTimeoutFlag                  = "plan-timeout"
 	StatsNamespace                   = "stats-namespace"
 	AllowDraftPRs                    = "allow-draft-prs"
 	PortFlag                         = "port"
@@ -493,6 +494,13 @@ var stringFlags = map[string]stringFlag{
 	WebPasswordFlag: {
 		description:  "Password used for Web Basic Authentication on Atlantis HTTP Middleware",
 		defaultValue: DefaultWebPassword,
+	},
+	PlanTimeoutFlag: {
+		description: "Duration after which a plan is considered stale and will be discarded on apply. " +
+			"The lock will be released so another user can plan. " +
+			"Uses Go duration format (e.g. 15m, 1h, 2h30m). " +
+			"If empty or zero, plans never expire (default behavior).",
+		defaultValue: "",
 	},
 }
 

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -125,6 +125,7 @@ var testFlags = map[string]any{
 	ParallelPlanFlag:                 true,
 	ParallelApplyFlag:                true,
 	PendingApplyStatusFlag:           false,
+	PlanTimeoutFlag:                  "15m",
 	QuietPolicyChecks:                false,
 	RedisHost:                        "",
 	RedisInsecureSkipVerify:          false,

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -1108,6 +1108,21 @@ Defaults to `false`.
 
 Only supported on GitLab
 
+### `--plan-timeout`
+
+```bash
+atlantis server --plan-timeout=15m
+# or
+ATLANTIS_PLAN_TIMEOUT=15m
+```
+
+Duration after which a plan is considered stale and will be discarded on apply.
+Uses Go duration format (e.g. `15m`, `1h`, `2h30m`).
+When apply is run after the timeout has elapsed, the plan file is deleted, the lock is released,
+and the user is asked to re-plan.
+
+If empty or zero, plans never expire. Defaults to empty (no timeout).
+
 ### `--port` <Badge text="v0.1.3+" type="info"/>
 
 ```bash

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/core/runtime"
@@ -245,6 +246,7 @@ type DefaultProjectCommandRunner struct {
 	WorkingDirLocker          WorkingDirLocker
 	CommandRequirementHandler CommandRequirementHandler
 	CancellationTracker       CancellationTracker
+	PlanTimeout               time.Duration
 }
 
 // Plan runs terraform plan for the project described by ctx.
@@ -684,6 +686,19 @@ func (p *DefaultProjectCommandRunner) doApply(ctx command.ProjectContext) (apply
 		return "", lockAttempt.LockFailureReason, nil
 	}
 	ctx.Log.Debug("acquired lock for project")
+
+	if p.PlanTimeout > 0 && !lockAttempt.LockTime.IsZero() && time.Since(lockAttempt.LockTime) > p.PlanTimeout {
+		ctx.Log.Info("plan has expired (created %s ago, timeout %s), discarding", time.Since(lockAttempt.LockTime).Round(time.Second), p.PlanTimeout)
+		planFile := filepath.Join(absPath, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+		if removeErr := os.Remove(planFile); removeErr != nil && !os.IsNotExist(removeErr) {
+			ctx.Log.Err("failed to remove expired plan file: %v", removeErr)
+		}
+		if unlockErr := lockAttempt.UnlockFn(); unlockErr != nil {
+			ctx.Log.Err("failed to release lock for expired plan: %v", unlockErr)
+		}
+		return "", fmt.Sprintf("The plan has expired (created %s ago, timeout is %s). Please run `atlantis plan` again.",
+			time.Since(lockAttempt.LockTime).Round(time.Second), p.PlanTimeout), nil
+	}
 
 	// Acquire internal lock for the directory we're going to operate in.
 	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.Apply)

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -17,7 +17,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-version"
 	. "github.com/petergtz/pegomock/v4"
@@ -541,6 +544,237 @@ func TestDefaultProjectCommandRunner_ApplyRunStepFailure(t *testing.T) {
 	Assert(t, res.ApplySuccess == "", "exp apply failure")
 
 	mockApply.VerifyWasCalledOnce().Run(ctx, nil, repoDir, expEnvs)
+}
+
+func TestDefaultProjectCommandRunner_ApplyPlanExpired(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockLocker := mocks.NewMockProjectLocker()
+	mockSender := mocks.NewMockWebhooksSender()
+	applyReqHandler := &events.DefaultCommandRequirementHandler{
+		WorkingDir: mockWorkingDir,
+	}
+
+	runner := events.DefaultProjectCommandRunner{
+		Locker:                    mockLocker,
+		LockURLGenerator:          mockURLGenerator{},
+		WorkingDir:                mockWorkingDir,
+		WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: applyReqHandler,
+		Webhooks:                  mockSender,
+		PlanTimeout:               1 * time.Millisecond,
+	}
+	repoDir := t.TempDir()
+
+	// Create a plan file that should be deleted on expiry.
+	planFile := filepath.Join(repoDir, "default.tfplan")
+	Ok(t, os.WriteFile(planFile, []byte("fake-plan"), 0600))
+
+	When(mockWorkingDir.GetWorkingDir(
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Any[string](),
+	)).ThenReturn(repoDir, nil)
+
+	unlocked := false
+	When(mockLocker.TryLock(
+		Any[logging.SimpleLogging](),
+		Any[models.PullRequest](),
+		Any[models.User](),
+		Any[string](),
+		Any[models.Project](),
+		AnyBool(),
+	)).ThenReturn(&events.TryLockResponse{
+		LockAcquired: true,
+		LockKey:      "lock-key",
+		LockTime:     time.Now().Add(-1 * time.Hour),
+		UnlockFn:     func() error { unlocked = true; return nil },
+	}, nil)
+
+	ctx := command.ProjectContext{
+		Log:               logging.NewNoopLogger(t),
+		Steps:             valid.DefaultApplyStage.Steps,
+		Workspace:         "default",
+		ApplyRequirements: []string{},
+		RepoRelDir:        ".",
+	}
+
+	res := runner.Apply(ctx)
+	Assert(t, res.ApplySuccess == "", "expected no apply output")
+	Assert(t, strings.Contains(res.Failure, "plan has expired"), "expected expiry failure message, got: %s", res.Failure)
+	Assert(t, strings.Contains(res.Failure, "atlantis plan"), "expected re-plan hint in message")
+	Assert(t, unlocked, "expected lock to be released")
+	_, err := os.Stat(planFile)
+	Assert(t, os.IsNotExist(err), "expected plan file to be deleted")
+}
+
+func TestDefaultProjectCommandRunner_ApplyPlanNotExpired(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockApply := mocks.NewMockStepRunner()
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockLocker := mocks.NewMockProjectLocker()
+	mockSender := mocks.NewMockWebhooksSender()
+	applyReqHandler := &events.DefaultCommandRequirementHandler{
+		WorkingDir: mockWorkingDir,
+	}
+
+	runner := events.DefaultProjectCommandRunner{
+		Locker:                    mockLocker,
+		LockURLGenerator:          mockURLGenerator{},
+		ApplyStepRunner:           mockApply,
+		WorkingDir:                mockWorkingDir,
+		WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: applyReqHandler,
+		Webhooks:                  mockSender,
+		PlanTimeout:               1 * time.Hour,
+	}
+	repoDir := t.TempDir()
+	When(mockWorkingDir.GetWorkingDir(
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Any[string](),
+	)).ThenReturn(repoDir, nil)
+	When(mockLocker.TryLock(
+		Any[logging.SimpleLogging](),
+		Any[models.PullRequest](),
+		Any[models.User](),
+		Any[string](),
+		Any[models.Project](),
+		AnyBool(),
+	)).ThenReturn(&events.TryLockResponse{
+		LockAcquired: true,
+		LockKey:      "lock-key",
+		LockTime:     time.Now(),
+	}, nil)
+
+	ctx := command.ProjectContext{
+		Log: logging.NewNoopLogger(t),
+		Steps: []valid.Step{
+			{StepName: "apply"},
+		},
+		Workspace:         "default",
+		ApplyRequirements: []string{},
+		RepoRelDir:        ".",
+	}
+	expEnvs := map[string]string{}
+	When(mockApply.Run(ctx, nil, repoDir, expEnvs)).ThenReturn("apply", nil)
+
+	res := runner.Apply(ctx)
+	Equals(t, "apply", res.ApplySuccess)
+	Equals(t, "", res.Failure)
+	mockApply.VerifyWasCalledOnce().Run(ctx, nil, repoDir, expEnvs)
+}
+
+func TestDefaultProjectCommandRunner_ApplyNoPlanTimeout(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockApply := mocks.NewMockStepRunner()
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockLocker := mocks.NewMockProjectLocker()
+	mockSender := mocks.NewMockWebhooksSender()
+	applyReqHandler := &events.DefaultCommandRequirementHandler{
+		WorkingDir: mockWorkingDir,
+	}
+
+	runner := events.DefaultProjectCommandRunner{
+		Locker:                    mockLocker,
+		LockURLGenerator:          mockURLGenerator{},
+		ApplyStepRunner:           mockApply,
+		WorkingDir:                mockWorkingDir,
+		WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: applyReqHandler,
+		Webhooks:                  mockSender,
+		// PlanTimeout is zero — timeout disabled
+	}
+	repoDir := t.TempDir()
+	When(mockWorkingDir.GetWorkingDir(
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Any[string](),
+	)).ThenReturn(repoDir, nil)
+	When(mockLocker.TryLock(
+		Any[logging.SimpleLogging](),
+		Any[models.PullRequest](),
+		Any[models.User](),
+		Any[string](),
+		Any[models.Project](),
+		AnyBool(),
+	)).ThenReturn(&events.TryLockResponse{
+		LockAcquired: true,
+		LockKey:      "lock-key",
+		LockTime:     time.Now().Add(-24 * time.Hour),
+	}, nil)
+
+	ctx := command.ProjectContext{
+		Log: logging.NewNoopLogger(t),
+		Steps: []valid.Step{
+			{StepName: "apply"},
+		},
+		Workspace:         "default",
+		ApplyRequirements: []string{},
+		RepoRelDir:        ".",
+	}
+	expEnvs := map[string]string{}
+	When(mockApply.Run(ctx, nil, repoDir, expEnvs)).ThenReturn("apply", nil)
+
+	res := runner.Apply(ctx)
+	Equals(t, "apply", res.ApplySuccess)
+	Equals(t, "", res.Failure)
+}
+
+func TestDefaultProjectCommandRunner_ApplyPlanExpiredZeroLockTime(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockApply := mocks.NewMockStepRunner()
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockLocker := mocks.NewMockProjectLocker()
+	mockSender := mocks.NewMockWebhooksSender()
+	applyReqHandler := &events.DefaultCommandRequirementHandler{
+		WorkingDir: mockWorkingDir,
+	}
+
+	runner := events.DefaultProjectCommandRunner{
+		Locker:                    mockLocker,
+		LockURLGenerator:          mockURLGenerator{},
+		ApplyStepRunner:           mockApply,
+		WorkingDir:                mockWorkingDir,
+		WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: applyReqHandler,
+		Webhooks:                  mockSender,
+		PlanTimeout:               1 * time.Millisecond,
+	}
+	repoDir := t.TempDir()
+	When(mockWorkingDir.GetWorkingDir(
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Any[string](),
+	)).ThenReturn(repoDir, nil)
+	When(mockLocker.TryLock(
+		Any[logging.SimpleLogging](),
+		Any[models.PullRequest](),
+		Any[models.User](),
+		Any[string](),
+		Any[models.Project](),
+		AnyBool(),
+	)).ThenReturn(&events.TryLockResponse{
+		LockAcquired: true,
+		LockKey:      "lock-key",
+		// LockTime is zero value — should skip expiry check
+	}, nil)
+
+	ctx := command.ProjectContext{
+		Log: logging.NewNoopLogger(t),
+		Steps: []valid.Step{
+			{StepName: "apply"},
+		},
+		Workspace:         "default",
+		ApplyRequirements: []string{},
+		RepoRelDir:        ".",
+	}
+	expEnvs := map[string]string{}
+	When(mockApply.Run(ctx, nil, repoDir, expEnvs)).ThenReturn("apply", nil)
+
+	res := runner.Apply(ctx)
+	Equals(t, "apply", res.ApplySuccess)
+	Equals(t, "", res.Failure)
 }
 
 // Test run and env steps. We don't use mocks for this test since we're

--- a/server/events/project_locker.go
+++ b/server/events/project_locker.go
@@ -15,6 +15,7 @@ package events
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/runatlantis/atlantis/server/core/locking"
 	"github.com/runatlantis/atlantis/server/events/models"
@@ -56,6 +57,9 @@ type TryLockResponse struct {
 	UnlockFn func() error
 	// LockKey is the key for the lock if the lock was acquired.
 	LockKey string
+	// LockTime is when the lock was originally created. Used for plan
+	// expiration checks.
+	LockTime time.Time
 }
 
 // TryLock implements ProjectLocker.TryLock.
@@ -90,6 +94,7 @@ func (p *DefaultProjectLocker) TryLock(log logging.SimpleLogging, pull models.Pu
 			_, err := p.Locker.Unlock(lockAttempt.LockKey)
 			return err
 		},
-		LockKey: lockAttempt.LockKey,
+		LockKey:  lockAttempt.LockKey,
+		LockTime: lockAttempt.CurrLock.Time,
 	}, nil
 }

--- a/server/events/project_locker_test.go
+++ b/server/events/project_locker_test.go
@@ -16,6 +16,7 @@ package events_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/runatlantis/atlantis/server/core/locking"
 	"github.com/runatlantis/atlantis/server/core/locking/mocks"
@@ -201,6 +202,68 @@ func TestDefaultProjectLocker_RepoLocking(t *testing.T) {
 			res, err := locker.TryLock(logging.NewNoopLogger(t), expPull, expUser, expWorkspace, expProject, tt.repoLocking)
 			Ok(t, err)
 			Equals(t, true, res.LockAcquired)
+		})
+	}
+}
+
+func TestDefaultProjectLocker_TryLockPopulatesLockTime(t *testing.T) {
+	lockTime := time.Date(2025, 6, 15, 10, 30, 0, 0, time.UTC)
+
+	tests := []struct {
+		name         string
+		lockAcquired bool
+		description  string
+	}{
+		{
+			name:         "fresh lock",
+			lockAcquired: true,
+		},
+		{
+			name:         "re-acquired from same PR",
+			lockAcquired: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			var githubClient *github.Client
+			mockClient := vcs.NewClientProxy(githubClient, nil, nil, nil, nil, nil)
+			mockLocker := mocks.NewMockLocker(ctrl)
+			locker := events.DefaultProjectLocker{
+				Locker:    mockLocker,
+				VCSClient: mockClient,
+			}
+
+			expProject := models.Project{}
+			expWorkspace := "default"
+			expPull := models.PullRequest{Num: 2}
+			expUser := models.User{}
+			lockKey := "key"
+
+			mockLocker.EXPECT().TryLock(expProject, expWorkspace, expPull, expUser).Return(
+				locking.TryLockResponse{
+					LockAcquired: tt.lockAcquired,
+					CurrLock: models.ProjectLock{
+						Pull: expPull,
+						Time: lockTime,
+					},
+					LockKey: lockKey,
+				},
+				nil,
+			)
+			if tt.lockAcquired {
+				mockLocker.EXPECT().Unlock(lockKey).Return(nil, nil)
+			} else {
+				mockLocker.EXPECT().Unlock(lockKey).Return(nil, nil)
+			}
+
+			res, err := locker.TryLock(logging.NewNoopLogger(t), expPull, expUser, expWorkspace, expProject, true)
+			Ok(t, err)
+			Equals(t, true, res.LockAcquired)
+			Equals(t, lockTime, res.LockTime)
+
+			err = res.UnlockFn()
+			Ok(t, err)
 		})
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -172,6 +172,23 @@ type WebhookConfig struct {
 //go:embed static
 var staticAssets embed.FS
 
+// ParsePlanTimeout parses a plan timeout string into a time.Duration.
+// Returns zero duration for empty input (no timeout). Returns an error
+// for invalid or negative durations.
+func ParsePlanTimeout(s string) (time.Duration, error) {
+	if s == "" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("parsing plan-timeout %q: %w", s, err)
+	}
+	if d < 0 {
+		return 0, fmt.Errorf("plan-timeout must not be negative, got %s", d)
+	}
+	return d, nil
+}
+
 // NewServer returns a new server. If there are issues starting the server or
 // its dependencies an error will be returned. This is like the main() function
 // for the server CLI command because it injects all the dependencies.
@@ -696,6 +713,14 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 
 	cancellationTracker := events.NewCancellationTracker()
 
+	planTimeout, err := ParsePlanTimeout(userConfig.PlanTimeout)
+	if err != nil {
+		return nil, err
+	}
+	if planTimeout > 0 {
+		logger.Info("Plan timeout configured: %s", planTimeout)
+	}
+
 	projectCommandRunner := &events.DefaultProjectCommandRunner{
 		VcsClient:        vcsClient,
 		Locker:           projectLocker,
@@ -735,6 +760,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		WorkingDirLocker:          workingDirLocker,
 		CommandRequirementHandler: applyRequirementHandler,
 		CancellationTracker:       cancellationTracker,
+		PlanTimeout:               planTimeout,
 	}
 
 	dbUpdater := &events.DBUpdater{

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -289,6 +290,65 @@ func TestParseAtlantisURL(t *testing.T) {
 			} else {
 				Ok(t, err)
 				Equals(t, c.ExpURL, act.String())
+			}
+		})
+	}
+}
+
+func TestParsePlanTimeout(t *testing.T) {
+	cases := []struct {
+		description     string
+		timeout         string
+		expectError     string
+		expectZero      bool
+		expectPositive  bool
+	}{
+		{
+			description:    "valid duration 15m",
+			timeout:        "15m",
+			expectPositive: true,
+		},
+		{
+			description:    "valid duration 1h",
+			timeout:        "1h",
+			expectPositive: true,
+		},
+		{
+			description:    "valid duration 2h30m",
+			timeout:        "2h30m",
+			expectPositive: true,
+		},
+		{
+			description: "empty means no timeout",
+			timeout:     "",
+			expectZero:  true,
+		},
+		{
+			description: "invalid duration string",
+			timeout:     "abc",
+			expectError: "invalid duration",
+		},
+		{
+			description: "negative duration",
+			timeout:     "-5m",
+			expectError: "negative",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			timeout, err := server.ParsePlanTimeout(c.timeout)
+			if c.expectError != "" {
+				Assert(t, err != nil, "expected error for timeout %q", c.timeout)
+				Assert(t, strings.Contains(err.Error(), c.expectError),
+					"expected error containing %q, got: %v", c.expectError, err)
+			} else {
+				Ok(t, err)
+				if c.expectZero {
+					Equals(t, time.Duration(0), timeout)
+				}
+				if c.expectPositive {
+					Assert(t, timeout > 0, "expected positive duration, got %s", timeout)
+				}
 			}
 		})
 	}

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -89,6 +89,7 @@ type UserConfig struct {
 	ParallelPoolSize                int    `mapstructure:"parallel-pool-size"`
 	ParallelPlan                    bool   `mapstructure:"parallel-plan"`
 	ParallelApply                   bool   `mapstructure:"parallel-apply"`
+	PlanTimeout                     string `mapstructure:"plan-timeout"`
 	PendingApplyStatus              bool   `mapstructure:"pending-apply-status"`
 	StatsNamespace                  string `mapstructure:"stats-namespace"`
 	PlanDrafts                      bool   `mapstructure:"allow-draft-prs"`


### PR DESCRIPTION
## what

- Adds a `--plan-timeout` server flag that sets a maximum age for Terraform plans. When `atlantis apply` is run after the timeout has elapsed, the plan is discarded, the lock is released, and the user sees a message asking them to re-plan.
- Default behavior is unchanged - if the flag is not set (or set to empty/zero), plans never expire.
- Includes documentation, flag registration, unit tests, and validation for the new option.

## why

- Long-lived plans can become stale and dangerous to apply. This gives administrators a knob to enforce plan freshness and automatically free locks held by forgotten plans.

## how

- `ProjectLock` already stores a `Time` field when the lock is created during `atlantis plan`.
- The new `--plan-timeout` flag is parsed as a `time.Duration` (e.g. `15m`, `2h30m`).
- When `atlantis apply` runs, `doApply()` checks `time.Since(lockTime)` against the configured timeout.
- If expired: the `.tfplan` file is removed, the lock is released, and a failure message is returned.
- If not expired (or timeout is zero): behavior is identical to before.

## tests

`TestDefaultProjectCommandRunner_ApplyPlanExpired` - expired plan is rejected, file deleted, lock released
`TestDefaultProjectCommandRunner_ApplyPlanNotExpired` - recent plan proceeds normally
`TestDefaultProjectCommandRunner_ApplyNoPlanTimeout` - zero timeout preserves backward compatibility
`TestDefaultProjectCommandRunner_ApplyPlanExpiredZeroLockTime` - zero lock time skips the check
`TestDefaultProjectLocker_TryLockPopulatesLockTime` - lock time propagated for fresh and re-acquired locks
`TestParsePlanTimeout` - valid durations, empty input, invalid strings, and negative durations

## references

closes #270 
