### PR TITLE
fix: skip non-git subdirs in pending plan finder

### DIFF
--- a/server/events/pending_plan_finder.go
+++ b/server/events/pending_plan_finder.go
@@ -4,13 +4,11 @@
 package events
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"github.com/runatlantis/atlantis/server/core/runtime"
 	"github.com/runatlantis/atlantis/server/utils"
@@ -52,24 +50,33 @@ func (p *DefaultPendingPlanFinder) findWithAbsPaths(pullDir string) ([]PendingPl
 	if err != nil {
 		return nil, nil, err
 	}
+	absPullDir, err := filepath.Abs(pullDir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting absolute pull directory: %w", err)
+	}
+
 	var plans []PendingPlan
 	var absPaths []string
 	for _, workspaceDir := range workspaceDirs {
-		// Skip non-directory entries (files, symlinks) — workspace clones are always directories.
+		// Skip non-directory entries (files, symlinks); workspace clones are always directories.
 		if !workspaceDir.IsDir() {
 			continue
 		}
 
 		workspace := workspaceDir.Name()
-		repoDir := filepath.Join(pullDir, workspace)
+		repoDir, err := workspaceRepoDir(absPullDir, workspace)
+		if err != nil {
+			return nil, nil, err
+		}
 
-		// Skip directories that are not git repositories (e.g. stray directories
-		// left by external processes). Workspace clones always have a .git entry.
-		if _, statErr := os.Stat(filepath.Join(repoDir, ".git")); statErr != nil {
-			if os.IsNotExist(statErr) || errors.Is(statErr, syscall.ENOTDIR) {
-				continue
-			}
-			return nil, nil, fmt.Errorf("checking git repository in '%s': %w", repoDir, statErr)
+		// Skip directories that are not workspace clone roots (e.g. stray
+		// directories left by external processes).
+		workspaceIsGitRoot, err := isGitWorkTreeRoot(repoDir)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !workspaceIsGitRoot {
+			continue
 		}
 
 		// Any generated plans should be untracked by git since Atlantis created
@@ -102,6 +109,33 @@ func (p *DefaultPendingPlanFinder) findWithAbsPaths(pullDir string) ([]PendingPl
 		}
 	}
 	return plans, absPaths, nil
+}
+
+func workspaceRepoDir(absPullDir, workspace string) (string, error) {
+	repoDir := filepath.Clean(filepath.Join(absPullDir, workspace))
+	rel, err := filepath.Rel(absPullDir, repoDir)
+	if err != nil {
+		return "", fmt.Errorf("checking workspace directory %q: %w", workspace, err)
+	}
+	if rel == "." || rel == ".." || filepath.IsAbs(rel) || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("workspace directory %q escapes pull directory %q", workspace, absPullDir)
+	}
+	return repoDir, nil
+}
+
+func isGitWorkTreeRoot(repoDir string) (bool, error) {
+	showPrefixCmd := exec.Command("git", "rev-parse", "--is-inside-work-tree", "--show-prefix") // nolint: gosec
+	showPrefixCmd.Dir = repoDir
+	showPrefixOut, err := showPrefixCmd.CombinedOutput()
+	if err != nil {
+		output := string(showPrefixOut)
+		if strings.Contains(output, "not a git repository") || strings.Contains(output, "must be run in a work tree") {
+			return false, nil
+		}
+		return false, fmt.Errorf("checking git repository in '%s' directory: %s: %w", repoDir, output, err)
+	}
+	lines := strings.Split(string(showPrefixOut), "\n")
+	return len(lines) >= 2 && lines[0] == "true" && lines[1] == "", nil
 }
 
 // deletePlans deletes all plans in pullDir.

--- a/server/events/pending_plan_finder.go
+++ b/server/events/pending_plan_finder.go
@@ -56,6 +56,12 @@ func (p *DefaultPendingPlanFinder) findWithAbsPaths(pullDir string) ([]PendingPl
 		workspace := workspaceDir.Name()
 		repoDir := filepath.Join(pullDir, workspace)
 
+		// Skip directories that are not git repositories (e.g. stray directories
+		// left by external processes). Workspace clones always have a .git entry.
+		if _, err := os.Stat(filepath.Join(repoDir, ".git")); os.IsNotExist(err) {
+			continue
+		}
+
 		// Any generated plans should be untracked by git since Atlantis created
 		// them.
 		lsCmd := exec.Command("git", "ls-files", ".", "--others") // nolint: gosec

--- a/server/events/pending_plan_finder.go
+++ b/server/events/pending_plan_finder.go
@@ -4,11 +4,13 @@
 package events
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/runatlantis/atlantis/server/core/runtime"
 	"github.com/runatlantis/atlantis/server/utils"
@@ -53,13 +55,21 @@ func (p *DefaultPendingPlanFinder) findWithAbsPaths(pullDir string) ([]PendingPl
 	var plans []PendingPlan
 	var absPaths []string
 	for _, workspaceDir := range workspaceDirs {
+		// Skip non-directory entries (files, symlinks) — workspace clones are always directories.
+		if !workspaceDir.IsDir() {
+			continue
+		}
+
 		workspace := workspaceDir.Name()
 		repoDir := filepath.Join(pullDir, workspace)
 
 		// Skip directories that are not git repositories (e.g. stray directories
 		// left by external processes). Workspace clones always have a .git entry.
-		if _, err := os.Stat(filepath.Join(repoDir, ".git")); os.IsNotExist(err) {
-			continue
+		if _, statErr := os.Stat(filepath.Join(repoDir, ".git")); statErr != nil {
+			if os.IsNotExist(statErr) || errors.Is(statErr, syscall.ENOTDIR) {
+				continue
+			}
+			return nil, nil, fmt.Errorf("checking git repository in '%s': %w", repoDir, statErr)
 		}
 
 		// Any generated plans should be untracked by git since Atlantis created

--- a/server/events/pending_plan_finder_test.go
+++ b/server/events/pending_plan_finder_test.go
@@ -66,6 +66,29 @@ func TestPendingPlanFinder_FindSkipsNonDirEntries(t *testing.T) {
 	Equals(t, "default", plans[0].Workspace)
 }
 
+// Directories that are only inside a parent git repo are not workspace clone roots.
+func TestPendingPlanFinder_FindSkipsDirInsideParentGitRepo(t *testing.T) {
+	gitDirName := "default"
+	notGitDirName := "reviews"
+	tmpDir := DirStructure(t, map[string]any{
+		gitDirName: map[string]any{
+			"default.tfplan": nil,
+		},
+		notGitDirName: map[string]any{
+			"some_file.tfplan": nil,
+		},
+	})
+	runCmd(t, tmpDir, "git", "init")
+	runCmd(t, filepath.Join(tmpDir, gitDirName), "git", "init")
+
+	pf := &events.DefaultPendingPlanFinder{}
+	plans, err := pf.Find(tmpDir)
+
+	Ok(t, err)
+	Equals(t, 1, len(plans))
+	Equals(t, gitDirName, plans[0].Workspace)
+}
+
 // Test different directory structures.
 func TestPendingPlanFinder_Find(t *testing.T) {
 	cases := []struct {

--- a/server/events/pending_plan_finder_test.go
+++ b/server/events/pending_plan_finder_test.go
@@ -4,7 +4,6 @@
 package events_test
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -22,10 +21,10 @@ func TestPendingPlanFinder_FindNoDir(t *testing.T) {
 	ErrEquals(t, "open /doesntexist: no such file or directory", err)
 }
 
-// If one of the dir in PR dir is not git dir then it should throw an error.
+// Non-git subdirectories in the pull dir should be silently skipped.
 func TestPendingPlanFinder_FindIncludingNotGitDir(t *testing.T) {
-	gitDirName := ".default"
-	notGitDirName := ".terragrunt-cache"
+	gitDirName := "default"
+	notGitDirName := "reviews"
 	tmpDir := DirStructure(t, map[string]any{
 		gitDirName: map[string]any{
 			"default.tfplan": nil,
@@ -34,14 +33,16 @@ func TestPendingPlanFinder_FindIncludingNotGitDir(t *testing.T) {
 			"some_file.tfplan": nil,
 		},
 	})
-	// Initialize git in 'default' directory
+	// Initialize git only in the workspace directory, not in the stray directory.
 	gitDir := filepath.Join(tmpDir, gitDirName)
 	runCmd(t, gitDir, "git", "init")
 	pf := &events.DefaultPendingPlanFinder{}
 
-	_, err := pf.Find(tmpDir)
-	ErrEquals(t, fmt.Sprintf("running 'git ls-files . --others' in '%s/%s' directory: fatal: "+
-		"not a git repository (or any of the parent directories): .git\n: exit status 128", tmpDir, notGitDirName), err)
+	plans, err := pf.Find(tmpDir)
+	Ok(t, err)
+	// Only the plan from the git workspace should be found; the reviews dir is skipped.
+	Equals(t, 1, len(plans))
+	Equals(t, gitDirName, plans[0].Workspace)
 }
 
 // Test different directory structures.

--- a/server/events/pending_plan_finder_test.go
+++ b/server/events/pending_plan_finder_test.go
@@ -45,6 +45,27 @@ func TestPendingPlanFinder_FindIncludingNotGitDir(t *testing.T) {
 	Equals(t, gitDirName, plans[0].Workspace)
 }
 
+// Non-directory entries (files, symlinks) in the pull dir should be silently skipped.
+func TestPendingPlanFinder_FindSkipsNonDirEntries(t *testing.T) {
+	tmpDir := DirStructure(t, map[string]any{
+		"default": map[string]any{
+			"default.tfplan": nil,
+		},
+	})
+	runCmd(t, filepath.Join(tmpDir, "default"), "git", "init")
+
+	// Create a plain file at the top level of the pull dir (not a workspace clone).
+	if err := os.WriteFile(filepath.Join(tmpDir, "somefile.txt"), []byte("data"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	pf := &events.DefaultPendingPlanFinder{}
+	plans, err := pf.Find(tmpDir)
+	Ok(t, err)
+	Equals(t, 1, len(plans))
+	Equals(t, "default", plans[0].Workspace)
+}
+
 // Test different directory structures.
 func TestPendingPlanFinder_Find(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION

## what

DefaultPendingPlanFinder iterated all subdirectories of the pull
working directory and ran `git ls-files` in each, assuming every
subdir was a workspace clone. Stray directories (e.g. `reviews`)
that are not git repositories caused a fatal error and blocked
`atlantis apply`.

Fix by checking for a `.git` entry before invoking `git ls-files`,
silently skipping any directory that is not a git repository.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>


## why

We've added an automated code-review process using `tfrev`, which saves files into the `working dir` and leverages Atlantis' auto-cleanup on merge functionality.

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## tests

* Unit tests updated

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

