### PR TITLE
fix: make go-generate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/moby/patternmatcher v0.6.1
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/opentofu/tofudl v0.0.1
-	github.com/petergtz/pegomock/v4 v4.3.0
+	github.com/petergtz/pegomock/v4 v4.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/redis/go-redis/v9 v9.17.3
 	github.com/remeh/sizedwaitgroup v1.0.0
@@ -73,6 +73,8 @@ require (
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
 	github.com/ProtonMail/go-mime v0.0.0-20230322103455-7d82a3887f2f // indirect
 	github.com/ProtonMail/gopenpgp/v2 v2.7.5 // indirect
+	github.com/alecthomas/kingpin/v2 v2.3.2 // indirect
+	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -123,12 +125,14 @@ require (
 	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
+	github.com/samber/lo v1.38.1 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/ulikunitz/xz v0.5.15 // indirect
+	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	github.com/zclconf/go-cty v1.16.3 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
@@ -143,4 +147,9 @@ require (
 	golang.org/x/time v0.8.0 // indirect
 	golang.org/x/tools v0.42.0 // indirect
 	google.golang.org/protobuf v1.36.7 // indirect
+)
+
+tool (
+	github.com/petergtz/pegomock/v4/pegomock
+	go.uber.org/mock/mockgen
 )

--- a/go.sum
+++ b/go.sum
@@ -56,11 +56,15 @@ github.com/ProtonMail/gopenpgp/v2 v2.7.5 h1:STOY3vgES59gNgoOt2w0nyHBjKViB/qSg7Nj
 github.com/ProtonMail/gopenpgp/v2 v2.7.5/go.mod h1:IhkNEDaxec6NyzSI0PlxapinnwPVIESk8/76da3Ct3g=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
+github.com/alecthomas/kingpin/v2 v2.3.2 h1:H0aULhgmSzN8xQ3nX1uxtdlTHYoPLu5AhHxWrKI6ocU=
+github.com/alecthomas/kingpin/v2 v2.3.2/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
+github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/alicebob/miniredis/v2 v2.36.1 h1:Dvc5oAnNOr7BIfPn7tF269U8DvRW1dBG2D5n0WrfYMI=
 github.com/alicebob/miniredis/v2 v2.36.1/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
@@ -363,6 +367,8 @@ github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/petergtz/pegomock/v4 v4.3.0 h1:GPHCrVK0Ao63qTBBLLpcI1jafy13S1KTsLbC/8jPFSU=
 github.com/petergtz/pegomock/v4 v4.3.0/go.mod h1:MWuKPa+Q58c+MtwRQKimUzOdOmrDMV71BOzYB7y0ukI=
+github.com/petergtz/pegomock/v4 v4.4.0 h1:JjK1IEXJ5DnNe9TRjE+UoIg6xPC+wQVkkXhJOh39rNw=
+github.com/petergtz/pegomock/v4 v4.4.0/go.mod h1:MWuKPa+Q58c+MtwRQKimUzOdOmrDMV71BOzYB7y0ukI=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=
 github.com/pjbgf/sha1cd v0.3.2/go.mod h1:zQWigSxVmsHEZow5qaLtPYxpcKMMQpa09ixqBxuCS6A=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
@@ -457,6 +463,8 @@ github.com/urfave/negroni/v3 v3.1.1 h1:6MS4nG9Jk/UuCACaUlNXCbiKa0ywF9LXz5dGu09v8
 github.com/urfave/negroni/v3 v3.1.1/go.mod h1:jWvnX03kcSjDBl/ShB0iHvx5uOs7mAzZXW+JvJ5XYAs=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
+github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
+github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/server/controllers/events/azuredevops_request_validator.go
+++ b/server/controllers/events/azuredevops_request_validator.go
@@ -11,7 +11,7 @@ import (
 	"github.com/drmaxgit/go-azuredevops/azuredevops"
 )
 
-//go:generate pegomock generate --package mocks -o mocks/mock_azuredevops_request_validator.go AzureDevopsRequestValidator
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_azuredevops_request_validator.go AzureDevopsRequestValidator
 
 // AzureDevopsRequestValidator handles checking if Azure DevOps requests
 // contain a valid Basic authentication username and password.

--- a/server/controllers/events/github_request_validator.go
+++ b/server/controllers/events/github_request_validator.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/go-github/v83/github"
 )
 
-//go:generate pegomock generate --package mocks -o mocks/mock_github_request_validator.go GithubRequestValidator
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_github_request_validator.go GithubRequestValidator
 
 // GithubRequestValidator handles checking if GitHub requests are signed
 // properly by the secret.

--- a/server/controllers/events/gitlab_request_parser_validator.go
+++ b/server/controllers/events/gitlab_request_parser_validator.go
@@ -25,7 +25,7 @@ import (
 
 const secretHeader = "X-Gitlab-Token" // #nosec
 
-//go:generate pegomock generate --package mocks -o mocks/mock_gitlab_request_parser_validator.go GitlabRequestParserValidator
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_gitlab_request_parser_validator.go GitlabRequestParserValidator
 
 // GitlabRequestParserValidator parses and validates GitLab requests.
 type GitlabRequestParserValidator interface {

--- a/server/controllers/events/mocks/mock_gitlab_request_parser_validator.go
+++ b/server/controllers/events/mocks/mock_gitlab_request_parser_validator.go
@@ -25,17 +25,17 @@ func NewMockGitlabRequestParserValidator(options ...pegomock.Option) *MockGitlab
 func (mock *MockGitlabRequestParserValidator) SetFailHandler(fh pegomock.FailHandler) { mock.fail = fh }
 func (mock *MockGitlabRequestParserValidator) FailHandler() pegomock.FailHandler      { return mock.fail }
 
-func (mock *MockGitlabRequestParserValidator) ParseAndValidate(r *http.Request, secret []byte) (interface{}, error) {
+func (mock *MockGitlabRequestParserValidator) ParseAndValidate(r *http.Request, secret []byte) (any, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockGitlabRequestParserValidator().")
 	}
 	_params := []pegomock.Param{r, secret}
-	_result := pegomock.GetGenericMockFrom(mock).Invoke("ParseAndValidate", _params, []reflect.Type{reflect.TypeOf((*interface{})(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
-	var _ret0 interface{}
+	_result := pegomock.GetGenericMockFrom(mock).Invoke("ParseAndValidate", _params, []reflect.Type{reflect.TypeOf((*any)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var _ret0 any
 	var _ret1 error
 	if len(_result) != 0 {
 		if _result[0] != nil {
-			_ret0 = _result[0].(interface{})
+			_ret0 = _result[0].(any)
 		}
 		if _result[1] != nil {
 			_ret1 = _result[1].(error)

--- a/server/controllers/web_templates/mocks/mock_template_writer.go
+++ b/server/controllers/web_templates/mocks/mock_template_writer.go
@@ -25,7 +25,7 @@ func NewMockTemplateWriter(options ...pegomock.Option) *MockTemplateWriter {
 func (mock *MockTemplateWriter) SetFailHandler(fh pegomock.FailHandler) { mock.fail = fh }
 func (mock *MockTemplateWriter) FailHandler() pegomock.FailHandler      { return mock.fail }
 
-func (mock *MockTemplateWriter) Execute(wr io.Writer, data interface{}) error {
+func (mock *MockTemplateWriter) Execute(wr io.Writer, data any) error {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockTemplateWriter().")
 	}
@@ -77,7 +77,7 @@ type VerifierMockTemplateWriter struct {
 	timeout                time.Duration
 }
 
-func (verifier *VerifierMockTemplateWriter) Execute(wr io.Writer, data interface{}) *MockTemplateWriter_Execute_OngoingVerification {
+func (verifier *VerifierMockTemplateWriter) Execute(wr io.Writer, data any) *MockTemplateWriter_Execute_OngoingVerification {
 	_params := []pegomock.Param{wr, data}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "Execute", _params, verifier.timeout)
 	return &MockTemplateWriter_Execute_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
@@ -88,12 +88,12 @@ type MockTemplateWriter_Execute_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockTemplateWriter_Execute_OngoingVerification) GetCapturedArguments() (io.Writer, interface{}) {
+func (c *MockTemplateWriter_Execute_OngoingVerification) GetCapturedArguments() (io.Writer, any) {
 	wr, data := c.GetAllCapturedArguments()
 	return wr[len(wr)-1], data[len(data)-1]
 }
 
-func (c *MockTemplateWriter_Execute_OngoingVerification) GetAllCapturedArguments() (_param0 []io.Writer, _param1 []interface{}) {
+func (c *MockTemplateWriter_Execute_OngoingVerification) GetAllCapturedArguments() (_param0 []io.Writer, _param1 []any) {
 	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(_params) > 0 {
 		if len(_params) > 0 {
@@ -103,9 +103,9 @@ func (c *MockTemplateWriter_Execute_OngoingVerification) GetAllCapturedArguments
 			}
 		}
 		if len(_params) > 1 {
-			_param1 = make([]interface{}, len(c.methodInvocations))
+			_param1 = make([]any, len(c.methodInvocations))
 			for u, param := range _params[1] {
-				_param1[u] = param.(interface{})
+				_param1[u] = param.(any)
 			}
 		}
 	}

--- a/server/controllers/web_templates/web_templates.go
+++ b/server/controllers/web_templates/web_templates.go
@@ -23,7 +23,7 @@ import (
 	"github.com/runatlantis/atlantis/server/jobs"
 )
 
-//go:generate pegomock generate --package mocks -o mocks/mock_template_writer.go TemplateWriter
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_template_writer.go TemplateWriter
 
 //go:embed templates/*
 var templatesFS embed.FS

--- a/server/core/db/db.go
+++ b/server/core/db/db.go
@@ -23,7 +23,7 @@ import (
 	"github.com/runatlantis/atlantis/server/events/models"
 )
 
-//go:generate mockgen -package mocks -destination mocks/mock_database.go . Database
+//go:generate go tool mockgen -package mocks -destination mocks/mock_database.go . Database
 
 // Database is an implementation of the database API we require.
 type Database interface {

--- a/server/core/locking/apply_locking.go
+++ b/server/core/locking/apply_locking.go
@@ -11,7 +11,7 @@ import (
 	"github.com/runatlantis/atlantis/server/events/command"
 )
 
-//go:generate mockgen -package mocks -destination mocks/mock_apply_lock_checker.go . ApplyLockChecker
+//go:generate go tool mockgen -package mocks -destination mocks/mock_apply_lock_checker.go . ApplyLockChecker
 
 // ApplyLockChecker is an implementation of the global apply lock retrieval.
 // It returns an object that contains information about apply locks status.
@@ -19,7 +19,7 @@ type ApplyLockChecker interface {
 	CheckApplyLock() (ApplyCommandLock, error)
 }
 
-//go:generate mockgen -package mocks -destination mocks/mock_apply_locker.go . ApplyLocker
+//go:generate go tool mockgen -package mocks -destination mocks/mock_apply_locker.go . ApplyLocker
 
 // ApplyLocker interface that manages locks for apply command runner
 type ApplyLocker interface {

--- a/server/core/locking/locking.go
+++ b/server/core/locking/locking.go
@@ -40,7 +40,7 @@ type Client struct {
 	database db.Database
 }
 
-//go:generate mockgen -package mocks -destination mocks/mock_locker.go . Locker
+//go:generate go tool mockgen -package mocks -destination mocks/mock_locker.go . Locker
 
 type Locker interface {
 	TryLock(p models.Project, workspace string, pull models.PullRequest, user models.User) (TryLockResponse, error)

--- a/server/core/runtime/cache/version_path.go
+++ b/server/core/runtime/cache/version_path.go
@@ -11,8 +11,8 @@ import (
 	"github.com/runatlantis/atlantis/server/core/runtime/models"
 )
 
-//go:generate pegomock generate --package mocks -o mocks/mock_version_path.go ExecutionVersionCache
-//go:generate pegomock generate --package mocks -o mocks/mock_key_serializer.go KeySerializer
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_version_path.go ExecutionVersionCache
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_key_serializer.go KeySerializer
 
 type ExecutionVersionCache interface {
 	Get(key *version.Version) (string, error)

--- a/server/core/runtime/executor.go
+++ b/server/core/runtime/executor.go
@@ -9,7 +9,7 @@ import (
 	"github.com/runatlantis/atlantis/server/logging"
 )
 
-//go:generate pegomock generate --package mocks -o mocks/mock_versionedexecutorworkflow.go VersionedExecutorWorkflow
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_versionedexecutorworkflow.go VersionedExecutorWorkflow
 
 // VersionedExecutorWorkflow defines a versioned execution for a given project context
 type VersionedExecutorWorkflow interface {

--- a/server/core/runtime/external_team_allowlist_runner.go
+++ b/server/core/runtime/external_team_allowlist_runner.go
@@ -13,7 +13,7 @@ import (
 	"github.com/runatlantis/atlantis/server/events/models"
 )
 
-//go:generate pegomock generate --package mocks -o mocks/mock_external_team_allowlist_runner.go ExternalTeamAllowlistRunner
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_external_team_allowlist_runner.go ExternalTeamAllowlistRunner
 type ExternalTeamAllowlistRunner interface {
 	Run(ctx models.TeamAllowlistCheckerContext, shell, shellArgs, command string) (string, error)
 }

--- a/server/core/runtime/models/exec.go
+++ b/server/core/runtime/models/exec.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-//go:generate pegomock generate --package mocks -o mocks/mock_exec.go Exec
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_exec.go Exec
 
 type Exec interface {
 	LookPath(file string) (string, error)

--- a/server/core/runtime/models/filepath.go
+++ b/server/core/runtime/models/filepath.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 )
 
-//go:generate pegomock generate --package mocks -o mocks/mock_filepath.go FilePath
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_filepath.go FilePath
 
 type FilePath interface {
 	NotExists() bool

--- a/server/core/runtime/policy/conftest_client.go
+++ b/server/core/runtime/policy/conftest_client.go
@@ -80,7 +80,7 @@ func (c ConftestTestCommandArgs) build() ([]string, error) {
 
 // SourceResolver resolves the policy set to a local fs path
 //
-//go:generate pegomock generate --package mocks -o mocks/mock_conftest_client.go SourceResolver
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_conftest_client.go SourceResolver
 type SourceResolver interface {
 	Resolve(policySet valid.PolicySet) (string, error)
 }
@@ -108,7 +108,7 @@ func (p *SourceResolverProxy) Resolve(policySet valid.PolicySet) (string, error)
 	}
 }
 
-//go:generate pegomock generate --package mocks -o mocks/mock_downloader.go Downloader
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_downloader.go Downloader
 
 type Downloader interface {
 	GetAny(dst, src string) error

--- a/server/core/runtime/post_workflow_hook_runner.go
+++ b/server/core/runtime/post_workflow_hook_runner.go
@@ -14,7 +14,7 @@ import (
 	"github.com/runatlantis/atlantis/server/jobs"
 )
 
-//go:generate pegomock generate --package mocks -o mocks/mock_post_workflows_hook_runner.go PostWorkflowHookRunner
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_post_workflows_hook_runner.go PostWorkflowHookRunner
 type PostWorkflowHookRunner interface {
 	Run(ctx models.WorkflowHookCommandContext, command string, shell string, shellArgs string, path string) (string, string, error)
 }

--- a/server/core/runtime/pre_workflow_hook_runner.go
+++ b/server/core/runtime/pre_workflow_hook_runner.go
@@ -14,7 +14,7 @@ import (
 	"github.com/runatlantis/atlantis/server/jobs"
 )
 
-//go:generate pegomock generate --package mocks -o mocks/mock_pre_workflows_hook_runner.go PreWorkflowHookRunner
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_pre_workflows_hook_runner.go PreWorkflowHookRunner
 type PreWorkflowHookRunner interface {
 	Run(ctx models.WorkflowHookCommandContext, command string, shell string, shellArgs string, path string) (string, string, error)
 }

--- a/server/core/runtime/pull_approved_checker.go
+++ b/server/core/runtime/pull_approved_checker.go
@@ -8,7 +8,7 @@ import (
 	"github.com/runatlantis/atlantis/server/logging"
 )
 
-//go:generate pegomock generate --package mocks -o mocks/mock_pull_approved_checker.go PullApprovedChecker
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_pull_approved_checker.go PullApprovedChecker
 
 type PullApprovedChecker interface {
 	PullIsApproved(logger logging.SimpleLogging, baseRepo models.Repo, pull models.PullRequest) (models.ApprovalStatus, error)

--- a/server/core/runtime/runtime.go
+++ b/server/core/runtime/runtime.go
@@ -38,7 +38,7 @@ type TerraformExec interface {
 // It's split from TerraformExec because due to a bug in pegomock with channels,
 // we can't generate a mock for it so we hand-write it for this specific method.
 //
-//go:generate pegomock generate --package mocks -o mocks/mock_async_tfexec.go AsyncTFExec
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_async_tfexec.go AsyncTFExec
 type AsyncTFExec interface {
 	// RunCommandAsync runs terraform with args. It immediately returns an
 	// input and output channel. Callers can use the output channel to
@@ -52,14 +52,14 @@ type AsyncTFExec interface {
 // StatusUpdater brings the interface from CommitStatusUpdater into this package
 // without causing circular imports.
 //
-//go:generate pegomock generate --package mocks -o mocks/mock_status_updater.go StatusUpdater
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_status_updater.go StatusUpdater
 type StatusUpdater interface {
 	UpdateProject(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus, url string, res *command.ProjectCommandOutput) error
 }
 
 // Runner mirrors events.StepRunner as a way to bring it into this package
 //
-//go:generate pegomock generate --package mocks -o mocks/mock_runner.go Runner
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_runner.go Runner
 type Runner interface {
 	Run(ctx command.ProjectContext, extraArgs []string, path string, envs map[string]string) (string, error)
 }

--- a/server/core/terraform/downloader.go
+++ b/server/core/terraform/downloader.go
@@ -16,7 +16,7 @@ import (
 	"github.com/opentofu/tofudl"
 )
 
-//go:generate pegomock generate --package mocks -o mocks/mock_downloader.go Downloader
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_downloader.go Downloader
 
 // Downloader is for downloading terraform versions.
 type Downloader interface {

--- a/server/core/terraform/tfclient/terraform_client.go
+++ b/server/core/terraform/tfclient/terraform_client.go
@@ -41,7 +41,7 @@ import (
 
 var LogStreamingValidCmds = [...]string{"init", "plan", "apply"}
 
-//go:generate pegomock generate --package mocks -o mocks/mock_terraform_client.go Client
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_terraform_client.go Client
 
 type Client interface {
 	// RunCommandWithVersion executes terraform with args in path. If v is nil,

--- a/server/events/cancellation_tracker.go
+++ b/server/events/cancellation_tracker.go
@@ -1,6 +1,6 @@
 package events
 
-//go:generate pegomock generate --package mocks -o mocks/mock_cancellation_tracker.go CancellationTracker
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_cancellation_tracker.go CancellationTracker
 import (
 	"fmt"
 	"sync"

--- a/server/events/command_requirement_handler.go
+++ b/server/events/command_requirement_handler.go
@@ -12,7 +12,7 @@ import (
 	"github.com/runatlantis/atlantis/server/events/models"
 )
 
-//go:generate pegomock generate --package mocks -o mocks/mock_command_requirement_handler.go CommandRequirementHandler
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_command_requirement_handler.go CommandRequirementHandler
 type CommandRequirementHandler interface {
 	ValidateProjectDependencies(ctx command.ProjectContext) (string, error)
 	ValidatePlanProject(repoDir string, ctx command.ProjectContext) (string, error)

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -37,7 +37,7 @@ const (
 	ShutdownComment = "Atlantis server is shutting down, please try again later."
 )
 
-//go:generate pegomock generate github.com/runatlantis/atlantis/server/events --package mocks -o mocks/mock_command_runner.go CommandRunner
+//go:generate go tool pegomock generate github.com/runatlantis/atlantis/server/events --package mocks -o mocks/mock_command_runner.go CommandRunner
 
 // CommandRunner is the first step after a command request has been parsed.
 type CommandRunner interface {
@@ -48,7 +48,7 @@ type CommandRunner interface {
 	RunAutoplanCommand(baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User)
 }
 
-//go:generate pegomock generate github.com/runatlantis/atlantis/server/events --package mocks -o mocks/mock_github_pull_getter.go GithubPullGetter
+//go:generate go tool pegomock generate github.com/runatlantis/atlantis/server/events --package mocks -o mocks/mock_github_pull_getter.go GithubPullGetter
 
 // GithubPullGetter makes API calls to get pull requests.
 type GithubPullGetter interface {
@@ -56,7 +56,7 @@ type GithubPullGetter interface {
 	GetPullRequest(logger logging.SimpleLogging, repo models.Repo, pullNum int) (*github.PullRequest, error)
 }
 
-//go:generate pegomock generate github.com/runatlantis/atlantis/server/events --package mocks -o mocks/mock_azuredevops_pull_getter.go AzureDevopsPullGetter
+//go:generate go tool pegomock generate github.com/runatlantis/atlantis/server/events --package mocks -o mocks/mock_azuredevops_pull_getter.go AzureDevopsPullGetter
 
 // AzureDevopsPullGetter makes API calls to get pull requests.
 type AzureDevopsPullGetter interface {
@@ -64,7 +64,7 @@ type AzureDevopsPullGetter interface {
 	GetPullRequest(logger logging.SimpleLogging, repo models.Repo, pullNum int) (*azuredevops.GitPullRequest, error)
 }
 
-//go:generate pegomock generate github.com/runatlantis/atlantis/server/events --package mocks -o mocks/mock_gitlab_merge_request_getter.go GitlabMergeRequestGetter
+//go:generate go tool pegomock generate github.com/runatlantis/atlantis/server/events --package mocks -o mocks/mock_gitlab_merge_request_getter.go GitlabMergeRequestGetter
 
 // GitlabMergeRequestGetter makes API calls to get merge requests.
 type GitlabMergeRequestGetter interface {

--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -58,7 +58,7 @@ const (
 // and pasting GitHub comments.
 var multiLineRegex = regexp.MustCompile(`.*\r?\n[^\r\n]+`)
 
-//go:generate pegomock generate --package mocks -o mocks/mock_comment_parsing.go CommentParsing
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_comment_parsing.go CommentParsing
 
 // CommentParsing handles parsing pull request comments.
 type CommentParsing interface {
@@ -67,7 +67,7 @@ type CommentParsing interface {
 	Parse(comment string, vcsHost models.VCSHostType) CommentParseResult
 }
 
-//go:generate pegomock generate --package mocks -o mocks/mock_comment_building.go CommentBuilder
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_comment_building.go CommentBuilder
 
 // CommentBuilder builds comment commands that can be used on pull requests.
 type CommentBuilder interface {

--- a/server/events/commit_status_updater.go
+++ b/server/events/commit_status_updater.go
@@ -25,7 +25,7 @@ import (
 	"golang.org/x/text/language"
 )
 
-//go:generate pegomock generate github.com/runatlantis/atlantis/server/events --package mocks -o mocks/mock_commit_status_updater.go CommitStatusUpdater
+//go:generate go tool pegomock generate github.com/runatlantis/atlantis/server/events --package mocks -o mocks/mock_commit_status_updater.go CommitStatusUpdater
 
 // CommitStatusUpdater updates the status of a commit with the VCS host. We set
 // the status to signify whether the plan/apply succeeds.

--- a/server/events/delete_lock_command.go
+++ b/server/events/delete_lock_command.go
@@ -10,7 +10,7 @@ import (
 	"github.com/runatlantis/atlantis/server/logging"
 )
 
-//go:generate pegomock generate github.com/runatlantis/atlantis/server/events --package mocks -o mocks/mock_delete_lock_command.go DeleteLockCommand
+//go:generate go tool pegomock generate github.com/runatlantis/atlantis/server/events --package mocks -o mocks/mock_delete_lock_command.go DeleteLockCommand
 
 // DeleteLockCommand is the first step after a command request has been parsed.
 type DeleteLockCommand interface {

--- a/server/events/event_parser.go
+++ b/server/events/event_parser.go
@@ -208,7 +208,7 @@ func NewCommentCommand(repoRelDir string, flags []string, name command.Name, sub
 	}
 }
 
-//go:generate pegomock generate github.com/runatlantis/atlantis/server/events --package mocks -o mocks/mock_event_parsing.go EventParsing
+//go:generate go tool pegomock generate github.com/runatlantis/atlantis/server/events --package mocks -o mocks/mock_event_parsing.go EventParsing
 
 // EventParsing parses webhook events from different VCS hosts into their
 // respective Atlantis models.

--- a/server/events/mock_workingdir_test.go
+++ b/server/events/mock_workingdir_test.go
@@ -147,6 +147,21 @@ func (mock *MockWorkingDir) GetWorkingDir(r models.Repo, p models.PullRequest, w
 	return _ret0, _ret1
 }
 
+func (mock *MockWorkingDir) GitReadLock(r models.Repo, p models.PullRequest, workspace string) func() {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockWorkingDir().")
+	}
+	_params := []pegomock.Param{r, p, workspace}
+	_result := pegomock.GetGenericMockFrom(mock).Invoke("GitReadLock", _params, []reflect.Type{reflect.TypeOf((*func())(nil)).Elem()})
+	var _ret0 func()
+	if len(_result) != 0 {
+		if _result[0] != nil {
+			_ret0 = _result[0].(func())
+		}
+	}
+	return _ret0
+}
+
 func (mock *MockWorkingDir) HasDiverged(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) bool {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockWorkingDir().")
@@ -179,22 +194,6 @@ func (mock *MockWorkingDir) MergeAgain(logger logging.SimpleLogging, headRepo mo
 		}
 	}
 	return _ret0, _ret1
-}
-
-func (mock *MockWorkingDir) GitReadLock(r models.Repo, p models.PullRequest, workspace string) func() {
-	if mock == nil {
-		panic("mock must not be nil. Use myMock := NewMockWorkingDir().")
-	}
-	_params := []pegomock.Param{r, p, workspace}
-	_result := pegomock.GetGenericMockFrom(mock).Invoke("GitReadLock", _params, []reflect.Type{reflect.TypeOf((*func())(nil)).Elem()})
-	var _ret0 func()
-	if len(_result) != 0 && _result[0] != nil {
-		_ret0 = _result[0].(func())
-	}
-	if _ret0 == nil {
-		_ret0 = func() {}
-	}
-	return _ret0
 }
 
 func (mock *MockWorkingDir) VerifyWasCalledOnce() *VerifierMockWorkingDir {
@@ -527,6 +526,47 @@ func (c *MockWorkingDir_GetWorkingDir_OngoingVerification) GetCapturedArguments(
 }
 
 func (c *MockWorkingDir_GetWorkingDir_OngoingVerification) GetAllCapturedArguments() (_param0 []models.Repo, _param1 []models.PullRequest, _param2 []string) {
+	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(_params) > 0 {
+		if len(_params) > 0 {
+			_param0 = make([]models.Repo, len(c.methodInvocations))
+			for u, param := range _params[0] {
+				_param0[u] = param.(models.Repo)
+			}
+		}
+		if len(_params) > 1 {
+			_param1 = make([]models.PullRequest, len(c.methodInvocations))
+			for u, param := range _params[1] {
+				_param1[u] = param.(models.PullRequest)
+			}
+		}
+		if len(_params) > 2 {
+			_param2 = make([]string, len(c.methodInvocations))
+			for u, param := range _params[2] {
+				_param2[u] = param.(string)
+			}
+		}
+	}
+	return
+}
+
+func (verifier *VerifierMockWorkingDir) GitReadLock(r models.Repo, p models.PullRequest, workspace string) *MockWorkingDir_GitReadLock_OngoingVerification {
+	_params := []pegomock.Param{r, p, workspace}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "GitReadLock", _params, verifier.timeout)
+	return &MockWorkingDir_GitReadLock_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockWorkingDir_GitReadLock_OngoingVerification struct {
+	mock              *MockWorkingDir
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockWorkingDir_GitReadLock_OngoingVerification) GetCapturedArguments() (models.Repo, models.PullRequest, string) {
+	r, p, workspace := c.GetAllCapturedArguments()
+	return r[len(r)-1], p[len(p)-1], workspace[len(workspace)-1]
+}
+
+func (c *MockWorkingDir_GitReadLock_OngoingVerification) GetAllCapturedArguments() (_param0 []models.Repo, _param1 []models.PullRequest, _param2 []string) {
 	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(_params) > 0 {
 		if len(_params) > 0 {

--- a/server/events/mocks/mock_working_dir.go
+++ b/server/events/mocks/mock_working_dir.go
@@ -4,12 +4,11 @@
 package mocks
 
 import (
-	"reflect"
-	"time"
-
 	pegomock "github.com/petergtz/pegomock/v4"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	logging "github.com/runatlantis/atlantis/server/logging"
+	"reflect"
+	"time"
 )
 
 type MockWorkingDir struct {
@@ -148,6 +147,21 @@ func (mock *MockWorkingDir) GetWorkingDir(r models.Repo, p models.PullRequest, w
 	return _ret0, _ret1
 }
 
+func (mock *MockWorkingDir) GitReadLock(r models.Repo, p models.PullRequest, workspace string) func() {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockWorkingDir().")
+	}
+	_params := []pegomock.Param{r, p, workspace}
+	_result := pegomock.GetGenericMockFrom(mock).Invoke("GitReadLock", _params, []reflect.Type{reflect.TypeOf((*func())(nil)).Elem()})
+	var _ret0 func()
+	if len(_result) != 0 {
+		if _result[0] != nil {
+			_ret0 = _result[0].(func())
+		}
+	}
+	return _ret0
+}
+
 func (mock *MockWorkingDir) HasDiverged(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) bool {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockWorkingDir().")
@@ -180,22 +194,6 @@ func (mock *MockWorkingDir) MergeAgain(logger logging.SimpleLogging, headRepo mo
 		}
 	}
 	return _ret0, _ret1
-}
-
-func (mock *MockWorkingDir) GitReadLock(r models.Repo, p models.PullRequest, workspace string) func() {
-	if mock == nil {
-		panic("mock must not be nil. Use myMock := NewMockWorkingDir().")
-	}
-	_params := []pegomock.Param{r, p, workspace}
-	_result := pegomock.GetGenericMockFrom(mock).Invoke("GitReadLock", _params, []reflect.Type{reflect.TypeOf((*func())(nil)).Elem()})
-	var _ret0 func()
-	if len(_result) != 0 && _result[0] != nil {
-		_ret0 = _result[0].(func())
-	}
-	if _ret0 == nil {
-		_ret0 = func() {}
-	}
-	return _ret0
 }
 
 func (mock *MockWorkingDir) VerifyWasCalledOnce() *VerifierMockWorkingDir {
@@ -528,6 +526,47 @@ func (c *MockWorkingDir_GetWorkingDir_OngoingVerification) GetCapturedArguments(
 }
 
 func (c *MockWorkingDir_GetWorkingDir_OngoingVerification) GetAllCapturedArguments() (_param0 []models.Repo, _param1 []models.PullRequest, _param2 []string) {
+	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(_params) > 0 {
+		if len(_params) > 0 {
+			_param0 = make([]models.Repo, len(c.methodInvocations))
+			for u, param := range _params[0] {
+				_param0[u] = param.(models.Repo)
+			}
+		}
+		if len(_params) > 1 {
+			_param1 = make([]models.PullRequest, len(c.methodInvocations))
+			for u, param := range _params[1] {
+				_param1[u] = param.(models.PullRequest)
+			}
+		}
+		if len(_params) > 2 {
+			_param2 = make([]string, len(c.methodInvocations))
+			for u, param := range _params[2] {
+				_param2[u] = param.(string)
+			}
+		}
+	}
+	return
+}
+
+func (verifier *VerifierMockWorkingDir) GitReadLock(r models.Repo, p models.PullRequest, workspace string) *MockWorkingDir_GitReadLock_OngoingVerification {
+	_params := []pegomock.Param{r, p, workspace}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "GitReadLock", _params, verifier.timeout)
+	return &MockWorkingDir_GitReadLock_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockWorkingDir_GitReadLock_OngoingVerification struct {
+	mock              *MockWorkingDir
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockWorkingDir_GitReadLock_OngoingVerification) GetCapturedArguments() (models.Repo, models.PullRequest, string) {
+	r, p, workspace := c.GetAllCapturedArguments()
+	return r[len(r)-1], p[len(p)-1], workspace[len(workspace)-1]
+}
+
+func (c *MockWorkingDir_GitReadLock_OngoingVerification) GetAllCapturedArguments() (_param0 []models.Repo, _param1 []models.PullRequest, _param2 []string) {
 	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(_params) > 0 {
 		if len(_params) > 0 {

--- a/server/events/mocks/mock_working_dir_locker.go
+++ b/server/events/mocks/mock_working_dir_locker.go
@@ -4,11 +4,10 @@
 package mocks
 
 import (
-	"reflect"
-	"time"
-
 	pegomock "github.com/petergtz/pegomock/v4"
 	command "github.com/runatlantis/atlantis/server/events/command"
+	"reflect"
+	"time"
 )
 
 type MockWorkingDirLocker struct {
@@ -90,8 +89,8 @@ type VerifierMockWorkingDirLocker struct {
 	timeout                time.Duration
 }
 
-func (verifier *VerifierMockWorkingDirLocker) TryLock(repoFullName string, pullNum int, workspace string, path string, cmdName command.Name) *MockWorkingDirLocker_TryLock_OngoingVerification {
-	_params := []pegomock.Param{repoFullName, pullNum, workspace, path, cmdName}
+func (verifier *VerifierMockWorkingDirLocker) TryLock(repoFullName string, pullNum int, workspace string, path string, projectName string, cmdName command.Name) *MockWorkingDirLocker_TryLock_OngoingVerification {
+	_params := []pegomock.Param{repoFullName, pullNum, workspace, path, projectName, cmdName}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "TryLock", _params, verifier.timeout)
 	return &MockWorkingDirLocker_TryLock_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -101,12 +100,12 @@ type MockWorkingDirLocker_TryLock_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockWorkingDirLocker_TryLock_OngoingVerification) GetCapturedArguments() (string, int, string, string, command.Name) {
-	repoFullName, pullNum, workspace, path, cmdName := c.GetAllCapturedArguments()
-	return repoFullName[len(repoFullName)-1], pullNum[len(pullNum)-1], workspace[len(workspace)-1], path[len(path)-1], cmdName[len(cmdName)-1]
+func (c *MockWorkingDirLocker_TryLock_OngoingVerification) GetCapturedArguments() (string, int, string, string, string, command.Name) {
+	repoFullName, pullNum, workspace, path, projectName, cmdName := c.GetAllCapturedArguments()
+	return repoFullName[len(repoFullName)-1], pullNum[len(pullNum)-1], workspace[len(workspace)-1], path[len(path)-1], projectName[len(projectName)-1], cmdName[len(cmdName)-1]
 }
 
-func (c *MockWorkingDirLocker_TryLock_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []int, _param2 []string, _param3 []string, _param4 []command.Name) {
+func (c *MockWorkingDirLocker_TryLock_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []int, _param2 []string, _param3 []string, _param4 []string, _param5 []command.Name) {
 	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(_params) > 0 {
 		if len(_params) > 0 {
@@ -134,9 +133,15 @@ func (c *MockWorkingDirLocker_TryLock_OngoingVerification) GetAllCapturedArgumen
 			}
 		}
 		if len(_params) > 4 {
-			_param4 = make([]command.Name, len(c.methodInvocations))
+			_param4 = make([]string, len(c.methodInvocations))
 			for u, param := range _params[4] {
-				_param4[u] = param.(command.Name)
+				_param4[u] = param.(string)
+			}
+		}
+		if len(_params) > 5 {
+			_param5 = make([]command.Name, len(c.methodInvocations))
+			for u, param := range _params[5] {
+				_param5[u] = param.(command.Name)
 			}
 		}
 	}

--- a/server/events/pending_plan_finder.go
+++ b/server/events/pending_plan_finder.go
@@ -14,7 +14,7 @@ import (
 	"github.com/runatlantis/atlantis/server/utils"
 )
 
-//go:generate pegomock generate --package mocks -o mocks/mock_pending_plan_finder.go PendingPlanFinder
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_pending_plan_finder.go PendingPlanFinder
 
 type PendingPlanFinder interface {
 	Find(pullDir string) ([]PendingPlan, error)

--- a/server/events/post_workflow_hooks_command_runner.go
+++ b/server/events/post_workflow_hooks_command_runner.go
@@ -15,14 +15,14 @@ import (
 	"github.com/runatlantis/atlantis/server/events/vcs"
 )
 
-//go:generate pegomock generate --package mocks -o mocks/mock_post_workflow_hook_url_generator.go PostWorkflowHookURLGenerator
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_post_workflow_hook_url_generator.go PostWorkflowHookURLGenerator
 
 // PostWorkflowHookURLGenerator generates urls to view the post workflow progress.
 type PostWorkflowHookURLGenerator interface {
 	GenerateProjectWorkflowHookURL(hookID string) (string, error)
 }
 
-//go:generate pegomock generate --package mocks -o mocks/mock_post_workflows_hooks_command_runner.go PostWorkflowHooksCommandRunner
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_post_workflows_hooks_command_runner.go PostWorkflowHooksCommandRunner
 
 type PostWorkflowHooksCommandRunner interface {
 	RunPostHooks(ctx *command.Context, cmd *CommentCommand) error

--- a/server/events/post_workflow_hooks_command_runner_test.go
+++ b/server/events/post_workflow_hooks_command_runner_test.go
@@ -259,7 +259,7 @@ func TestRunPostHooks_Clone(t *testing.T) {
 
 		whPostWorkflowHookRunner.VerifyWasCalled(Never()).Run(Any[models.WorkflowHookCommandContext](),
 			Eq(testHook.RunCommand), Eq(defaultShell), Eq(defaultShellArgs), Eq(repoDir))
-		postWhWorkingDirLocker.VerifyWasCalled(Never()).TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace, "path", command.Plan)
+		postWhWorkingDirLocker.VerifyWasCalled(Never()).TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace, "path", "", command.Plan)
 		postWhWorkingDir.VerifyWasCalled(Never()).Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))
 	})

--- a/server/events/pre_workflow_hooks_command_runner.go
+++ b/server/events/pre_workflow_hooks_command_runner.go
@@ -15,14 +15,14 @@ import (
 	"github.com/runatlantis/atlantis/server/events/vcs"
 )
 
-//go:generate pegomock generate --package mocks -o mocks/mock_pre_workflow_hook_url_generator.go PreWorkflowHookURLGenerator
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_pre_workflow_hook_url_generator.go PreWorkflowHookURLGenerator
 
 // PreWorkflowHookURLGenerator generates urls to view the pre workflow progress.
 type PreWorkflowHookURLGenerator interface {
 	GenerateProjectWorkflowHookURL(hookID string) (string, error)
 }
 
-//go:generate pegomock generate --package mocks -o mocks/mock_pre_workflows_hooks_command_runner.go PreWorkflowHooksCommandRunner
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_pre_workflows_hooks_command_runner.go PreWorkflowHooksCommandRunner
 
 type PreWorkflowHooksCommandRunner interface {
 	RunPreHooks(ctx *command.Context, cmd *CommentCommand) error

--- a/server/events/pre_workflow_hooks_command_runner_test.go
+++ b/server/events/pre_workflow_hooks_command_runner_test.go
@@ -187,7 +187,7 @@ func TestRunPreHooks_Clone(t *testing.T) {
 
 		whPreWorkflowHookRunner.VerifyWasCalled(Never()).Run(Any[models.WorkflowHookCommandContext](), Eq(testHook.RunCommand),
 			Eq(defaultShell), Eq(defaultShellArgs), Eq(repoDir))
-		preWhWorkingDirLocker.VerifyWasCalled(Never()).TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace, "", command.Plan)
+		preWhWorkingDirLocker.VerifyWasCalled(Never()).TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace, "", "", command.Plan)
 		preWhWorkingDir.VerifyWasCalled(Never()).Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))
 	})

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -194,7 +194,7 @@ type ProjectStateCommandBuilder interface {
 	BuildStateRmCommands(ctx *command.Context, comment *CommentCommand) ([]command.ProjectContext, error)
 }
 
-//go:generate pegomock generate github.com/runatlantis/atlantis/server/events --package mocks -o mocks/mock_project_command_builder.go ProjectCommandBuilder
+//go:generate go tool pegomock generate github.com/runatlantis/atlantis/server/events --package mocks -o mocks/mock_project_command_builder.go ProjectCommandBuilder
 
 // ProjectCommandBuilder builds commands that run on individual projects.
 type ProjectCommandBuilder interface {

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -43,7 +43,7 @@ func (d DirNotExistErr) Error() string {
 	return fmt.Sprintf("dir %q does not exist", d.RepoRelDir)
 }
 
-//go:generate pegomock generate --package mocks -o mocks/mock_lock_url_generator.go LockURLGenerator
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_lock_url_generator.go LockURLGenerator
 
 // LockURLGenerator generates urls to locks.
 type LockURLGenerator interface {
@@ -51,7 +51,7 @@ type LockURLGenerator interface {
 	GenerateLockURL(lockID string) string
 }
 
-//go:generate pegomock generate --package mocks -o mocks/mock_step_runner.go StepRunner
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_step_runner.go StepRunner
 
 // StepRunner runs steps. Steps are individual pieces of execution like
 // `terraform plan`.
@@ -60,7 +60,7 @@ type StepRunner interface {
 	Run(ctx command.ProjectContext, extraArgs []string, path string, envs map[string]string) (string, error)
 }
 
-//go:generate pegomock generate --package mocks -o mocks/mock_custom_step_runner.go CustomStepRunner
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_custom_step_runner.go CustomStepRunner
 
 // CustomStepRunner runs custom run steps.
 type CustomStepRunner interface {
@@ -77,7 +77,7 @@ type CustomStepRunner interface {
 	) (string, error)
 }
 
-//go:generate pegomock generate --package mocks -o mocks/mock_env_step_runner.go EnvStepRunner
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_env_step_runner.go EnvStepRunner
 
 // EnvStepRunner runs env steps.
 type EnvStepRunner interface {
@@ -104,7 +104,7 @@ type MultiEnvStepRunner interface {
 	) (string, error)
 }
 
-//go:generate pegomock generate --package mocks -o mocks/mock_webhooks_sender.go WebhooksSender
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_webhooks_sender.go WebhooksSender
 
 // WebhooksSender sends webhook.
 type WebhooksSender interface {
@@ -112,7 +112,7 @@ type WebhooksSender interface {
 	Send(log logging.SimpleLogging, res webhooks.ApplyResult) error
 }
 
-//go:generate pegomock generate --package mocks -o mocks/mock_project_command_runner.go ProjectCommandRunner
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_project_command_runner.go ProjectCommandRunner
 
 type ProjectPlanCommandRunner interface {
 	// Plan runs terraform plan for the project described by ctx.
@@ -161,7 +161,7 @@ type ProjectCommandRunner interface {
 	ProjectStateCommandRunner
 }
 
-//go:generate pegomock generate --package mocks -o mocks/mock_job_url_setter.go JobURLSetter
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_job_url_setter.go JobURLSetter
 
 type JobURLSetter interface {
 	// SetJobURLWithStatus sets the commit status for the project represented by
@@ -169,7 +169,7 @@ type JobURLSetter interface {
 	SetJobURLWithStatus(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus, res *command.ProjectCommandOutput) error
 }
 
-//go:generate pegomock generate --package mocks -o mocks/mock_job_message_sender.go JobMessageSender
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_job_message_sender.go JobMessageSender
 
 type JobMessageSender interface {
 	Send(ctx command.ProjectContext, msg string, operationComplete bool)

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -67,6 +67,7 @@ func TestDefaultProjectCommandRunner_Plan(t *testing.T) {
 	repoDir := t.TempDir()
 	When(mockWorkingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](),
 		Any[string]())).ThenReturn(repoDir, nil)
+	When(mockWorkingDir.GitReadLock(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).ThenReturn(func() {})
 	When(mockLocker.TryLock(Any[logging.SimpleLogging](), Any[models.PullRequest](), Any[models.User](), Any[string](),
 		Any[models.Project](), AnyBool())).ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key"}, nil)
 
@@ -429,6 +430,7 @@ func TestDefaultProjectCommandRunner_Apply(t *testing.T) {
 				Any[models.PullRequest](),
 				Any[string](),
 			)).ThenReturn(repoDir, nil)
+			When(mockWorkingDir.GitReadLock(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).ThenReturn(func() {})
 			When(mockLocker.TryLock(
 				Any[logging.SimpleLogging](),
 				Any[models.PullRequest](),
@@ -511,6 +513,7 @@ func TestDefaultProjectCommandRunner_ApplyRunStepFailure(t *testing.T) {
 		Any[models.PullRequest](),
 		Any[string](),
 	)).ThenReturn(repoDir, nil)
+	When(mockWorkingDir.GitReadLock(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).ThenReturn(func() {})
 	When(mockLocker.TryLock(
 		Any[logging.SimpleLogging](),
 		Any[models.PullRequest](),
@@ -579,6 +582,7 @@ func TestDefaultProjectCommandRunner_RunEnvSteps(t *testing.T) {
 	repoDir := t.TempDir()
 	When(mockWorkingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](),
 		Any[string]())).ThenReturn(repoDir, nil)
+	When(mockWorkingDir.GitReadLock(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).ThenReturn(func() {})
 	When(mockLocker.TryLock(Any[logging.SimpleLogging](), Any[models.PullRequest](), Any[models.User](), Any[string](),
 		Any[models.Project](), AnyBool())).ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key"}, nil)
 
@@ -721,6 +725,7 @@ func TestDefaultProjectCommandRunner_Import(t *testing.T) {
 			repoDir := t.TempDir()
 			When(mockWorkingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](),
 				Any[string]())).ThenReturn(repoDir, nil)
+			When(mockWorkingDir.GitReadLock(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).ThenReturn(func() {})
 			if c.setup != nil {
 				c.setup(repoDir, ctx, mockLocker, mockInit, mockImport)
 			}
@@ -892,6 +897,7 @@ func TestDefaultProjectCommandRunner_CustomPolicyCheckNames(t *testing.T) {
 				Any[models.PullRequest](),
 				Any[string](),
 			)).ThenReturn(repoDir, nil)
+			When(mockWorkingDir.GitReadLock(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).ThenReturn(func() {})
 
 			When(mockLocker.TryLock(
 				Any[logging.SimpleLogging](),
@@ -1020,6 +1026,7 @@ func TestDefaultProjectCommandRunner_CustomPolicyCheck_EmptyOutputsArray(t *test
 				Any[models.PullRequest](),
 				Any[string](),
 			)).ThenReturn(repoDir, nil)
+			When(mockWorkingDir.GitReadLock(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).ThenReturn(func() {})
 
 			When(mockLocker.TryLock(
 				Any[logging.SimpleLogging](),
@@ -1184,6 +1191,7 @@ func TestDefaultProjectCommandRunner_CustomPolicyCheckFailureDetection(t *testin
 				Any[models.PullRequest](),
 				Any[string](),
 			)).ThenReturn(repoDir, nil)
+			When(mockWorkingDir.GitReadLock(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).ThenReturn(func() {})
 
 			When(mockLocker.TryLock(
 				Any[logging.SimpleLogging](),
@@ -1316,6 +1324,7 @@ func TestDefaultProjectCommandRunner_CustomPolicyCheck_NoPreOrPostConftestOutput
 				Any[models.PullRequest](),
 				Any[string](),
 			)).ThenReturn(repoDir, nil)
+			When(mockWorkingDir.GitReadLock(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).ThenReturn(func() {})
 
 			When(mockLocker.TryLock(
 				Any[logging.SimpleLogging](),
@@ -1887,6 +1896,7 @@ func TestDefaultProjectCommandRunner_ApprovePolicies(t *testing.T) {
 				Any[models.PullRequest](),
 				Any[string](),
 			)).ThenReturn(repoDir, nil)
+			When(mockWorkingDir.GitReadLock(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).ThenReturn(func() {})
 			When(mockLocker.TryLock(
 				Any[logging.SimpleLogging](),
 				Any[models.PullRequest](),

--- a/server/events/project_locker.go
+++ b/server/events/project_locker.go
@@ -22,7 +22,7 @@ import (
 	"github.com/runatlantis/atlantis/server/logging"
 )
 
-//go:generate pegomock generate --package mocks -o mocks/mock_project_lock.go ProjectLocker
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_project_lock.go ProjectLocker
 
 // ProjectLocker locks this project against other plans being run until this
 // project is unlocked.

--- a/server/events/pull_closed_executor.go
+++ b/server/events/pull_closed_executor.go
@@ -31,13 +31,13 @@ import (
 	"github.com/runatlantis/atlantis/server/jobs"
 )
 
-//go:generate pegomock generate github.com/runatlantis/atlantis/server/events --package mocks -o mocks/mock_resource_cleaner.go ResourceCleaner
+//go:generate go tool pegomock generate github.com/runatlantis/atlantis/server/events --package mocks -o mocks/mock_resource_cleaner.go ResourceCleaner
 
 type ResourceCleaner interface {
 	CleanUp(pullInfo jobs.PullInfo)
 }
 
-//go:generate pegomock generate github.com/runatlantis/atlantis/server/events --package mocks -o mocks/mock_pull_cleaner.go PullCleaner
+//go:generate go tool pegomock generate github.com/runatlantis/atlantis/server/events --package mocks -o mocks/mock_pull_cleaner.go PullCleaner
 
 // PullCleaner cleans up pull requests after they're closed/merged.
 type PullCleaner interface {

--- a/server/events/vcs/client.go
+++ b/server/events/vcs/client.go
@@ -18,7 +18,7 @@ import (
 	"github.com/runatlantis/atlantis/server/logging"
 )
 
-//go:generate pegomock generate --package mocks -o mocks/mock_client.go github.com/runatlantis/atlantis/server/events/vcs Client
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_client.go github.com/runatlantis/atlantis/server/events/vcs Client
 
 // Client is used to make API calls to a VCS host like GitHub or GitLab.
 type Client interface {

--- a/server/events/vcs/github/credentials.go
+++ b/server/events/vcs/github/credentials.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/go-github/v83/github"
 )
 
-//go:generate pegomock generate --package mocks -o mocks/mock_credentials.go Credentials
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_credentials.go Credentials
 
 // GithubCredentials handles creating http.Clients that authenticate.
 type Credentials interface {

--- a/server/events/vcs/github/instrumented_client.go
+++ b/server/events/vcs/github/instrumented_client.go
@@ -28,7 +28,7 @@ func NewInstrumentedGithubClient(client *Client, statsScope tally.Scope, logger 
 	}
 }
 
-//go:generate pegomock generate --package mocks -o mocks/mock_github_pull_request_getter.go GithubPullRequestGetter
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_github_pull_request_getter.go GithubPullRequestGetter
 
 type GithubPullRequestGetter interface {
 	GetPullRequest(logger logging.SimpleLogging, repo models.Repo, pullNum int) (*github.PullRequest, error)

--- a/server/events/vcs/pull_status_fetcher.go
+++ b/server/events/vcs/pull_status_fetcher.go
@@ -10,7 +10,7 @@ import (
 	"github.com/runatlantis/atlantis/server/logging"
 )
 
-//go:generate pegomock generate github.com/runatlantis/atlantis/server/events/vcs --package mocks -o mocks/mock_pull_req_status_fetcher.go PullReqStatusFetcher
+//go:generate go tool pegomock generate github.com/runatlantis/atlantis/server/events/vcs --package mocks -o mocks/mock_pull_req_status_fetcher.go PullReqStatusFetcher
 
 type PullReqStatusFetcher interface {
 	FetchPullStatus(logger logging.SimpleLogging, pull models.PullRequest) (models.PullReqStatus, error)

--- a/server/events/webhooks/slack_client.go
+++ b/server/events/webhooks/slack_client.go
@@ -24,7 +24,7 @@ const (
 	slackFailureColour = "danger"
 )
 
-//go:generate pegomock generate --package mocks -o mocks/mock_slack_client.go SlackClient
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_slack_client.go SlackClient
 
 // SlackClient handles making API calls to Slack.
 type SlackClient interface {
@@ -33,7 +33,7 @@ type SlackClient interface {
 	PostMessage(channel string, applyResult ApplyResult) error
 }
 
-//go:generate pegomock generate --package mocks -o mocks/mock_underlying_slack_client.go UnderlyingSlackClient
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_underlying_slack_client.go UnderlyingSlackClient
 
 // UnderlyingSlackClient wraps the nlopes/slack.Client implementation so
 // we can mock it during tests.

--- a/server/events/webhooks/webhooks.go
+++ b/server/events/webhooks/webhooks.go
@@ -27,7 +27,7 @@ const SlackKind = "slack"
 const HttpKind = "http"
 const ApplyEvent = "apply"
 
-//go:generate pegomock generate --package mocks -o mocks/mock_sender.go Sender
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_sender.go Sender
 
 // Sender sends webhooks.
 type Sender interface {

--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -37,8 +37,8 @@ const prSourceRemote = "source"
 var gitLocks sync.Map
 var recheckRequiredMap sync.Map
 
-//go:generate pegomock generate github.com/runatlantis/atlantis/server/events --package mocks -o mocks/mock_working_dir.go WorkingDir
-//go:generate pegomock generate github.com/runatlantis/atlantis/server/events --package events WorkingDir
+//go:generate go tool pegomock generate github.com/runatlantis/atlantis/server/events --package mocks -o mocks/mock_working_dir.go WorkingDir
+//go:generate go tool pegomock generate github.com/runatlantis/atlantis/server/events --package events WorkingDir
 
 // WorkingDir handles the workspace on disk for running commands.
 type WorkingDir interface {

--- a/server/events/working_dir_locker.go
+++ b/server/events/working_dir_locker.go
@@ -21,7 +21,7 @@ import (
 	"github.com/runatlantis/atlantis/server/events/command"
 )
 
-//go:generate pegomock generate --package mocks -o mocks/mock_working_dir_locker.go WorkingDirLocker
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_working_dir_locker.go WorkingDirLocker
 
 // WorkingDirLocker is used to prevent multiple commands from executing
 // at the same time for a single repo, pull, and workspace. We need to prevent

--- a/server/jobs/job_url_setter.go
+++ b/server/jobs/job_url_setter.go
@@ -8,14 +8,14 @@ import (
 	"github.com/runatlantis/atlantis/server/events/models"
 )
 
-//go:generate pegomock generate --package mocks -o mocks/mock_project_job_url_generator.go ProjectJobURLGenerator
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_project_job_url_generator.go ProjectJobURLGenerator
 
 // ProjectJobURLGenerator generates urls to view project's progress.
 type ProjectJobURLGenerator interface {
 	GenerateProjectJobURL(p command.ProjectContext) (string, error)
 }
 
-//go:generate pegomock generate --package mocks -o mocks/mock_project_status_updater.go ProjectStatusUpdater
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_project_status_updater.go ProjectStatusUpdater
 
 type ProjectStatusUpdater interface {
 	// UpdateProject sets the commit status for the project represented by

--- a/server/jobs/project_command_output_handler.go
+++ b/server/jobs/project_command_output_handler.go
@@ -71,7 +71,7 @@ type AsyncProjectCommandOutputHandler struct {
 	pullToJobMapping sync.Map
 }
 
-//go:generate pegomock generate --package mocks -o mocks/mock_project_command_output_handler.go ProjectCommandOutputHandler
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_project_command_output_handler.go ProjectCommandOutputHandler
 
 type ProjectCommandOutputHandler interface {
 	// Send will enqueue the msg and wait for Handle() to receive the message.

--- a/server/logging/mocks/mock_simple_logging.go
+++ b/server/logging/mocks/mock_simple_logging.go
@@ -25,7 +25,7 @@ func NewMockSimpleLogging(options ...pegomock.Option) *MockSimpleLogging {
 func (mock *MockSimpleLogging) SetFailHandler(fh pegomock.FailHandler) { mock.fail = fh }
 func (mock *MockSimpleLogging) FailHandler() pegomock.FailHandler      { return mock.fail }
 
-func (mock *MockSimpleLogging) Debug(format string, a ...interface{}) {
+func (mock *MockSimpleLogging) Debug(format string, a ...any) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockSimpleLogging().")
 	}
@@ -36,7 +36,7 @@ func (mock *MockSimpleLogging) Debug(format string, a ...interface{}) {
 	pegomock.GetGenericMockFrom(mock).Invoke("Debug", _params, []reflect.Type{})
 }
 
-func (mock *MockSimpleLogging) Err(format string, a ...interface{}) {
+func (mock *MockSimpleLogging) Err(format string, a ...any) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockSimpleLogging().")
 	}
@@ -77,7 +77,7 @@ func (mock *MockSimpleLogging) GetHistory() string {
 	return _ret0
 }
 
-func (mock *MockSimpleLogging) Info(format string, a ...interface{}) {
+func (mock *MockSimpleLogging) Info(format string, a ...any) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockSimpleLogging().")
 	}
@@ -88,7 +88,7 @@ func (mock *MockSimpleLogging) Info(format string, a ...interface{}) {
 	pegomock.GetGenericMockFrom(mock).Invoke("Info", _params, []reflect.Type{})
 }
 
-func (mock *MockSimpleLogging) Log(level logging.LogLevel, format string, a ...interface{}) {
+func (mock *MockSimpleLogging) Log(level logging.LogLevel, format string, a ...any) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockSimpleLogging().")
 	}
@@ -107,7 +107,7 @@ func (mock *MockSimpleLogging) SetLevel(lvl logging.LogLevel) {
 	pegomock.GetGenericMockFrom(mock).Invoke("SetLevel", _params, []reflect.Type{})
 }
 
-func (mock *MockSimpleLogging) Warn(format string, a ...interface{}) {
+func (mock *MockSimpleLogging) Warn(format string, a ...any) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockSimpleLogging().")
 	}
@@ -118,7 +118,7 @@ func (mock *MockSimpleLogging) Warn(format string, a ...interface{}) {
 	pegomock.GetGenericMockFrom(mock).Invoke("Warn", _params, []reflect.Type{})
 }
 
-func (mock *MockSimpleLogging) With(a ...interface{}) logging.SimpleLogging {
+func (mock *MockSimpleLogging) With(a ...any) logging.SimpleLogging {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockSimpleLogging().")
 	}
@@ -136,7 +136,7 @@ func (mock *MockSimpleLogging) With(a ...interface{}) logging.SimpleLogging {
 	return _ret0
 }
 
-func (mock *MockSimpleLogging) WithHistory(a ...interface{}) logging.SimpleLogging {
+func (mock *MockSimpleLogging) WithHistory(a ...any) logging.SimpleLogging {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockSimpleLogging().")
 	}
@@ -191,7 +191,7 @@ type VerifierMockSimpleLogging struct {
 	timeout                time.Duration
 }
 
-func (verifier *VerifierMockSimpleLogging) Debug(format string, a ...interface{}) *MockSimpleLogging_Debug_OngoingVerification {
+func (verifier *VerifierMockSimpleLogging) Debug(format string, a ...any) *MockSimpleLogging_Debug_OngoingVerification {
 	_params := []pegomock.Param{format}
 	for _, param := range a {
 		_params = append(_params, param)
@@ -205,12 +205,12 @@ type MockSimpleLogging_Debug_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockSimpleLogging_Debug_OngoingVerification) GetCapturedArguments() (string, []interface{}) {
+func (c *MockSimpleLogging_Debug_OngoingVerification) GetCapturedArguments() (string, []any) {
 	format, a := c.GetAllCapturedArguments()
 	return format[len(format)-1], a[len(a)-1]
 }
 
-func (c *MockSimpleLogging_Debug_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 [][]interface{}) {
+func (c *MockSimpleLogging_Debug_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 [][]any) {
 	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(_params) > 0 {
 		if len(_params) > 0 {
@@ -219,12 +219,12 @@ func (c *MockSimpleLogging_Debug_OngoingVerification) GetAllCapturedArguments() 
 				_param0[u] = param.(string)
 			}
 		}
-		_param1 = make([][]interface{}, len(c.methodInvocations))
+		_param1 = make([][]any, len(c.methodInvocations))
 		for u := 0; u < len(c.methodInvocations); u++ {
-			_param1[u] = make([]interface{}, len(_params)-1)
+			_param1[u] = make([]any, len(_params)-1)
 			for x := 1; x < len(_params); x++ {
 				if _params[x][u] != nil {
-					_param1[u][x-1] = _params[x][u].(interface{})
+					_param1[u][x-1] = _params[x][u].(any)
 				}
 			}
 		}
@@ -232,7 +232,7 @@ func (c *MockSimpleLogging_Debug_OngoingVerification) GetAllCapturedArguments() 
 	return
 }
 
-func (verifier *VerifierMockSimpleLogging) Err(format string, a ...interface{}) *MockSimpleLogging_Err_OngoingVerification {
+func (verifier *VerifierMockSimpleLogging) Err(format string, a ...any) *MockSimpleLogging_Err_OngoingVerification {
 	_params := []pegomock.Param{format}
 	for _, param := range a {
 		_params = append(_params, param)
@@ -246,12 +246,12 @@ type MockSimpleLogging_Err_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockSimpleLogging_Err_OngoingVerification) GetCapturedArguments() (string, []interface{}) {
+func (c *MockSimpleLogging_Err_OngoingVerification) GetCapturedArguments() (string, []any) {
 	format, a := c.GetAllCapturedArguments()
 	return format[len(format)-1], a[len(a)-1]
 }
 
-func (c *MockSimpleLogging_Err_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 [][]interface{}) {
+func (c *MockSimpleLogging_Err_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 [][]any) {
 	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(_params) > 0 {
 		if len(_params) > 0 {
@@ -260,12 +260,12 @@ func (c *MockSimpleLogging_Err_OngoingVerification) GetAllCapturedArguments() (_
 				_param0[u] = param.(string)
 			}
 		}
-		_param1 = make([][]interface{}, len(c.methodInvocations))
+		_param1 = make([][]any, len(c.methodInvocations))
 		for u := 0; u < len(c.methodInvocations); u++ {
-			_param1[u] = make([]interface{}, len(_params)-1)
+			_param1[u] = make([]any, len(_params)-1)
 			for x := 1; x < len(_params); x++ {
 				if _params[x][u] != nil {
-					_param1[u][x-1] = _params[x][u].(interface{})
+					_param1[u][x-1] = _params[x][u].(any)
 				}
 			}
 		}
@@ -307,7 +307,7 @@ func (c *MockSimpleLogging_GetHistory_OngoingVerification) GetCapturedArguments(
 func (c *MockSimpleLogging_GetHistory_OngoingVerification) GetAllCapturedArguments() {
 }
 
-func (verifier *VerifierMockSimpleLogging) Info(format string, a ...interface{}) *MockSimpleLogging_Info_OngoingVerification {
+func (verifier *VerifierMockSimpleLogging) Info(format string, a ...any) *MockSimpleLogging_Info_OngoingVerification {
 	_params := []pegomock.Param{format}
 	for _, param := range a {
 		_params = append(_params, param)
@@ -321,12 +321,12 @@ type MockSimpleLogging_Info_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockSimpleLogging_Info_OngoingVerification) GetCapturedArguments() (string, []interface{}) {
+func (c *MockSimpleLogging_Info_OngoingVerification) GetCapturedArguments() (string, []any) {
 	format, a := c.GetAllCapturedArguments()
 	return format[len(format)-1], a[len(a)-1]
 }
 
-func (c *MockSimpleLogging_Info_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 [][]interface{}) {
+func (c *MockSimpleLogging_Info_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 [][]any) {
 	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(_params) > 0 {
 		if len(_params) > 0 {
@@ -335,12 +335,12 @@ func (c *MockSimpleLogging_Info_OngoingVerification) GetAllCapturedArguments() (
 				_param0[u] = param.(string)
 			}
 		}
-		_param1 = make([][]interface{}, len(c.methodInvocations))
+		_param1 = make([][]any, len(c.methodInvocations))
 		for u := 0; u < len(c.methodInvocations); u++ {
-			_param1[u] = make([]interface{}, len(_params)-1)
+			_param1[u] = make([]any, len(_params)-1)
 			for x := 1; x < len(_params); x++ {
 				if _params[x][u] != nil {
-					_param1[u][x-1] = _params[x][u].(interface{})
+					_param1[u][x-1] = _params[x][u].(any)
 				}
 			}
 		}
@@ -348,7 +348,7 @@ func (c *MockSimpleLogging_Info_OngoingVerification) GetAllCapturedArguments() (
 	return
 }
 
-func (verifier *VerifierMockSimpleLogging) Log(level logging.LogLevel, format string, a ...interface{}) *MockSimpleLogging_Log_OngoingVerification {
+func (verifier *VerifierMockSimpleLogging) Log(level logging.LogLevel, format string, a ...any) *MockSimpleLogging_Log_OngoingVerification {
 	_params := []pegomock.Param{level, format}
 	for _, param := range a {
 		_params = append(_params, param)
@@ -362,12 +362,12 @@ type MockSimpleLogging_Log_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockSimpleLogging_Log_OngoingVerification) GetCapturedArguments() (logging.LogLevel, string, []interface{}) {
+func (c *MockSimpleLogging_Log_OngoingVerification) GetCapturedArguments() (logging.LogLevel, string, []any) {
 	level, format, a := c.GetAllCapturedArguments()
 	return level[len(level)-1], format[len(format)-1], a[len(a)-1]
 }
 
-func (c *MockSimpleLogging_Log_OngoingVerification) GetAllCapturedArguments() (_param0 []logging.LogLevel, _param1 []string, _param2 [][]interface{}) {
+func (c *MockSimpleLogging_Log_OngoingVerification) GetAllCapturedArguments() (_param0 []logging.LogLevel, _param1 []string, _param2 [][]any) {
 	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(_params) > 0 {
 		if len(_params) > 0 {
@@ -382,12 +382,12 @@ func (c *MockSimpleLogging_Log_OngoingVerification) GetAllCapturedArguments() (_
 				_param1[u] = param.(string)
 			}
 		}
-		_param2 = make([][]interface{}, len(c.methodInvocations))
+		_param2 = make([][]any, len(c.methodInvocations))
 		for u := 0; u < len(c.methodInvocations); u++ {
-			_param2[u] = make([]interface{}, len(_params)-2)
+			_param2[u] = make([]any, len(_params)-2)
 			for x := 2; x < len(_params); x++ {
 				if _params[x][u] != nil {
-					_param2[u][x-2] = _params[x][u].(interface{})
+					_param2[u][x-2] = _params[x][u].(any)
 				}
 			}
 		}
@@ -424,7 +424,7 @@ func (c *MockSimpleLogging_SetLevel_OngoingVerification) GetAllCapturedArguments
 	return
 }
 
-func (verifier *VerifierMockSimpleLogging) Warn(format string, a ...interface{}) *MockSimpleLogging_Warn_OngoingVerification {
+func (verifier *VerifierMockSimpleLogging) Warn(format string, a ...any) *MockSimpleLogging_Warn_OngoingVerification {
 	_params := []pegomock.Param{format}
 	for _, param := range a {
 		_params = append(_params, param)
@@ -438,12 +438,12 @@ type MockSimpleLogging_Warn_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockSimpleLogging_Warn_OngoingVerification) GetCapturedArguments() (string, []interface{}) {
+func (c *MockSimpleLogging_Warn_OngoingVerification) GetCapturedArguments() (string, []any) {
 	format, a := c.GetAllCapturedArguments()
 	return format[len(format)-1], a[len(a)-1]
 }
 
-func (c *MockSimpleLogging_Warn_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 [][]interface{}) {
+func (c *MockSimpleLogging_Warn_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 [][]any) {
 	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(_params) > 0 {
 		if len(_params) > 0 {
@@ -452,12 +452,12 @@ func (c *MockSimpleLogging_Warn_OngoingVerification) GetAllCapturedArguments() (
 				_param0[u] = param.(string)
 			}
 		}
-		_param1 = make([][]interface{}, len(c.methodInvocations))
+		_param1 = make([][]any, len(c.methodInvocations))
 		for u := 0; u < len(c.methodInvocations); u++ {
-			_param1[u] = make([]interface{}, len(_params)-1)
+			_param1[u] = make([]any, len(_params)-1)
 			for x := 1; x < len(_params); x++ {
 				if _params[x][u] != nil {
-					_param1[u][x-1] = _params[x][u].(interface{})
+					_param1[u][x-1] = _params[x][u].(any)
 				}
 			}
 		}
@@ -465,7 +465,7 @@ func (c *MockSimpleLogging_Warn_OngoingVerification) GetAllCapturedArguments() (
 	return
 }
 
-func (verifier *VerifierMockSimpleLogging) With(a ...interface{}) *MockSimpleLogging_With_OngoingVerification {
+func (verifier *VerifierMockSimpleLogging) With(a ...any) *MockSimpleLogging_With_OngoingVerification {
 	_params := []pegomock.Param{}
 	for _, param := range a {
 		_params = append(_params, param)
@@ -479,20 +479,20 @@ type MockSimpleLogging_With_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockSimpleLogging_With_OngoingVerification) GetCapturedArguments() []interface{} {
+func (c *MockSimpleLogging_With_OngoingVerification) GetCapturedArguments() []any {
 	a := c.GetAllCapturedArguments()
 	return a[len(a)-1]
 }
 
-func (c *MockSimpleLogging_With_OngoingVerification) GetAllCapturedArguments() (_param0 [][]interface{}) {
+func (c *MockSimpleLogging_With_OngoingVerification) GetAllCapturedArguments() (_param0 [][]any) {
 	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(_params) > 0 {
-		_param0 = make([][]interface{}, len(c.methodInvocations))
+		_param0 = make([][]any, len(c.methodInvocations))
 		for u := 0; u < len(c.methodInvocations); u++ {
-			_param0[u] = make([]interface{}, len(_params)-0)
+			_param0[u] = make([]any, len(_params)-0)
 			for x := 0; x < len(_params); x++ {
 				if _params[x][u] != nil {
-					_param0[u][x-0] = _params[x][u].(interface{})
+					_param0[u][x-0] = _params[x][u].(any)
 				}
 			}
 		}
@@ -500,7 +500,7 @@ func (c *MockSimpleLogging_With_OngoingVerification) GetAllCapturedArguments() (
 	return
 }
 
-func (verifier *VerifierMockSimpleLogging) WithHistory(a ...interface{}) *MockSimpleLogging_WithHistory_OngoingVerification {
+func (verifier *VerifierMockSimpleLogging) WithHistory(a ...any) *MockSimpleLogging_WithHistory_OngoingVerification {
 	_params := []pegomock.Param{}
 	for _, param := range a {
 		_params = append(_params, param)
@@ -514,20 +514,20 @@ type MockSimpleLogging_WithHistory_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockSimpleLogging_WithHistory_OngoingVerification) GetCapturedArguments() []interface{} {
+func (c *MockSimpleLogging_WithHistory_OngoingVerification) GetCapturedArguments() []any {
 	a := c.GetAllCapturedArguments()
 	return a[len(a)-1]
 }
 
-func (c *MockSimpleLogging_WithHistory_OngoingVerification) GetAllCapturedArguments() (_param0 [][]interface{}) {
+func (c *MockSimpleLogging_WithHistory_OngoingVerification) GetAllCapturedArguments() (_param0 [][]any) {
 	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(_params) > 0 {
-		_param0 = make([][]interface{}, len(c.methodInvocations))
+		_param0 = make([][]any, len(c.methodInvocations))
 		for u := 0; u < len(c.methodInvocations); u++ {
-			_param0[u] = make([]interface{}, len(_params)-0)
+			_param0[u] = make([]any, len(_params)-0)
 			for x := 0; x < len(_params); x++ {
 				if _params[x][u] != nil {
-					_param0[u][x-0] = _params[x][u].(interface{})
+					_param0[u][x-0] = _params[x][u].(any)
 				}
 			}
 		}

--- a/server/logging/simple_logger.go
+++ b/server/logging/simple_logger.go
@@ -25,7 +25,7 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
-//go:generate pegomock generate --package mocks -o mocks/mock_simple_logging.go SimpleLogging
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_simple_logging.go SimpleLogging
 
 // SimpleLogging is the interface used for logging throughout the codebase.
 type SimpleLogging interface {

--- a/server/scheduled/executor_service.go
+++ b/server/scheduled/executor_service.go
@@ -103,7 +103,7 @@ func (s *ExecutorService) runScheduledJob(ctx context.Context, wg *sync.WaitGrou
 
 }
 
-//go:generate pegomock generate --package mocks -o mocks/mock_executor_service_job.go Job
+//go:generate go tool pegomock generate --package mocks -o mocks/mock_executor_service_job.go Job
 type Job interface {
 	Run()
 }


### PR DESCRIPTION
## what

- Bump pegomock from to v4.4.0 to fix Go type alias handling.
- Use `go tool` to manage pegomock and mockgen.
- Regenerate mocks.
- Update tests to mock `GitReadLock`

## why

- `make go-generate` is currently broken.
- Using `go tool` directives ensures contributors don't need to manually `go install` the tools.

## tests

- `make go-generate` completes successfully
- All tests pass.

## references

- closes #4664
