### PR TITLE
fix: update openssh-server version to fix Docker build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ ENV DEBIAN_GIT_VERSION="1:2.39.5-0+deb12u2"
 # renovate: datasource=repology depName=debian_12/unzip versioning=loose
 ENV DEBIAN_UNZIP_VERSION="6.0-28"
 # renovate: datasource=repology depName=debian_12/openssh-server versioning=loose
-ENV DEBIAN_OPENSSH_SERVER_VERSION="1:9.2p1-2+deb12u7"
+ENV DEBIAN_OPENSSH_SERVER_VERSION="1:9.2p1-2+deb12u9"
 # renovate: datasource=repology depName=debian_12/dumb-init versioning=loose
 ENV DEBIAN_DUMB_INIT_VERSION="1.2.5-2"
 # renovate: datasource=repology depName=debian_12/gnupg versioning=loose


### PR DESCRIPTION
## what

Bump `DEBIAN_OPENSSH_SERVER_VERSION` from `1:9.2p1-2+deb12u7` to `1:9.2p1-2+deb12u9` in the Dockerfile

## why

`docker build .` is currently failing:

```
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 openssh-server : Depends: openssh-client (= 1:9.2p1-2+deb12u7) but 1:9.2p1-2+deb12u9 is to be installed
E: Unable to correct problems, you have held broken packages.
```

<details>
<summary>Full build logs</summary>

```
#0 building with "default" instance using docker driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 10.48kB done
#1 DONE 0.1s

#2 resolve image config for docker-image://docker.io/docker/dockerfile:1@sha256:2780b5c3bab67f1f76c781860de469442999ed1a0d7992a5efdf2cffc0e3d769
#2 DONE 0.3s

#3 docker-image://docker.io/docker/dockerfile:1@sha256:2780b5c3bab67f1f76c781860de469442999ed1a0d7992a5efdf2cffc0e3d769
#3 CACHED

#4 [internal] load metadata for docker.io/library/debian:12.13-slim@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d
#4 DONE 0.3s

#5 [internal] load .dockerignore
#5 transferring context: 176B done
#5 DONE 0.1s

#6 [debian-base 1/2] FROM docker.io/library/debian:12.13-slim@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d
#6 CACHED

#7 [debian-base 2/2] RUN apt-get update &&     apt-get install -y --no-install-recommends         ca-certificates=20230311+deb12u1         curl=7.88.1-10+deb12u14         git=1:2.39.5-0+deb12u2         unzip=6.0-28         openssh-server=1:9.2p1-2+deb12u7         dumb-init=1.2.5-2         gnupg=2.2.40-1.1+deb12u2         openssl=3.0.17-1~deb12u2 &&     apt-get clean &&     rm -rf /var/lib/apt/lists/*
#7 0.754 Get:1 http://deb.debian.org/debian bookworm InRelease [151 kB]
#7 0.816 Get:2 http://deb.debian.org/debian bookworm-updates InRelease [55.4 kB]
#7 0.846 Get:3 http://deb.debian.org/debian-security bookworm-security InRelease [48.0 kB]
#7 0.880 Get:4 http://deb.debian.org/debian bookworm/main amd64 Packages [8792 kB]
#7 2.610 Get:5 http://deb.debian.org/debian bookworm-updates/main amd64 Packages [6924 B]
#7 2.611 Get:6 http://deb.debian.org/debian-security bookworm-security/main amd64 Packages [294 kB]
#7 3.112 Fetched 9347 kB in 2s (3870 kB/s)
#7 3.112 Reading package lists...
#7 3.453 Reading package lists...
#7 3.772 Building dependency tree...
#7 3.833 Reading state information...
#7 3.857 Some packages could not be installed. This may mean that you have
#7 3.857 requested an impossible situation or if you are using the unstable
#7 3.857 distribution that some required packages have not yet been created
#7 3.857 or been moved out of Incoming.
#7 3.857 The following information may help to resolve the situation:
#7 3.857 
#7 3.857 The following packages have unmet dependencies:
#7 3.892  openssh-server : Depends: openssh-client (= 1:9.2p1-2+deb12u7) but 1:9.2p1-2+deb12u9 is to be installed
#7 3.895 E: Unable to correct problems, you have held broken packages.
#7 ERROR: process "/bin/sh -c apt-get update &&     apt-get install -y --no-install-recommends         ca-certificates=${DEBIAN_CA_CERTIFICATES_VERSION}         curl=${DEBIAN_CURL_VERSION}         git=${DEBIAN_GIT_VERSION}         unzip=${DEBIAN_UNZIP_VERSION}         openssh-server=${DEBIAN_OPENSSH_SERVER_VERSION}         dumb-init=${DEBIAN_DUMB_INIT_VERSION}         gnupg=${DEBIAN_GNUPG_VERSION}         openssl=${DEBIAN_OPENSSL_VERSION} &&     apt-get clean &&     rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
------
 > [debian-base 2/2] RUN apt-get update &&     apt-get install -y --no-install-recommends         ca-certificates=20230311+deb12u1         curl=7.88.1-10+deb12u14         git=1:2.39.5-0+deb12u2         unzip=6.0-28         openssh-server=1:9.2p1-2+deb12u7         dumb-init=1.2.5-2         gnupg=2.2.40-1.1+deb12u2         openssl=3.0.17-1~deb12u2 &&     apt-get clean &&     rm -rf /var/lib/apt/lists/*:
3.833 Reading state information...
3.857 Some packages could not be installed. This may mean that you have
3.857 requested an impossible situation or if you are using the unstable
3.857 distribution that some required packages have not yet been created
3.857 or been moved out of Incoming.
3.857 The following information may help to resolve the situation:
3.857 
3.857 The following packages have unmet dependencies:
3.892  openssh-server : Depends: openssh-client (= 1:9.2p1-2+deb12u7) but 1:9.2p1-2+deb12u9 is to be installed
3.895 E: Unable to correct problems, you have held broken packages.
------
Dockerfile:76
--------------------
  75 |     # We place this last as it will bust less docker layer caches when packages update
  76 | >>> RUN apt-get update && \
  77 | >>>     apt-get install -y --no-install-recommends \
  78 | >>>         ca-certificates=${DEBIAN_CA_CERTIFICATES_VERSION} \
  79 | >>>         curl=${DEBIAN_CURL_VERSION} \
  80 | >>>         git=${DEBIAN_GIT_VERSION} \
  81 | >>>         unzip=${DEBIAN_UNZIP_VERSION} \
  82 | >>>         openssh-server=${DEBIAN_OPENSSH_SERVER_VERSION} \
  83 | >>>         dumb-init=${DEBIAN_DUMB_INIT_VERSION} \
  84 | >>>         gnupg=${DEBIAN_GNUPG_VERSION} \
  85 | >>>         openssl=${DEBIAN_OPENSSL_VERSION} && \
  86 | >>>     apt-get clean && \
  87 | >>>     rm -rf /var/lib/apt/lists/*
  88 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update &&     apt-get install -y --no-install-recommends         ca-certificates=${DEBIAN_CA_CERTIFICATES_VERSION}         curl=${DEBIAN_CURL_VERSION}         git=${DEBIAN_GIT_VERSION}         unzip=${DEBIAN_UNZIP_VERSION}         openssh-server=${DEBIAN_OPENSSH_SERVER_VERSION}         dumb-init=${DEBIAN_DUMB_INIT_VERSION}         gnupg=${DEBIAN_GNUPG_VERSION}         openssl=${DEBIAN_OPENSSL_VERSION} &&     apt-get clean &&     rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
```

</details>


## references

- Introduced in #5760 ?
