### PR TITLE
feat: show policy approvers in PR comments

### DIFF
--- a/server/core/config/valid/policies.go
+++ b/server/core/config/valid/policies.go
@@ -54,6 +54,27 @@ func (p *PolicySets) HasTeamOwners() bool {
 	return hasTeamOwners
 }
 
+// MergedWith returns a new PolicyOwners combining o and other, deduplicating case-insensitively.
+func (o PolicyOwners) MergedWith(other PolicyOwners) PolicyOwners {
+	return PolicyOwners{
+		Users: mergeUniqueStrings(o.Users, other.Users),
+		Teams: mergeUniqueStrings(o.Teams, other.Teams),
+	}
+}
+
+func mergeUniqueStrings(a, b []string) []string {
+	seen := map[string]bool{}
+	result := []string{}
+	for _, s := range append(a, b...) {
+		lower := strings.ToLower(s)
+		if !seen[lower] {
+			seen[lower] = true
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
 func (o *PolicyOwners) IsOwner(username string, userTeams []string) bool {
 	for _, uname := range o.Users {
 		if strings.EqualFold(uname, username) {

--- a/server/core/runtime/policy/conftest_client.go
+++ b/server/core/runtime/policy/conftest_client.go
@@ -232,6 +232,8 @@ func (c *ConfTestExecutorWorkflow) Run(ctx command.ProjectContext, executablePat
 			PolicyOutput:  cmdOutput,
 			Passed:        passed,
 			ReqApprovals:  policySet.ApproveCount,
+			OwnerUsers:    ctx.PolicySets.Owners.MergedWith(policySet.Owners).Users,
+			OwnerTeams:    ctx.PolicySets.Owners.MergedWith(policySet.Owners).Teams,
 		})
 	}
 

--- a/server/core/runtime/policy/conftest_client_test.go
+++ b/server/core/runtime/policy/conftest_client_test.go
@@ -190,7 +190,7 @@ func TestRun(t *testing.T) {
 		var extraArgs []string
 
 		expectedOutput := "Success"
-		expectedResult := `[{"PolicySetName":"policy1","PolicyOutput":"Success","Passed":true,"ReqApprovals":0,"CurApprovals":0},{"PolicySetName":"policy2","PolicyOutput":"Success","Passed":true,"ReqApprovals":0,"CurApprovals":0}]`
+		expectedResult := `[{"PolicySetName":"policy1","PolicyOutput":"Success","Passed":true,"ReqApprovals":0,"CurApprovals":0,"OwnerUsers":[],"OwnerTeams":[]},{"PolicySetName":"policy2","PolicyOutput":"Success","Passed":true,"ReqApprovals":0,"CurApprovals":0,"OwnerUsers":[],"OwnerTeams":[]}]`
 
 		expectedArgsPolicy1 := []string{executablePath, "test", "-p", localPolicySetPath1, filepath.Join(workdir, "testproj-default.json"), "--no-color"}
 		expectedArgsPolicy2 := []string{executablePath, "test", "-p", localPolicySetPath2, filepath.Join(workdir, "testproj-default.json"), "--no-color"}
@@ -215,7 +215,7 @@ func TestRun(t *testing.T) {
 		extraArgs := []string{"--all-namespaces"}
 
 		expectedOutput := "Success"
-		expectedResult := `[{"PolicySetName":"policy1","PolicyOutput":"","Passed":true,"ReqApprovals":0,"CurApprovals":0},{"PolicySetName":"policy2","PolicyOutput":"","Passed":true,"ReqApprovals":0,"CurApprovals":0}]`
+		expectedResult := `[{"PolicySetName":"policy1","PolicyOutput":"","Passed":true,"ReqApprovals":0,"CurApprovals":0,"OwnerUsers":[],"OwnerTeams":[]},{"PolicySetName":"policy2","PolicyOutput":"","Passed":true,"ReqApprovals":0,"CurApprovals":0,"OwnerUsers":[],"OwnerTeams":[]}]`
 
 		expectedArgsPolicy1 := []string{executablePath, "test", "-p", localPolicySetPath1, filepath.Join(workdir, "testproj-default.json"), "--no-color"}
 		expectedArgsPolicy2 := []string{executablePath, "test", "-p", localPolicySetPath2, filepath.Join(workdir, "testproj-default.json"), "--no-color"}
@@ -240,7 +240,7 @@ func TestRun(t *testing.T) {
 		var extraArgs []string
 
 		expectedOutput := "Success"
-		expectedResult := `[{"PolicySetName":"policy1","PolicyOutput":"Success","Passed":true,"ReqApprovals":0,"CurApprovals":0}]`
+		expectedResult := `[{"PolicySetName":"policy1","PolicyOutput":"Success","Passed":true,"ReqApprovals":0,"CurApprovals":0,"OwnerUsers":[],"OwnerTeams":[]}]`
 
 		expectedArgsPolicy1 := []string{executablePath, "test", "-p", localPolicySetPath1, filepath.Join(workdir, "testproj-default.json"), "--no-color"}
 		expectedArgsPolicy2 := []string{executablePath, "test", "-p", localPolicySetPath2, filepath.Join(workdir, "testproj-default.json"), "--no-color"}
@@ -283,7 +283,7 @@ func TestRun(t *testing.T) {
 
 		expectedOutputPolicy1 := fmt.Sprintf("FAIL - %s - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions", filepath.Join(workdir, "testproj-default.json"))
 		expectedOutputPolicy2 := "Success"
-		expectedResult := `[{"PolicySetName":"policy1","PolicyOutput":"FAIL - <redacted plan file> - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions","Passed":false,"ReqApprovals":0,"CurApprovals":0},{"PolicySetName":"policy2","PolicyOutput":"Success","Passed":true,"ReqApprovals":0,"CurApprovals":0}]`
+		expectedResult := `[{"PolicySetName":"policy1","PolicyOutput":"FAIL - <redacted plan file> - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions","Passed":false,"ReqApprovals":0,"CurApprovals":0,"OwnerUsers":[],"OwnerTeams":[]},{"PolicySetName":"policy2","PolicyOutput":"Success","Passed":true,"ReqApprovals":0,"CurApprovals":0,"OwnerUsers":[],"OwnerTeams":[]}]`
 
 		expectedArgsPolicy1 := []string{executablePath, "test", "-p", localPolicySetPath1, filepath.Join(workdir, "testproj-default.json"), "--no-color"}
 		expectedArgsPolicy2 := []string{executablePath, "test", "-p", localPolicySetPath2, filepath.Join(workdir, "testproj-default.json"), "--no-color"}
@@ -305,7 +305,7 @@ func TestRun(t *testing.T) {
 		var extraArgs []string
 
 		expectedOutput := fmt.Sprintf("FAIL - %s - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions", filepath.Join(workdir, "testproj-default.json"))
-		expectedResult := `[{"PolicySetName":"policy1","PolicyOutput":"FAIL - <redacted plan file> - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions","Passed":false,"ReqApprovals":0,"CurApprovals":0},{"PolicySetName":"policy2","PolicyOutput":"FAIL - <redacted plan file> - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions","Passed":false,"ReqApprovals":0,"CurApprovals":0}]`
+		expectedResult := `[{"PolicySetName":"policy1","PolicyOutput":"FAIL - <redacted plan file> - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions","Passed":false,"ReqApprovals":0,"CurApprovals":0,"OwnerUsers":[],"OwnerTeams":[]},{"PolicySetName":"policy2","PolicyOutput":"FAIL - <redacted plan file> - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions","Passed":false,"ReqApprovals":0,"CurApprovals":0,"OwnerUsers":[],"OwnerTeams":[]}]`
 
 		expectedArgsPolicy1 := []string{executablePath, "test", "-p", localPolicySetPath1, filepath.Join(workdir, "testproj-default.json"), "--no-color"}
 		expectedArgsPolicy2 := []string{executablePath, "test", "-p", localPolicySetPath2, filepath.Join(workdir, "testproj-default.json"), "--no-color"}
@@ -323,12 +323,57 @@ func TestRun(t *testing.T) {
 
 	})
 
+	t.Run("owners populated from global and per-set config", func(t *testing.T) {
+		var extraArgs []string
+
+		expectedOutput := fmt.Sprintf("FAIL - %s - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions", filepath.Join(workdir, "testproj-default.json"))
+		// policy1 has a per-set team; policy2 inherits only the global user
+		// global owner "admin-user" should appear in both; "infra-team" only in policy1
+		expectedResult := `[{"PolicySetName":"policy1","PolicyOutput":"FAIL - <redacted plan file> - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions","Passed":false,"ReqApprovals":0,"CurApprovals":0,"OwnerUsers":["admin-user"],"OwnerTeams":["infra-team"]},{"PolicySetName":"policy2","PolicyOutput":"FAIL - <redacted plan file> - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions","Passed":false,"ReqApprovals":0,"CurApprovals":0,"OwnerUsers":["admin-user"],"OwnerTeams":[]}]`
+
+		policySet1WithOwners := valid.PolicySet{
+			Source: valid.LocalPolicySet,
+			Path:   policySetPath1,
+			Name:   policySetName1,
+			Owners: valid.PolicyOwners{Teams: []string{"infra-team"}},
+		}
+		policySet2NoOwners := valid.PolicySet{
+			Source: valid.LocalPolicySet,
+			Path:   policySetPath2,
+			Name:   policySetName2,
+		}
+
+		ctxWithOwners := command.ProjectContext{
+			PolicySets: valid.PolicySets{
+				Owners:     valid.PolicyOwners{Users: []string{"admin-user"}},
+				PolicySets: []valid.PolicySet{policySet1WithOwners, policySet2NoOwners},
+			},
+			ProjectName: "testproj",
+			Workspace:   "default",
+			Log:         log,
+		}
+
+		expectedArgsPolicy1 := []string{executablePath, "test", "-p", localPolicySetPath1, filepath.Join(workdir, "testproj-default.json"), "--no-color"}
+		expectedArgsPolicy2 := []string{executablePath, "test", "-p", localPolicySetPath2, filepath.Join(workdir, "testproj-default.json"), "--no-color"}
+
+		When(mockResolver.Resolve(policySet1WithOwners)).ThenReturn(localPolicySetPath1, nil)
+		When(mockResolver.Resolve(policySet2NoOwners)).ThenReturn(localPolicySetPath2, nil)
+
+		When(mockExec.CombinedOutput(expectedArgsPolicy1, envs, workdir)).ThenReturn(expectedOutput, errors.New("exit status code 1"))
+		When(mockExec.CombinedOutput(expectedArgsPolicy2, envs, workdir)).ThenReturn(expectedOutput, errors.New("exit status code 1"))
+
+		result, err := subject.Run(ctxWithOwners, executablePath, envs, workdir, extraArgs)
+
+		Equals(t, result, expectedResult)
+		Assert(t, err != nil, "error is expected")
+	})
+
 	t.Run("parse error should fail policy", func(t *testing.T) {
 		var extraArgs []string
 
 		// Simulate a Rego parse error output
 		parseErrorOutput := "Error: running test: load: loading policies: load: 2 errors occurred during loading:"
-		expectedResult := `[{"PolicySetName":"policy1","PolicyOutput":"Error: running test: load: loading policies: load: 2 errors occurred during loading:","Passed":false,"ReqApprovals":0,"CurApprovals":0}]`
+		expectedResult := `[{"PolicySetName":"policy1","PolicyOutput":"Error: running test: load: loading policies: load: 2 errors occurred during loading:","Passed":false,"ReqApprovals":0,"CurApprovals":0,"OwnerUsers":[],"OwnerTeams":[]}]`
 
 		expectedArgsPolicy := []string{executablePath, "test", "-p", localPolicySetPath1, filepath.Join(workdir, "testproj-default.json"), "--no-color"}
 

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -397,6 +397,8 @@ type PolicySetResult struct {
 	Passed        bool
 	ReqApprovals  int
 	CurApprovals  int
+	OwnerUsers    []string
+	OwnerTeams    []string
 }
 
 // PolicySetApproval tracks the number of approvals a given policy set has.

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -527,7 +527,13 @@ func (p *DefaultProjectCommandRunner) doPolicyCheck(ctx command.ProjectContext) 
 				policyOutput = output
 			}
 
-			policySetResults = append(policySetResults, models.PolicySetResult{PolicySetName: policySetName, PolicyOutput: policyOutput, Passed: passed, ReqApprovals: 1, CurApprovals: 0})
+			var merged valid.PolicyOwners
+			if index < len(inputPolicySets) {
+				merged = ctx.PolicySets.Owners.MergedWith(inputPolicySets[index].Owners)
+			} else {
+				merged = ctx.PolicySets.Owners
+			}
+			policySetResults = append(policySetResults, models.PolicySetResult{PolicySetName: policySetName, PolicyOutput: policyOutput, Passed: passed, ReqApprovals: 1, CurApprovals: 0, OwnerUsers: merged.Users, OwnerTeams: merged.Teams})
 		}
 	}
 

--- a/server/events/templates/policy_check_results_unwrapped.tmpl
+++ b/server/events/templates/policy_check_results_unwrapped.tmpl
@@ -26,6 +26,11 @@
   ```shell
   {{ .ApprovePoliciesCmd }}
   ```
+{{- range .PolicySetResults -}}
+{{- if and (not .Passed) (ne .CurApprovals .ReqApprovals) (or .OwnerUsers .OwnerTeams) }}
+* **{{ .PolicySetName }}** approval required from:{{ if .OwnerTeams }} teams: `{{ join "`, `" .OwnerTeams }}`{{ end }}{{ if .OwnerUsers }} users: `{{ join "`, `" .OwnerUsers }}`{{ end }}
+{{- end -}}
+{{- end }}
 {{- end }}
 * :put_litter_in_its_place: To **delete** this plan and lock, click [here]({{ .LockURL }})
 * :repeat: To re-run policies **plan** this project again by commenting:

--- a/server/events/templates/policy_check_results_wrapped.tmpl
+++ b/server/events/templates/policy_check_results_wrapped.tmpl
@@ -31,6 +31,11 @@
   ```shell
   {{ .ApprovePoliciesCmd }}
   ```
+{{- range .PolicySetResults -}}
+{{- if and (not .Passed) (ne .CurApprovals .ReqApprovals) (or .OwnerUsers .OwnerTeams) }}
+* **{{ .PolicySetName }}** approval required from:{{ if .OwnerTeams }} teams: `{{ join "`, `" .OwnerTeams }}`{{ end }}{{ if .OwnerUsers }} users: `{{ join "`, `" .OwnerUsers }}`{{ end }}
+{{- end -}}
+{{- end }}
 {{- end }}
 * :put_litter_in_its_place: To **delete** this plan and lock, click [here]({{ .LockURL }})
 * :repeat: To re-run policies **plan** this project again by commenting:


### PR DESCRIPTION
## Summary

When a conftest policy check fails, Atlantis posts a GitHub comment with a \"Policy Approval Status\" section but doesn't indicate *who* is allowed to approve — forcing contributors to hunt through Atlantis config to find the right team or person to contact.

This PR surfaces the configured owner teams and users directly in the PR comment for each failing policy set:

- Adds `OwnerUsers []string` and `OwnerTeams []string` to `PolicySetResult`
- Populates them in `conftest_client.go` and `project_command_runner.go` by merging global (`PolicySets.Owners`) and per-set owners with case-insensitive deduplication
- Renders approver info in both wrapped and unwrapped policy check comment templates — only when owners are configured, so existing behaviour is unchanged when no owners are set

**Example output** (when owners are configured):
```
#### Policy Approval Status:
...
* :white_check_mark: To **approve** this project, comment:
  ```shell
  atlantis approve_policies ...
  ```
* **common-policies** approval required from: teams: `infra-team` users: `alice`
```

## Test plan

- [x] Existing unit tests pass: `go test ./server/events/... ./server/core/runtime/policy/...`
- [x] Updated `conftest_client_test.go` expected JSON strings to include new fields
- [x] Template change is backward-compatible: no output change when `OwnerUsers` and `OwnerTeams` are both empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)