### PR TITLE
feat: add per-repo bundle_uri option for git clone

### DIFF
--- a/runatlantis.io/docs/server-side-repo-config.md
+++ b/runatlantis.io/docs/server-side-repo-config.md
@@ -104,6 +104,10 @@ repos:
     ignore_paths:
       - foo/*
 
+  # bundle_uri specifies a bundle URI to pass to git clone via --bundle-uri for faster cloning.
+  # See https://git-scm.com/docs/bundle-uri for more information.
+  bundle_uri: https://bundle-server.example.com/org/repo
+
   # id can also be an exact match.
 - id: github.com/myorg/specific-repo
 

--- a/server/core/config/raw/global_cfg.go
+++ b/server/core/config/raw/global_cfg.go
@@ -44,6 +44,7 @@ type Repo struct {
 	CustomPolicyCheck         *bool          `yaml:"custom_policy_check,omitempty" json:"custom_policy_check,omitempty"`
 	AutoDiscover              *AutoDiscover  `yaml:"autodiscover,omitempty" json:"autodiscover,omitempty"`
 	SilencePRComments         []string       `yaml:"silence_pr_comments,omitempty" json:"silence_pr_comments,omitempty"`
+	BundleURI                 string         `yaml:"bundle_uri,omitempty" json:"bundle_uri,omitempty"`
 }
 
 func (g GlobalCfg) Validate() error {
@@ -397,5 +398,6 @@ OuterGlobalImportReqs:
 		CustomPolicyCheck:         r.CustomPolicyCheck,
 		AutoDiscover:              autoDiscover,
 		SilencePRComments:         r.SilencePRComments,
+		BundleURI:                 r.BundleURI,
 	}
 }

--- a/server/core/config/valid/global_cfg.go
+++ b/server/core/config/valid/global_cfg.go
@@ -93,6 +93,7 @@ type Repo struct {
 	CustomPolicyCheck         *bool
 	AutoDiscover              *AutoDiscover
 	SilencePRComments         []string
+	BundleURI                 string
 }
 
 type MergedProjectCfg struct {
@@ -714,6 +715,15 @@ func (g GlobalCfg) MatchingRepo(repoID string) *Repo {
 		}
 	}
 	return nil
+}
+
+// RepoBundleURI returns the bundle URI configured for the given repo, or empty string if not set.
+func (g GlobalCfg) RepoBundleURI(repoID string) string {
+	repo := g.MatchingRepo(repoID)
+	if repo != nil {
+		return repo.BundleURI
+	}
+	return ""
 }
 
 // RepoConfigFile returns a repository specific file path

--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	"github.com/moby/patternmatcher"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/core/runtime"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/logging"
@@ -90,6 +91,8 @@ type FileWorkspace struct {
 	// the ref "pull/PR_NUMBER/head" from the "origin" remote. If this is false,
 	// we fetch "+refs/heads/$HEAD_BRANCH" from the "<prSourceRemote>" remote.
 	GithubAppEnabled bool
+	// GlobalCfg is the server-side repo config used to look up per-repo settings.
+	GlobalCfg valid.GlobalCfg
 	// use the global setting without overriding
 	GpgNoSigningEnabled bool
 	// flag indicating if we have to merge with potential new changes upstream (directly after grabbing project lock)
@@ -472,22 +475,33 @@ func (w *FileWorkspace) forceClone(logger logging.SimpleLogging, c wrappedGitCon
 		baseCloneURL = w.TestingOverrideBaseCloneURL
 	}
 
+	bundleURI := w.GlobalCfg.RepoBundleURI(c.pr.BaseRepo.ID())
+
 	// if branch strategy, use depth=1
 	if !w.CheckoutMerge {
-		return w.wrappedGit(logger, c, "clone", "--depth=1", "--branch", c.pr.HeadBranch, "--single-branch", headCloneURL, c.dir)
+		cloneArgs := []string{"clone", "--branch", c.pr.HeadBranch, "--single-branch"}
+		// --bundle-uri is incompatible with --depth
+		if bundleURI != "" {
+			cloneArgs = append(cloneArgs, "--bundle-uri", bundleURI)
+		} else {
+			cloneArgs = append(cloneArgs, "--depth=1")
+		}
+		cloneArgs = append(cloneArgs, headCloneURL, c.dir)
+		return w.wrappedGit(logger, c, cloneArgs...)
 	}
 
 	// if merge strategy...
 
-	// if no checkout depth, omit depth arg
-	if w.CheckoutDepth == 0 {
-		if err := w.wrappedGit(logger, c, "clone", "--branch", c.pr.BaseBranch, "--single-branch", baseCloneURL, c.dir); err != nil {
-			return err
-		}
-	} else {
-		if err := w.wrappedGit(logger, c, "clone", "--depth", fmt.Sprint(w.CheckoutDepth), "--branch", c.pr.BaseBranch, "--single-branch", baseCloneURL, c.dir); err != nil {
-			return err
-		}
+	cloneArgs := []string{"clone", "--branch", c.pr.BaseBranch, "--single-branch"}
+	// --bundle-uri is incompatible with --depth
+	if bundleURI != "" {
+		cloneArgs = append(cloneArgs, "--bundle-uri", bundleURI)
+	} else if w.CheckoutDepth != 0 {
+		cloneArgs = append(cloneArgs, "--depth", fmt.Sprint(w.CheckoutDepth))
+	}
+	cloneArgs = append(cloneArgs, baseCloneURL, c.dir)
+	if err := w.wrappedGit(logger, c, cloneArgs...); err != nil {
+		return err
 	}
 
 	if err := w.wrappedGit(logger, c, "remote", "add", prSourceRemote, headCloneURL); err != nil {

--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/logging"
@@ -106,6 +107,48 @@ func TestClone_MainBranchWithMergeStrategy(t *testing.T) {
 	// Check that our proof file is still there, proving that we didn't reclone.
 	_, err = os.Stat(filepath.Join(cloneDir, "proof"))
 	Ok(t, err)
+}
+
+// Test that clone works with a bundle URI
+func TestClone_BundleURI(t *testing.T) {
+	repoDir := initRepo(t)
+	expCommit := runCmd(t, repoDir, "git", "rev-parse", "HEAD")
+
+	dataDir := t.TempDir()
+
+	// Create a bundle from the repo.
+	bundlePath := filepath.Join(dataDir, "repo.bundle")
+	runCmd(t, repoDir, "git", "bundle", "create", bundlePath, "--all")
+
+	logger := logging.NewNoopLogger(t)
+
+	repoID := "github.com/test/repo"
+	wd := &events.FileWorkspace{
+		DataDir:                     dataDir,
+		CheckoutMerge:               false,
+		TestingOverrideHeadCloneURL: fmt.Sprintf("file://%s", repoDir),
+		GpgNoSigningEnabled:         true,
+		GlobalCfg: valid.GlobalCfg{
+			Repos: []valid.Repo{
+				{
+					ID:        repoID,
+					BundleURI: bundlePath,
+				},
+			},
+		},
+	}
+
+	cloneDir, err := wd.Clone(logger, models.Repo{}, models.PullRequest{
+		BaseRepo: models.Repo{
+			VCSHost:  models.VCSHost{Hostname: "github.com"},
+			FullName: "test/repo",
+		},
+		HeadBranch: "branch",
+	}, "default")
+	Ok(t, err)
+
+	actCommit := runCmd(t, cloneDir, "git", "rev-parse", "HEAD")
+	Equals(t, expCommit, actCommit)
 }
 
 // Test that if we don't have any existing files, we check out the repo

--- a/server/server.go
+++ b/server/server.go
@@ -525,6 +525,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		DataDir:          userConfig.DataDir,
 		CheckoutMerge:    userConfig.CheckoutStrategy == "merge",
 		CheckoutDepth:    userConfig.CheckoutDepth,
+		GlobalCfg:        globalCfg,
 		GithubAppEnabled: githubAppEnabled,
 	}
 


### PR DESCRIPTION
## what

Allow specifying a `bundle_uri` option in the repo config for cloning repos. See: https://git-scm.com/docs/bundle-uri

## why

We have a large monorepo that takes a long time to clone. Bundles dramatically decrease that time.

## tests

I've added a workdir test.