### PR TITLE
feat: add PROJECT_NAME as a usable environment variable in pre and post hooks

### DIFF
--- a/runatlantis.io/docs/post-workflow-hooks.md
+++ b/runatlantis.io/docs/post-workflow-hooks.md
@@ -118,4 +118,5 @@ command](custom-workflows.md#custom-run-command).
   * `COMMAND_NAME` - The name of the command that is being executed, i.e. `plan`, `apply` etc.
   * `COMMAND_HAS_ERRORS` - Indicates whether any errors occurred during the execution of the command (`plan`, `apply`). If set to `true`, at least one error was encountered; otherwise, it is `false`.
   * `OUTPUT_STATUS_FILE` - An output file to customize the success or failure status. ex. `echo 'failure' > $OUTPUT_STATUS_FILE`.
+  * `PROJECT_NAME` - Project name passed by the `-p` option. If `-p` is not provided, this value is empty.
 :::

--- a/runatlantis.io/docs/pre-workflow-hooks.md
+++ b/runatlantis.io/docs/pre-workflow-hooks.md
@@ -114,4 +114,6 @@ command](custom-workflows.md#custom-run-command).
       every character is escaped, ex. `atlantis plan -- arg1 arg2` will result in `COMMENT_ARGS=\a\r\g\1,\a\r\g\2`.
   * `COMMAND_NAME` - The name of the command that is being executed, i.e. `plan`, `apply` etc.
   * `OUTPUT_STATUS_FILE` - An output file to customize the success or failure status. ex. `echo 'failure' > $OUTPUT_STATUS_FILE`.
+  * `PROJECT_NAME` - Project name passed by the `-p` option. If `-p` is not provided, this value is empty.
+
 :::

--- a/server/core/runtime/post_workflow_hook_runner.go
+++ b/server/core/runtime/post_workflow_hook_runner.go
@@ -48,6 +48,7 @@ func (wh DefaultPostWorkflowHookRunner) Run(ctx models.WorkflowHookCommandContex
 		"OUTPUT_STATUS_FILE": outputFilePath,
 		"COMMAND_NAME":       ctx.CommandName,
 		"COMMAND_HAS_ERRORS": fmt.Sprintf("%t", ctx.CommandHasErrors),
+		"PROJECT_NAME":       ctx.ProjectName,
 	}
 
 	finalEnvVars := baseEnvVars

--- a/server/core/runtime/post_workflow_hook_runner_test.go
+++ b/server/core/runtime/post_workflow_hook_runner_test.go
@@ -91,10 +91,10 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 			ExpDescription: "",
 		},
 		{
-			Command:        "echo base_repo_name=$BASE_REPO_NAME base_repo_owner=$BASE_REPO_OWNER head_repo_name=$HEAD_REPO_NAME head_repo_owner=$HEAD_REPO_OWNER head_branch_name=$HEAD_BRANCH_NAME head_commit=$HEAD_COMMIT base_branch_name=$BASE_BRANCH_NAME pull_num=$PULL_NUM pull_url=$PULL_URL pull_author=$PULL_AUTHOR",
+			Command:        "echo base_repo_name=$BASE_REPO_NAME base_repo_owner=$BASE_REPO_OWNER head_repo_name=$HEAD_REPO_NAME head_repo_owner=$HEAD_REPO_OWNER head_branch_name=$HEAD_BRANCH_NAME head_commit=$HEAD_COMMIT base_branch_name=$BASE_BRANCH_NAME pull_num=$PULL_NUM pull_url=$PULL_URL pull_author=$PULL_AUTHOR project_name=$PROJECT_NAME",
 			Shell:          defaultShell,
 			ShellArgs:      defaultShellArgs,
-			ExpOut:         "base_repo_name=basename base_repo_owner=baseowner head_repo_name=headname head_repo_owner=headowner head_branch_name=add-feat head_commit=12345abcdef base_branch_name=main pull_num=2 pull_url=https://github.com/runatlantis/atlantis/pull/2 pull_author=acme\r\n",
+			ExpOut:         "base_repo_name=basename base_repo_owner=baseowner head_repo_name=headname head_repo_owner=headowner head_branch_name=add-feat head_commit=12345abcdef base_branch_name=main pull_num=2 pull_url=https://github.com/runatlantis/atlantis/pull/2 pull_author=acme project_name=*\r\n",
 			ExpErr:         "",
 			ExpDescription: "",
 		},
@@ -189,6 +189,7 @@ func TestPostWorkflowHookRunner_Run(t *testing.T) {
 				Log:              logger,
 				CommandName:      "plan",
 				CommandHasErrors: false,
+				ProjectName:      "*",
 			}
 			_, desc, err := r.Run(ctx, c.Command, c.Shell, c.ShellArgs, tmpDir)
 			if c.ExpErr != "" {

--- a/server/core/runtime/pre_workflow_hook_runner.go
+++ b/server/core/runtime/pre_workflow_hook_runner.go
@@ -47,6 +47,7 @@ func (wh DefaultPreWorkflowHookRunner) Run(ctx models.WorkflowHookCommandContext
 		"USER_NAME":          ctx.User.Username,
 		"OUTPUT_STATUS_FILE": outputFilePath,
 		"COMMAND_NAME":       ctx.CommandName,
+		"PROJECT_NAME":       ctx.ProjectName,
 	}
 
 	finalEnvVars := baseEnvVars

--- a/server/core/runtime/pre_workflow_hook_runner_test.go
+++ b/server/core/runtime/pre_workflow_hook_runner_test.go
@@ -111,10 +111,10 @@ func TestPreWorkflowHookRunner_Run(t *testing.T) {
 			ExpDescription: "",
 		},
 		{
-			Command:        "echo base_repo_name=$BASE_REPO_NAME base_repo_owner=$BASE_REPO_OWNER head_repo_name=$HEAD_REPO_NAME head_repo_owner=$HEAD_REPO_OWNER head_branch_name=$HEAD_BRANCH_NAME head_commit=$HEAD_COMMIT base_branch_name=$BASE_BRANCH_NAME pull_num=$PULL_NUM pull_url=$PULL_URL pull_author=$PULL_AUTHOR",
+			Command:        "echo base_repo_name=$BASE_REPO_NAME base_repo_owner=$BASE_REPO_OWNER head_repo_name=$HEAD_REPO_NAME head_repo_owner=$HEAD_REPO_OWNER head_branch_name=$HEAD_BRANCH_NAME head_commit=$HEAD_COMMIT base_branch_name=$BASE_BRANCH_NAME pull_num=$PULL_NUM pull_url=$PULL_URL pull_author=$PULL_AUTHOR project_name=$PROJECT_NAME",
 			Shell:          defaultShell,
 			ShellArgs:      defaultShellArgs,
-			ExpOut:         "base_repo_name=basename base_repo_owner=baseowner head_repo_name=headname head_repo_owner=headowner head_branch_name=add-feat head_commit=12345abcdef base_branch_name=main pull_num=2 pull_url=https://github.com/runatlantis/atlantis/pull/2 pull_author=acme\r\n",
+			ExpOut:         "base_repo_name=basename base_repo_owner=baseowner head_repo_name=headname head_repo_owner=headowner head_branch_name=add-feat head_commit=12345abcdef base_branch_name=main pull_num=2 pull_url=https://github.com/runatlantis/atlantis/pull/2 pull_author=acme project_name=*\r\n",
 			ExpErr:         "",
 			ExpDescription: "",
 		},
@@ -200,6 +200,7 @@ func TestPreWorkflowHookRunner_Run(t *testing.T) {
 				},
 				Log:         logger,
 				CommandName: "plan",
+				ProjectName: "*",
 			}
 			_, desc, err := r.Run(ctx, c.Command, c.Shell, c.ShellArgs, tmpDir)
 			if c.ExpErr != "" {

--- a/server/events/post_workflow_hooks_command_runner.go
+++ b/server/events/post_workflow_hooks_command_runner.go
@@ -84,6 +84,7 @@ func (w *DefaultPostWorkflowHooksCommandRunner) RunPostHooks(ctx *command.Contex
 			CommandName:        cmd.Name.String(),
 			CommandHasErrors:   ctx.CommandHasErrors,
 			API:                ctx.API,
+			ProjectName:        cmd.ProjectName,
 		},
 		postWorkflowHooks, repoDir)
 

--- a/server/events/post_workflow_hooks_command_runner_test.go
+++ b/server/events/post_workflow_hooks_command_runner_test.go
@@ -360,7 +360,7 @@ func TestRunPostHooks_Clone(t *testing.T) {
 		Assert(t, *unlockCalled == true, "unlock function called")
 	})
 
-	t.Run("comment args passed to webhooks", func(t *testing.T) {
+	t.Run("comment args and projectname passed to webhooks", func(t *testing.T) {
 		postWorkflowHooksSetup(t)
 
 		unlockCalled := newBool(false)
@@ -378,29 +378,41 @@ func TestRunPostHooks_Clone(t *testing.T) {
 				},
 			},
 		}
+		postWh.GlobalCfg = globalCfg
 
 		planCmd := &events.CommentCommand{
-			Name:  command.Plan,
-			Flags: []string{"comment", "args"},
+			Name:        command.Plan,
+			Flags:       []string{"comment", "args"},
+			ProjectName: "*",
 		}
 
 		expectedCtx := pCtx
+		expectedCtx.HookStepName = "post plan #0"
+		expectedCtx.HookDescription = "Post workflow hook #0"
 		expectedCtx.EscapedCommentArgs = []string{"\\c\\o\\m\\m\\e\\n\\t", "\\a\\r\\g\\s"}
-
-		postWh.GlobalCfg = globalCfg
+		expectedCtx.ProjectName = "*"
 
 		When(postWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
 			events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(unlockFn, nil)
 		When(postWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))).ThenReturn(repoDir, nil)
-		When(whPostWorkflowHookRunner.Run(Any[models.WorkflowHookCommandContext](), Eq(testHook.RunCommand),
-			Any[string](), Any[string](), Eq(repoDir))).ThenReturn(result, runtimeDesc, nil)
+		When(whPostWorkflowHookRunner.Run(
+			ArgThat[models.WorkflowHookCommandContext](WorkflowHookCommandContextMatcher{expected: expectedCtx}),
+			Eq(testHook.RunCommand),
+			Any[string](),
+			Any[string](),
+			Eq(repoDir),
+		)).ThenReturn(result, runtimeDesc, nil)
 
 		err := postWh.RunPostHooks(ctx, planCmd)
 
 		Ok(t, err)
-		whPostWorkflowHookRunner.VerifyWasCalledOnce().Run(Any[models.WorkflowHookCommandContext](),
-			Eq(testHook.RunCommand), Eq(defaultShell), Eq(defaultShellArgs), Eq(repoDir))
+		whPostWorkflowHookRunner.VerifyWasCalledOnce().Run(
+			ArgThat[models.WorkflowHookCommandContext](WorkflowHookCommandContextMatcher{expected: expectedCtx}),
+			Eq(testHook.RunCommand),
+			Eq(defaultShell),
+			Eq(defaultShellArgs),
+			Eq(repoDir))
 		Assert(t, *unlockCalled == true, "unlock function called")
 	})
 

--- a/server/events/post_workflow_hooks_command_runner_test.go
+++ b/server/events/post_workflow_hooks_command_runner_test.go
@@ -231,6 +231,7 @@ func TestRunPostHooks_Clone(t *testing.T) {
 			Eq(defaultShellArgs),
 			Eq(repoDir))
 		Assert(t, *unlockCalled == true, "unlock function called")
+		ctx.CommandHasErrors = false
 	})
 	t.Run("success hooks not in cfg", func(t *testing.T) {
 		postWorkflowHooksSetup(t)

--- a/server/events/pre_workflow_hooks_command_runner.go
+++ b/server/events/pre_workflow_hooks_command_runner.go
@@ -83,6 +83,7 @@ func (w *DefaultPreWorkflowHooksCommandRunner) RunPreHooks(ctx *command.Context,
 			EscapedCommentArgs: escapedArgs,
 			CommandName:        cmd.Name.String(),
 			API:                ctx.API,
+			ProjectName:        cmd.ProjectName,
 		},
 		preWorkflowHooks, repoDir)
 

--- a/server/events/pre_workflow_hooks_command_runner_test.go
+++ b/server/events/pre_workflow_hooks_command_runner_test.go
@@ -289,7 +289,7 @@ func TestRunPreHooks_Clone(t *testing.T) {
 		Assert(t, *unlockCalled == true, "unlock function called")
 	})
 
-	t.Run("comment args passed to webhooks", func(t *testing.T) {
+	t.Run("comment args and projectname passed to webhooks", func(t *testing.T) {
 		preWorkflowHooksSetup(t)
 
 		var unlockCalled = newBool(false)
@@ -309,12 +309,16 @@ func TestRunPreHooks_Clone(t *testing.T) {
 		}
 
 		planCmd := &events.CommentCommand{
-			Name:  command.Plan,
-			Flags: []string{"comment", "args"},
+			Name:        command.Plan,
+			Flags:       []string{"comment", "args"},
+			ProjectName: "*",
 		}
 
 		expectedCtx := pCtx
+		expectedCtx.HookDescription = "Pre workflow hook #0"
+		expectedCtx.HookStepName = "pre plan #0"
 		expectedCtx.EscapedCommentArgs = []string{"\\c\\o\\m\\m\\e\\n\\t", "\\a\\r\\g\\s"}
+		expectedCtx.ProjectName = "*"
 
 		preWh.GlobalCfg = globalCfg
 
@@ -322,14 +326,23 @@ func TestRunPreHooks_Clone(t *testing.T) {
 			events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(unlockFn, nil)
 		When(preWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))).ThenReturn(repoDir, nil)
-		When(whPreWorkflowHookRunner.Run(Any[models.WorkflowHookCommandContext](), Eq(testHook.RunCommand), Any[string](),
-			Any[string](), Eq(repoDir))).ThenReturn(result, runtimeDesc, nil)
+		When(whPreWorkflowHookRunner.Run(
+			ArgThat[models.WorkflowHookCommandContext](WorkflowHookCommandContextMatcher{expected: expectedCtx}),
+			Eq(testHook.RunCommand),
+			Any[string](),
+			Any[string](),
+			Eq(repoDir),
+		)).ThenReturn(result, runtimeDesc, nil)
 
 		err := preWh.RunPreHooks(ctx, planCmd)
 
 		Ok(t, err)
-		whPreWorkflowHookRunner.VerifyWasCalledOnce().Run(Any[models.WorkflowHookCommandContext](), Eq(testHook.RunCommand),
-			Eq(defaultShell), Eq(defaultShellArgs), Eq(repoDir))
+		whPreWorkflowHookRunner.VerifyWasCalledOnce().Run(
+			ArgThat[models.WorkflowHookCommandContext](WorkflowHookCommandContextMatcher{expected: expectedCtx}),
+			Eq(testHook.RunCommand),
+			Eq(defaultShell),
+			Eq(defaultShellArgs),
+			Eq(repoDir))
 		Assert(t, *unlockCalled == true, "unlock function called")
 	})
 


### PR DESCRIPTION
## what

Add `PROJECT_NAME` environment variable for pre and post hook. This variable contains what `-p` would have.
Fix `comment args` tests that were not properly checking that the resulting context did contain the comment args.

## why

I am using pre-workflow hook to generate repo level atlantis.yaml and also a lot of other files related to the `-p` option. As of right, we are always generating all project files but we would like to be a more specific when a user add the `-p` option to only render that project's files. This PR would allow that.

## tests
Tested this patch in my environment. I added a `-p projectname`. I can see it in logs that I added (not present in this PR) but also in my pre and post script hook.

## references
closes #6439

