### PR TITLE
feat: Re-download terraform binary if it appears to be invalid.

### DIFF
--- a/server/core/terraform/tfclient/terraform_client.go
+++ b/server/core/terraform/tfclient/terraform_client.go
@@ -746,7 +746,7 @@ func getVersion(tfBinary string, binName string) (*version.Version, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), versionCommandTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, tfBinary, "version") // #nosec
-	cmd.Env = append(os.Environ(), "CHECKPOINT_DISABLE=1")
+	cmd.Env = terraformVersionEnv(os.Environ())
 	versionOutBytes, err := cmd.Output()
 	versionOutput := string(versionOutBytes)
 	if ctx.Err() == context.DeadlineExceeded {
@@ -760,6 +760,18 @@ func getVersion(tfBinary string, binName string) (*version.Version, error) {
 		return nil, fmt.Errorf("could not parse %s version from %s", binName, versionOutput)
 	}
 	return version.NewVersion(match[1])
+}
+
+func terraformVersionEnv(env []string) []string {
+	out := make([]string, 0, len(env)+3)
+	for _, envVar := range env {
+		key, _, ok := strings.Cut(envVar, "=")
+		if ok && (key == "CHECKPOINT_DISABLE" || key == "TF_CLI_ARGS" || key == "TF_CLI_ARGS_version") {
+			continue
+		}
+		out = append(out, envVar)
+	}
+	return append(out, "CHECKPOINT_DISABLE=1", "TF_CLI_ARGS=", "TF_CLI_ARGS_version=")
 }
 
 // rcFileContents is a format string to be used with Sprintf that can be used

--- a/server/core/terraform/tfclient/terraform_client.go
+++ b/server/core/terraform/tfclient/terraform_client.go
@@ -620,6 +620,10 @@ func redownloadVersionBinary(
 
 	if currentPath, ok := getVersionBinaryPath(versions, versionsLock, v); ok && currentPath != binPath {
 		return currentPath, nil
+	} else if ok {
+		if err := validateVersionBinary(currentPath, dist.BinName()); err == nil {
+			return currentPath, nil
+		}
 	}
 	deleteVersionBinaryPath(versions, versionsLock, v, binPath)
 	if isManagedVersionBinary(binPath, binDir) {

--- a/server/core/terraform/tfclient/terraform_client.go
+++ b/server/core/terraform/tfclient/terraform_client.go
@@ -72,6 +72,8 @@ type DefaultClient struct {
 	// versionLocks serializes install/remove operations for each Terraform version.
 	// Use versionsLock to control access.
 	versionLocks map[string]*sync.Mutex
+	// downloadLock serializes downloader installs that share intermediate paths in binDir.
+	downloadLock *sync.Mutex
 
 	// versionsLock is used to ensure versions isn't being concurrently written to.
 	versionsLock *sync.Mutex
@@ -115,6 +117,7 @@ func NewClientWithDefaultVersion(
 	versions := make(map[string]string)
 	versionLocks := make(map[string]*sync.Mutex)
 	var versionsLock sync.Mutex
+	var downloadLock sync.Mutex
 
 	localPath, err := exec.LookPath(distribution.BinName())
 	if err != nil && defaultVersionStr == "" {
@@ -143,7 +146,7 @@ func NewClientWithDefaultVersion(
 		ensureVersionFunc := func() {
 			// Since ensureVersion might end up downloading terraform,
 			// we call it asynchronously so as to not delay server startup.
-			_, err := ensureVersion(log, distribution, versions, versionLocks, &versionsLock, defaultVersion, binDir, tfDownloadURL, tfDownloadAllowed, true)
+			_, err := ensureVersion(log, distribution, versions, versionLocks, &versionsLock, &downloadLock, defaultVersion, binDir, tfDownloadURL, tfDownloadAllowed, true)
 			if err != nil {
 				log.Err("could not download %s %s: %s", distribution.BinName(), defaultVersion.String(), err)
 			}
@@ -176,6 +179,7 @@ func NewClientWithDefaultVersion(
 		versionsLock:            &versionsLock,
 		versions:                versions,
 		versionLocks:            versionLocks,
+		downloadLock:            &downloadLock,
 		usePluginCache:          usePluginCache,
 		projectCmdOutputHandler: projectCmdOutputHandler,
 	}, nil
@@ -331,7 +335,7 @@ func (c *DefaultClient) EnsureVersion(log logging.SimpleLogging, d terraform.Dis
 	}
 
 	d = c.effectiveDistribution(d)
-	_, err := ensureVersion(log, d, c.versions, c.versionLocks, c.versionsLock, v, c.binDir, c.downloadBaseURL, c.downloadAllowed, true)
+	_, err := ensureVersion(log, d, c.versions, c.versionLocks, c.versionsLock, c.downloadLock, v, c.binDir, c.downloadBaseURL, c.downloadAllowed, true)
 	if err != nil {
 		return err
 	}
@@ -411,7 +415,7 @@ func (c *DefaultClient) prepCmd(log logging.SimpleLogging, d terraform.Distribut
 	} else {
 		var err error
 		d = c.effectiveDistribution(d)
-		binPath, err = ensureVersion(log, d, c.versions, c.versionLocks, c.versionsLock, v, c.binDir, c.downloadBaseURL, c.downloadAllowed, true)
+		binPath, err = ensureVersion(log, d, c.versions, c.versionLocks, c.versionsLock, c.downloadLock, v, c.binDir, c.downloadBaseURL, c.downloadAllowed, true)
 		if err != nil {
 			return "", nil, err
 		}
@@ -494,6 +498,7 @@ func ensureVersion(
 	versions map[string]string,
 	versionLocks map[string]*sync.Mutex,
 	versionsLock *sync.Mutex,
+	downloadLock *sync.Mutex,
 	v *version.Version,
 	binDir string,
 	downloadURL string,
@@ -504,7 +509,7 @@ func ensureVersion(
 		return "", errors.New("terraform distribution is nil")
 	}
 
-	binPath, err := findOrDownloadVersionBinaryPath(log, dist, versions, versionLocks, versionsLock, v, binDir, downloadURL, downloadsAllowed)
+	binPath, err := findOrDownloadVersionBinaryPath(log, dist, versions, versionLocks, versionsLock, downloadLock, v, binDir, downloadURL, downloadsAllowed)
 	if err != nil {
 		return "", err
 	}
@@ -520,7 +525,7 @@ func ensureVersion(
 	}
 
 	log.Warn("%s binary %s failed execution validation, attempting to re-download", binName, binPath)
-	binPath, err = redownloadVersionBinary(log, dist, versions, versionLocks, versionsLock, v, binPath, binDir, downloadURL)
+	binPath, err = redownloadVersionBinary(log, dist, versions, versionLocks, versionsLock, downloadLock, v, binPath, binDir, downloadURL)
 	if err != nil {
 		return "", err
 	}
@@ -552,6 +557,7 @@ func findOrDownloadVersionBinaryPath(
 	versions map[string]string,
 	versionLocks map[string]*sync.Mutex,
 	versionsLock *sync.Mutex,
+	downloadLock *sync.Mutex,
 	v *version.Version,
 	binDir string,
 	downloadURL string,
@@ -595,7 +601,7 @@ func findOrDownloadVersionBinaryPath(
 	}
 
 	log.Info("could not find %s version %s in PATH or %s", dist.BinName(), v.String(), binDir)
-	execPath, err := downloadVersionBinary(log, dist, v, binDir, downloadURL)
+	execPath, err := downloadVersionBinary(log, dist, downloadLock, v, binDir, downloadURL)
 	if err != nil {
 		return "", err
 	}
@@ -609,6 +615,7 @@ func redownloadVersionBinary(
 	versions map[string]string,
 	versionLocks map[string]*sync.Mutex,
 	versionsLock *sync.Mutex,
+	downloadLock *sync.Mutex,
 	v *version.Version,
 	binPath string,
 	binDir string,
@@ -632,7 +639,7 @@ func redownloadVersionBinary(
 		}
 	}
 
-	execPath, err := downloadVersionBinary(log, dist, v, binDir, downloadURL)
+	execPath, err := downloadVersionBinary(log, dist, downloadLock, v, binDir, downloadURL)
 	if err != nil {
 		return "", err
 	}
@@ -643,10 +650,14 @@ func redownloadVersionBinary(
 func downloadVersionBinary(
 	log logging.SimpleLogging,
 	dist terraform.Distribution,
+	downloadLock *sync.Mutex,
 	v *version.Version,
 	binDir string,
 	downloadURL string,
 ) (string, error) {
+	downloadLock.Lock()
+	defer downloadLock.Unlock()
+
 	log.Info("downloading %s version %s from download URL %s", dist.BinName(), v.String(), downloadURL)
 
 	execPath, err := dist.Downloader().Install(context.Background(), binDir, downloadURL, v)

--- a/server/core/terraform/tfclient/terraform_client.go
+++ b/server/core/terraform/tfclient/terraform_client.go
@@ -492,23 +492,40 @@ func ensureVersion(
 	if err != nil {
 		return "", err
 	}
-	// Attempt to exercise the binary to make sure it works.
-	// For example, users sometimes change out architectures of the underlying host, which produces weird errors later
-	cmd := exec.Command(binPath, "version")
+	// Try to run version. If it doesn't work, try deleting the binary and redownloading it
+	for attempt := range 2 {
+		cmd := exec.Command(binPath, "version")
 
-	// Don't waste time trying to check for newer versions of terraform
-	cmd.Env = append(os.Environ(),
-		"CHECKPOINT_DISABLE=1",
-	)
+		// Don't waste time trying to check for newer versions of terraform
+		cmd.Env = append(os.Environ(),
+			"CHECKPOINT_DISABLE=1",
+		)
 
-	output, err := cmd.CombinedOutput()
-	if err != nil {
+		output, err := cmd.CombinedOutput()
+		if err == nil {
+			break
+		}
+		if attempt == 0 && downloadsAllowed {
+			log.Warn("Terraform binary %s appears to be invalid, attempting to re-download", binPath)
+			delete(versions, v.String())
+			err := os.Remove(binPath)
+			if err != nil {
+				return "", fmt.Errorf("removing binary for redownload %s: %v", binPath, err)
+			}
+
+			binPath, err = findOrDownloadVersionBinaryPath(log, dist, versions, v, binDir, downloadURL, downloadsAllowed)
+			if err != nil {
+				return "", err
+			}
+			continue
+		}
 		return "", fmt.Errorf(
 			"terraform binary at %s failed to execute: %w\noutput:\n%s",
 			binPath,
 			err,
 			string(output),
 		)
+
 	}
 	return binPath, nil
 }

--- a/server/core/terraform/tfclient/terraform_client.go
+++ b/server/core/terraform/tfclient/terraform_client.go
@@ -7,6 +7,7 @@ package tfclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -329,6 +330,7 @@ func (c *DefaultClient) EnsureVersion(log logging.SimpleLogging, d terraform.Dis
 		v = c.defaultVersion
 	}
 
+	d = c.effectiveDistribution(d)
 	_, err := ensureVersion(log, d, c.versions, c.versionLocks, c.versionsLock, v, c.binDir, c.downloadBaseURL, c.downloadAllowed, true)
 	if err != nil {
 		return err
@@ -408,6 +410,7 @@ func (c *DefaultClient) prepCmd(log logging.SimpleLogging, d terraform.Distribut
 		binPath = c.overrideTF
 	} else {
 		var err error
+		d = c.effectiveDistribution(d)
 		binPath, err = ensureVersion(log, d, c.versions, c.versionLocks, c.versionsLock, v, c.binDir, c.downloadBaseURL, c.downloadAllowed, true)
 		if err != nil {
 			return "", nil, err
@@ -432,6 +435,13 @@ func (c *DefaultClient) prepCmd(log logging.SimpleLogging, d terraform.Distribut
 	envVars = append(envVars, os.Environ()...)
 	tfCmd := fmt.Sprintf("%s %s", binPath, strings.Join(args, " "))
 	return tfCmd, envVars, nil
+}
+
+func (c *DefaultClient) effectiveDistribution(d terraform.Distribution) terraform.Distribution {
+	if d != nil {
+		return d
+	}
+	return c.distribution
 }
 
 // RunCommandAsync runs terraform with args. It immediately returns an
@@ -490,6 +500,10 @@ func ensureVersion(
 	downloadsAllowed bool,
 	redownloadOnFailedExecution bool,
 ) (string, error) {
+	if dist == nil {
+		return "", errors.New("terraform distribution is nil")
+	}
+
 	binPath, err := findOrDownloadVersionBinaryPath(log, dist, versions, versionLocks, versionsLock, v, binDir, downloadURL, downloadsAllowed)
 	if err != nil {
 		return "", err

--- a/server/core/terraform/tfclient/terraform_client.go
+++ b/server/core/terraform/tfclient/terraform_client.go
@@ -68,6 +68,9 @@ type DefaultClient struct {
 	// to the absolute path of that binary on disk (if it exists).
 	// Use versionsLock to control access.
 	versions map[string]string
+	// versionLocks serializes install/remove operations for each Terraform version.
+	// Use versionsLock to control access.
+	versionLocks map[string]*sync.Mutex
 
 	// versionsLock is used to ensure versions isn't being concurrently written to.
 	versionsLock *sync.Mutex
@@ -109,6 +112,7 @@ func NewClientWithDefaultVersion(
 	var finalDefaultVersion *version.Version
 	var localVersion *version.Version
 	versions := make(map[string]string)
+	versionLocks := make(map[string]*sync.Mutex)
 	var versionsLock sync.Mutex
 
 	localPath, err := exec.LookPath(distribution.BinName())
@@ -138,7 +142,7 @@ func NewClientWithDefaultVersion(
 		ensureVersionFunc := func() {
 			// Since ensureVersion might end up downloading terraform,
 			// we call it asynchronously so as to not delay server startup.
-			_, err := ensureVersion(log, distribution, versions, &versionsLock, defaultVersion, binDir, tfDownloadURL, tfDownloadAllowed, true)
+			_, err := ensureVersion(log, distribution, versions, versionLocks, &versionsLock, defaultVersion, binDir, tfDownloadURL, tfDownloadAllowed, true)
 			if err != nil {
 				log.Err("could not download %s %s: %s", distribution.BinName(), defaultVersion.String(), err)
 			}
@@ -170,6 +174,7 @@ func NewClientWithDefaultVersion(
 		downloadAllowed:         tfDownloadAllowed,
 		versionsLock:            &versionsLock,
 		versions:                versions,
+		versionLocks:            versionLocks,
 		usePluginCache:          usePluginCache,
 		projectCmdOutputHandler: projectCmdOutputHandler,
 	}, nil
@@ -324,7 +329,7 @@ func (c *DefaultClient) EnsureVersion(log logging.SimpleLogging, d terraform.Dis
 		v = c.defaultVersion
 	}
 
-	_, err := ensureVersion(log, d, c.versions, c.versionsLock, v, c.binDir, c.downloadBaseURL, c.downloadAllowed, true)
+	_, err := ensureVersion(log, d, c.versions, c.versionLocks, c.versionsLock, v, c.binDir, c.downloadBaseURL, c.downloadAllowed, true)
 	if err != nil {
 		return err
 	}
@@ -403,7 +408,7 @@ func (c *DefaultClient) prepCmd(log logging.SimpleLogging, d terraform.Distribut
 		binPath = c.overrideTF
 	} else {
 		var err error
-		binPath, err = ensureVersion(log, d, c.versions, c.versionsLock, v, c.binDir, c.downloadBaseURL, c.downloadAllowed, true)
+		binPath, err = ensureVersion(log, d, c.versions, c.versionLocks, c.versionsLock, v, c.binDir, c.downloadBaseURL, c.downloadAllowed, true)
 		if err != nil {
 			return "", nil, err
 		}
@@ -477,6 +482,7 @@ func ensureVersion(
 	log logging.SimpleLogging,
 	dist terraform.Distribution,
 	versions map[string]string,
+	versionLocks map[string]*sync.Mutex,
 	versionsLock *sync.Mutex,
 	v *version.Version,
 	binDir string,
@@ -484,7 +490,7 @@ func ensureVersion(
 	downloadsAllowed bool,
 	redownloadOnFailedExecution bool,
 ) (string, error) {
-	binPath, err := findOrDownloadVersionBinaryPath(log, dist, versions, versionsLock, v, binDir, downloadURL, downloadsAllowed)
+	binPath, err := findOrDownloadVersionBinaryPath(log, dist, versions, versionLocks, versionsLock, v, binDir, downloadURL, downloadsAllowed)
 	if err != nil {
 		return "", err
 	}
@@ -500,18 +506,10 @@ func ensureVersion(
 	}
 
 	log.Warn("%s binary %s failed execution validation, attempting to re-download", binName, binPath)
-	deleteVersionBinaryPath(versions, versionsLock, v, binPath)
-	if isManagedVersionBinary(binPath, binDir) {
-		if err := os.Remove(binPath); err != nil && !os.IsNotExist(err) {
-			return "", fmt.Errorf("removing cached %s binary for redownload at %s: %w", binName, binPath, err)
-		}
-	}
-
-	binPath, err = downloadVersionBinary(log, dist, v, binDir, downloadURL)
+	binPath, err = redownloadVersionBinary(log, dist, versions, versionLocks, versionsLock, v, binPath, binDir, downloadURL)
 	if err != nil {
 		return "", err
 	}
-	setVersionBinaryPath(versions, versionsLock, v, binPath)
 	if err := validateVersionBinary(binPath, binName); err != nil {
 		return "", invalidVersionBinaryError(binPath, binName, err)
 	}
@@ -538,12 +536,21 @@ func findOrDownloadVersionBinaryPath(
 	log logging.SimpleLogging,
 	dist terraform.Distribution,
 	versions map[string]string,
+	versionLocks map[string]*sync.Mutex,
 	versionsLock *sync.Mutex,
 	v *version.Version,
 	binDir string,
 	downloadURL string,
 	downloadsAllowed bool,
 ) (string, error) {
+	if binPath, ok := getVersionBinaryPath(versions, versionsLock, v); ok {
+		return binPath, nil
+	}
+
+	versionLock := getVersionOperationLock(versionLocks, versionsLock, v)
+	versionLock.Lock()
+	defer versionLock.Unlock()
+
 	if binPath, ok := getVersionBinaryPath(versions, versionsLock, v); ok {
 		return binPath, nil
 	}
@@ -582,6 +589,39 @@ func findOrDownloadVersionBinaryPath(
 	return execPath, nil
 }
 
+func redownloadVersionBinary(
+	log logging.SimpleLogging,
+	dist terraform.Distribution,
+	versions map[string]string,
+	versionLocks map[string]*sync.Mutex,
+	versionsLock *sync.Mutex,
+	v *version.Version,
+	binPath string,
+	binDir string,
+	downloadURL string,
+) (string, error) {
+	versionLock := getVersionOperationLock(versionLocks, versionsLock, v)
+	versionLock.Lock()
+	defer versionLock.Unlock()
+
+	if currentPath, ok := getVersionBinaryPath(versions, versionsLock, v); ok && currentPath != binPath {
+		return currentPath, nil
+	}
+	deleteVersionBinaryPath(versions, versionsLock, v, binPath)
+	if isManagedVersionBinary(binPath, binDir) {
+		if err := os.Remove(binPath); err != nil && !os.IsNotExist(err) {
+			return "", fmt.Errorf("removing cached %s binary for redownload at %s: %w", dist.BinName(), binPath, err)
+		}
+	}
+
+	execPath, err := downloadVersionBinary(log, dist, v, binDir, downloadURL)
+	if err != nil {
+		return "", err
+	}
+	setVersionBinaryPath(versions, versionsLock, v, execPath)
+	return execPath, nil
+}
+
 func downloadVersionBinary(
 	log logging.SimpleLogging,
 	dist terraform.Distribution,
@@ -598,6 +638,19 @@ func downloadVersionBinary(
 
 	log.Info("Downloaded %s %s to %s", dist.BinName(), v.String(), execPath)
 	return execPath, nil
+}
+
+func getVersionOperationLock(versionLocks map[string]*sync.Mutex, versionsLock *sync.Mutex, v *version.Version) *sync.Mutex {
+	versionsLock.Lock()
+	defer versionsLock.Unlock()
+
+	lockKey := v.String()
+	versionLock, ok := versionLocks[lockKey]
+	if !ok {
+		versionLock = &sync.Mutex{}
+		versionLocks[lockKey] = versionLock
+	}
+	return versionLock
 }
 
 func getVersionBinaryPath(versions map[string]string, versionsLock *sync.Mutex, v *version.Version) (string, bool) {

--- a/server/core/terraform/tfclient/terraform_client.go
+++ b/server/core/terraform/tfclient/terraform_client.go
@@ -487,6 +487,43 @@ func ensureVersion(
 	downloadURL string,
 	downloadsAllowed bool,
 ) (string, error) {
+
+	binPath, err := findOrDownloadVersionBinaryPath(log, dist, versions, v, binDir, downloadURL, downloadsAllowed)
+	if err != nil {
+		return "", err
+	}
+	// Attempt to exercise the binary to make sure it works.
+	// For example, users sometimes change out architectures of the underlying host, which produces weird errors later
+	cmd := exec.Command(binPath, "version")
+
+	// Don't waste time trying to check for newer versions of terraform
+	cmd.Env = append(os.Environ(),
+		"CHECKPOINT_DISABLE=1",
+	)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf(
+			"terraform binary at %s failed to execute: %w\noutput:\n%s",
+			binPath,
+			err,
+			string(output),
+		)
+	}
+	return binPath, nil
+}
+
+// findOrDownloadVersionBinaryPath returns the path to a terraform binary of version v.
+// It will download this version if we don't have it.
+func findOrDownloadVersionBinaryPath(
+	log logging.SimpleLogging,
+	dist terraform.Distribution,
+	versions map[string]string,
+	v *version.Version,
+	binDir string,
+	downloadURL string,
+	downloadsAllowed bool,
+) (string, error) {
 	if binPath, ok := versions[v.String()]; ok {
 		return binPath, nil
 	}

--- a/server/core/terraform/tfclient/terraform_client.go
+++ b/server/core/terraform/tfclient/terraform_client.go
@@ -407,7 +407,7 @@ func (c *DefaultClient) prepCmd(log logging.SimpleLogging, d terraform.Distribut
 	} else {
 		var err error
 		c.versionsLock.Lock()
-		binPath, err = ensureVersion(log, d, c.versions, v, c.binDir, c.downloadBaseURL, c.downloadAllowed, false)
+		binPath, err = ensureVersion(log, d, c.versions, v, c.binDir, c.downloadBaseURL, c.downloadAllowed, true)
 		c.versionsLock.Unlock()
 		if err != nil {
 			return "", nil, err

--- a/server/core/terraform/tfclient/terraform_client.go
+++ b/server/core/terraform/tfclient/terraform_client.go
@@ -488,7 +488,6 @@ func ensureVersion(
 	downloadsAllowed bool,
 	redownloadOnFailedExecution bool,
 ) (string, error) {
-
 	binPath, err := findOrDownloadVersionBinaryPath(log, dist, versions, v, binDir, downloadURL, downloadsAllowed)
 	if err != nil {
 		return "", err
@@ -496,36 +495,44 @@ func ensureVersion(
 	if !redownloadOnFailedExecution {
 		return binPath, nil
 	}
-	// Try running a test command (i.e. `terraform version`). If it doesn't work, try deleting the binary and redownloading it
-	for attempt := range 2 {
 
-		_, err := getVersion(binPath, dist.BinName())
-		if err == nil {
-			// The command succeeded, the installed binary looks good
-			break
+	binName := dist.BinName()
+	if err := validateVersionBinary(binPath, binName); err == nil {
+		return binPath, nil
+	} else if !downloadsAllowed {
+		return "", invalidVersionBinaryError(binPath, binName, err)
+	}
+
+	log.Warn("%s binary %s failed execution validation, attempting to re-download", binName, binPath)
+	delete(versions, v.String())
+	if isManagedVersionBinary(binPath, binDir) {
+		if err := os.Remove(binPath); err != nil && !os.IsNotExist(err) {
+			return "", fmt.Errorf("removing cached %s binary for redownload at %s: %w", binName, binPath, err)
 		}
-		if attempt == 0 && downloadsAllowed {
-			log.Warn("%s binary %s failed execution validation, attempting to re-download", dist.BinName(), binPath)
-			delete(versions, v.String())
-			err := os.Remove(binPath)
-			if err != nil {
-				return "", fmt.Errorf("removing binary for redownload %s: %v", binPath, err)
-			}
+	}
 
-			binPath, err = findOrDownloadVersionBinaryPath(log, dist, versions, v, binDir, downloadURL, downloadsAllowed)
-			if err != nil {
-				return "", err
-			}
-			continue
-		}
-		return "", fmt.Errorf(
-			"terraform binary at %s failed to execute: %w",
-			binPath,
-			err,
-		)
-
+	binPath, err = downloadVersionBinary(log, dist, versions, v, binDir, downloadURL)
+	if err != nil {
+		return "", err
+	}
+	if err := validateVersionBinary(binPath, binName); err != nil {
+		return "", invalidVersionBinaryError(binPath, binName, err)
 	}
 	return binPath, nil
+}
+
+func validateVersionBinary(binPath string, binName string) error {
+	_, err := getVersion(binPath, binName)
+	return err
+}
+
+func invalidVersionBinaryError(binPath string, binName string, err error) error {
+	return fmt.Errorf("%s binary at %s failed to execute: %w", binName, binPath, err)
+}
+
+func isManagedVersionBinary(binPath string, binDir string) bool {
+	rel, err := filepath.Rel(binDir, binPath)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
 }
 
 // findOrDownloadVersionBinaryPath returns the path to a terraform binary of version v.
@@ -569,11 +576,20 @@ func findOrDownloadVersionBinaryPath(
 	}
 
 	log.Info("could not find %s version %s in PATH or %s", dist.BinName(), v.String(), binDir)
+	return downloadVersionBinary(log, dist, versions, v, binDir, downloadURL)
+}
 
+func downloadVersionBinary(
+	log logging.SimpleLogging,
+	dist terraform.Distribution,
+	versions map[string]string,
+	v *version.Version,
+	binDir string,
+	downloadURL string,
+) (string, error) {
 	log.Info("downloading %s version %s from download URL %s", dist.BinName(), v.String(), downloadURL)
 
 	execPath, err := dist.Downloader().Install(context.Background(), binDir, downloadURL, v)
-
 	if err != nil {
 		return "", fmt.Errorf("error downloading %s version %s: %w", dist.BinName(), v.String(), err)
 	}

--- a/server/core/terraform/tfclient/terraform_client.go
+++ b/server/core/terraform/tfclient/terraform_client.go
@@ -30,6 +30,8 @@ import (
 
 var LogStreamingValidCmds = [...]string{"init", "plan", "apply"}
 
+const versionCommandTimeout = 10 * time.Second
+
 //go:generate go tool pegomock generate --package mocks -o mocks/mock_terraform_client.go Client
 
 type Client interface {
@@ -136,9 +138,7 @@ func NewClientWithDefaultVersion(
 		ensureVersionFunc := func() {
 			// Since ensureVersion might end up downloading terraform,
 			// we call it asynchronously so as to not delay server startup.
-			versionsLock.Lock()
-			_, err := ensureVersion(log, distribution, versions, defaultVersion, binDir, tfDownloadURL, tfDownloadAllowed, true)
-			versionsLock.Unlock()
+			_, err := ensureVersion(log, distribution, versions, &versionsLock, defaultVersion, binDir, tfDownloadURL, tfDownloadAllowed, true)
 			if err != nil {
 				log.Err("could not download %s %s: %s", distribution.BinName(), defaultVersion.String(), err)
 			}
@@ -324,10 +324,7 @@ func (c *DefaultClient) EnsureVersion(log logging.SimpleLogging, d terraform.Dis
 		v = c.defaultVersion
 	}
 
-	var err error
-	c.versionsLock.Lock()
-	_, err = ensureVersion(log, d, c.versions, v, c.binDir, c.downloadBaseURL, c.downloadAllowed, true)
-	c.versionsLock.Unlock()
+	_, err := ensureVersion(log, d, c.versions, c.versionsLock, v, c.binDir, c.downloadBaseURL, c.downloadAllowed, true)
 	if err != nil {
 		return err
 	}
@@ -406,9 +403,7 @@ func (c *DefaultClient) prepCmd(log logging.SimpleLogging, d terraform.Distribut
 		binPath = c.overrideTF
 	} else {
 		var err error
-		c.versionsLock.Lock()
-		binPath, err = ensureVersion(log, d, c.versions, v, c.binDir, c.downloadBaseURL, c.downloadAllowed, true)
-		c.versionsLock.Unlock()
+		binPath, err = ensureVersion(log, d, c.versions, c.versionsLock, v, c.binDir, c.downloadBaseURL, c.downloadAllowed, true)
 		if err != nil {
 			return "", nil, err
 		}
@@ -482,13 +477,14 @@ func ensureVersion(
 	log logging.SimpleLogging,
 	dist terraform.Distribution,
 	versions map[string]string,
+	versionsLock *sync.Mutex,
 	v *version.Version,
 	binDir string,
 	downloadURL string,
 	downloadsAllowed bool,
 	redownloadOnFailedExecution bool,
 ) (string, error) {
-	binPath, err := findOrDownloadVersionBinaryPath(log, dist, versions, v, binDir, downloadURL, downloadsAllowed)
+	binPath, err := findOrDownloadVersionBinaryPath(log, dist, versions, versionsLock, v, binDir, downloadURL, downloadsAllowed)
 	if err != nil {
 		return "", err
 	}
@@ -504,17 +500,18 @@ func ensureVersion(
 	}
 
 	log.Warn("%s binary %s failed execution validation, attempting to re-download", binName, binPath)
-	delete(versions, v.String())
+	deleteVersionBinaryPath(versions, versionsLock, v, binPath)
 	if isManagedVersionBinary(binPath, binDir) {
 		if err := os.Remove(binPath); err != nil && !os.IsNotExist(err) {
 			return "", fmt.Errorf("removing cached %s binary for redownload at %s: %w", binName, binPath, err)
 		}
 	}
 
-	binPath, err = downloadVersionBinary(log, dist, versions, v, binDir, downloadURL)
+	binPath, err = downloadVersionBinary(log, dist, v, binDir, downloadURL)
 	if err != nil {
 		return "", err
 	}
+	setVersionBinaryPath(versions, versionsLock, v, binPath)
 	if err := validateVersionBinary(binPath, binName); err != nil {
 		return "", invalidVersionBinaryError(binPath, binName, err)
 	}
@@ -541,12 +538,13 @@ func findOrDownloadVersionBinaryPath(
 	log logging.SimpleLogging,
 	dist terraform.Distribution,
 	versions map[string]string,
+	versionsLock *sync.Mutex,
 	v *version.Version,
 	binDir string,
 	downloadURL string,
 	downloadsAllowed bool,
 ) (string, error) {
-	if binPath, ok := versions[v.String()]; ok {
+	if binPath, ok := getVersionBinaryPath(versions, versionsLock, v); ok {
 		return binPath, nil
 	}
 
@@ -555,7 +553,7 @@ func findOrDownloadVersionBinaryPath(
 	// terraform{version} binaries. In this case we don't want to re-download.
 	binFile := dist.BinName() + v.String()
 	if binPath, err := exec.LookPath(binFile); err == nil {
-		versions[v.String()] = binPath
+		setVersionBinaryPath(versions, versionsLock, v, binPath)
 		return binPath, nil
 	}
 
@@ -563,7 +561,7 @@ func findOrDownloadVersionBinaryPath(
 	// This could happen if Atlantis was restarted without losing its disk.
 	dest := filepath.Join(binDir, binFile)
 	if _, err := os.Stat(dest); err == nil {
-		versions[v.String()] = dest
+		setVersionBinaryPath(versions, versionsLock, v, dest)
 		return dest, nil
 	}
 	if !downloadsAllowed {
@@ -576,13 +574,17 @@ func findOrDownloadVersionBinaryPath(
 	}
 
 	log.Info("could not find %s version %s in PATH or %s", dist.BinName(), v.String(), binDir)
-	return downloadVersionBinary(log, dist, versions, v, binDir, downloadURL)
+	execPath, err := downloadVersionBinary(log, dist, v, binDir, downloadURL)
+	if err != nil {
+		return "", err
+	}
+	setVersionBinaryPath(versions, versionsLock, v, execPath)
+	return execPath, nil
 }
 
 func downloadVersionBinary(
 	log logging.SimpleLogging,
 	dist terraform.Distribution,
-	versions map[string]string,
 	v *version.Version,
 	binDir string,
 	downloadURL string,
@@ -595,8 +597,28 @@ func downloadVersionBinary(
 	}
 
 	log.Info("Downloaded %s %s to %s", dist.BinName(), v.String(), execPath)
-	versions[v.String()] = execPath
 	return execPath, nil
+}
+
+func getVersionBinaryPath(versions map[string]string, versionsLock *sync.Mutex, v *version.Version) (string, bool) {
+	versionsLock.Lock()
+	defer versionsLock.Unlock()
+	binPath, ok := versions[v.String()]
+	return binPath, ok
+}
+
+func setVersionBinaryPath(versions map[string]string, versionsLock *sync.Mutex, v *version.Version, binPath string) {
+	versionsLock.Lock()
+	defer versionsLock.Unlock()
+	versions[v.String()] = binPath
+}
+
+func deleteVersionBinaryPath(versions map[string]string, versionsLock *sync.Mutex, v *version.Version, binPath string) {
+	versionsLock.Lock()
+	defer versionsLock.Unlock()
+	if versions[v.String()] == binPath {
+		delete(versions, v.String())
+	}
 }
 
 // generateRCFile generates a .terraformrc file containing config for tfeToken
@@ -639,8 +661,15 @@ func isAsyncEligibleCommand(cmd string) bool {
 }
 
 func getVersion(tfBinary string, binName string) (*version.Version, error) {
-	versionOutBytes, err := exec.Command(tfBinary, "version").Output() // #nosec
+	ctx, cancel := context.WithTimeout(context.Background(), versionCommandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, tfBinary, "version") // #nosec
+	cmd.Env = append(os.Environ(), "CHECKPOINT_DISABLE=1")
+	versionOutBytes, err := cmd.Output()
 	versionOutput := string(versionOutBytes)
+	if ctx.Err() == context.DeadlineExceeded {
+		return nil, fmt.Errorf("running %s version timed out after %s", binName, versionCommandTimeout)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("running %s version: %s: %w", binName, versionOutput, err)
 	}

--- a/server/core/terraform/tfclient/terraform_client.go
+++ b/server/core/terraform/tfclient/terraform_client.go
@@ -492,21 +492,16 @@ func ensureVersion(
 	if err != nil {
 		return "", err
 	}
-	// Try to run version. If it doesn't work, try deleting the binary and redownloading it
+	// Try running a test command (i.e. `terraform version`). If it doesn't work, try deleting the binary and redownloading it
 	for attempt := range 2 {
-		cmd := exec.Command(binPath, "version")
 
-		// Don't waste time trying to check for newer versions of terraform
-		cmd.Env = append(os.Environ(),
-			"CHECKPOINT_DISABLE=1",
-		)
-
-		output, err := cmd.CombinedOutput()
+		_, err := getVersion(binPath, dist.BinName())
 		if err == nil {
+			// The command succeeded, the installed binary looks good
 			break
 		}
 		if attempt == 0 && downloadsAllowed {
-			log.Warn("Terraform binary %s appears to be invalid, attempting to re-download", binPath)
+			log.Warn("%s binary %s failed execution validation, attempting to re-download", dist.BinName(), binPath)
 			delete(versions, v.String())
 			err := os.Remove(binPath)
 			if err != nil {
@@ -520,10 +515,9 @@ func ensureVersion(
 			continue
 		}
 		return "", fmt.Errorf(
-			"terraform binary at %s failed to execute: %w\noutput:\n%s",
+			"terraform binary at %s failed to execute: %w",
 			binPath,
 			err,
-			string(output),
 		)
 
 	}

--- a/server/core/terraform/tfclient/terraform_client.go
+++ b/server/core/terraform/tfclient/terraform_client.go
@@ -137,7 +137,7 @@ func NewClientWithDefaultVersion(
 			// Since ensureVersion might end up downloading terraform,
 			// we call it asynchronously so as to not delay server startup.
 			versionsLock.Lock()
-			_, err := ensureVersion(log, distribution, versions, defaultVersion, binDir, tfDownloadURL, tfDownloadAllowed)
+			_, err := ensureVersion(log, distribution, versions, defaultVersion, binDir, tfDownloadURL, tfDownloadAllowed, true)
 			versionsLock.Unlock()
 			if err != nil {
 				log.Err("could not download %s %s: %s", distribution.BinName(), defaultVersion.String(), err)
@@ -326,7 +326,7 @@ func (c *DefaultClient) EnsureVersion(log logging.SimpleLogging, d terraform.Dis
 
 	var err error
 	c.versionsLock.Lock()
-	_, err = ensureVersion(log, d, c.versions, v, c.binDir, c.downloadBaseURL, c.downloadAllowed)
+	_, err = ensureVersion(log, d, c.versions, v, c.binDir, c.downloadBaseURL, c.downloadAllowed, true)
 	c.versionsLock.Unlock()
 	if err != nil {
 		return err
@@ -407,7 +407,7 @@ func (c *DefaultClient) prepCmd(log logging.SimpleLogging, d terraform.Distribut
 	} else {
 		var err error
 		c.versionsLock.Lock()
-		binPath, err = ensureVersion(log, d, c.versions, v, c.binDir, c.downloadBaseURL, c.downloadAllowed)
+		binPath, err = ensureVersion(log, d, c.versions, v, c.binDir, c.downloadBaseURL, c.downloadAllowed, false)
 		c.versionsLock.Unlock()
 		if err != nil {
 			return "", nil, err
@@ -486,11 +486,15 @@ func ensureVersion(
 	binDir string,
 	downloadURL string,
 	downloadsAllowed bool,
+	redownloadOnFailedExecution bool,
 ) (string, error) {
 
 	binPath, err := findOrDownloadVersionBinaryPath(log, dist, versions, v, binDir, downloadURL, downloadsAllowed)
 	if err != nil {
 		return "", err
+	}
+	if !redownloadOnFailedExecution {
+		return binPath, nil
 	}
 	// Try running a test command (i.e. `terraform version`). If it doesn't work, try deleting the binary and redownloading it
 	for attempt := range 2 {

--- a/server/core/terraform/tfclient/terraform_client_test.go
+++ b/server/core/terraform/tfclient/terraform_client_test.go
@@ -480,6 +480,59 @@ func TestRunCommandWithVersion_SerializesConcurrentInstallsForSameVersion(t *tes
 	Equals(t, int32(1), downloader.calls.Load())
 }
 
+func TestRunCommandWithVersion_SerializesConcurrentDownloadsAcrossVersions(t *testing.T) {
+	logger := logging.NewNoopLogger(t)
+	tmp, binDir, cacheDir := mkSubDirs(t)
+	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
+	ctx := command.ProjectContext{
+		Log:        logging.NewNoopLogger(t),
+		Workspace:  "default",
+		RepoRelDir: ".",
+	}
+
+	pathDir := filepath.Join(tmp, "path")
+	Ok(t, os.MkdirAll(pathDir, 0700))
+	Ok(t, writeExecutable(filepath.Join(pathDir, "terraform"), "echo '\nTerraform v0.11.10\n'"))
+	defer tempSetEnv(t, "PATH", fmt.Sprintf("%s:%s", pathDir, os.Getenv("PATH")))()
+
+	firstVersion, err := version.NewVersion("99.99.99")
+	Ok(t, err)
+	secondVersion, err := version.NewVersion("98.98.98")
+	Ok(t, err)
+
+	downloader := &trackingDownloader{delay: 500 * time.Millisecond}
+	distribution := terraform.NewDistributionTerraformWithDownloader(downloader)
+	c, err := tfclient.NewClient(logger, distribution, binDir, cacheDir, "", "", "", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, true, true, projectCmdOutputHandler)
+	Ok(t, err)
+
+	runVersion := func(v *version.Version) <-chan error {
+		errCh := make(chan error, 1)
+		go func() {
+			output, err := c.RunCommandWithVersion(ctx, tmp, []string{"version"}, map[string]string{}, distribution, v, "")
+			if err != nil {
+				errCh <- err
+				return
+			}
+			expectedOutput := fmt.Sprintf("\nTerraform v%s\n\n", v.String())
+			if output != expectedOutput {
+				errCh <- fmt.Errorf("unexpected output: %q", output)
+				return
+			}
+			errCh <- nil
+		}()
+		return errCh
+	}
+
+	firstErr := runVersion(firstVersion)
+	waitForAtomicAtLeast(t, &downloader.active, 1, time.Second)
+	secondErr := runVersion(secondVersion)
+
+	Ok(t, <-firstErr)
+	Ok(t, <-secondErr)
+	Equals(t, int32(1), downloader.maxConcurrent.Load())
+	Equals(t, int32(2), downloader.calls.Load())
+}
+
 func TestEnsureVersion_ReusesConcurrentManagedBinaryRepair(t *testing.T) {
 	logger := logging.NewNoopLogger(t)
 	tmp, binDir, cacheDir := mkSubDirs(t)
@@ -769,6 +822,18 @@ func waitForFileSize(t *testing.T, path string, minSize int64, timeout time.Dura
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("timed out waiting for %s to reach size %d", path, minSize)
+}
+
+func waitForAtomicAtLeast(t *testing.T, counter *atomic.Int32, min int32, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if counter.Load() >= min {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for counter to reach %d", min)
 }
 
 type trackingDownloader struct {

--- a/server/core/terraform/tfclient/terraform_client_test.go
+++ b/server/core/terraform/tfclient/terraform_client_test.go
@@ -480,6 +480,47 @@ func TestRunCommandWithVersion_SerializesConcurrentInstallsForSameVersion(t *tes
 	Equals(t, int32(1), downloader.calls.Load())
 }
 
+func TestEnsureVersion_ReusesConcurrentManagedBinaryRepair(t *testing.T) {
+	logger := logging.NewNoopLogger(t)
+	tmp, binDir, cacheDir := mkSubDirs(t)
+	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
+
+	pathDir := filepath.Join(tmp, "path")
+	Ok(t, os.MkdirAll(pathDir, 0700))
+	Ok(t, writeExecutable(filepath.Join(pathDir, "terraform"), "echo '\nTerraform v0.11.10\n'"))
+	defer tempSetEnv(t, "PATH", fmt.Sprintf("%s:%s", pathDir, os.Getenv("PATH")))()
+
+	v, err := version.NewVersion("99.99.99")
+	Ok(t, err)
+
+	startedFile := filepath.Join(tmp, "broken-validation-started")
+	releaseFile := filepath.Join(tmp, "release-broken-validation")
+	Ok(t, writeExecutable(
+		filepath.Join(binDir, "terraform99.99.99"),
+		fmt.Sprintf("printf x >> %q\nwhile [ ! -f %q ]; do sleep 0.01; done\nexit 1", startedFile, releaseFile),
+	))
+
+	downloader := &trackingDownloader{}
+	distribution := terraform.NewDistributionTerraformWithDownloader(downloader)
+	c, err := tfclient.NewClient(logger, distribution, binDir, cacheDir, "", "", "", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, true, true, projectCmdOutputHandler)
+	Ok(t, err)
+
+	errCh := make(chan error, 2)
+	for range 2 {
+		go func() {
+			errCh <- c.EnsureVersion(logger, distribution, v)
+		}()
+	}
+
+	waitForFileSize(t, startedFile, 2, time.Second)
+	Ok(t, os.WriteFile(releaseFile, []byte("release"), 0600))
+
+	for range 2 {
+		Ok(t, <-errCh)
+	}
+	Equals(t, int32(1), downloader.calls.Load())
+}
+
 // Test that EnsureVersion downloads terraform.
 func TestEnsureVersion_downloaded(t *testing.T) {
 	logger := logging.NewNoopLogger(t)
@@ -716,6 +757,18 @@ func waitForFile(t *testing.T, path string, timeout time.Duration) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("timed out waiting for %s", path)
+}
+
+func waitForFileSize(t *testing.T, path string, minSize int64, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if stat, err := os.Stat(path); err == nil && stat.Size() >= minSize {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s to reach size %d", path, minSize)
 }
 
 type trackingDownloader struct {

--- a/server/core/terraform/tfclient/terraform_client_test.go
+++ b/server/core/terraform/tfclient/terraform_client_test.go
@@ -317,6 +317,76 @@ func TestEnsureVersion_downloaded(t *testing.T) {
 	mockDownloader.VerifyWasCalledEventually(Once(), 2*time.Second).Install(context.Background(), binDir, cmd.DefaultTFDownloadURL, v)
 }
 
+// Test that EnsureVersion fails if the thing it downloads fails to run.
+func TestEnsureVersion_fails_if_cant_execute(t *testing.T) {
+	logger := logging.NewNoopLogger(t)
+	RegisterMockTestingT(t)
+	_, binDir, cacheDir := mkSubDirs(t)
+	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
+
+	mockDownloader := mocks.NewMockDownloader()
+	distribution := terraform.NewDistributionTerraformWithDownloader(mockDownloader)
+
+	downloadsAllowed := true
+	c, err := tfclient.NewTestClient(logger, distribution, binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, downloadsAllowed, true, projectCmdOutputHandler)
+	Ok(t, err)
+
+	Equals(t, "0.11.10", c.DefaultVersion().String())
+
+	v, err := version.NewVersion("99.99.99")
+	Ok(t, err)
+
+	When(mockDownloader.Install(context.Background(), binDir, cmd.DefaultTFDownloadURL, v)).Then(func(params []Param) ReturnValues {
+		binPath := filepath.Join(params[1].(string), "terraform99.99.99")
+		err := os.WriteFile(binPath, []byte("#!/bin/sh\nexit 1"), 0700) // #nosec G306
+		return []ReturnValue{binPath, err}
+	})
+
+	err = c.EnsureVersion(logger, distribution, v)
+
+	ErrContains(t, "failed to execute", err)
+
+	mockDownloader.VerifyWasCalledEventually(Twice(), 2*time.Second).Install(context.Background(), binDir, cmd.DefaultTFDownloadURL, v)
+}
+
+// Test that EnsureVersion fixes a broken binary.
+func TestEnsureVersion_fixes_broken_binary(t *testing.T) {
+	logger := logging.NewNoopLogger(t)
+	RegisterMockTestingT(t)
+	_, binDir, cacheDir := mkSubDirs(t)
+	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
+
+	mockDownloader := mocks.NewMockDownloader()
+	distribution := terraform.NewDistributionTerraformWithDownloader(mockDownloader)
+
+	downloadsAllowed := true
+	c, err := tfclient.NewTestClient(logger, distribution, binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, downloadsAllowed, true, projectCmdOutputHandler)
+	Ok(t, err)
+
+	Equals(t, "0.11.10", c.DefaultVersion().String())
+
+	v, err := version.NewVersion("99.99.99")
+	Ok(t, err)
+
+	When(mockDownloader.Install(context.Background(), binDir, cmd.DefaultTFDownloadURL, v)).Then(func(params []Param) ReturnValues {
+		binPath := filepath.Join(params[1].(string), "terraform99.99.99")
+		err := os.WriteFile(binPath, []byte("#!/bin/sh\nexit 1"), 0700) // #nosec G306
+		return []ReturnValue{binPath, err}
+	})
+
+	When(mockDownloader.Install(context.Background(), binDir, cmd.DefaultTFDownloadURL, v)).Then(func(params []Param) ReturnValues {
+		binPath := filepath.Join(params[1].(string), "terraform99.99.99")
+		err := os.WriteFile(binPath, []byte("#!/bin/sh\necho '\nTerraform v99.99.99'\n"), 0700) // #nosec G306
+		return []ReturnValue{binPath, err}
+	})
+
+	err = c.EnsureVersion(logger, distribution, v)
+
+	Ok(t, err)
+
+	mockDownloader.VerifyWasCalledEventually(Once(), 2*time.Second).Install(context.Background(), binDir, cmd.DefaultTFDownloadURL, v)
+}
+
 // Test that EnsureVersion downloads terraform from a custom URL.
 func TestEnsureVersion_downloaded_customURL(t *testing.T) {
 	logger := logging.NewNoopLogger(t)

--- a/server/core/terraform/tfclient/terraform_client_test.go
+++ b/server/core/terraform/tfclient/terraform_client_test.go
@@ -355,6 +355,48 @@ func TestRunCommandWithVersion_UsesClientDistributionWhenArgNil(t *testing.T) {
 	Equals(t, "\nTerraform v99.99.99\n\n", output)
 }
 
+func TestRunCommandWithVersion_ValidatesVersionWithoutInheritedCLIArgs(t *testing.T) {
+	logger := logging.NewNoopLogger(t)
+	RegisterMockTestingT(t)
+	tmp, binDir, cacheDir := mkSubDirs(t)
+	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
+	ctx := command.ProjectContext{
+		Log:        logging.NewNoopLogger(t),
+		Workspace:  "default",
+		RepoRelDir: ".",
+	}
+
+	pathDir := filepath.Join(tmp, "path")
+	Ok(t, os.MkdirAll(pathDir, 0700))
+	Ok(t, writeExecutable(filepath.Join(pathDir, "terraform"), "echo 'Terraform v0.11.10'"))
+	defer tempSetEnv(t, "PATH", fmt.Sprintf("%s:%s", pathDir, os.Getenv("PATH")))()
+	defer tempSetEnv(t, "TF_CLI_ARGS", "-json")()
+	defer tempSetEnv(t, "TF_CLI_ARGS_version", "-json")()
+
+	v, err := version.NewVersion("99.99.99")
+	Ok(t, err)
+	Ok(t, writeExecutable(filepath.Join(binDir, "terraform99.99.99"), `if [ "$1" = "version" ]; then
+	if [ -n "${TF_CLI_ARGS:-}" ] || [ -n "${TF_CLI_ARGS_version:-}" ]; then
+		echo "poisoned cli args"
+		exit 1
+	fi
+	echo 'Terraform v99.99.99'
+	exit 0
+fi
+echo ran "$1"`))
+
+	mockDownloader := mocks.NewMockDownloader()
+	distribution := terraform.NewDistributionTerraformWithDownloader(mockDownloader)
+	c, err := tfclient.NewClient(logger, distribution, binDir, cacheDir, "", "", "", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, false, true, projectCmdOutputHandler)
+	Ok(t, err)
+
+	output, err := c.RunCommandWithVersion(ctx, tmp, []string{"plan"}, map[string]string{}, distribution, v, "")
+
+	Assert(t, err == nil, "err: %s: %s", err, output)
+	Equals(t, "ran plan\n", output)
+	mockDownloader.VerifyWasCalled(Never())
+}
+
 func TestRunCommandWithVersion_DoesNotHoldVersionLockDuringValidation(t *testing.T) {
 	logger := logging.NewNoopLogger(t)
 	tmp, binDir, cacheDir := mkSubDirs(t)

--- a/server/core/terraform/tfclient/terraform_client_test.go
+++ b/server/core/terraform/tfclient/terraform_client_test.go
@@ -325,6 +325,85 @@ func TestRunCommandWithVersion_RedownloadsBrokenManagedBinary(t *testing.T) {
 	mockDownloader.VerifyWasCalledEventually(Once(), 2*time.Second).Install(context.Background(), binDir, cmd.DefaultTFDownloadURL, v)
 }
 
+func TestRunCommandWithVersion_DoesNotHoldVersionLockDuringValidation(t *testing.T) {
+	logger := logging.NewNoopLogger(t)
+	tmp, binDir, cacheDir := mkSubDirs(t)
+	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
+	ctx := command.ProjectContext{
+		Log:        logging.NewNoopLogger(t),
+		Workspace:  "default",
+		RepoRelDir: ".",
+	}
+
+	pathDir := filepath.Join(tmp, "path")
+	Ok(t, os.MkdirAll(pathDir, 0700))
+	Ok(t, writeExecutable(filepath.Join(pathDir, "terraform"), "echo '\nTerraform v0.11.10\n'"))
+	defer tempSetEnv(t, "PATH", fmt.Sprintf("%s:%s", pathDir, os.Getenv("PATH")))()
+
+	slowVersion, err := version.NewVersion("99.99.99")
+	Ok(t, err)
+	fastVersion, err := version.NewVersion("98.98.98")
+	Ok(t, err)
+
+	startedFile := filepath.Join(tmp, "slow-validation-started")
+	Ok(t, writeExecutable(
+		filepath.Join(binDir, "terraform99.99.99"),
+		fmt.Sprintf("printf started > %q\nsleep 2\nexit 1", startedFile),
+	))
+	Ok(t, writeExecutable(filepath.Join(binDir, "terraform98.98.98"), "echo '\nTerraform v98.98.98\n'"))
+
+	mockDownloader := mocks.NewMockDownloader()
+	distribution := terraform.NewDistributionTerraformWithDownloader(mockDownloader)
+	c, err := tfclient.NewClient(logger, distribution, binDir, cacheDir, "", "", "", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, false, true, projectCmdOutputHandler)
+	Ok(t, err)
+
+	slowDone := make(chan error, 1)
+	go func() {
+		_, err := c.RunCommandWithVersion(ctx, tmp, []string{"version"}, map[string]string{}, distribution, slowVersion, "")
+		slowDone <- err
+	}()
+	waitForFile(t, startedFile, time.Second)
+
+	fastDone := make(chan error, 1)
+	go func() {
+		output, err := c.RunCommandWithVersion(ctx, tmp, []string{"version"}, map[string]string{}, distribution, fastVersion, "")
+		if err != nil {
+			fastDone <- err
+			return
+		}
+		if output != "\nTerraform v98.98.98\n\n" {
+			fastDone <- fmt.Errorf("unexpected output: %q", output)
+			return
+		}
+		fastDone <- nil
+	}()
+
+	var fastErr error
+	timedOut := false
+	select {
+	case fastErr = <-fastDone:
+	case <-time.After(750 * time.Millisecond):
+		timedOut = true
+	}
+
+	var slowErr error
+	select {
+	case slowErr = <-slowDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("slow validation did not finish")
+	}
+	ErrContains(t, "failed to execute", slowErr)
+
+	if timedOut {
+		select {
+		case fastErr = <-fastDone:
+		case <-time.After(time.Second):
+		}
+		t.Fatalf("second Terraform command blocked behind slow version validation: %v", fastErr)
+	}
+	Ok(t, fastErr)
+}
+
 // Test that EnsureVersion downloads terraform.
 func TestEnsureVersion_downloaded(t *testing.T) {
 	logger := logging.NewNoopLogger(t)
@@ -549,6 +628,18 @@ func tempSetEnv(t *testing.T, key string, value string) func() {
 
 func writeExecutable(path string, body string) error {
 	return os.WriteFile(path, []byte("#!/bin/sh\n"+body), 0700) // #nosec G306
+}
+
+func waitForFile(t *testing.T, path string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", path)
 }
 
 // returns parent, bindir, cachedir

--- a/server/core/terraform/tfclient/terraform_client_test.go
+++ b/server/core/terraform/tfclient/terraform_client_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -404,6 +405,52 @@ func TestRunCommandWithVersion_DoesNotHoldVersionLockDuringValidation(t *testing
 	Ok(t, fastErr)
 }
 
+func TestRunCommandWithVersion_SerializesConcurrentInstallsForSameVersion(t *testing.T) {
+	logger := logging.NewNoopLogger(t)
+	tmp, binDir, cacheDir := mkSubDirs(t)
+	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
+	ctx := command.ProjectContext{
+		Log:        logging.NewNoopLogger(t),
+		Workspace:  "default",
+		RepoRelDir: ".",
+	}
+
+	pathDir := filepath.Join(tmp, "path")
+	Ok(t, os.MkdirAll(pathDir, 0700))
+	Ok(t, writeExecutable(filepath.Join(pathDir, "terraform"), "echo '\nTerraform v0.11.10\n'"))
+	defer tempSetEnv(t, "PATH", fmt.Sprintf("%s:%s", pathDir, os.Getenv("PATH")))()
+
+	v, err := version.NewVersion("99.99.99")
+	Ok(t, err)
+
+	downloader := &trackingDownloader{delay: 200 * time.Millisecond}
+	distribution := terraform.NewDistributionTerraformWithDownloader(downloader)
+	c, err := tfclient.NewClient(logger, distribution, binDir, cacheDir, "", "", "", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, true, true, projectCmdOutputHandler)
+	Ok(t, err)
+
+	errCh := make(chan error, 2)
+	for range 2 {
+		go func() {
+			output, err := c.RunCommandWithVersion(ctx, tmp, []string{"version"}, map[string]string{}, distribution, v, "")
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if output != "\nTerraform v99.99.99\n\n" {
+				errCh <- fmt.Errorf("unexpected output: %q", output)
+				return
+			}
+			errCh <- nil
+		}()
+	}
+
+	for range 2 {
+		Ok(t, <-errCh)
+	}
+	Equals(t, int32(1), downloader.maxConcurrent.Load())
+	Equals(t, int32(1), downloader.calls.Load())
+}
+
 // Test that EnsureVersion downloads terraform.
 func TestEnsureVersion_downloaded(t *testing.T) {
 	logger := logging.NewNoopLogger(t)
@@ -640,6 +687,33 @@ func waitForFile(t *testing.T, path string, timeout time.Duration) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("timed out waiting for %s", path)
+}
+
+type trackingDownloader struct {
+	active        atomic.Int32
+	calls         atomic.Int32
+	delay         time.Duration
+	maxConcurrent atomic.Int32
+}
+
+func (d *trackingDownloader) Install(_ context.Context, dir string, _ string, v *version.Version) (string, error) {
+	active := d.active.Add(1)
+	defer d.active.Add(-1)
+	d.calls.Add(1)
+	d.recordMaxConcurrent(active)
+	time.Sleep(d.delay)
+
+	binPath := filepath.Join(dir, "terraform"+v.String())
+	return binPath, writeExecutable(binPath, fmt.Sprintf("echo '\nTerraform v%s\n'", v.String()))
+}
+
+func (d *trackingDownloader) recordMaxConcurrent(active int32) {
+	for {
+		current := d.maxConcurrent.Load()
+		if active <= current || d.maxConcurrent.CompareAndSwap(current, active) {
+			return
+		}
+	}
 }
 
 // returns parent, bindir, cachedir

--- a/server/core/terraform/tfclient/terraform_client_test.go
+++ b/server/core/terraform/tfclient/terraform_client_test.go
@@ -318,7 +318,7 @@ func TestEnsureVersion_downloaded(t *testing.T) {
 }
 
 // Test that EnsureVersion fails if the thing it downloads fails to run.
-func TestEnsureVersion_fails_if_cant_execute(t *testing.T) {
+func TestEnsureVersion_ErrsWhenDownloadedBinaryCannotExecute(t *testing.T) {
 	logger := logging.NewNoopLogger(t)
 	RegisterMockTestingT(t)
 	_, binDir, cacheDir := mkSubDirs(t)
@@ -338,7 +338,7 @@ func TestEnsureVersion_fails_if_cant_execute(t *testing.T) {
 
 	When(mockDownloader.Install(context.Background(), binDir, cmd.DefaultTFDownloadURL, v)).Then(func(params []Param) ReturnValues {
 		binPath := filepath.Join(params[1].(string), "terraform99.99.99")
-		err := os.WriteFile(binPath, []byte("#!/bin/sh\nexit 1"), 0700) // #nosec G306
+		err := writeExecutable(binPath, "exit 1")
 		return []ReturnValue{binPath, err}
 	})
 
@@ -350,11 +350,65 @@ func TestEnsureVersion_fails_if_cant_execute(t *testing.T) {
 }
 
 // Test that EnsureVersion fixes a broken binary.
-func TestEnsureVersion_fixes_broken_binary(t *testing.T) {
+func TestEnsureVersion_RedownloadsBrokenManagedBinary(t *testing.T) {
 	logger := logging.NewNoopLogger(t)
 	RegisterMockTestingT(t)
-	_, binDir, cacheDir := mkSubDirs(t)
+	tmp, binDir, cacheDir := mkSubDirs(t)
 	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
+	ctx := command.ProjectContext{
+		Log:        logging.NewNoopLogger(t),
+		Workspace:  "default",
+		RepoRelDir: ".",
+	}
+
+	mockDownloader := mocks.NewMockDownloader()
+	distribution := terraform.NewDistributionTerraformWithDownloader(mockDownloader)
+
+	downloadsAllowed := true
+	c, err := tfclient.NewTestClient(logger, distribution, binDir, cacheDir, "", "", "0.11.10", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, downloadsAllowed, true, projectCmdOutputHandler)
+	Ok(t, err)
+
+	Equals(t, "0.11.10", c.DefaultVersion().String())
+
+	v, err := version.NewVersion("99.99.99")
+	Ok(t, err)
+
+	binPath := filepath.Join(binDir, "terraform99.99.99")
+	Ok(t, writeExecutable(binPath, "exit 1"))
+
+	When(mockDownloader.Install(context.Background(), binDir, cmd.DefaultTFDownloadURL, v)).Then(func(params []Param) ReturnValues {
+		binPath := filepath.Join(params[1].(string), "terraform99.99.99")
+		err := writeExecutable(binPath, "echo '\nTerraform v99.99.99\n'")
+		return []ReturnValue{binPath, err}
+	})
+
+	err = c.EnsureVersion(logger, distribution, v)
+
+	Ok(t, err)
+
+	output, err := c.RunCommandWithVersion(ctx, tmp, []string{"terraform", "init"}, map[string]string{}, distribution, v, "")
+	Assert(t, err == nil, "err: %s: %s", err, output)
+	Equals(t, "\nTerraform v99.99.99\n\n", output)
+
+	mockDownloader.VerifyWasCalledEventually(Once(), 2*time.Second).Install(context.Background(), binDir, cmd.DefaultTFDownloadURL, v)
+}
+
+func TestEnsureVersion_RedownloadsWithoutRemovingPathBinary(t *testing.T) {
+	logger := logging.NewNoopLogger(t)
+	RegisterMockTestingT(t)
+	tmp, binDir, cacheDir := mkSubDirs(t)
+	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
+	ctx := command.ProjectContext{
+		Log:        logging.NewNoopLogger(t),
+		Workspace:  "default",
+		RepoRelDir: ".",
+	}
+
+	pathDir := filepath.Join(tmp, "path")
+	Ok(t, os.MkdirAll(pathDir, 0700))
+	pathBinary := filepath.Join(pathDir, "terraform99.99.99")
+	Ok(t, writeExecutable(pathBinary, "exit 1"))
+	defer tempSetEnv(t, "PATH", fmt.Sprintf("%s:%s", pathDir, os.Getenv("PATH")))()
 
 	mockDownloader := mocks.NewMockDownloader()
 	distribution := terraform.NewDistributionTerraformWithDownloader(mockDownloader)
@@ -370,19 +424,19 @@ func TestEnsureVersion_fixes_broken_binary(t *testing.T) {
 
 	When(mockDownloader.Install(context.Background(), binDir, cmd.DefaultTFDownloadURL, v)).Then(func(params []Param) ReturnValues {
 		binPath := filepath.Join(params[1].(string), "terraform99.99.99")
-		err := os.WriteFile(binPath, []byte("#!/bin/sh\nexit 1"), 0700) // #nosec G306
-		return []ReturnValue{binPath, err}
-	})
-
-	When(mockDownloader.Install(context.Background(), binDir, cmd.DefaultTFDownloadURL, v)).Then(func(params []Param) ReturnValues {
-		binPath := filepath.Join(params[1].(string), "terraform99.99.99")
-		err := os.WriteFile(binPath, []byte("#!/bin/sh\necho '\nTerraform v99.99.99'\n"), 0700) // #nosec G306
+		err := writeExecutable(binPath, "echo '\nTerraform v99.99.99\n'")
 		return []ReturnValue{binPath, err}
 	})
 
 	err = c.EnsureVersion(logger, distribution, v)
-
 	Ok(t, err)
+
+	_, err = os.Stat(pathBinary)
+	Ok(t, err)
+
+	output, err := c.RunCommandWithVersion(ctx, tmp, []string{"terraform", "init"}, map[string]string{}, distribution, v, "")
+	Assert(t, err == nil, "err: %s: %s", err, output)
+	Equals(t, "\nTerraform v99.99.99\n\n", output)
 
 	mockDownloader.VerifyWasCalledEventually(Once(), 2*time.Second).Install(context.Background(), binDir, cmd.DefaultTFDownloadURL, v)
 }
@@ -451,6 +505,10 @@ func tempSetEnv(t *testing.T, key string, value string) func() {
 	orig := os.Getenv(key)
 	Ok(t, os.Setenv(key, value))
 	return func() { os.Setenv(key, orig) }
+}
+
+func writeExecutable(path string, body string) error {
+	return os.WriteFile(path, []byte("#!/bin/sh\n"+body), 0700) // #nosec G306
 }
 
 // returns parent, bindir, cachedir

--- a/server/core/terraform/tfclient/terraform_client_test.go
+++ b/server/core/terraform/tfclient/terraform_client_test.go
@@ -285,6 +285,46 @@ func TestRunCommandWithVersion_DLsTF(t *testing.T) {
 	Equals(t, "\nTerraform v99.99.99\n\n", output)
 }
 
+func TestRunCommandWithVersion_RedownloadsBrokenManagedBinary(t *testing.T) {
+	logger := logging.NewNoopLogger(t)
+	RegisterMockTestingT(t)
+	tmp, binDir, cacheDir := mkSubDirs(t)
+	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
+	ctx := command.ProjectContext{
+		Log:        logging.NewNoopLogger(t),
+		Workspace:  "default",
+		RepoRelDir: ".",
+	}
+
+	v, err := version.NewVersion("99.99.99")
+	Ok(t, err)
+
+	pathDir := filepath.Join(tmp, "path")
+	Ok(t, os.MkdirAll(pathDir, 0700))
+	Ok(t, writeExecutable(filepath.Join(pathDir, "terraform"), "echo '\nTerraform v0.11.10\n'"))
+	defer tempSetEnv(t, "PATH", fmt.Sprintf("%s:%s", pathDir, os.Getenv("PATH")))()
+
+	binPath := filepath.Join(binDir, "terraform99.99.99")
+	Ok(t, writeExecutable(binPath, "exit 1"))
+
+	mockDownloader := mocks.NewMockDownloader()
+	distribution := terraform.NewDistributionTerraformWithDownloader(mockDownloader)
+	When(mockDownloader.Install(context.Background(), binDir, cmd.DefaultTFDownloadURL, v)).Then(func(params []Param) ReturnValues {
+		binPath := filepath.Join(params[1].(string), "terraform99.99.99")
+		err := writeExecutable(binPath, "echo '\nTerraform v99.99.99\n'")
+		return []ReturnValue{binPath, err}
+	})
+
+	c, err := tfclient.NewClient(logger, distribution, binDir, cacheDir, "", "", "", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, true, true, projectCmdOutputHandler)
+	Ok(t, err)
+
+	output, err := c.RunCommandWithVersion(ctx, tmp, []string{"terraform", "init"}, map[string]string{}, distribution, v, "")
+
+	Assert(t, err == nil, "err: %s: %s", err, output)
+	Equals(t, "\nTerraform v99.99.99\n\n", output)
+	mockDownloader.VerifyWasCalledEventually(Once(), 2*time.Second).Install(context.Background(), binDir, cmd.DefaultTFDownloadURL, v)
+}
+
 // Test that EnsureVersion downloads terraform.
 func TestEnsureVersion_downloaded(t *testing.T) {
 	logger := logging.NewNoopLogger(t)

--- a/server/core/terraform/tfclient/terraform_client_test.go
+++ b/server/core/terraform/tfclient/terraform_client_test.go
@@ -326,6 +326,35 @@ func TestRunCommandWithVersion_RedownloadsBrokenManagedBinary(t *testing.T) {
 	mockDownloader.VerifyWasCalledEventually(Once(), 2*time.Second).Install(context.Background(), binDir, cmd.DefaultTFDownloadURL, v)
 }
 
+func TestRunCommandWithVersion_UsesClientDistributionWhenArgNil(t *testing.T) {
+	logger := logging.NewNoopLogger(t)
+	tmp, binDir, cacheDir := mkSubDirs(t)
+	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
+	ctx := command.ProjectContext{
+		Log:        logging.NewNoopLogger(t),
+		Workspace:  "default",
+		RepoRelDir: ".",
+	}
+
+	pathDir := filepath.Join(tmp, "path")
+	Ok(t, os.MkdirAll(pathDir, 0700))
+	Ok(t, writeExecutable(filepath.Join(pathDir, "terraform"), "echo '\nTerraform v0.11.10\n'"))
+	defer tempSetEnv(t, "PATH", fmt.Sprintf("%s:%s", pathDir, os.Getenv("PATH")))()
+
+	v, err := version.NewVersion("99.99.99")
+	Ok(t, err)
+	Ok(t, writeExecutable(filepath.Join(binDir, "terraform99.99.99"), "echo '\nTerraform v99.99.99\n'"))
+
+	distribution := terraform.NewDistributionTerraformWithDownloader(mocks.NewMockDownloader())
+	c, err := tfclient.NewClient(logger, distribution, binDir, cacheDir, "", "", "", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL, false, true, projectCmdOutputHandler)
+	Ok(t, err)
+
+	output, err := c.RunCommandWithVersion(ctx, tmp, []string{"version"}, map[string]string{}, nil, v, "")
+
+	Assert(t, err == nil, "err: %s: %s", err, output)
+	Equals(t, "\nTerraform v99.99.99\n\n", output)
+}
+
 func TestRunCommandWithVersion_DoesNotHoldVersionLockDuringValidation(t *testing.T) {
 	logger := logging.NewNoopLogger(t)
 	tmp, binDir, cacheDir := mkSubDirs(t)


### PR DESCRIPTION
## what

Run `terraform -version` after installing/checking for the install of terraform.

## why

If the terraform binary is invalid an any way, for example it was built for the wrong arch, we now immediately detect that, and attempt to delete the file and retrigger the download, in the hopes the new version will work. If the second version also fails, we simply fail (which is also an improvement over the previous code, because before an error about architecture would be buried and confusing, see #5670)

I believe that running `terraform version` or `tofu version` should be very fast and safe. However if it turns out this has any risk of false positives or performance issues, it's probably not worth doing.

## tests

I built an incompatible binary of terraform locally, and put it where the cache would pick it up, then it correctly deleted the old version and downloaded a new one.

```
{"level":"warn","ts":"2026-05-07T17:27:21.584-0400","caller":"tfclient/terraform_client.go:509","msg":"Terraform binary /Users/lmassa/.atlantis/bin/terraform1.9.8 appears to be invalid, attempting to re-download","json":{},"stacktrace":"github.com/runatlantis/atlantis/server/core/terraform/tfclient.ensureVersion\n\t/Users/lmassa/atlantis/server/core/terraform/tfclient/terraform_client.go:509\ngithub.com/runatlantis/atlantis/server/core/terraform/tfclient.NewClientWithDefaultVersion.func1\n\t/Users/lmassa/atlantis/server/core/terraform/tfclient/terraform_client.go:140"}
{"level":"info","ts":"2026-05-07T17:27:21.585-0400","caller":"tfclient/terraform_client.go:573","msg":"could not find terraform version 1.9.8 in PATH or /Users/lmassa/.atlantis/bin","json":{}}
{"level":"info","ts":"2026-05-07T17:27:21.585-0400","caller":"tfclient/terraform_client.go:575","msg":"downloading terraform version 1.9.8 from download URL https://releases.hashicorp.com","json":{}}
...
{"level":"info","ts":"2026-05-07T17:27:34.888-0400","caller":"tfclient/terraform_client.go:583","msg":"Downloaded terraform 1.9.8 to /Users/lmassa/.atlantis/bin/terraform1.9.8","json":{}}
```

## references

Closes: #5670
