### PR TITLE
fix(github): check ruleset required reviewer approvals in IsMergeable…

### DIFF
--- a/server/events/vcs/github/client.go
+++ b/server/events/vcs/github/client.go
@@ -591,13 +591,19 @@ func (g *Client) GetPullRequestMergeabilityInfo(
 	requiredWorkflows []WorkflowFileReference,
 	checkRuns []CheckRun,
 	statusContexts []StatusContext,
+	pendingRequiredReviewerApproval bool,
 	err error,
 ) {
 	var query struct {
 		Repository struct {
 			PullRequest struct {
-				ReviewDecision githubv4.String
-				BaseRef        struct {
+				ReviewDecision           githubv4.String
+				LatestOpinionatedReviews struct {
+					Nodes []struct {
+						State githubv4.String
+					}
+				} `graphql:"latestOpinionatedReviews(first: 100)"`
+				BaseRef struct {
 					BranchProtectionRule struct {
 						RequiredStatusChecks []struct {
 							Context githubv4.String
@@ -619,6 +625,9 @@ func (g *Client) GetPullRequestMergeabilityInfo(
 								WorkflowsParameters struct {
 									Workflows []WorkflowFileReference
 								} `graphql:"... on WorkflowsParameters"`
+								PullRequestParameters struct {
+									RequiredApprovingReviewCount githubv4.Int
+								} `graphql:"... on PullRequestParameters"`
 							}
 						}
 					} `graphql:"rules(first: 100, after: $ruleCursor)"`
@@ -663,6 +672,13 @@ pagination:
 
 		reviewDecision = query.Repository.PullRequest.ReviewDecision
 
+		approvedReviewCount := 0
+		for _, review := range query.Repository.PullRequest.LatestOpinionatedReviews.Nodes {
+			if review.State == "APPROVED" {
+				approvedReviewCount++
+			}
+		}
+
 		for _, rule := range query.Repository.PullRequest.BaseRef.BranchProtectionRule.RequiredStatusChecks {
 			requiredChecksSet[rule.Context] = struct{}{}
 		}
@@ -679,6 +695,11 @@ pagination:
 			case "WORKFLOWS":
 				for _, workflow := range rule.Parameters.WorkflowsParameters.Workflows {
 					requiredWorkflows = append(requiredWorkflows, workflow.Copy())
+				}
+			case "PULL_REQUEST":
+				required := int(rule.Parameters.PullRequestParameters.RequiredApprovingReviewCount)
+				if required > 0 && approvedReviewCount < required {
+					pendingRequiredReviewerApproval = true
 				}
 			default:
 				continue
@@ -716,14 +737,14 @@ pagination:
 	}
 
 	if err != nil {
-		return "", nil, nil, nil, nil, fmt.Errorf("fetching rulesets, branch protections and status checks from GraphQL: %w", err)
+		return "", nil, nil, nil, nil, false, fmt.Errorf("fetching rulesets, branch protections and status checks from GraphQL: %w", err)
 	}
 
 	for context := range requiredChecksSet {
 		requiredChecks = append(requiredChecks, context)
 	}
 
-	return reviewDecision, requiredChecks, requiredWorkflows, checkRuns, statusContexts, nil
+	return reviewDecision, requiredChecks, requiredWorkflows, checkRuns, statusContexts, pendingRequiredReviewerApproval, nil
 }
 
 func CheckSuitePassed(checkSuite CheckSuite) bool {
@@ -805,17 +826,22 @@ func (g *Client) IsMergeableMinusApply(logger logging.SimpleLogging, repo models
 	if pull.Number == nil {
 		return false, errors.New("pull request number is nil")
 	}
-	reviewDecision, requiredChecks, requiredWorkflows, checkRuns, statusContexts, err := g.GetPullRequestMergeabilityInfo(repo, pull)
+	reviewDecision, requiredChecks, requiredWorkflows, checkRuns, statusContexts, pendingRequiredReviewerApproval, err := g.GetPullRequestMergeabilityInfo(repo, pull)
 	if err != nil {
 		return false, err
 	}
 
 	notMergeablePrefix := fmt.Sprintf("Pull Request %s/%s:%s is not mergeable", repo.Owner, repo.Name, strconv.Itoa(*pull.Number))
 
-	// Review decision takes CODEOWNERS into account
-	// Empty review decision means review is not required
+	// reviewDecision covers CODEOWNERS and classic branch protection review requirements.
+	// Empty/null means GitHub rulesets may be enforcing reviews via required_reviewers
+	// instead — check that separately via pendingRequiredReviewerApproval.
 	if reviewDecision != "APPROVED" && len(reviewDecision) != 0 {
 		logger.Debug("%s: Review Decision: %s", notMergeablePrefix, reviewDecision)
+		return false, nil
+	}
+	if pendingRequiredReviewerApproval {
+		logger.Debug("%s: Pending required reviewer approval from ruleset", notMergeablePrefix)
 		return false, nil
 	}
 

--- a/server/events/vcs/github/client_test.go
+++ b/server/events/vcs/github/client_test.go
@@ -999,6 +999,24 @@ func TestClient_PullIsMergeableWithAllowMergeableBypassApply(t *testing.T) {
 				IsMergeable: true,
 			},
 		},
+		// Ruleset-enforced required reviewer approvals (reviewDecision is null when rulesets control reviews)
+		{
+			"blocked",
+			"ruleset-required-reviewer-pending.json",
+			"null",
+			models.MergeableStatus{
+				IsMergeable: false,
+				Reason:      "PR is in state blocked, and cannot bypass mergeable requirements",
+			},
+		},
+		{
+			"blocked",
+			"ruleset-required-reviewer-approved.json",
+			"null",
+			models.MergeableStatus{
+				IsMergeable: true,
+			},
+		},
 	}
 
 	// Use a real GitHub json response and edit the mergeable_state field.

--- a/server/events/vcs/github/testdata/pull-request-mergeability/ruleset-required-reviewer-approved.json
+++ b/server/events/vcs/github/testdata/pull-request-mergeability/ruleset-required-reviewer-approved.json
@@ -1,0 +1,55 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "reviewDecision": null,
+        "latestOpinionatedReviews": {
+          "nodes": [
+            {
+              "state": "APPROVED"
+            }
+          ]
+        },
+        "baseRef": {
+          "branchProtectionRule": {
+            "requiredStatusChecks": []
+          },
+          "rules": {
+            "pageInfo": {
+              "endCursor": "QWERTY",
+              "hasNextPage": false
+            },
+            "nodes": [
+              {
+                "type": "PULL_REQUEST",
+                "repositoryRuleset": {
+                  "enforcement": "ACTIVE"
+                },
+                "parameters": {
+                  "requiredApprovingReviewCount": 1
+                }
+              }
+            ]
+          }
+        },
+        "commits": {
+          "nodes": [
+            {
+              "commit": {
+                "statusCheckRollup": {
+                  "contexts": {
+                    "pageInfo": {
+                      "endCursor": "QWERTY",
+                      "hasNextPage": false
+                    },
+                    "nodes": []
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/server/events/vcs/github/testdata/pull-request-mergeability/ruleset-required-reviewer-pending.json
+++ b/server/events/vcs/github/testdata/pull-request-mergeability/ruleset-required-reviewer-pending.json
@@ -1,0 +1,51 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "reviewDecision": null,
+        "latestOpinionatedReviews": {
+          "nodes": []
+        },
+        "baseRef": {
+          "branchProtectionRule": {
+            "requiredStatusChecks": []
+          },
+          "rules": {
+            "pageInfo": {
+              "endCursor": "QWERTY",
+              "hasNextPage": false
+            },
+            "nodes": [
+              {
+                "type": "PULL_REQUEST",
+                "repositoryRuleset": {
+                  "enforcement": "ACTIVE"
+                },
+                "parameters": {
+                  "requiredApprovingReviewCount": 1
+                }
+              }
+            ]
+          }
+        },
+        "commits": {
+          "nodes": [
+            {
+              "commit": {
+                "statusCheckRollup": {
+                  "contexts": {
+                    "pageInfo": {
+                      "endCursor": "QWERTY",
+                      "hasNextPage": false
+                    },
+                    "nodes": []
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary                                                                                                                               
                                                                                                                                            
   - **Bug:** When GitHub enforces review requirements via rulesets (not classic branch protection), `reviewDecision` is `null` in the      
   GraphQL API. This caused `ATLANTIS_GH_ALLOW_MERGEABLE_BYPASS_APPLY` to silently allow applies on PRs that hadn't received required
   approvals.
   - **Fix:** Extend `GetPullRequestMergeabilityInfo` to also query `PULL_REQUEST` ruleset rules for `requiredApprovingReviewCount` and
   the PR's `latestOpinionatedReviews`. `IsMergeableMinusApply` now blocks when a ruleset requires approvals but the PR hasn't received
   enough — regardless of `reviewDecision` being `null`.
   - **Tests:** Two new test cases covering the pending and approved states for ruleset-enforced reviewer requirements.

   ## Root Cause

   GitHub populates `reviewDecision` only for classic branch protection and CODEOWNERS + `require_code_owner_review`. When
   `required_reviewers` in a ruleset is the enforcement mechanism, GitHub returns `null` for `reviewDecision` — it's a gap in the GraphQL
    API where the newer ruleset system doesn't feed into the older `reviewDecision` field.

   ## Changes

   `server/events/vcs/github/client.go`:
   - Extended `GetPullRequestMergeabilityInfo` GraphQL query to include `latestOpinionatedReviews` on the PR and
   `PullRequestParameters.requiredApprovingReviewCount` on ruleset rule nodes
   - Added `pendingRequiredReviewerApproval bool` to the return signature
   - Handle `PULL_REQUEST` ruleset rule type in the loop: compare approved review count against the required count
   - Updated `IsMergeableMinusApply` to check `pendingRequiredReviewerApproval` after the `reviewDecision` check