### PR TITLE
feat: Add glob_file_match option

### DIFF
--- a/server/core/config/parser_validator.go
+++ b/server/core/config/parser_validator.go
@@ -258,7 +258,7 @@ func (p *ParserValidator) applyLegacyShellParsing(cfg *valid.RepoCfg) error {
 
 // expandProjectGlobs expands projects with glob patterns in their dir field
 // into multiple projects, one for each matching directory that contains
-// Terraform files (.tf).
+// files matching the project's glob_file_match patterns (default: "*.tf").
 func (p *ParserValidator) expandProjectGlobs(absRepoDir string, projects []raw.Project) ([]raw.Project, error) {
 	var expandedProjects []raw.Project
 
@@ -276,7 +276,7 @@ func (p *ParserValidator) expandProjectGlobs(absRepoDir string, projects []raw.P
 			return nil, fmt.Errorf("error expanding glob pattern %q: %w", *project.Dir, err)
 		}
 
-		// Filter matches to only include directories with Terraform files
+		// Filter matches to only include directories with matching files
 		for _, match := range matches {
 			// Check if it's a directory
 			info, err := os.Stat(match)
@@ -284,12 +284,12 @@ func (p *ParserValidator) expandProjectGlobs(absRepoDir string, projects []raw.P
 				continue
 			}
 
-			// Check if the directory contains any .tf files
-			hasTerraformFiles, err := p.dirContainsTerraformFiles(match)
+			// Check if the directory contains any files matching the patterns
+			hasMatchingFiles, err := p.dirContainsMatchingFiles(match, project.GlobFileMatch)
 			if err != nil {
-				return nil, fmt.Errorf("error checking for Terraform files in %q: %w", match, err)
+				return nil, fmt.Errorf("error checking for matching files in %q: %w", match, err)
 			}
-			if !hasTerraformFiles {
+			if !hasMatchingFiles {
 				continue
 			}
 
@@ -309,15 +309,28 @@ func (p *ParserValidator) expandProjectGlobs(absRepoDir string, projects []raw.P
 	return expandedProjects, nil
 }
 
-// dirContainsTerraformFiles returns true if the directory contains at least one .tf file.
-func (p *ParserValidator) dirContainsTerraformFiles(dir string) (bool, error) {
+// dirContainsMatchingFiles returns true if the directory contains at least one file
+// matching any of the given patterns. If patterns is nil, defaults to ["*.tf"].
+func (p *ParserValidator) dirContainsMatchingFiles(dir string, patterns []string) (bool, error) {
+	if patterns == nil {
+		patterns = []string{"*.tf"}
+	}
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return false, err
 	}
 	for _, entry := range entries {
-		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".tf") {
-			return true, nil
+		if entry.IsDir() {
+			continue
+		}
+		for _, pattern := range patterns {
+			matched, err := filepath.Match(pattern, entry.Name())
+			if err != nil {
+				return false, fmt.Errorf("invalid pattern %q: %w", pattern, err)
+			}
+			if matched {
+				return true, nil
+			}
 		}
 	}
 	return false, nil
@@ -347,6 +360,8 @@ func (p *ParserValidator) copyProjectWithDir(original raw.Project, newDir string
 		PolicyCheck:               original.PolicyCheck,
 		CustomPolicyCheck:         original.CustomPolicyCheck,
 		SilencePRComments:         original.SilencePRComments,
+		// GlobFileMatch is intentionally not copied: it is consumed during glob expansion
+		// and the expanded projects have literal dir paths, so the field no longer applies.
 	}
 
 	// Note: We intentionally do NOT copy the Name field.

--- a/server/core/config/parser_validator_test.go
+++ b/server/core/config/parser_validator_test.go
@@ -2300,3 +2300,98 @@ projects:
 		Assert(t, p.Name == nil, "expanded projects should not have names")
 	}
 }
+
+// Test that glob_file_match filters directories by specific file patterns.
+func TestParseRepoCfg_GlobExpansionGlobFileMatch(t *testing.T) {
+	// Create a temp directory with the following structure:
+	// repo/
+	//   modules/
+	//     with-terragrunt/
+	//       terragrunt.hcl
+	//     with-tf/
+	//       main.tf
+	//     with-both/
+	//       terragrunt.hcl
+	//       main.tf
+	//     empty/
+	//       readme.md
+
+	tmpDir := t.TempDir()
+
+	dirs := []string{
+		"modules/with-terragrunt",
+		"modules/with-tf",
+		"modules/with-both",
+		"modules/empty",
+	}
+	for _, dir := range dirs {
+		err := os.MkdirAll(filepath.Join(tmpDir, dir), 0755)
+		Ok(t, err)
+	}
+	Ok(t, os.WriteFile(filepath.Join(tmpDir, "modules/with-terragrunt/terragrunt.hcl"), []byte(""), 0600))
+	Ok(t, os.WriteFile(filepath.Join(tmpDir, "modules/with-tf/main.tf"), []byte(""), 0600))
+	Ok(t, os.WriteFile(filepath.Join(tmpDir, "modules/with-both/terragrunt.hcl"), []byte(""), 0600))
+	Ok(t, os.WriteFile(filepath.Join(tmpDir, "modules/with-both/main.tf"), []byte(""), 0600))
+	Ok(t, os.WriteFile(filepath.Join(tmpDir, "modules/empty/readme.md"), []byte(""), 0600))
+
+	cases := []struct {
+		description string
+		input       string
+		expDirs     []string
+	}{
+		{
+			description: "glob_file_match terragrunt.hcl only",
+			input: `
+version: 3
+projects:
+- dir: "modules/*"
+  glob_file_match:
+  - "terragrunt.hcl"
+`,
+			expDirs: []string{"modules/with-terragrunt", "modules/with-both"},
+		},
+		{
+			description: "default (no glob_file_match) matches *.tf",
+			input: `
+version: 3
+projects:
+- dir: "modules/*"
+`,
+			expDirs: []string{"modules/with-tf", "modules/with-both"},
+		},
+		{
+			description: "multiple patterns match any",
+			input: `
+version: 3
+projects:
+- dir: "modules/*"
+  glob_file_match:
+  - "terragrunt.hcl"
+  - "*.tf"
+`,
+			expDirs: []string{"modules/with-terragrunt", "modules/with-tf", "modules/with-both"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			err := os.WriteFile(filepath.Join(tmpDir, "atlantis.yaml"), []byte(c.input), 0600)
+			Ok(t, err)
+
+			r := config.ParserValidator{}
+			cfg, err := r.ParseRepoCfg(tmpDir, globalCfg, "", "")
+			Ok(t, err)
+
+			var actualDirs []string
+			for _, p := range cfg.Projects {
+				actualDirs = append(actualDirs, p.Dir)
+			}
+
+			Equals(t, len(c.expDirs), len(actualDirs))
+			for _, expDir := range c.expDirs {
+				found := slices.Contains(actualDirs, expDir)
+				Assert(t, found, "expected dir %q not found in actual dirs %v", expDir, actualDirs)
+			}
+		})
+	}
+}

--- a/server/core/config/raw/project.go
+++ b/server/core/config/raw/project.go
@@ -44,6 +44,7 @@ type Project struct {
 	PolicyCheck               *bool      `yaml:"policy_check,omitempty"`
 	CustomPolicyCheck         *bool      `yaml:"custom_policy_check,omitempty"`
 	SilencePRComments         []string   `yaml:"silence_pr_comments,omitempty"`
+	GlobFileMatch             []string   `yaml:"glob_file_match,omitempty"`
 }
 
 func (p Project) Validate() error {
@@ -96,6 +97,40 @@ func (p Project) Validate() error {
 		return nil
 	}
 
+	validGlobFileMatch := func(value any) error {
+		patterns, ok := value.([]string)
+		if !ok {
+			return errors.New("glob_file_match must be a list of patterns")
+		}
+		if patterns == nil {
+			// Field was omitted in YAML; nil is fine — dirContainsMatchingFiles defaults to ["*.tf"].
+			return nil
+		}
+		if len(patterns) == 0 {
+			// Explicit `glob_file_match: []` is rejected to avoid silent "match nothing" behaviour.
+			return errors.New("glob_file_match cannot be an empty list; omit the field to use the default (*.tf)")
+		}
+		for _, pattern := range patterns {
+			if pattern == "" {
+				return errors.New("glob_file_match patterns cannot be empty strings")
+			}
+			if _, err := filepath.Match(pattern, ""); err != nil {
+				return fmt.Errorf("invalid glob_file_match pattern %q: %w", pattern, err)
+			}
+			// glob_file_match patterns are matched against entry.Name(), which is a base filename
+			// only. Disallow any path separators to avoid patterns that can never match, such as
+			// "subdir/*.tf" or "**/*.tf".
+			if strings.Contains(pattern, "/") {
+				return fmt.Errorf("invalid glob_file_match pattern %q: must be a basename pattern without path separators", pattern)
+			}
+			sep := string(filepath.Separator)
+			if sep != "/" && strings.Contains(pattern, sep) {
+				return fmt.Errorf("invalid glob_file_match pattern %q: must be a basename pattern without path separators", pattern)
+			}
+		}
+		return nil
+	}
+
 	// Validate that name doesn't contain glob patterns - glob expansion only works for 'dir'
 	if p.Name != nil && ContainsGlobPattern(*p.Name) {
 		return errors.New("name: cannot contain glob pattern characters ('*', '?', '['); glob expansion is only supported in the 'dir' field")
@@ -105,6 +140,13 @@ func (p Project) Validate() error {
 	// because glob patterns expand to multiple projects which can't share the same name
 	if p.Name != nil && p.Dir != nil && ContainsGlobPattern(*p.Dir) {
 		return errors.New("name: cannot be used with glob patterns in 'dir'; glob patterns expand to multiple projects which cannot share the same name")
+	}
+
+	// Cross-field validation: glob_file_match only applies during glob expansion,
+	// so it has no effect when dir is a literal path. Check for non-nil (not just
+	// non-empty) so an explicit `glob_file_match: []` also triggers this error.
+	if p.GlobFileMatch != nil && (p.Dir == nil || !ContainsGlobPattern(*p.Dir)) {
+		return errors.New("glob_file_match: can only be used when 'dir' contains a glob pattern")
 	}
 
 	return validation.ValidateStruct(&p,
@@ -117,6 +159,7 @@ func (p Project) Validate() error {
 		validation.Field(&p.DependsOn, validation.By(DependsOn)),
 		validation.Field(&p.Name, validation.By(validName)),
 		validation.Field(&p.Branch, validation.By(branchValid)),
+		validation.Field(&p.GlobFileMatch, validation.By(validGlobFileMatch)),
 	)
 }
 

--- a/server/core/config/raw/project_test.go
+++ b/server/core/config/raw/project_test.go
@@ -36,6 +36,18 @@ func TestProject_UnmarshalYAML(t *testing.T) {
 			},
 		},
 		{
+			description: "glob_file_match field parsed",
+			input: `
+dir: mydir
+glob_file_match:
+- "terragrunt.hcl"
+- "*.tf"`,
+			exp: raw.Project{
+				Dir:           String("mydir"),
+				GlobFileMatch: []string{"terragrunt.hcl", "*.tf"},
+			},
+		},
+		{
 			description: "all fields set including mergeable apply requirement",
 			input: `
 name: myname
@@ -417,6 +429,62 @@ func TestProject_Validate(t *testing.T) {
 				Name: String("networking"),
 			},
 			expErr: "",
+		},
+		// glob_file_match tests
+		{
+			description: "valid glob_file_match patterns",
+			input: raw.Project{
+				Dir:           String("modules/*"),
+				GlobFileMatch: []string{"terragrunt.hcl", "*.tf"},
+			},
+			expErr: "",
+		},
+		{
+			description: "glob_file_match with empty string pattern",
+			input: raw.Project{
+				Dir:           String("modules/*"),
+				GlobFileMatch: []string{""},
+			},
+			expErr: "glob_file_match: glob_file_match patterns cannot be empty strings.",
+		},
+		{
+			description: "glob_file_match with invalid pattern syntax",
+			input: raw.Project{
+				Dir:           String("modules/*"),
+				GlobFileMatch: []string{"[invalid"},
+			},
+			expErr: "glob_file_match: invalid glob_file_match pattern \"[invalid\": syntax error in pattern.",
+		},
+		{
+			description: "explicit empty glob_file_match list should fail",
+			input: raw.Project{
+				Dir:           String("modules/*"),
+				GlobFileMatch: []string{},
+			},
+			expErr: "glob_file_match: glob_file_match cannot be an empty list; omit the field to use the default (*.tf).",
+		},
+		{
+			description: "explicit empty glob_file_match on non-glob dir should fail with cross-field error",
+			input: raw.Project{
+				Dir:           String("modules/networking"),
+				GlobFileMatch: []string{},
+			},
+			expErr: "glob_file_match: can only be used when 'dir' contains a glob pattern",
+		},
+		{
+			description: "glob_file_match on non-glob dir should fail",
+			input: raw.Project{
+				Dir:           String("modules/networking"),
+				GlobFileMatch: []string{"terragrunt.hcl"},
+			},
+			expErr: "glob_file_match: can only be used when 'dir' contains a glob pattern",
+		},
+		{
+			description: "glob_file_match with nil dir should fail",
+			input: raw.Project{
+				GlobFileMatch: []string{"terragrunt.hcl"},
+			},
+			expErr: "glob_file_match: can only be used when 'dir' contains a glob pattern",
 		},
 	}
 	validation.ErrorTag = "yaml"


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

- Add `glob_file_match` parameter to `project` to customize folders discovered by `expandProjectGlobs` (default to `["*.tf"]` if not defined).

Example:
```yaml
projects:
- dir: a/**/*
  glob_file_match:
  - "*.tf"
  - "terragrunt.hcl"
```

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

- Allow `expandProjectGlobs` to match with folders that doesn't contains `.tf` files
- Allow to match terragrunt-only folders

## tests

<!--
- [ ] I have tested my changes by ...
-->

- [X] Tested with terragrunt-only (`["terragrunt.hcl"]`)
- [X] Tested with no value (i.e. default)
- [X] Tested with both (`["*.tf", "terragrunt.hcl"]`)

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

- Fix https://github.com/runatlantis/atlantis/issues/6340
- Extend https://github.com/runatlantis/atlantis/pull/6006
