### PR TITLE
docs: add gitea-base-url to Gitea startup example

### DIFF
--- a/runatlantis.io/docs/deployment.md
+++ b/runatlantis.io/docs/deployment.md
@@ -727,11 +727,12 @@ atlantis server \
 ##### Gitea
 
 ```bash
+GITEA_BASE_URL=YOUR_GITEA_BASE_URL # ex. https://gitea.example.com:3000
 atlantis server \
 --atlantis-url="$URL" \
 --gitea-user="$USERNAME" \
 --gitea-token="$TOKEN" \
---gitea-base-url="$GITEABASEURL" \
+--gitea-base-url="$GITEA_BASE_URL" \
 --gitea-webhook-secret="$SECRET" \
 --gitea-page-size=30 \
 --repo-allowlist="$REPO_ALLOWLIST"

--- a/runatlantis.io/docs/deployment.md
+++ b/runatlantis.io/docs/deployment.md
@@ -731,6 +731,7 @@ atlantis server \
 --atlantis-url="$URL" \
 --gitea-user="$USERNAME" \
 --gitea-token="$TOKEN" \
+--gitea-base-url="$GITEABASEURL" \
 --gitea-webhook-secret="$SECRET" \
 --gitea-page-size=30 \
 --repo-allowlist="$REPO_ALLOWLIST"


### PR DESCRIPTION
## what

The “Roll Your Own → Gitea” startup command currently omits the ‎`--gitea-base-url` flag.

When running Atlantis against a self-hosted Gitea instance, Atlantis fails to start if ‎`--gitea-base-url` is not provided. This change updates the Gitea example to include the required flag:

GITEABASEURL=YOUR_GITEA_BASE_URL # ex. https://gitea.example.com:3000
atlantis server \
  --atlantis-url="$URL" \
  --gitea-user="$USERNAME" \
  --gitea-token="$TOKEN" \
  --gitea-base-url="$GITEABASEURL" \
  --gitea-webhook-secret="$SECRET" \
  --gitea-page-size=30 \
  --repo-allowlist="$REPO_ALLOWLIST"

## why

- Atlantis fails to start when configured with Gitea but without ‎`--gitea-base-url`, so the existing example is incomplete.
- Adding ‎`--gitea-base-url` makes the documentation accurate and directly usable for self-hosted Gitea instances.
- This change aligns the Gitea example with other self-hosted provider examples that explicitly document their base URL/hostname.

## tests

‎- [x] I have verified the updated command against a self-hosted Gitea instance

## references

- Atlantis documentation: “Roll Your Own → Startup Command → Gitea” section (updated in this PR).

