### PR TITLE
fix: parallel_plan and parallel_apply

### DIFF
--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -830,10 +830,6 @@ func (p *DefaultProjectCommandRunner) doStateRm(ctx command.ProjectContext) (out
 func (p *DefaultProjectCommandRunner) runSteps(steps []valid.Step, ctx command.ProjectContext, absPath string) ([]string, error) {
 	var outputs []string
 
-	// Hold a read lock for the whole step run so clone/reset/merge cannot run in this dir until we're done.
-	unlock := p.WorkingDir.GitReadLock(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)
-	defer unlock()
-
 	envs := make(map[string]string)
 	for _, step := range steps {
 		var out string


### PR DESCRIPTION
## what
Fix the parallel plan and apply function.

## why
Atlantis should run in parallel.


## tests
I tested the change with my test project, which has more than 50 project in it. Without this change, it takes around 15minutes to run the entire thing. With my change, this is significantly reduce to approximately 3minutes, running 15 worker in parallel.


## references

closes #6426

