### PR TITLE
chore: Clarify role of AI tooling in PRs

### DIFF
--- a/AI_USAGE_POLICY.md
+++ b/AI_USAGE_POLICY.md
@@ -35,7 +35,7 @@ Atlantis maintainers use several AI tools as part of the development workflow. T
 
 ### Dosu
 
-[Dosu](https://dosu.dev/) is used in Issues to help provide users with context to the codebase. Feel free to ask it follow-up questions via `@dosu`, but note that it is only basing its answers on the code and history, so may lack high level goals of the project.
+[Dosu](https://dosu.dev/) is used in Issues to help provide users with context to the codebase. Feel free to ask it follow-up questions via `@dosu`, but note that it is only basing its answers on the code and history, so may lack high-level goals of the project.
 
 ### Copilot
 

--- a/AI_USAGE_POLICY.md
+++ b/AI_USAGE_POLICY.md
@@ -31,16 +31,25 @@ Current AI tools are useful as coding assistants — but not as autonomous contr
 
 ## AI Tooling in Atlantis Workflows
 
-Atlantis maintainers use the following AI tools as part of the standard development workflow:
+Atlantis maintainers use several AI tools as part of the development workflow. These tools may change over time as the ecosystem evolves.
 
-* **GitHub Copilot / Claude** — Used to assist with code authorship, refactoring, and documentation. See [AGENTS.md](AGENTS.md) for guidance on how AI coding agents should interact with this repository.
-* **CodeRabbit** — Used as an automated AI code reviewer on pull requests. CodeRabbit comments are suggestions and starting points; contributors and maintainers apply human judgment to decide what to act on.
+### Dosu
 
-When responding to CodeRabbit review comments, contributors should:
+[Dosu](https://dosu.dev/) is used in Issues to help provide users with context to the codebase. Feel free to ask it follow-up questions via `@dosu`, but note that it is only basing its answers on the code and history, so may lack high level goals of the project.
+
+### Copilot
+
+[GitHub Copilot](https://github.com/features/copilot) is used in Pull Requests to summarize, as well as add comments and suggestions.
+
+When responding to Copilot review comments, contributors should:
 
 * Evaluate each suggestion on its technical merits
 * Not blindly apply AI-suggested changes without understanding them
 * Feel free to dismiss suggestions that are incorrect or not applicable, with a brief explanation
+
+Reviewers will typically require that all comments be resolved before approving a pull request, including comments from Copilot. Contributors are expected to apply human judgment and may dismiss suggestions that are incorrect, irrelevant, or not useful, but comments should still be explicitly resolved. If these automated reviews stop providing enough value to justify the overhead, we may revisit this policy.
+
+See [AGENTS.md](AGENTS.md) for guidance on how AI coding agents should interact with this repository.
 
 ## Legal and Licensing Considerations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ If you have any questions about the contribution process, see [Atlantis Contribu
 
 ## Resolving Comments
 
-It is the Author's responsibility to review and resolve all comments on their PRs. Even if no change is made, it's still important to engage with the feedback from the community.
+It is the PR author's responsibility to review and resolve all comments on their PRs. Even if no change is made, it's still important to engage with the feedback from the community.
 
 This also applies to comments from Copilot, see our [AI Usage Policy](AI_USAGE_POLICY.md#copilot) for more details.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@
 - [Reporting Issues](#reporting-issues)
 - [Reporting Security Issues](#reporting-security-issues)
 - [Creating a Pull Request](#creating-a-pull-request)
+  - [Resolving Comments](#resolving-comments)
 - [Developing](#developing)
   - [Updating The Website](#updating-the-website)
   - [Running Atlantis Locally](#running-atlantis-locally)
@@ -40,6 +41,12 @@ We take security issues seriously. Please report a security vulnerability to the
   * Link to any issues, including one you may have made
 
 If you have any questions about the contribution process, see [Atlantis Contributors on Slack](https://cloud-native.slack.com/archives/C07T45G27EZ).
+
+## Resolving Comments
+
+It is the Author's responsibility to review and resolve all comments on their PRs. Even if no change is made, it's still important to engage with the feedback from the community.
+
+This also applies to comments from Copilot, see our [AI Usage PolicyCreate a GitHub token](https://github.com/runatlantis/atlantis/tree/main/AI_USAGE_POLICY.md#copilot) for more details.
 
 # Developing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ If you have any questions about the contribution process, see [Atlantis Contribu
 
 It is the Author's responsibility to review and resolve all comments on their PRs. Even if no change is made, it's still important to engage with the feedback from the community.
 
-This also applies to comments from Copilot, see our [AI Usage PolicyCreate a GitHub token](https://github.com/runatlantis/atlantis/tree/main/AI_USAGE_POLICY.md#copilot) for more details.
+This also applies to comments from Copilot, see our [AI Usage Policy](AI_USAGE_POLICY.md#copilot) for more details.
 
 # Developing
 


### PR DESCRIPTION
## what

- Clean up AI tooling section to explain the specific tools we currently use, and how contributors should interact with them.
- Add a section to CONTRIBUTING that clarifies that all comments must be resolved, and cross links to AI page.
- Remove references to CodeRabbit and Claude

## why

Previously it was unclear who was supposed to be looking at the Copilot suggestions, and whether users should be waiting for reviewers to do that. We also more broadly didn't document that the author is responsible for reviewing and resolving all comments before a PR is reviewed.

We don't currently use CodeRabbit or Claude, but I added language that explained that could evolve in that direction in the future.

## tests

N/A

## references

N/A

