### PR TITLE
fix: prevent diffKeywordRegex from falsely matching YAML key=value list items in heredocs

### DIFF
--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -437,7 +437,7 @@ func (p *PlanSuccess) NoChanges() bool {
 
 // Diff Markdown regexes
 var (
-	diffKeywordRegex  = regexp.MustCompile(`(?m)^( +)([-+~]\s)([a-zA-Z_][\w]*\s*)(=|\s->\s|\(known after apply\)|\{)(.*)`)
+	diffKeywordRegex  = regexp.MustCompile(`(?m)^( +)([-+~]\s)([a-zA-Z_][\w]*\s*)(\s=\s|\s->\s|\(known after apply\)|\{)(.*)`)
 	diffResourceRegex = regexp.MustCompile(`(?m)^( +)([-+~]\s)((?:resource|data|module)\s+.+\{.*)`)
 	diffHeredocRegex  = regexp.MustCompile(`(?m)^( +)([-+~]\s)(<<)(.*)`)
 	diffColonRegex    = regexp.MustCompile(`(?m)^( +)([-+~]\s)( {4,}[a-zA-Z_][\w-]*:.*)`)

--- a/server/events/models/models_test.go
+++ b/server/events/models/models_test.go
@@ -978,6 +978,52 @@ Plan: 1 to add, 0 to change, 0 to destroy.`,
     }`,
 		},
 		{
+			// Regression test for https://github.com/runatlantis/atlantis/issues/6419
+			// YAML list items using key=value format (e.g. ArgoCD syncOptions) inside a heredoc
+			// must not be mistaken for Terraform diff markers.
+			"argocd application with yaml key=value list items in heredoc",
+			`  # argocd_application.example will be updated in-place
+  ~ resource "argocd_application" "example" {
+        id   = "my-app"
+      ~ metadata {
+          ~ resource_version = "12345" -> (known after apply)
+        }
+        spec = <<-EOT
+            destination:
+              namespace: default
+              server: https://kubernetes.default.svc
+            source:
+              repoURL: https://github.com/example/repo
+            syncPolicy:
+              automated:
+                prune: true
+                selfHeal: true
+              syncOptions:
+              - ServerSideApply=true
+        EOT
+    }`,
+			`# argocd_application.example will be updated in-place
+!   resource "argocd_application" "example" {
+        id   = "my-app"
+!       metadata {
+!           resource_version = "12345" -> (known after apply)
+        }
+        spec = <<-EOT
+            destination:
+              namespace: default
+              server: https://kubernetes.default.svc
+            source:
+              repoURL: https://github.com/example/repo
+            syncPolicy:
+              automated:
+                prune: true
+                selfHeal: true
+              syncOptions:
+              - ServerSideApply=true
+        EOT
+    }`,
+		},
+		{
 			"cloudformation stack with extra-spaced yaml list items in heredoc",
 			`  + resource "aws_cloudformation_stack" "conditions" {
       + id            = (known after apply)


### PR DESCRIPTION
## Summary

- `diffKeywordRegex` was matching YAML list items like `- ServerSideApply=true` (used in ArgoCD `syncOptions`) as Terraform diff markers, causing false removals to appear in PR comments even when there was no actual plan change.
- Fix: require `\s=\s` (spaces around `=`) instead of bare `=` — Terraform HCL attribute assignments always use ` = `, while YAML `key=value` pairs never do.
- Added a regression test covering an ArgoCD Application resource with `syncOptions` in a heredoc.

Closes https://github.com/runatlantis/atlantis/issues/6419

## Root Cause

Introduced in #6069, which changed the operator alternation in `diffKeywordRegex` from `\s=\s` to `=`. This broadened matching to unintentionally cover YAML list items of the form `- Key=Value` inside heredoc strings.

## Test plan

- [x] Added failing test (`argocd application with yaml key=value list items in heredoc`) that reproduces the false positive before the fix
- [x] All `TestDiffMarkdownFormattedTerraformOutput` tests pass after the fix, including all CloudFormation cases added in #6069

🤖 Generated with [Claude Code](https://claude.com/claude-code)