### PR TITLE
fix: divergence check order issue

### DIFF
--- a/server/events/command_requirement_handler.go
+++ b/server/events/command_requirement_handler.go
@@ -23,6 +23,7 @@ type CommandRequirementHandler interface {
 
 type UndivergedProjectImpactResolver interface {
 	HasUndivergedImpact(ctx command.ProjectContext, repoDir string, workingDir WorkingDir) (handled bool, impacted bool, err error)
+	HasUndivergedImpactFromPullHead(ctx command.ProjectContext, repoDir string, workingDir WorkingDir) (handled bool, impacted bool, err error)
 }
 
 type DefaultCommandRequirementHandler struct {
@@ -84,10 +85,10 @@ func (a *DefaultCommandRequirementHandler) validateCommandRequirement(repoDir st
 				return fmt.Sprintf("Pull request must be mergeable before running %s%s.", cmd, suffix), nil
 			}
 		case raw.UnDivergedRequirement:
-			diverged, err := a.hasUndivergedImpact(repoDir, ctx)
+			diverged, err := a.hasUndivergedImpact(repoDir, ctx, cmd)
 			if err != nil {
 				ctx.Log.Warn("evaluating undiverged requirement has failed, falling back to full divergence check: %s", err)
-				diverged = a.WorkingDir.HasDiverged(ctx.Log, repoDir, ctx.RepoRelDir, nil, ctx.Pull)
+				diverged = a.hasDiverged(repoDir, ctx, cmd, nil)
 			}
 			if diverged {
 				return fmt.Sprintf("Default branch must be rebased onto pull request before running %s.", cmd), nil
@@ -153,17 +154,31 @@ func isAtlantisProjectPlanStatus(statusName, vcsStatusName string) bool {
 	return strings.HasPrefix(statusName, vcsStatusName+"/plan: ")
 }
 
-func (a *DefaultCommandRequirementHandler) hasUndivergedImpact(repoDir string, ctx command.ProjectContext) (bool, error) {
+func (a *DefaultCommandRequirementHandler) hasUndivergedImpact(repoDir string, ctx command.ProjectContext, cmd command.Name) (bool, error) {
 	if a.ProjectImpactResolver == nil {
-		return a.WorkingDir.HasDiverged(ctx.Log, repoDir, ctx.RepoRelDir, ctx.AutoplanWhenModified, ctx.Pull), nil
+		return a.hasDiverged(repoDir, ctx, cmd, ctx.AutoplanWhenModified), nil
 	}
 
-	handled, impacted, err := a.ProjectImpactResolver.HasUndivergedImpact(ctx, repoDir, a.WorkingDir)
+	var handled bool
+	var impacted bool
+	var err error
+	if cmd == command.Plan {
+		handled, impacted, err = a.ProjectImpactResolver.HasUndivergedImpactFromPullHead(ctx, repoDir, a.WorkingDir)
+	} else {
+		handled, impacted, err = a.ProjectImpactResolver.HasUndivergedImpact(ctx, repoDir, a.WorkingDir)
+	}
 	if err != nil {
 		return false, err
 	}
 	if !handled {
-		return a.WorkingDir.HasDiverged(ctx.Log, repoDir, ctx.RepoRelDir, ctx.AutoplanWhenModified, ctx.Pull), nil
+		return a.hasDiverged(repoDir, ctx, cmd, ctx.AutoplanWhenModified), nil
 	}
 	return impacted, nil
+}
+
+func (a *DefaultCommandRequirementHandler) hasDiverged(repoDir string, ctx command.ProjectContext, cmd command.Name, autoplanWhenModified []string) bool {
+	if cmd == command.Plan {
+		return a.WorkingDir.HasDivergedFromPullHead(ctx.Log, repoDir, ctx.RepoRelDir, autoplanWhenModified, ctx.Pull)
+	}
+	return a.WorkingDir.HasDiverged(ctx.Log, repoDir, ctx.RepoRelDir, autoplanWhenModified, ctx.Pull)
 }

--- a/server/events/command_requirement_handler_test.go
+++ b/server/events/command_requirement_handler_test.go
@@ -53,7 +53,7 @@ func TestAggregateApplyRequirements_ValidatePlanProject(t *testing.T) {
 				ProjectPlanStatus: models.PassedPolicyCheckStatus,
 			},
 			setup: func(workingDir *mocks.MockWorkingDir) {
-				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(false)
+				When(workingDir.HasDivergedFromPullHead(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(false)
 			},
 			wantErr: assert.NoError,
 		},
@@ -99,7 +99,7 @@ func TestAggregateApplyRequirements_ValidatePlanProject(t *testing.T) {
 				PlanRequirements: []string{raw.UnDivergedRequirement},
 			},
 			setup: func(workingDir *mocks.MockWorkingDir) {
-				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(true)
+				When(workingDir.HasDivergedFromPullHead(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(true)
 			},
 			wantFailure: "Default branch must be rebased onto pull request before running plan.",
 			wantErr:     assert.NoError,

--- a/server/events/mock_workingdir_test.go
+++ b/server/events/mock_workingdir_test.go
@@ -4,12 +4,11 @@
 package events
 
 import (
-	"reflect"
-	"time"
-
 	pegomock "github.com/petergtz/pegomock/v4"
 	models "github.com/runatlantis/atlantis/server/events/models"
 	logging "github.com/runatlantis/atlantis/server/logging"
+	"reflect"
+	"time"
 )
 
 type MockWorkingDir struct {
@@ -110,6 +109,25 @@ func (mock *MockWorkingDir) GetDivergedFiles(logger logging.SimpleLogging, clone
 	return _ret0, _ret1
 }
 
+func (mock *MockWorkingDir) GetDivergedFilesFromPullHead(logger logging.SimpleLogging, cloneDir string, pullRequest models.PullRequest) ([]string, error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockWorkingDir().")
+	}
+	_params := []pegomock.Param{logger, cloneDir, pullRequest}
+	_result := pegomock.GetGenericMockFrom(mock).Invoke("GetDivergedFilesFromPullHead", _params, []reflect.Type{reflect.TypeOf((*[]string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var _ret0 []string
+	var _ret1 error
+	if len(_result) != 0 {
+		if _result[0] != nil {
+			_ret0 = _result[0].([]string)
+		}
+		if _result[1] != nil {
+			_ret1 = _result[1].(error)
+		}
+	}
+	return _ret0, _ret1
+}
+
 func (mock *MockWorkingDir) GetGitUntrackedFiles(logger logging.SimpleLogging, r models.Repo, p models.PullRequest, workspace string) ([]string, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockWorkingDir().")
@@ -188,6 +206,21 @@ func (mock *MockWorkingDir) HasDiverged(logger logging.SimpleLogging, cloneDir s
 	}
 	_params := []pegomock.Param{logger, cloneDir, projectPath, autoplanWhenModified, pullRequest}
 	_result := pegomock.GetGenericMockFrom(mock).Invoke("HasDiverged", _params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem()})
+	var _ret0 bool
+	if len(_result) != 0 {
+		if _result[0] != nil {
+			_ret0 = _result[0].(bool)
+		}
+	}
+	return _ret0
+}
+
+func (mock *MockWorkingDir) HasDivergedFromPullHead(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) bool {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockWorkingDir().")
+	}
+	_params := []pegomock.Param{logger, cloneDir, projectPath, autoplanWhenModified, pullRequest}
+	_result := pegomock.GetGenericMockFrom(mock).Invoke("HasDivergedFromPullHead", _params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem()})
 	var _ret0 bool
 	if len(_result) != 0 {
 		if _result[0] != nil {
@@ -488,6 +521,47 @@ func (c *MockWorkingDir_GetDivergedFiles_OngoingVerification) GetAllCapturedArgu
 	return
 }
 
+func (verifier *VerifierMockWorkingDir) GetDivergedFilesFromPullHead(logger logging.SimpleLogging, cloneDir string, pullRequest models.PullRequest) *MockWorkingDir_GetDivergedFilesFromPullHead_OngoingVerification {
+	_params := []pegomock.Param{logger, cloneDir, pullRequest}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "GetDivergedFilesFromPullHead", _params, verifier.timeout)
+	return &MockWorkingDir_GetDivergedFilesFromPullHead_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockWorkingDir_GetDivergedFilesFromPullHead_OngoingVerification struct {
+	mock              *MockWorkingDir
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockWorkingDir_GetDivergedFilesFromPullHead_OngoingVerification) GetCapturedArguments() (logging.SimpleLogging, string, models.PullRequest) {
+	logger, cloneDir, pullRequest := c.GetAllCapturedArguments()
+	return logger[len(logger)-1], cloneDir[len(cloneDir)-1], pullRequest[len(pullRequest)-1]
+}
+
+func (c *MockWorkingDir_GetDivergedFilesFromPullHead_OngoingVerification) GetAllCapturedArguments() (_param0 []logging.SimpleLogging, _param1 []string, _param2 []models.PullRequest) {
+	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(_params) > 0 {
+		if len(_params) > 0 {
+			_param0 = make([]logging.SimpleLogging, len(c.methodInvocations))
+			for u, param := range _params[0] {
+				_param0[u] = param.(logging.SimpleLogging)
+			}
+		}
+		if len(_params) > 1 {
+			_param1 = make([]string, len(c.methodInvocations))
+			for u, param := range _params[1] {
+				_param1[u] = param.(string)
+			}
+		}
+		if len(_params) > 2 {
+			_param2 = make([]models.PullRequest, len(c.methodInvocations))
+			for u, param := range _params[2] {
+				_param2[u] = param.(models.PullRequest)
+			}
+		}
+	}
+	return
+}
+
 func (verifier *VerifierMockWorkingDir) GetGitUntrackedFiles(logger logging.SimpleLogging, r models.Repo, p models.PullRequest, workspace string) *MockWorkingDir_GetGitUntrackedFiles_OngoingVerification {
 	_params := []pegomock.Param{logger, r, p, workspace}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "GetGitUntrackedFiles", _params, verifier.timeout)
@@ -669,6 +743,59 @@ func (c *MockWorkingDir_HasDiverged_OngoingVerification) GetCapturedArguments() 
 }
 
 func (c *MockWorkingDir_HasDiverged_OngoingVerification) GetAllCapturedArguments() (_param0 []logging.SimpleLogging, _param1 []string, _param2 []string, _param3 [][]string, _param4 []models.PullRequest) {
+	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(_params) > 0 {
+		if len(_params) > 0 {
+			_param0 = make([]logging.SimpleLogging, len(c.methodInvocations))
+			for u, param := range _params[0] {
+				_param0[u] = param.(logging.SimpleLogging)
+			}
+		}
+		if len(_params) > 1 {
+			_param1 = make([]string, len(c.methodInvocations))
+			for u, param := range _params[1] {
+				_param1[u] = param.(string)
+			}
+		}
+		if len(_params) > 2 {
+			_param2 = make([]string, len(c.methodInvocations))
+			for u, param := range _params[2] {
+				_param2[u] = param.(string)
+			}
+		}
+		if len(_params) > 3 {
+			_param3 = make([][]string, len(c.methodInvocations))
+			for u, param := range _params[3] {
+				_param3[u] = param.([]string)
+			}
+		}
+		if len(_params) > 4 {
+			_param4 = make([]models.PullRequest, len(c.methodInvocations))
+			for u, param := range _params[4] {
+				_param4[u] = param.(models.PullRequest)
+			}
+		}
+	}
+	return
+}
+
+func (verifier *VerifierMockWorkingDir) HasDivergedFromPullHead(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) *MockWorkingDir_HasDivergedFromPullHead_OngoingVerification {
+	_params := []pegomock.Param{logger, cloneDir, projectPath, autoplanWhenModified, pullRequest}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "HasDivergedFromPullHead", _params, verifier.timeout)
+	return &MockWorkingDir_HasDivergedFromPullHead_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockWorkingDir_HasDivergedFromPullHead_OngoingVerification struct {
+	mock              *MockWorkingDir
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockWorkingDir_HasDivergedFromPullHead_OngoingVerification) GetCapturedArguments() (logging.SimpleLogging, string, string, []string, models.PullRequest) {
+	logger, cloneDir, projectPath, autoplanWhenModified, pullRequest := c.GetAllCapturedArguments()
+	return logger[len(logger)-1], cloneDir[len(cloneDir)-1], projectPath[len(projectPath)-1], autoplanWhenModified[len(autoplanWhenModified)-1], pullRequest[len(pullRequest)-1]
+}
+
+func (c *MockWorkingDir_HasDivergedFromPullHead_OngoingVerification) GetAllCapturedArguments() (_param0 []logging.SimpleLogging, _param1 []string, _param2 []string, _param3 [][]string, _param4 []models.PullRequest) {
 	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(_params) > 0 {
 		if len(_params) > 0 {

--- a/server/events/mocks/mock_working_dir.go
+++ b/server/events/mocks/mock_working_dir.go
@@ -109,6 +109,25 @@ func (mock *MockWorkingDir) GetDivergedFiles(logger logging.SimpleLogging, clone
 	return _ret0, _ret1
 }
 
+func (mock *MockWorkingDir) GetDivergedFilesFromPullHead(logger logging.SimpleLogging, cloneDir string, pullRequest models.PullRequest) ([]string, error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockWorkingDir().")
+	}
+	_params := []pegomock.Param{logger, cloneDir, pullRequest}
+	_result := pegomock.GetGenericMockFrom(mock).Invoke("GetDivergedFilesFromPullHead", _params, []reflect.Type{reflect.TypeOf((*[]string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var _ret0 []string
+	var _ret1 error
+	if len(_result) != 0 {
+		if _result[0] != nil {
+			_ret0 = _result[0].([]string)
+		}
+		if _result[1] != nil {
+			_ret1 = _result[1].(error)
+		}
+	}
+	return _ret0, _ret1
+}
+
 func (mock *MockWorkingDir) GetGitUntrackedFiles(logger logging.SimpleLogging, r models.Repo, p models.PullRequest, workspace string) ([]string, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockWorkingDir().")
@@ -187,6 +206,21 @@ func (mock *MockWorkingDir) HasDiverged(logger logging.SimpleLogging, cloneDir s
 	}
 	_params := []pegomock.Param{logger, cloneDir, projectPath, autoplanWhenModified, pullRequest}
 	_result := pegomock.GetGenericMockFrom(mock).Invoke("HasDiverged", _params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem()})
+	var _ret0 bool
+	if len(_result) != 0 {
+		if _result[0] != nil {
+			_ret0 = _result[0].(bool)
+		}
+	}
+	return _ret0
+}
+
+func (mock *MockWorkingDir) HasDivergedFromPullHead(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) bool {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockWorkingDir().")
+	}
+	_params := []pegomock.Param{logger, cloneDir, projectPath, autoplanWhenModified, pullRequest}
+	_result := pegomock.GetGenericMockFrom(mock).Invoke("HasDivergedFromPullHead", _params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem()})
 	var _ret0 bool
 	if len(_result) != 0 {
 		if _result[0] != nil {
@@ -487,6 +521,47 @@ func (c *MockWorkingDir_GetDivergedFiles_OngoingVerification) GetAllCapturedArgu
 	return
 }
 
+func (verifier *VerifierMockWorkingDir) GetDivergedFilesFromPullHead(logger logging.SimpleLogging, cloneDir string, pullRequest models.PullRequest) *MockWorkingDir_GetDivergedFilesFromPullHead_OngoingVerification {
+	_params := []pegomock.Param{logger, cloneDir, pullRequest}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "GetDivergedFilesFromPullHead", _params, verifier.timeout)
+	return &MockWorkingDir_GetDivergedFilesFromPullHead_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockWorkingDir_GetDivergedFilesFromPullHead_OngoingVerification struct {
+	mock              *MockWorkingDir
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockWorkingDir_GetDivergedFilesFromPullHead_OngoingVerification) GetCapturedArguments() (logging.SimpleLogging, string, models.PullRequest) {
+	logger, cloneDir, pullRequest := c.GetAllCapturedArguments()
+	return logger[len(logger)-1], cloneDir[len(cloneDir)-1], pullRequest[len(pullRequest)-1]
+}
+
+func (c *MockWorkingDir_GetDivergedFilesFromPullHead_OngoingVerification) GetAllCapturedArguments() (_param0 []logging.SimpleLogging, _param1 []string, _param2 []models.PullRequest) {
+	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(_params) > 0 {
+		if len(_params) > 0 {
+			_param0 = make([]logging.SimpleLogging, len(c.methodInvocations))
+			for u, param := range _params[0] {
+				_param0[u] = param.(logging.SimpleLogging)
+			}
+		}
+		if len(_params) > 1 {
+			_param1 = make([]string, len(c.methodInvocations))
+			for u, param := range _params[1] {
+				_param1[u] = param.(string)
+			}
+		}
+		if len(_params) > 2 {
+			_param2 = make([]models.PullRequest, len(c.methodInvocations))
+			for u, param := range _params[2] {
+				_param2[u] = param.(models.PullRequest)
+			}
+		}
+	}
+	return
+}
+
 func (verifier *VerifierMockWorkingDir) GetGitUntrackedFiles(logger logging.SimpleLogging, r models.Repo, p models.PullRequest, workspace string) *MockWorkingDir_GetGitUntrackedFiles_OngoingVerification {
 	_params := []pegomock.Param{logger, r, p, workspace}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "GetGitUntrackedFiles", _params, verifier.timeout)
@@ -668,6 +743,59 @@ func (c *MockWorkingDir_HasDiverged_OngoingVerification) GetCapturedArguments() 
 }
 
 func (c *MockWorkingDir_HasDiverged_OngoingVerification) GetAllCapturedArguments() (_param0 []logging.SimpleLogging, _param1 []string, _param2 []string, _param3 [][]string, _param4 []models.PullRequest) {
+	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(_params) > 0 {
+		if len(_params) > 0 {
+			_param0 = make([]logging.SimpleLogging, len(c.methodInvocations))
+			for u, param := range _params[0] {
+				_param0[u] = param.(logging.SimpleLogging)
+			}
+		}
+		if len(_params) > 1 {
+			_param1 = make([]string, len(c.methodInvocations))
+			for u, param := range _params[1] {
+				_param1[u] = param.(string)
+			}
+		}
+		if len(_params) > 2 {
+			_param2 = make([]string, len(c.methodInvocations))
+			for u, param := range _params[2] {
+				_param2[u] = param.(string)
+			}
+		}
+		if len(_params) > 3 {
+			_param3 = make([][]string, len(c.methodInvocations))
+			for u, param := range _params[3] {
+				_param3[u] = param.([]string)
+			}
+		}
+		if len(_params) > 4 {
+			_param4 = make([]models.PullRequest, len(c.methodInvocations))
+			for u, param := range _params[4] {
+				_param4[u] = param.(models.PullRequest)
+			}
+		}
+	}
+	return
+}
+
+func (verifier *VerifierMockWorkingDir) HasDivergedFromPullHead(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) *MockWorkingDir_HasDivergedFromPullHead_OngoingVerification {
+	_params := []pegomock.Param{logger, cloneDir, projectPath, autoplanWhenModified, pullRequest}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "HasDivergedFromPullHead", _params, verifier.timeout)
+	return &MockWorkingDir_HasDivergedFromPullHead_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockWorkingDir_HasDivergedFromPullHead_OngoingVerification struct {
+	mock              *MockWorkingDir
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockWorkingDir_HasDivergedFromPullHead_OngoingVerification) GetCapturedArguments() (logging.SimpleLogging, string, string, []string, models.PullRequest) {
+	logger, cloneDir, projectPath, autoplanWhenModified, pullRequest := c.GetAllCapturedArguments()
+	return logger[len(logger)-1], cloneDir[len(cloneDir)-1], projectPath[len(projectPath)-1], autoplanWhenModified[len(autoplanWhenModified)-1], pullRequest[len(pullRequest)-1]
+}
+
+func (c *MockWorkingDir_HasDivergedFromPullHead_OngoingVerification) GetAllCapturedArguments() (_param0 []logging.SimpleLogging, _param1 []string, _param2 []string, _param3 [][]string, _param4 []models.PullRequest) {
 	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(_params) > 0 {
 		if len(_params) > 0 {

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -677,6 +677,9 @@ func (p *DefaultProjectCommandRunner) doPlan(ctx command.ProjectContext) (*model
 	// Acquire internal lock for the directory we're going to operate in.
 	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.Plan)
 	if err != nil {
+		if unlockErr := lockAttempt.UnlockFn(); unlockErr != nil {
+			ctx.Log.Err("error unlocking state after plan error: %v", unlockErr)
+		}
 		return nil, "", err
 	}
 	defer unlockFn()
@@ -689,6 +692,7 @@ func (p *DefaultProjectCommandRunner) doPlan(ctx command.ProjectContext) (*model
 		}
 		return nil, "", err
 	}
+
 	mergedAgain, err := p.WorkingDir.MergeAgain(ctx.Log, ctx.HeadRepo, ctx.Pull, ctx.Workspace)
 	if err != nil {
 		if unlockErr := lockAttempt.UnlockFn(); unlockErr != nil {
@@ -699,11 +703,23 @@ func (p *DefaultProjectCommandRunner) doPlan(ctx command.ProjectContext) (*model
 
 	projAbsPath := filepath.Join(repoDir, ctx.RepoRelDir)
 	if _, err = os.Stat(projAbsPath); os.IsNotExist(err) {
+		if unlockErr := lockAttempt.UnlockFn(); unlockErr != nil {
+			ctx.Log.Err("error unlocking state after plan error: %v", unlockErr)
+		}
 		return nil, "", DirNotExistErr{RepoRelDir: ctx.RepoRelDir}
 	}
 
+	// Validate requirements after refreshing the merge checkout so project path
+	// checks and plan execution use the same tree.
 	failure, err := p.CommandRequirementHandler.ValidatePlanProject(repoDir, ctx)
 	if failure != "" || err != nil {
+		if deleteErr := p.WorkingDir.DeletePlan(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName); deleteErr != nil {
+			ctx.Log.Err("error deleting stale plan after plan validation failure: %v", deleteErr)
+			return nil, failure, fmt.Errorf("deleting stale plan after plan validation failure: %w", deleteErr)
+		}
+		if unlockErr := lockAttempt.UnlockFn(); unlockErr != nil {
+			ctx.Log.Err("error unlocking state after plan error: %v", unlockErr)
+		}
 		return nil, failure, err
 	}
 

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/hashicorp/go-version"
@@ -282,6 +283,193 @@ func TestDefaultProjectCommandRunner_ApplyNotMergeable(t *testing.T) {
 
 	res := runner.Apply(ctx)
 	Equals(t, "Pull request must be mergeable before running apply.", res.Failure)
+}
+
+// Regression test for: a pre-plan requirement failure must stop before plan
+// execution side effects after the merge checkout has been refreshed.
+func TestDefaultProjectCommandRunner_PlanUndivergedBlocksAfterMergeAgain(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockLocker := mocks.NewMockProjectLocker()
+	runner := &events.DefaultProjectCommandRunner{
+		Locker:           mockLocker,
+		LockURLGenerator: mockURLGenerator{},
+		WorkingDir:       mockWorkingDir,
+		WorkingDirLocker: events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: &events.DefaultCommandRequirementHandler{
+			WorkingDir: mockWorkingDir,
+		},
+	}
+	log := logging.NewNoopLogger(t)
+	ctx := command.ProjectContext{
+		Log:              log,
+		PlanRequirements: []string{"undiverged"},
+		RepoRelDir:       ".",
+		Workspace:        "default",
+	}
+	repoDir := t.TempDir()
+	When(mockLocker.TryLock(Any[logging.SimpleLogging](), Any[models.PullRequest](), Any[models.User](),
+		Any[string](), Any[models.Project](), AnyBool())).
+		ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key", UnlockFn: func() error { return nil }}, nil)
+	When(mockWorkingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](),
+		Any[string]())).ThenReturn(repoDir, nil)
+	When(mockWorkingDir.HasDivergedFromPullHead(Any[logging.SimpleLogging](), Any[string](), Any[string](),
+		Any[[]string](), Any[models.PullRequest]())).ThenReturn(true)
+
+	res := runner.Plan(ctx)
+
+	Equals(t, "Default branch must be rebased onto pull request before running plan.", res.Failure)
+	mockWorkingDir.VerifyWasCalledOnce().MergeAgain(
+		Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Any[string]())
+}
+
+func TestDefaultProjectCommandRunner_PlanChecksProjectPathAfterMergeAgain(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockLocker := mocks.NewMockProjectLocker()
+	repoDir := t.TempDir()
+	workingDir := &mergeCreatesProjectWorkingDir{
+		repoDir:     repoDir,
+		projectPath: "project1",
+	}
+	runner := &events.DefaultProjectCommandRunner{
+		Locker:           mockLocker,
+		LockURLGenerator: mockURLGenerator{},
+		WorkingDir:       workingDir,
+		WorkingDirLocker: events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: &events.DefaultCommandRequirementHandler{
+			WorkingDir: workingDir,
+		},
+	}
+	ctx := command.ProjectContext{
+		Log:        logging.NewNoopLogger(t),
+		RepoRelDir: "project1",
+		Workspace:  "default",
+		Pull: models.PullRequest{
+			Num:      1,
+			BaseRepo: models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	When(mockLocker.TryLock(Any[logging.SimpleLogging](), Any[models.PullRequest](), Any[models.User](),
+		Any[string](), Any[models.Project](), AnyBool())).
+		ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key", UnlockFn: func() error { return nil }}, nil)
+
+	res := runner.Plan(ctx)
+
+	Equals(t, "", res.Failure)
+	Ok(t, res.Error)
+	Assert(t, res.PlanSuccess != nil, "expected plan success")
+	Assert(t, workingDir.mergeCalled, "expected merge checkout refresh")
+}
+
+func TestDefaultProjectCommandRunner_PlanValidationFailureKeepsLockWhenDeletePlanFails(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockLocker := mocks.NewMockProjectLocker()
+	runner := &events.DefaultProjectCommandRunner{
+		Locker:           mockLocker,
+		LockURLGenerator: mockURLGenerator{},
+		WorkingDir:       mockWorkingDir,
+		WorkingDirLocker: events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: &events.DefaultCommandRequirementHandler{
+			WorkingDir: mockWorkingDir,
+		},
+	}
+	log := logging.NewNoopLogger(t)
+	ctx := command.ProjectContext{
+		Log:              log,
+		PlanRequirements: []string{"undiverged"},
+		RepoRelDir:       ".",
+		Workspace:        "default",
+		ProjectName:      "project",
+		Pull: models.PullRequest{
+			Num:      1,
+			BaseRepo: models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	repoDir := t.TempDir()
+	unlockCalls := 0
+	When(mockLocker.TryLock(Any[logging.SimpleLogging](), Any[models.PullRequest](), Any[models.User](),
+		Any[string](), Any[models.Project](), AnyBool())).
+		ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key", UnlockFn: func() error {
+			unlockCalls++
+			return nil
+		}}, nil)
+	When(mockWorkingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](),
+		Any[string]())).ThenReturn(repoDir, nil)
+	When(mockWorkingDir.HasDivergedFromPullHead(Any[logging.SimpleLogging](), Any[string](), Any[string](),
+		Any[[]string](), Any[models.PullRequest]())).ThenReturn(true)
+	When(mockWorkingDir.DeletePlan(Any[logging.SimpleLogging](), Eq(ctx.Pull.BaseRepo), Eq(ctx.Pull),
+		Eq(ctx.Workspace), Eq(ctx.RepoRelDir), Eq(ctx.ProjectName))).ThenReturn(errors.New("delete failed"))
+
+	res := runner.Plan(ctx)
+
+	Equals(t, "Default branch must be rebased onto pull request before running plan.", res.Failure)
+	Assert(t, res.Error != nil, "expected delete plan error")
+	Equals(t, "deleting stale plan after plan validation failure: delete failed", res.Error.Error())
+	Equals(t, 0, unlockCalls)
+	mockWorkingDir.VerifyWasCalledOnce().DeletePlan(Any[logging.SimpleLogging](), Eq(ctx.Pull.BaseRepo), Eq(ctx.Pull),
+		Eq(ctx.Workspace), Eq(ctx.RepoRelDir), Eq(ctx.ProjectName))
+	mockWorkingDir.VerifyWasCalledOnce().MergeAgain(
+		Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Any[string]())
+}
+
+type mergeCreatesProjectWorkingDir struct {
+	repoDir     string
+	projectPath string
+	mergeCalled bool
+}
+
+func (m *mergeCreatesProjectWorkingDir) Clone(logging.SimpleLogging, models.Repo, models.PullRequest, string) (string, error) {
+	return m.repoDir, nil
+}
+
+func (m *mergeCreatesProjectWorkingDir) MergeAgain(logging.SimpleLogging, models.Repo, models.PullRequest, string) (bool, error) {
+	m.mergeCalled = true
+	return true, os.MkdirAll(filepath.Join(m.repoDir, m.projectPath), 0o755)
+}
+
+func (m *mergeCreatesProjectWorkingDir) GetWorkingDir(models.Repo, models.PullRequest, string) (string, error) {
+	return m.repoDir, nil
+}
+
+func (m *mergeCreatesProjectWorkingDir) HasDiverged(logging.SimpleLogging, string, string, []string, models.PullRequest) bool {
+	return false
+}
+
+func (m *mergeCreatesProjectWorkingDir) HasDivergedFromPullHead(logging.SimpleLogging, string, string, []string, models.PullRequest) bool {
+	return false
+}
+
+func (m *mergeCreatesProjectWorkingDir) GetDivergedFiles(logging.SimpleLogging, string, models.PullRequest) ([]string, error) {
+	return nil, nil
+}
+
+func (m *mergeCreatesProjectWorkingDir) GetDivergedFilesFromPullHead(logging.SimpleLogging, string, models.PullRequest) ([]string, error) {
+	return nil, nil
+}
+
+func (m *mergeCreatesProjectWorkingDir) GetPullDir(models.Repo, models.PullRequest) (string, error) {
+	return m.repoDir, nil
+}
+
+func (m *mergeCreatesProjectWorkingDir) Delete(logging.SimpleLogging, models.Repo, models.PullRequest) error {
+	return nil
+}
+
+func (m *mergeCreatesProjectWorkingDir) DeleteForWorkspace(logging.SimpleLogging, models.Repo, models.PullRequest, string) error {
+	return nil
+}
+
+func (m *mergeCreatesProjectWorkingDir) DeletePlan(logging.SimpleLogging, models.Repo, models.PullRequest, string, string, string) error {
+	return nil
+}
+
+func (m *mergeCreatesProjectWorkingDir) GetGitUntrackedFiles(logging.SimpleLogging, models.Repo, models.PullRequest, string) ([]string, error) {
+	return nil, nil
+}
+
+func (m *mergeCreatesProjectWorkingDir) GitReadLock(models.Repo, models.PullRequest, string) func() {
+	return func() {}
 }
 
 // Test that if undiverged is required and the PR is diverged we give an error.

--- a/server/events/undiverged_project_impact.go
+++ b/server/events/undiverged_project_impact.go
@@ -59,6 +59,23 @@ func (r *undivergedProjectImpactResolver) HasUndivergedImpact(
 	repoDir string,
 	workingDir WorkingDir,
 ) (handled bool, impacted bool, err error) {
+	return r.hasUndivergedImpact(ctx, repoDir, workingDir, false)
+}
+
+func (r *undivergedProjectImpactResolver) HasUndivergedImpactFromPullHead(
+	ctx command.ProjectContext,
+	repoDir string,
+	workingDir WorkingDir,
+) (handled bool, impacted bool, err error) {
+	return r.hasUndivergedImpact(ctx, repoDir, workingDir, true)
+}
+
+func (r *undivergedProjectImpactResolver) hasUndivergedImpact(
+	ctx command.ProjectContext,
+	repoDir string,
+	workingDir WorkingDir,
+	fromPullHead bool,
+) (handled bool, impacted bool, err error) {
 	target, err := r.resolveTarget(ctx, repoDir)
 	if err != nil {
 		return false, false, err
@@ -72,7 +89,12 @@ func (r *undivergedProjectImpactResolver) HasUndivergedImpact(
 		return false, false, nil
 	}
 
-	divergedFiles, err := workingDir.GetDivergedFiles(ctx.Log, repoDir, ctx.Pull)
+	var divergedFiles []string
+	if fromPullHead {
+		divergedFiles, err = workingDir.GetDivergedFilesFromPullHead(ctx.Log, repoDir, ctx.Pull)
+	} else {
+		divergedFiles, err = workingDir.GetDivergedFiles(ctx.Log, repoDir, ctx.Pull)
+	}
 	if err != nil {
 		return true, false, err
 	}

--- a/server/events/undiverged_project_impact_test.go
+++ b/server/events/undiverged_project_impact_test.go
@@ -285,6 +285,10 @@ func (s stubUndivergedProjectImpactResolver) HasUndivergedImpact(command.Project
 	return s.handled, s.impacted, s.err
 }
 
+func (s stubUndivergedProjectImpactResolver) HasUndivergedImpactFromPullHead(command.ProjectContext, string, WorkingDir) (bool, bool, error) {
+	return s.handled, s.impacted, s.err
+}
+
 func configuredProjectRepo(t *testing.T) string {
 	t.Helper()
 

--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -54,15 +54,21 @@ type WorkingDir interface {
 	// GetWorkingDir returns the path to the workspace for this repo and pull.
 	// If workspace does not exist on disk, error will be of type os.IsNotExist.
 	GetWorkingDir(r models.Repo, p models.PullRequest, workspace string) (string, error)
-	// HasDiverged checks if the branch has diverged from the base branch.
+	// HasDiverged checks if the checkout has diverged from the base branch.
 	// When autoplanWhenModified patterns are provided, only divergence affecting
 	// files matching those patterns is considered. When patterns are empty,
 	// any divergence is reported.
 	HasDiverged(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) bool
+	// HasDivergedFromPullHead checks if the pull request head has diverged from
+	// the base branch.
+	HasDivergedFromPullHead(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) bool
 	// GetDivergedFiles returns the files changed on the base branch since the
 	// current checkout. When merge checkout is disabled there is no divergence
 	// check, so this returns no files and no error.
 	GetDivergedFiles(logger logging.SimpleLogging, cloneDir string, pullRequest models.PullRequest) ([]string, error)
+	// GetDivergedFilesFromPullHead returns the files changed on the base branch
+	// since the pull request head.
+	GetDivergedFilesFromPullHead(logger logging.SimpleLogging, cloneDir string, pullRequest models.PullRequest) ([]string, error)
 	GetPullDir(r models.Repo, p models.PullRequest) (string, error)
 	// Delete deletes the workspace for this repo and pull.
 	Delete(logger logging.SimpleLogging, r models.Repo, p models.PullRequest) error
@@ -312,9 +318,28 @@ func (w *FileWorkspace) HasDiverged(logger logging.SimpleLogging, cloneDir strin
 	defer unlockGitRefLock()
 
 	if len(autoplanWhenModified) > 0 {
-		return w.hasDivergedForPatterns(logger, cloneDir, projectPath, autoplanWhenModified, pullRequest)
+		return w.hasDivergedForPatterns(logger, cloneDir, projectPath, autoplanWhenModified, pullRequest, w.getDivergedFiles)
 	}
 	return w.hasDiverged(logger, cloneDir)
+}
+
+func (w *FileWorkspace) HasDivergedFromPullHead(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) bool {
+	logger.Debug("HasDivergedFromPullHead: starting divergence check in %s", cloneDir)
+	if !w.CheckoutMerge {
+		logger.Debug("HasDivergedFromPullHead: CheckoutMerge is false, skipping divergence check")
+		return false
+	}
+
+	unlockGitReadLock := w.gitReadLock(cloneDir)
+	defer unlockGitReadLock()
+
+	unlockGitRefLock := w.gitRefLock(cloneDir)
+	defer unlockGitRefLock()
+
+	if len(autoplanWhenModified) > 0 {
+		return w.hasDivergedForPatterns(logger, cloneDir, projectPath, autoplanWhenModified, pullRequest, w.getDivergedFilesFromPullHead)
+	}
+	return w.hasDivergedFromPullHead(logger, cloneDir, pullRequest)
 }
 
 func (w *FileWorkspace) GetDivergedFiles(logger logging.SimpleLogging, cloneDir string, pullRequest models.PullRequest) ([]string, error) {
@@ -331,6 +356,22 @@ func (w *FileWorkspace) GetDivergedFiles(logger logging.SimpleLogging, cloneDir 
 	defer unlockGitRefLock()
 
 	return w.getDivergedFiles(logger, cloneDir, pullRequest)
+}
+
+func (w *FileWorkspace) GetDivergedFilesFromPullHead(logger logging.SimpleLogging, cloneDir string, pullRequest models.PullRequest) ([]string, error) {
+	logger.Debug("GetDivergedFilesFromPullHead: getting diverged files in %s", cloneDir)
+	if !w.CheckoutMerge {
+		logger.Debug("GetDivergedFilesFromPullHead: CheckoutMerge is false, skipping diverged file lookup")
+		return nil, nil
+	}
+
+	unlockGitReadLock := w.gitReadLock(cloneDir)
+	defer unlockGitReadLock()
+
+	unlockGitRefLock := w.gitRefLock(cloneDir)
+	defer unlockGitRefLock()
+
+	return w.getDivergedFilesFromPullHead(logger, cloneDir, pullRequest)
 }
 
 // hasDiverged runs fetch and git status to detect divergence. Caller must hold
@@ -360,13 +401,30 @@ func (w *FileWorkspace) hasDiverged(logger logging.SimpleLogging, cloneDir strin
 	return hasDiverged
 }
 
+func (w *FileWorkspace) hasDivergedFromPullHead(logger logging.SimpleLogging, cloneDir string, pullRequest models.PullRequest) bool {
+	if pullRequest.BaseBranch == "" {
+		logger.Debug("HasDiverged: pull request base branch is empty, using git status divergence check")
+		return w.hasDiverged(logger, cloneDir)
+	}
+
+	divergedFiles, err := w.getDivergedFilesFromPullHead(logger, cloneDir, pullRequest)
+	if err != nil {
+		logger.Warn("HasDiverged: getting changed files has failed: %s", err)
+		return true
+	}
+
+	hasDiverged := len(divergedFiles) > 0
+	logger.Debug("HasDiverged: result=%t", hasDiverged)
+	return hasDiverged
+}
+
 // hasDivergedForPatterns checks if the base branch has new commits that affect files
 // matching the given when_modified patterns. Caller must hold gitRefLock and gitReadLock.
-func (w *FileWorkspace) hasDivergedForPatterns(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) bool {
+func (w *FileWorkspace) hasDivergedForPatterns(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest, getDivergedFiles func(logging.SimpleLogging, string, models.PullRequest) ([]string, error)) bool {
 	logger.Debug("HasDiverged: running targeted divergence check for project %s with %d patterns",
 		projectPath, len(autoplanWhenModified))
 
-	nonEmptyChangedFiles, err := w.getDivergedFiles(logger, cloneDir, pullRequest)
+	nonEmptyChangedFiles, err := getDivergedFiles(logger, cloneDir, pullRequest)
 	if err != nil {
 		logger.Warn("HasDiverged: getting changed files has failed: %s", err)
 		return true
@@ -427,6 +485,15 @@ func divergedFilesCommandError(action string, err error, output []byte) error {
 }
 
 func (w *FileWorkspace) getDivergedFiles(logger logging.SimpleLogging, cloneDir string, pullRequest models.PullRequest) ([]string, error) {
+	return w.getDivergedFilesFromRef(logger, cloneDir, pullRequest, "HEAD")
+}
+
+func (w *FileWorkspace) getDivergedFilesFromPullHead(logger logging.SimpleLogging, cloneDir string, pullRequest models.PullRequest) ([]string, error) {
+	pullHeadRef := w.pullHeadRef(logger, cloneDir)
+	return w.getDivergedFilesFromRef(logger, cloneDir, pullRequest, pullHeadRef)
+}
+
+func (w *FileWorkspace) getDivergedFilesFromRef(logger logging.SimpleLogging, cloneDir string, pullRequest models.PullRequest, startRef string) ([]string, error) {
 	logger.Debug("GetDivergedFiles: running git fetch")
 	fetchCmd := exec.Command("git", "fetch")
 	fetchCmd.Dir = cloneDir
@@ -436,7 +503,7 @@ func (w *FileWorkspace) getDivergedFiles(logger logging.SimpleLogging, cloneDir 
 	}
 
 	remoteRef := fmt.Sprintf("origin/%s", pullRequest.BaseBranch)
-	revisionRange := fmt.Sprintf("HEAD..%s", remoteRef)
+	revisionRange := fmt.Sprintf("%s..%s", startRef, remoteRef)
 
 	logger.Debug("GetDivergedFiles: getting changed files in %s", revisionRange)
 	changedFilesCmd := exec.Command("git", "log", revisionRange, "--name-only", "--format=") //nolint:gosec // remoteRef is from pullRequest.BaseBranch, a controlled VCS branch name
@@ -455,6 +522,19 @@ func (w *FileWorkspace) getDivergedFiles(logger logging.SimpleLogging, cloneDir 
 	}
 
 	return nonEmptyChangedFiles, nil
+}
+
+func (w *FileWorkspace) pullHeadRef(logger logging.SimpleLogging, cloneDir string) string {
+	headParentCmd := exec.Command("git", "rev-parse", "--verify", "HEAD^2")
+	headParentCmd.Dir = cloneDir
+	output, err := headParentCmd.CombinedOutput()
+	if err == nil {
+		logger.Debug("GetDivergedFiles: using pull request head ref %q", strings.TrimSpace(string(output)))
+		return "HEAD^2"
+	}
+
+	logger.Debug("GetDivergedFiles: HEAD^2 unavailable, using HEAD")
+	return "HEAD"
 }
 
 func (w *FileWorkspace) remoteHasBranch(logger logging.SimpleLogging, c wrappedGitContext, branch string) bool {

--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -1206,6 +1206,66 @@ func TestHasDiverged_WithEmptyPatterns(t *testing.T) {
 	Equals(t, true, hasDiverged)
 }
 
+func TestHasDivergedFromPullHead_FreshMergeCheckoutUsesPullHead(t *testing.T) {
+	repoDir := initRepo(t)
+
+	Ok(t, os.MkdirAll(filepath.Join(repoDir, "project1"), 0o755))
+	Ok(t, os.WriteFile(filepath.Join(repoDir, "project1", "main.tf"), []byte("resource initial\n"), 0o600))
+	runCmd(t, repoDir, "git", "add", "project1/main.tf")
+	runCmd(t, repoDir, "git", "commit", "-m", "add project1")
+
+	runCmd(t, repoDir, "git", "checkout", "-b", "stale-pr")
+	Ok(t, os.MkdirAll(filepath.Join(repoDir, "project2"), 0o755))
+	Ok(t, os.WriteFile(filepath.Join(repoDir, "project2", "main.tf"), []byte("resource pr\n"), 0o600))
+	runCmd(t, repoDir, "git", "add", "project2/main.tf")
+	runCmd(t, repoDir, "git", "commit", "-m", "add project2")
+	headCommit := strings.TrimSpace(runCmd(t, repoDir, "git", "rev-parse", "HEAD"))
+
+	runCmd(t, repoDir, "git", "checkout", "main")
+	Ok(t, os.WriteFile(filepath.Join(repoDir, "project1", "variables.tf"), []byte("variable base\n"), 0o600))
+	runCmd(t, repoDir, "git", "add", "project1/variables.tf")
+	runCmd(t, repoDir, "git", "commit", "-m", "update project1")
+
+	prDir := filepath.Join(repoDir, "repos", "0", "default")
+	Ok(t, os.MkdirAll(prDir, 0o755))
+	runCmd(t, prDir, "git", "clone", "--branch", "main", "--single-branch", repoDir, ".")
+	runCmd(t, prDir, "git", "remote", "add", "source", repoDir)
+	runCmd(t, prDir, "git", "fetch", "source", "+refs/heads/stale-pr")
+	runCmd(t, prDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
+	runCmd(t, prDir, "git", "config", "--local", "user.name", "atlantisbot")
+	runCmd(t, prDir, "git", "config", "--local", "commit.gpgsign", "false")
+	runCmd(t, prDir, "git", "merge", "-q", "--no-ff", "-m", "atlantis-merge", "FETCH_HEAD")
+
+	logger := logging.NewNoopLogger(t)
+	wd := &events.FileWorkspace{
+		DataDir:             repoDir,
+		CheckoutMerge:       true,
+		CheckoutDepth:       50,
+		GpgNoSigningEnabled: true,
+	}
+	pullRequest := models.PullRequest{
+		BaseRepo:   models.Repo{CloneURL: repoDir},
+		HeadBranch: "stale-pr",
+		BaseBranch: "main",
+		HeadCommit: headCommit,
+	}
+
+	hasDiverged := wd.HasDiverged(logger, prDir, ".", []string{}, pullRequest)
+	Equals(t, false, hasDiverged)
+
+	hasDiverged = wd.HasDiverged(logger, prDir, ".", []string{"project1/**"}, pullRequest)
+	Equals(t, false, hasDiverged)
+
+	hasDiverged = wd.HasDivergedFromPullHead(logger, prDir, ".", []string{}, pullRequest)
+	Equals(t, true, hasDiverged)
+
+	hasDiverged = wd.HasDivergedFromPullHead(logger, prDir, ".", []string{"project1/**"}, pullRequest)
+	Equals(t, true, hasDiverged)
+
+	hasDiverged = wd.HasDivergedFromPullHead(logger, prDir, ".", []string{"project2/**"}, pullRequest)
+	Equals(t, false, hasDiverged)
+}
+
 func TestHasDiverged_PatternHasDiverged(t *testing.T) {
 	// Initialize the git repo.
 	repoDir := initRepo(t)


### PR DESCRIPTION
## what

This PR addresses one issue which case the bug: the undiverged check on plan is currently a no-op with merge strategy.

* Reorder of doPlan to run ValidatePlanProject before WorkingDir.MergeAgain.

## why

The undiverged check is currently not evaluated during plan phase, which causes PR authors to be possibly silently planning on combined changes they haven't explicitly reviewed. The undiverged check should force them to explicitly rebase their PR before a successful plan can be executed.

Without the reordering MergeAgain re-merges the latest base into the working tree, which masks divergence by the time the check runs.

## tests

Test `TestDefaultProjectCommandRunner_PlanUndivergedBlocksBeforeMergeAgain` added

A plan run on a PR whose base branch has been updated by another PR before the plan is run now correctly reports to the user that the PR must be rebased:

```
{"level":"debug","ts":"2026-05-06T14:17:09.515Z","caller":"events/working_dir.go:405","msg":"GetDivergedFiles: running git fetch","json":{"repo":"atlantis-test-dummy","pull":"18"}}
{"level":"debug","ts":"2026-05-06T14:17:09.890Z","caller":"events/working_dir.go:420","msg":"GetDivergedFiles: getting changed files in HEAD^2..origin/master","json":{"repo":"atlantis-test-dummy","pull":"18"}}
{"level":"debug","ts":"2026-05-06T14:17:09.892Z","caller":"events/project_finder.go:180","msg":"found downstream projects for \"environments/dev/providers.tf\": []","json":{"repo":"atlantis-test-dummy","pull":"18"}}
{"level":"debug","ts":"2026-05-06T14:17:09.892Z","caller":"events/project_finder.go:187","msg":"checking if project at dir \"environments/dev\" workspace \"default\" was modified","json":{"repo":"atlantis-test-dummy","pull":"18"}}
{"level":"debug","ts":"2026-05-06T14:17:09.892Z","caller":"events/project_finder.go:228","msg":"file \"environments/dev/providers.tf\" matched pattern","json":{"repo":"atlantis-test-dummy","pull":"18"}}
{"level":"debug","ts":"2026-05-06T14:17:09.892Z","caller":"events/project_finder.go:187","msg":"checking if project at dir \"environments/prod\" workspace \"default\" was modified","json":{"repo":"atlantis-test-dummy","pull":"18"}}
```

<img width="816" height="71" alt="Screenshot 2026-05-06 at 16 20 29" src="https://github.com/user-attachments/assets/a53f8710-8f87-433f-b09d-755116a05820" />

## references

Closes #6451
