### PR TITLE
feat: stream project failure text to job page

### DIFF
--- a/server/core/runtime/run_step_runner.go
+++ b/server/core/runtime/run_step_runner.go
@@ -110,7 +110,13 @@ func (r *RunStepRunner) Run(
 	}
 
 	if err != nil {
-		err = fmt.Errorf("%s: running %q in %q: \n%s", err, command, path, output)
+		err = runStepError{
+			err:          err,
+			command:      command,
+			path:         path,
+			output:       output,
+			streamOutput: streamOutput,
+		}
 		if !ctx.CustomPolicyCheck {
 			ctx.Log.Debug("error: %s", err)
 		} else {
@@ -128,4 +134,23 @@ func (r *RunStepRunner) Run(
 	}
 
 	return output, nil
+}
+
+type runStepError struct {
+	err          error
+	command      string
+	path         string
+	output       string
+	streamOutput bool
+}
+
+func (e runStepError) Error() string {
+	return fmt.Sprintf("%s: running %q in %q: \n%s", e.err, e.command, e.path, e.output)
+}
+
+func (e runStepError) JobMessage() string {
+	if !e.streamOutput && e.output != "" {
+		return e.Error()
+	}
+	return e.err.Error()
 }

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -211,6 +211,8 @@ func (p *ProjectOutputWrapper) updateProjectPRStatus(commandName command.Name, c
 			ctx.Log.Err("updating project PR status", err)
 		}
 
+		p.streamFailureToJob(ctx, result)
+
 		return result
 	}
 
@@ -219,6 +221,20 @@ func (p *ProjectOutputWrapper) updateProjectPRStatus(commandName command.Name, c
 	}
 
 	return result
+}
+
+// streamFailureToJob emits the project's error and/or failure text to the job
+// output stream so the per-project job page linked from the VCS commit status
+// has a visible final status when plan or apply fails before producing any
+// terraform output (e.g. lock contention, depends_on, requirement checks).
+// Uses \r\n so the xterm-based job page renders the banner on its own lines.
+func (p *ProjectOutputWrapper) streamFailureToJob(ctx command.ProjectContext, result command.ProjectCommandOutput) {
+	if result.Error != nil {
+		p.JobMessageSender.Send(ctx, fmt.Sprintf("\r\nError:\r\n%s\r\n", result.Error.Error()), false)
+	}
+	if result.Failure != "" {
+		p.JobMessageSender.Send(ctx, fmt.Sprintf("\r\nFailure:\r\n%s\r\n", result.Failure), false)
+	}
 }
 
 // DefaultProjectCommandRunner implements ProjectCommandRunner.

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -203,6 +203,8 @@ func (p *ProjectOutputWrapper) updateProjectPRStatus(commandName command.Name, c
 			ctx.Log.Err("updating project PR status: %s", err)
 		}
 
+		p.streamFailureToJob(ctx, result)
+
 		return result
 	}
 
@@ -211,6 +213,64 @@ func (p *ProjectOutputWrapper) updateProjectPRStatus(commandName command.Name, c
 	}
 
 	return result
+}
+
+// streamFailureToJob emits the project's error and/or failure text to the job
+// output stream so the per-project job page linked from the VCS commit status
+// has a visible final status when plan or apply fails before producing any
+// terraform output (e.g. lock contention, depends_on, requirement checks).
+// Uses \r\n so the xterm-based job page renders the banner on its own lines.
+func (p *ProjectOutputWrapper) streamFailureToJob(ctx command.ProjectContext, result command.ProjectCommandOutput) {
+	if result.Error != nil {
+		p.JobMessageSender.Send(ctx, jobFailureBanner("Error", jobErrorMessage(result.Error)), false)
+	}
+	if result.Failure != "" {
+		p.JobMessageSender.Send(ctx, jobFailureBanner("Failure", result.Failure), false)
+	}
+}
+
+func jobFailureBanner(label string, message string) string {
+	return fmt.Sprintf("\r\n%s:\r\n%s\r\n", label, normalizeJobLineEndings(message))
+}
+
+func normalizeJobLineEndings(message string) string {
+	message = strings.ReplaceAll(message, "\r\n", "\n")
+	message = strings.ReplaceAll(message, "\r", "\n")
+	return strings.ReplaceAll(message, "\n", "\r\n")
+}
+
+func jobErrorMessage(err error) string {
+	if errWithOutput, ok := err.(interface{ JobMessage() string }); ok {
+		return errWithOutput.JobMessage()
+	}
+	return err.Error()
+}
+
+type errWithStepOutput struct {
+	err    error
+	output string
+}
+
+func (e errWithStepOutput) Error() string {
+	if e.output == "" {
+		return e.err.Error()
+	}
+	return fmt.Sprintf("%s\n%s", e.err, e.output)
+}
+
+func (e errWithStepOutput) Unwrap() error {
+	return e.err
+}
+
+func (e errWithStepOutput) JobMessage() string {
+	return jobErrorMessage(e.err)
+}
+
+func errorWithStepOutput(err error, outputs []string) error {
+	return errWithStepOutput{
+		err:    err,
+		output: strings.Join(outputs, "\n"),
+	}
 }
 
 // DefaultProjectCommandRunner implements ProjectCommandRunner.
@@ -745,7 +805,7 @@ func (p *DefaultProjectCommandRunner) doPlan(ctx command.ProjectContext) (*model
 		if unlockErr := lockAttempt.UnlockFn(); unlockErr != nil {
 			ctx.Log.Err("error unlocking state after plan error: %v", unlockErr)
 		}
-		return nil, "", fmt.Errorf("%s\n%s", err, strings.Join(outputs, "\n"))
+		return nil, "", errorWithStepOutput(err, outputs)
 	}
 
 	return &models.PlanSuccess{
@@ -813,7 +873,7 @@ func (p *DefaultProjectCommandRunner) doApply(ctx command.ProjectContext) (apply
 	})
 
 	if err != nil {
-		return "", "", fmt.Errorf("%s\n%s", err, strings.Join(outputs, "\n"))
+		return "", "", errorWithStepOutput(err, outputs)
 	}
 
 	return strings.Join(outputs, "\n"), "", nil

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -139,6 +139,11 @@ func TestProjectOutputWrapper(t *testing.T) {
 		RepoRelDir: ".",
 	}
 
+	const (
+		expErrorBanner   = "\r\nError:\r\nerror\r\n"
+		expFailureBanner = "\r\nFailure:\r\nfailure\r\n"
+	)
+
 	cases := []struct {
 		Description string
 		Failure     bool
@@ -162,6 +167,12 @@ func TestProjectOutputWrapper(t *testing.T) {
 			CommandName: command.Plan,
 		},
 		{
+			Description: "plan error and failure",
+			Error:       true,
+			Failure:     true,
+			CommandName: command.Plan,
+		},
+		{
 			Description: "apply success",
 			Success:     true,
 			CommandName: command.Apply,
@@ -174,6 +185,12 @@ func TestProjectOutputWrapper(t *testing.T) {
 		{
 			Description: "apply error",
 			Error:       true,
+			CommandName: command.Apply,
+		},
+		{
+			Description: "apply error and failure",
+			Error:       true,
+			Failure:     true,
 			CommandName: command.Apply,
 		},
 	}
@@ -199,16 +216,14 @@ func TestProjectOutputWrapper(t *testing.T) {
 					ApplySuccess: "exists",
 				}
 				expCommitStatus = models.SuccessCommitStatus
-			} else if c.Failure {
-				prjResult = command.ProjectCommandOutput{
-					Failure: "failure",
-				}
+			} else {
 				expCommitStatus = models.FailedCommitStatus
-			} else if c.Error {
-				prjResult = command.ProjectCommandOutput{
-					Error: errors.New("error"),
+				if c.Error {
+					prjResult.Error = errors.New("error")
 				}
-				expCommitStatus = models.FailedCommitStatus
+				if c.Failure {
+					prjResult.Failure = "failure"
+				}
 			}
 
 			When(mockProjectCommandRunner.Plan(Any[command.ProjectContext]())).ThenReturn(prjResult)
@@ -230,6 +245,23 @@ func TestProjectOutputWrapper(t *testing.T) {
 			case command.Apply:
 				mockProjectCommandRunner.VerifyWasCalledOnce().Apply(ctx)
 			}
+
+			// Assert the ordering and content of JobMessageSender.Send calls.
+			// Banners (if any) must be streamed before the OperationComplete signal
+			// so the xterm-based job page renders the final status.
+			inOrder := new(InOrderContext)
+			expectedSends := 0
+			if c.Error {
+				mockJobMessageSender.VerifyWasCalledInOrder(Once(), inOrder).Send(ctx, expErrorBanner, false)
+				expectedSends++
+			}
+			if c.Failure {
+				mockJobMessageSender.VerifyWasCalledInOrder(Once(), inOrder).Send(ctx, expFailureBanner, false)
+				expectedSends++
+			}
+			mockJobMessageSender.VerifyWasCalledInOrder(Once(), inOrder).Send(ctx, "", true)
+			expectedSends++
+			mockJobMessageSender.VerifyWasCalled(Times(expectedSends)).Send(Any[command.ProjectContext](), Any[string](), Any[bool]())
 		})
 	}
 }

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -132,12 +132,23 @@ func TestProjectOutputWrapper(t *testing.T) {
 		RepoRelDir: ".",
 	}
 
+	const (
+		expErrorBanner          = "\r\nError:\r\nerror\r\n"
+		expMultilineErrorBanner = "\r\nError:\r\nerror\r\nmore detail\r\n"
+		expFailureBanner        = "\r\nFailure:\r\nfailure\r\n"
+		expMultilineFailure     = "\r\nFailure:\r\nfailure\r\nmore detail\r\n"
+	)
+
 	cases := []struct {
-		Description string
-		Failure     bool
-		Error       bool
-		Success     bool
-		CommandName command.Name
+		Description      string
+		Failure          bool
+		Error            bool
+		Success          bool
+		CommandName      command.Name
+		ErrorMessage     string
+		FailureMessage   string
+		ExpErrorBanner   string
+		ExpFailureBanner string
 	}{
 		{
 			Description: "plan success",
@@ -150,8 +161,28 @@ func TestProjectOutputWrapper(t *testing.T) {
 			CommandName: command.Plan,
 		},
 		{
+			Description:      "plan multiline failure",
+			Failure:          true,
+			CommandName:      command.Plan,
+			FailureMessage:   "failure\nmore detail",
+			ExpFailureBanner: expMultilineFailure,
+		},
+		{
 			Description: "plan error",
 			Error:       true,
+			CommandName: command.Plan,
+		},
+		{
+			Description:    "plan multiline error",
+			Error:          true,
+			CommandName:    command.Plan,
+			ErrorMessage:   "error\nmore detail",
+			ExpErrorBanner: expMultilineErrorBanner,
+		},
+		{
+			Description: "plan error and failure",
+			Error:       true,
+			Failure:     true,
 			CommandName: command.Plan,
 		},
 		{
@@ -167,6 +198,12 @@ func TestProjectOutputWrapper(t *testing.T) {
 		{
 			Description: "apply error",
 			Error:       true,
+			CommandName: command.Apply,
+		},
+		{
+			Description: "apply error and failure",
+			Error:       true,
+			Failure:     true,
 			CommandName: command.Apply,
 		},
 	}
@@ -192,16 +229,22 @@ func TestProjectOutputWrapper(t *testing.T) {
 					ApplySuccess: "exists",
 				}
 				expCommitStatus = models.SuccessCommitStatus
-			} else if c.Failure {
-				prjResult = command.ProjectCommandOutput{
-					Failure: "failure",
-				}
+			} else {
 				expCommitStatus = models.FailedCommitStatus
-			} else if c.Error {
-				prjResult = command.ProjectCommandOutput{
-					Error: errors.New("error"),
+				if c.Error {
+					errorMessage := "error"
+					if c.ErrorMessage != "" {
+						errorMessage = c.ErrorMessage
+					}
+					prjResult.Error = errors.New(errorMessage)
 				}
-				expCommitStatus = models.FailedCommitStatus
+				if c.Failure {
+					failureMessage := "failure"
+					if c.FailureMessage != "" {
+						failureMessage = c.FailureMessage
+					}
+					prjResult.Failure = failureMessage
+				}
 			}
 
 			When(mockProjectCommandRunner.Plan(Any[command.ProjectContext]())).ThenReturn(prjResult)
@@ -223,8 +266,226 @@ func TestProjectOutputWrapper(t *testing.T) {
 			case command.Apply:
 				mockProjectCommandRunner.VerifyWasCalledOnce().Apply(ctx)
 			}
+
+			// Assert the ordering and content of JobMessageSender.Send calls.
+			// Banners (if any) must be streamed before the OperationComplete signal
+			// so the xterm-based job page renders the final status.
+			inOrder := new(InOrderContext)
+			expectedSends := 0
+			if c.Error {
+				expectedBanner := c.ExpErrorBanner
+				if expectedBanner == "" {
+					expectedBanner = expErrorBanner
+				}
+				mockJobMessageSender.VerifyWasCalledInOrder(Once(), inOrder).Send(ctx, expectedBanner, false)
+				expectedSends++
+			}
+			if c.Failure {
+				expectedBanner := c.ExpFailureBanner
+				if expectedBanner == "" {
+					expectedBanner = expFailureBanner
+				}
+				mockJobMessageSender.VerifyWasCalledInOrder(Once(), inOrder).Send(ctx, expectedBanner, false)
+				expectedSends++
+			}
+			mockJobMessageSender.VerifyWasCalledInOrder(Once(), inOrder).Send(ctx, "", true)
+			expectedSends++
+			mockJobMessageSender.VerifyWasCalled(Times(expectedSends)).Send(Any[command.ProjectContext](), Any[string](), Any[bool]())
 		})
 	}
+}
+
+func TestProjectOutputWrapperDoesNotReplayStreamedStepOutput(t *testing.T) {
+	RegisterMockTestingT(t)
+
+	mockLocker := mocks.NewMockProjectLocker()
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockPlan := mocks.NewMockStepRunner()
+	mockJobURLSetter := mocks.NewMockJobURLSetter()
+	mockJobMessageSender := mocks.NewMockJobMessageSender()
+	repoDir := t.TempDir()
+	ctx := command.ProjectContext{
+		Log:       logging.NewNoopLogger(t),
+		Steps:     []valid.Step{{StepName: "plan"}},
+		Workspace: "default",
+		Pull: models.PullRequest{
+			BaseRepo: models.Repo{FullName: "runatlantis/atlantis"},
+		},
+		RepoRelDir: ".",
+	}
+
+	When(mockLocker.TryLock(Any[logging.SimpleLogging](), Any[models.PullRequest](), Any[models.User](),
+		Any[string](), Any[models.Project](), AnyBool())).
+		ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key", UnlockFn: func() error { return nil }}, nil)
+	When(mockWorkingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](),
+		Any[string]())).ThenReturn(repoDir, nil)
+	When(mockWorkingDir.GitReadLock(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).ThenReturn(func() {})
+	When(mockPlan.Run(ctx, nil, repoDir, map[string]string{})).
+		ThenReturn("already streamed output", errors.New("error\nmore detail"))
+
+	runner := &events.ProjectOutputWrapper{
+		JobURLSetter:     mockJobURLSetter,
+		JobMessageSender: mockJobMessageSender,
+		ProjectCommandRunner: &events.DefaultProjectCommandRunner{
+			Locker:                    mockLocker,
+			LockURLGenerator:          mockURLGenerator{},
+			PlanStepRunner:            mockPlan,
+			WorkingDir:                mockWorkingDir,
+			WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+			CommandRequirementHandler: &events.DefaultCommandRequirementHandler{WorkingDir: mockWorkingDir},
+		},
+	}
+
+	result := runner.Plan(ctx)
+
+	ErrEquals(t, "error\nmore detail\nalready streamed output", result.Error)
+	inOrder := new(InOrderContext)
+	mockJobMessageSender.VerifyWasCalledInOrder(Once(), inOrder).Send(ctx, "\r\nError:\r\nerror\r\nmore detail\r\n", false)
+	mockJobMessageSender.VerifyWasCalledInOrder(Once(), inOrder).Send(ctx, "", true)
+	mockJobMessageSender.VerifyWasCalled(Times(2)).Send(Any[command.ProjectContext](), Any[string](), Any[bool]())
+}
+
+func TestProjectOutputWrapperDoesNotReplayCustomRunStepOutput(t *testing.T) {
+	RegisterMockTestingT(t)
+
+	tfClient := tfclientmocks.NewMockClient()
+	tfDistribution := terraform.NewDistributionTerraformWithDownloader(tmocks.NewMockDownloader())
+	tfVersion, err := version.NewVersion("0.12.0")
+	Ok(t, err)
+	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
+	run := runtime.RunStepRunner{
+		TerraformExecutor:       tfClient,
+		DefaultTFDistribution:   tfDistribution,
+		DefaultTFVersion:        tfVersion,
+		ProjectCmdOutputHandler: projectCmdOutputHandler,
+	}
+	mockLocker := mocks.NewMockProjectLocker()
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockJobURLSetter := mocks.NewMockJobURLSetter()
+	mockJobMessageSender := mocks.NewMockJobMessageSender()
+	repoDir := t.TempDir()
+	Ok(t, os.WriteFile(filepath.Join(repoDir, "output.txt"), []byte("already streamed output\n"), 0o600))
+	ctx := command.ProjectContext{
+		Log: logging.NewNoopLogger(t),
+		Steps: []valid.Step{
+			{
+				StepName:   "run",
+				RunCommand: "cat output.txt; exit 1",
+			},
+		},
+		Workspace: "default",
+		Pull: models.PullRequest{
+			BaseRepo: models.Repo{FullName: "runatlantis/atlantis"},
+		},
+		RepoRelDir: ".",
+	}
+
+	When(tfClient.EnsureVersion(Any[logging.SimpleLogging](), Any[terraform.Distribution](), Any[*version.Version]())).
+		ThenReturn(nil)
+	When(mockLocker.TryLock(Any[logging.SimpleLogging](), Any[models.PullRequest](), Any[models.User](),
+		Any[string](), Any[models.Project](), AnyBool())).
+		ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key", UnlockFn: func() error { return nil }}, nil)
+	When(mockWorkingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](),
+		Any[string]())).ThenReturn(repoDir, nil)
+	When(mockWorkingDir.GitReadLock(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).ThenReturn(func() {})
+
+	runner := &events.ProjectOutputWrapper{
+		JobURLSetter:     mockJobURLSetter,
+		JobMessageSender: mockJobMessageSender,
+		ProjectCommandRunner: &events.DefaultProjectCommandRunner{
+			Locker:                    mockLocker,
+			LockURLGenerator:          mockURLGenerator{},
+			RunStepRunner:             &run,
+			WorkingDir:                mockWorkingDir,
+			WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+			CommandRequirementHandler: &events.DefaultCommandRequirementHandler{WorkingDir: mockWorkingDir},
+		},
+	}
+
+	result := runner.Plan(ctx)
+
+	ErrContains(t, "already streamed output", result.Error)
+	_, messages, operationComplete := mockJobMessageSender.VerifyWasCalled(Times(2)).
+		Send(Any[command.ProjectContext](), Any[string](), Any[bool]()).GetAllCapturedArguments()
+	Assert(t, strings.Contains(messages[0], "\r\nError:\r\nrunning 'sh -c' 'cat output.txt; exit 1'"), fmt.Sprintf("expected error summary banner, got %q", messages[0]))
+	Assert(t, !strings.Contains(messages[0], "already streamed output"), fmt.Sprintf("expected banner not to replay run output, got %q", messages[0]))
+	Equals(t, "", messages[1])
+	Equals(t, false, operationComplete[0])
+	Equals(t, true, operationComplete[1])
+}
+
+func TestProjectOutputWrapperPreservesNonStreamedEnvStepOutput(t *testing.T) {
+	RegisterMockTestingT(t)
+
+	tfClient := tfclientmocks.NewMockClient()
+	tfDistribution := terraform.NewDistributionTerraformWithDownloader(tmocks.NewMockDownloader())
+	tfVersion, err := version.NewVersion("0.12.0")
+	Ok(t, err)
+	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
+	run := runtime.RunStepRunner{
+		TerraformExecutor:       tfClient,
+		DefaultTFDistribution:   tfDistribution,
+		DefaultTFVersion:        tfVersion,
+		ProjectCmdOutputHandler: projectCmdOutputHandler,
+	}
+	env := runtime.EnvStepRunner{
+		RunStepRunner: &run,
+	}
+	mockLocker := mocks.NewMockProjectLocker()
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockJobURLSetter := mocks.NewMockJobURLSetter()
+	mockJobMessageSender := mocks.NewMockJobMessageSender()
+	repoDir := t.TempDir()
+	Ok(t, os.WriteFile(filepath.Join(repoDir, "output.txt"), []byte("not streamed output\n"), 0o600))
+	ctx := command.ProjectContext{
+		Log: logging.NewNoopLogger(t),
+		Steps: []valid.Step{
+			{
+				StepName:   "env",
+				EnvVarName: "dynamic_var",
+				RunCommand: "cat output.txt; exit 1",
+			},
+		},
+		Workspace: "default",
+		Pull: models.PullRequest{
+			BaseRepo: models.Repo{FullName: "runatlantis/atlantis"},
+		},
+		RepoRelDir: ".",
+	}
+
+	When(tfClient.EnsureVersion(Any[logging.SimpleLogging](), Any[terraform.Distribution](), Any[*version.Version]())).
+		ThenReturn(nil)
+	When(mockLocker.TryLock(Any[logging.SimpleLogging](), Any[models.PullRequest](), Any[models.User](),
+		Any[string](), Any[models.Project](), AnyBool())).
+		ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key", UnlockFn: func() error { return nil }}, nil)
+	When(mockWorkingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](),
+		Any[string]())).ThenReturn(repoDir, nil)
+	When(mockWorkingDir.GitReadLock(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).ThenReturn(func() {})
+
+	runner := &events.ProjectOutputWrapper{
+		JobURLSetter:     mockJobURLSetter,
+		JobMessageSender: mockJobMessageSender,
+		ProjectCommandRunner: &events.DefaultProjectCommandRunner{
+			Locker:                    mockLocker,
+			LockURLGenerator:          mockURLGenerator{},
+			RunStepRunner:             &run,
+			EnvStepRunner:             &env,
+			WorkingDir:                mockWorkingDir,
+			WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+			CommandRequirementHandler: &events.DefaultCommandRequirementHandler{WorkingDir: mockWorkingDir},
+		},
+	}
+
+	result := runner.Plan(ctx)
+
+	ErrContains(t, "not streamed output", result.Error)
+	_, messages, operationComplete := mockJobMessageSender.VerifyWasCalled(Times(2)).
+		Send(Any[command.ProjectContext](), Any[string](), Any[bool]()).GetAllCapturedArguments()
+	Assert(t, strings.Contains(messages[0], "\r\nError:\r\n"), fmt.Sprintf("expected error banner, got %q", messages[0]))
+	Assert(t, strings.Contains(messages[0], "\r\nnot streamed output\r\n"), fmt.Sprintf("expected banner to include non-streamed output, got %q", messages[0]))
+	Equals(t, "", messages[1])
+	Equals(t, false, operationComplete[0])
+	Equals(t, true, operationComplete[1])
 }
 
 // Test what happens if there's no working dir. This signals that the project


### PR DESCRIPTION
When a plan or apply fails before producing any terraform output (e.g. lock contention, depends_on, requirement checks), the Atlantis job page linked from the GitHub commit status is blank because nothing is streamed to the output buffer before OperationComplete.

This is (normally) fine because the error is posted as a GitHub comment, but if you are someone who likes/needs to use `silence_pr_comments` because you have a lot of environments managed by Atlantis, then it's an issue because `silence_pr_comments` hides these errors.

This PR aims to fix that!

**Solution**: Emit a labeled Error:/Failure: banner to the job output stream from ProjectOutputWrapper.updateProjectPRStatus on the failure branch so the job page ends with a visible final status.

## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- Errors from lock contention, depends_on and requirement checks (e.g. approvals) will be logged in the streamed xterm output as well as in PR comments.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- If a user has `silence_pr_comments` enabled, they miss these errors, so this fixes that
- This should be harmless for users who do not use `silence_pr_comments` since it simply means the error will be in both a comment **_and_** in the streamed output
- We emit a labeled Error:/Failure: banner to the job output stream from ProjectOutputWrapper.updateProjectPRStatus on the failure branch so the job page ends with a visible final status.

## tests

<!--
- [ ] I have tested my changes by ...
-->
- Added tests to project_command_runner_test.go
- Built image locally and tested in my own environment
- Example of streamed error in xterm due to no-approval:
<img width="878" height="109" alt="Screenshot_2026-04-20_18-28-15" src="https://github.com/user-attachments/assets/40ef08c8-629f-4f42-a942-301216ee5d8d" />
- Example of streamed error in xterm due to lock contention:
<img width="1432" height="130" alt="Screenshot_2026-04-20_18-34-48" src="https://github.com/user-attachments/assets/8630260b-91ff-46f0-ab42-6b2bc122b719" />


## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
Refs: This was noted last year by a commenter [here](https://github.com/runatlantis/atlantis/issues/4386#issuecomment-3215062116) and obviously, also affects me or I wouldn't be submitting this ;)
