### PR TITLE
test(events): cover parallel project command execution

### DIFF
--- a/server/events/project_command_pool_executor_test.go
+++ b/server/events/project_command_pool_executor_test.go
@@ -217,6 +217,85 @@ func TestRunProjectCmdsWithCancellationTracker_NoCancellation(t *testing.T) {
 	assert.False(t, result.HasErrors())
 }
 
+func TestRunProjectCmdsWithCancellationTracker_ParallelPlanAndApplyRunConcurrently(t *testing.T) {
+	for _, cmdName := range []command.Name{command.Plan, command.Apply} {
+		t.Run(cmdName.String(), func(t *testing.T) {
+			tracker := NewCancellationTracker()
+			pull := models.PullRequest{Num: 4}
+			ctx := makeCtx(t, pull)
+			release := make(chan struct{})
+			var releaseOnce sync.Once
+			t.Cleanup(func() {
+				releaseOnce.Do(func() {
+					close(release)
+				})
+			})
+
+			entered := make(chan string, 2)
+			completed := make(chan string, 2)
+			resultCh := make(chan command.Result, 1)
+
+			cmds := []command.ProjectContext{
+				makeProjectContext("p1"),
+				makeProjectContext("p2"),
+			}
+			for i := range cmds {
+				cmds[i].CommandName = cmdName
+			}
+
+			blockingRunner := func(cmd command.ProjectContext) command.ProjectCommandOutput {
+				entered <- cmd.ProjectName
+				<-release
+				completed <- cmd.ProjectName
+
+				if cmd.CommandName == command.Apply {
+					return command.ProjectCommandOutput{ApplySuccess: "success"}
+				}
+				return command.ProjectCommandOutput{PlanSuccess: &models.PlanSuccess{}}
+			}
+
+			go func() {
+				resultCh <- runProjectCmdsWithCancellationTracker(ctx, cmds, tracker, 2, true, blockingRunner)
+			}()
+
+			enteredProjects := map[string]bool{}
+			for len(enteredProjects) < 2 {
+				select {
+				case projectName := <-entered:
+					enteredProjects[projectName] = true
+				case <-time.After(2 * time.Second):
+					t.Fatalf("timed out waiting for both %s projects to enter execution; entered=%v", cmdName.String(), enteredProjects)
+				}
+			}
+
+			select {
+			case projectName := <-completed:
+				t.Fatalf("%s project %q completed before release", cmdName.String(), projectName)
+			default:
+			}
+
+			releaseOnce.Do(func() {
+				close(release)
+			})
+
+			var result command.Result
+			select {
+			case result = <-resultCh:
+			case <-time.After(2 * time.Second):
+				t.Fatalf("timed out waiting for %s result after release", cmdName.String())
+			}
+
+			require.Len(t, result.ProjectResults, 2)
+			assert.False(t, result.HasErrors())
+			for _, projectName := range []string{"p1", "p2"} {
+				projectResult := findResult(result, projectName)
+				require.NotNil(t, projectResult)
+				require.NoError(t, projectResult.Error)
+			}
+		})
+	}
+}
+
 func TestRunProjectCmdsWithCancellationTracker_CancelBetweenGroups(t *testing.T) {
 	tracker := NewCancellationTracker()
 	pull := models.PullRequest{Num: 2}


### PR DESCRIPTION
## What

Adds a deterministic regression test for the shared project command pool executor used by parallel plan and parallel apply.

The new test covers both `command.Plan` and `command.Apply`, starts two projects in the same execution-order group with a pool size of two, and uses channels to prove both projects enter execution before either one is allowed to complete.

## Why

The existing executor tests showed that commands completed, but they did not prove that more than one project was actually in flight before completion. This catches regressions where the parallel executor path accidentally becomes serialized while still returning successful results.

## Validation

- `gofmt -w server/events/project_command_pool_executor_test.go`
- `GOCACHE=/private/tmp/codex-go-build go test ./server/events -run 'TestRunProjectCmdsWithCancellationTracker_ParallelPlanAndApplyRunConcurrently|TestRunProjectCmdsParallel|TestRunProjectCmdsWithCancellationTracker'`
- `goimports -l server/events/project_command_pool_executor_test.go`
- `git diff --check`

