### PR TITLE
docs: fix --emoji-reaction supported VCS list (remove Azure DevOps, add Gitea)

### DIFF
--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -537,7 +537,7 @@ atlantis server --emoji-reaction eyes
 ATLANTIS_EMOJI_REACTION=eyes
 ```
 
-The emoji reaction to use for marking processed comments. Currently supported on Azure DevOps, GitHub and GitLab. If not specified, Atlantis will not use an emoji reaction.
+The emoji reaction to use for marking processed comments. Currently supported on Gitea, GitHub and GitLab. If not specified, Atlantis will not use an emoji reaction.
 Defaults to "" (empty string).
 
 ::: warning NOTE
@@ -545,7 +545,7 @@ Each VCS provider supports a different list of emojis:
 
 - [GitHub](https://docs.github.com/en/rest/reactions/reactions?apiVersion=2022-11-28#about-reactions)
 - [GitLab](https://gitlab.com/gitlab-org/gitlab/-/blob/master/fixtures/emojis/digests.json)
-- [Azure DevOps](https://learn.microsoft.com/en-us/azure/devops/project/wiki/markdown-guidance?view=azure-devops#emoji)
+- [Gitea](https://docs.gitea.com/administration/customizing-gitea#reactions)
 
    :::
 


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->


- Remove Azure DevOps from the "Currently supported" sentence and the emoji reference list under `--emoji-reaction` in
  `runatlantis.io/docs/server-configuration.md`
- Add Gitea to the emoji reference list in the same section

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

Azure DevOps's `ReactToComment` has been a no-op stub since it was first added in #2706. However, #3456 added Azure DevOps to the "Currently supported" list in the docs, which did not match the implementation. On the other hand, Gitea's `ReactToComment` was actually implemented in #4229, but the docs were never updated to mention it. This PR corrects both discrepancies.

Current implementation status on `main`

- Azure DevOps
  - [`server/events/vcs/azuredevops/client.go#L147-L149`](https://github.com/runatlantis/atlantis/blob/main/server/events/vcs/azuredevops/client.go#L147-L149)
- Bitbucket Cloud
  - [`server/events/vcs/bitbucketcloud/client.go#L123-L126`](https://github.com/runatlantis/atlantis/blob/main/server/events/vcs/bitbucketcloud/client.go#L123-L126) 
- Bitbucket Server
  - [`server/events/vcs/bitbucketserver/client.go#L149-L151`](https://github.com/runatlantis/atlantis/blob/main/server/events/vcs/bitbucketserver/client.go#L149-L151)
- Gitea
  - [`server/events/vcs/gitea/client.go#L157-L175`](https://github.com/runatlantis/atlantis/blob/main/server/events/vcs/gitea/client.go#L157-L175)
- GitHub
  - [`server/events/vcs/github/client.go#L246-L253`](https://github.com/runatlantis/atlantis/blob/main/server/events/vcs/github/client.go#L246-L253)
- GitLab
  - [`server/events/vcs/gitlab/client.go#L195-L202`](https://github.com/runatlantis/atlantis/blob/main/server/events/vcs/gitlab/client.go#L195-L202)

```sh
$ git grep -n -A3 'func .* ReactToComment' 'server/events/vcs/*/client.go'
server/events/vcs/azuredevops/client.go:147:func (g *Client) ReactToComment(logger logging.SimpleLogging, repo models.Repo, pullNum int, commentID int64, reaction string) error { //nolint: revive
server/events/vcs/azuredevops/client.go-148-    return nil
server/events/vcs/azuredevops/client.go-149-}
server/events/vcs/azuredevops/client.go-150-
--
server/events/vcs/bitbucketcloud/client.go:123:func (b *Client) ReactToComment(_ logging.SimpleLogging, _ models.Repo, _ int, _ int64, _ string) error {
server/events/vcs/bitbucketcloud/client.go-124- // TODO: Bitbucket support for reactions
server/events/vcs/bitbucketcloud/client.go-125- return nil
server/events/vcs/bitbucketcloud/client.go-126-}
--
server/events/vcs/bitbucketserver/client.go:149:func (b *Client) ReactToComment(_ logging.SimpleLogging, _ models.Repo, _ int, _ int64, _ string) error {
server/events/vcs/bitbucketserver/client.go-150-        return nil
server/events/vcs/bitbucketserver/client.go-151-}
server/events/vcs/bitbucketserver/client.go-152-
--
server/events/vcs/gitea/client.go:157:func (c *Client) ReactToComment(logger logging.SimpleLogging, repo models.Repo, pullNum int, commentID int64, reaction string) error {
server/events/vcs/gitea/client.go-158-  logger.Debug("Adding reaction to Gitea pull request comment %d", commentID)
server/events/vcs/gitea/client.go-159-
server/events/vcs/gitea/client.go-160-  _, resp, err := c.giteaClient.PostIssueCommentReaction(repo.Owner, repo.Name, commentID, reaction)
--
server/events/vcs/github/client.go:246:func (g *Client) ReactToComment(logger logging.SimpleLogging, repo models.Repo, _ int, commentID int64, reaction string) error {
server/events/vcs/github/client.go-247- logger.Debug("Adding reaction to GitHub pull request comment %d", commentID)
server/events/vcs/github/client.go-248- _, resp, err := g.client.Reactions.CreateIssueCommentReaction(g.ctx, repo.Owner, repo.Name, commentID, reaction)
server/events/vcs/github/client.go-249- if resp != nil {
--
server/events/vcs/gitlab/client.go:195:func (g *Client) ReactToComment(logger logging.SimpleLogging, repo models.Repo, pullNum int, commentID int64, reaction string) error {
server/events/vcs/gitlab/client.go-196- logger.Debug("Adding reaction '%s' to comment %d on GitLab merge request %d", reaction, commentID, pullNum)
server/events/vcs/gitlab/client.go-197- _, resp, err := g.Client.AwardEmoji.CreateMergeRequestAwardEmojiOnNote(repo.FullName, pullNum, int(commentID), &gitlab.CreateAwardEmojiOptions{Name: reaction})
server/events/vcs/gitlab/client.go-198- if resp != nil {
```


## tests

<!--
- [ ] I have tested my changes by ...
-->

- Docs-only change, no code paths modified.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

- Introduced `--emoji-reaction` and added Azure DevOps no-op stub: #2706
- Added Azure DevOps to the docs list: #3456
- Implemented Gitea reactions: #4229

