### PR TITLE
feat(cancel): ability to suppress `atlantis cancel` comments when `--hide-unchanged-plan-comments` is set

### DIFF
--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -989,7 +989,7 @@ atlantis server --hide-unchanged-plan-comments
 ATLANTIS_HIDE_UNCHANGED_PLAN_COMMENTS=true
 ```
 
-Remove no-changes plan comments from the pull request.
+Remove no-changes plan comments and cancellation plan comments from the pull request.
 
 This is useful when you have many projects and want to keep the pull request clean from useless comments.
 

--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -7,6 +7,7 @@ package events
 import (
 	"bytes"
 	"embed"
+	"errors"
 	"fmt"
 	"strings"
 	"text/template"
@@ -124,12 +125,13 @@ type policyCheckResultsData struct {
 }
 
 type projectResultTmplData struct {
-	Workspace    string
-	RepoRelDir   string
-	ProjectName  string
-	Rendered     string
-	NoChanges    bool
-	IsSuccessful bool
+	Workspace       string
+	RepoRelDir      string
+	ProjectName     string
+	Rendered        string
+	NoChanges       bool
+	SuppressComment bool
+	IsSuccessful    bool
 }
 
 // Initialize templates
@@ -225,6 +227,11 @@ func (m *MarkdownRenderer) renderProjectResults(ctx *command.Context, results []
 			RepoRelDir:   result.RepoRelDir,
 			ProjectName:  result.ProjectName,
 			IsSuccessful: result.IsSuccessful(),
+		}
+		if common.Command == planCommandTitle && common.HideUnchangedPlanComments && isSuppressedPlanError(result.Error) {
+			resultData.SuppressComment = true
+			resultsTmplData = append(resultsTmplData, resultData)
+			continue
 		}
 		if result.PlanSuccess != nil {
 			result.PlanSuccess.TerraformOutput = strings.TrimSpace(result.PlanSuccess.TerraformOutput)
@@ -430,4 +437,12 @@ func (m *MarkdownRenderer) renderTemplateTrimSpace(tmpl *template.Template, data
 		return fmt.Sprintf("Failed to render template, this is a bug: %v", err)
 	}
 	return strings.TrimSpace(buf.String())
+}
+
+func isSuppressedPlanError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return errors.Is(err, errOperationCancelled) || err.Error() == operationCancelledErrMsg
 }

--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -4387,6 +4387,77 @@ Ran Plan for 3 projects:
   $$$
 `,
 		},
+		{
+			"hide cancelled plan errors when hide unchanged plans is enabled",
+			command.Plan,
+			"",
+			[]command.ProjectResult{
+				{
+					Workspace:  "workspace",
+					RepoRelDir: "path",
+					ProjectCommandOutput: command.ProjectCommandOutput{
+						PlanSuccess: &models.PlanSuccess{
+							TerraformOutput: "terraform-output",
+							LockURL:         "lock-url",
+							ApplyCmd:        "atlantis apply -d path -w workspace",
+							RePlanCmd:       "atlantis plan -d path -w workspace",
+						},
+					},
+				},
+				{
+					Workspace:   "workspace",
+					RepoRelDir:  "path2",
+					ProjectName: "projectname",
+					ProjectCommandOutput: command.ProjectCommandOutput{
+						Error: errors.New("operation cancelled via `atlantis cancel` command"),
+					},
+				},
+				{
+					Workspace:   "workspace",
+					RepoRelDir:  "path3",
+					ProjectName: "projectname2",
+					ProjectCommandOutput: command.ProjectCommandOutput{
+						Error: errors.New("operation cancelled via `atlantis cancel` command"),
+					},
+				},
+			},
+			models.Github,
+			`
+Ran Plan for 3 projects:
+
+1. dir: $path$ workspace: $workspace$
+---
+
+### 1. dir: $path$ workspace: $workspace$
+$$$diff
+terraform-output
+$$$
+
+* :arrow_forward: To **apply** this plan, comment:
+  $$$shell
+  atlantis apply -d path -w workspace
+  $$$
+* :put_litter_in_its_place: To **delete** this plan and lock, click [here](lock-url)
+* :repeat: To **plan** this project again, comment:
+  $$$shell
+  atlantis plan -d path -w workspace
+  $$$
+
+---
+### Plan Summary
+
+3 projects, 1 with changes, 0 with no changes, 2 failed
+
+* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
+  $$$shell
+  atlantis apply
+  $$$
+* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
+  $$$shell
+  atlantis unlock
+  $$$
+`,
+		},
 	}
 
 	r := events.NewMarkdownRenderer(
@@ -4440,3 +4511,46 @@ Ran Plan for 3 projects:
 		})
 	}
 }
+
+func TestRenderProjectResultsHideUnchangedPlansDoesNotHideNonCancellationErrors(t *testing.T) {
+	r := events.NewMarkdownRenderer(
+		false,      // gitlabSupportsCommonMark
+		false,      // disableApplyAll
+		false,      // disableApply
+		false,      // disableMarkdownFolding
+		false,      // disableRepoLocking
+		false,      // enableDiffMarkdownFormat
+		"",         // markdownTemplateOverridesDir
+		"atlantis", // executableName
+		true,       // hideUnchangedPlanComments
+		false,      // quietPolicyChecks
+	)
+
+	logger := logging.NewNoopLogger(t).WithHistory()
+	ctx := &command.Context{
+		Log: logger,
+		Pull: models.PullRequest{
+			BaseRepo: models.Repo{
+				VCSHost: models.VCSHost{Type: models.Github},
+			},
+		},
+	}
+
+	res := command.Result{
+		ProjectResults: []command.ProjectResult{
+			{
+				Workspace:  "workspace",
+				RepoRelDir: "path",
+				ProjectCommandOutput: command.ProjectCommandOutput{
+					Error: errors.New("some plan error"),
+				},
+			},
+		},
+	}
+
+	cmd := &events.CommentCommand{Name: command.Plan}
+	rendered := r.Render(ctx, res, cmd)
+
+	Assert(t, strings.Contains(rendered, "some plan error"), "expected non-cancellation plan errors to be rendered")
+}
+

--- a/server/events/project_command_pool_executor.go
+++ b/server/events/project_command_pool_executor.go
@@ -4,7 +4,7 @@
 package events
 
 import (
-	"fmt"
+	"errors"
 	"sort"
 	"sync"
 
@@ -14,6 +14,10 @@ import (
 )
 
 type prjCmdRunnerFunc func(ctx command.ProjectContext) command.ProjectCommandOutput
+
+const operationCancelledErrMsg = "operation cancelled via `atlantis cancel` command"
+
+var errOperationCancelled = errors.New(operationCancelledErrMsg)
 
 func RunOneProjectCmd(
 	runnerFunc prjCmdRunnerFunc,
@@ -81,7 +85,7 @@ func runProjectCmdsParallel(
 			results = append(results, command.ProjectResult{
 				Command: pCmd.CommandName,
 				ProjectCommandOutput: command.ProjectCommandOutput{
-					Error: fmt.Errorf("operation cancelled via `atlantis cancel` command"),
+					Error: errOperationCancelled,
 				},
 				RepoRelDir:  pCmd.RepoRelDir,
 				Workspace:   pCmd.Workspace,
@@ -227,7 +231,7 @@ func createCancelledResults(remainingGroups [][]command.ProjectContext) []comman
 			cancelledResults = append(cancelledResults, command.ProjectResult{
 				Command: cmd.CommandName,
 				ProjectCommandOutput: command.ProjectCommandOutput{
-					Error: fmt.Errorf("operation cancelled via `atlantis cancel` command"),
+					Error: errOperationCancelled,
 				},
 				RepoRelDir:  cmd.RepoRelDir,
 				Workspace:   cmd.Workspace,

--- a/server/events/templates/multi_project_header.tmpl
+++ b/server/events/templates/multi_project_header.tmpl
@@ -2,6 +2,7 @@
 Ran {{.Command}} for {{ len .Results }} projects:
 
 {{ range $result := .Results -}}
+{{ if $result.SuppressComment }}{{continue}}{{end -}}
 1. {{ if $result.ProjectName }}project: `{{ $result.ProjectName }}` {{ end }}dir: `{{ $result.RepoRelDir }}` workspace: `{{ $result.Workspace }}`
 {{ end -}}
 {{ if (gt (len .Results) 0) -}}

--- a/server/events/templates/multi_project_plan.tmpl
+++ b/server/events/templates/multi_project_plan.tmpl
@@ -3,6 +3,7 @@
 {{ $disableApplyAll := .DisableApplyAll -}}
 {{ $hideUnchangedPlans := .HideUnchangedPlanComments -}}
 {{ range $i, $result := .Results -}}
+{{ if $result.SuppressComment }}{{continue}}{{end -}}
 {{ if (and $hideUnchangedPlans $result.NoChanges) }}{{continue}}{{end -}}
 ### {{ add $i 1 }}. {{ if $result.ProjectName }}project: `{{ $result.ProjectName }}` {{ end }}dir: `{{ $result.RepoRelDir }}` workspace: `{{ $result.Workspace }}`
 {{ $result.Rendered }}


### PR DESCRIPTION
## what
Feature to suppress "noop" plan errors when `--hide-unchanged-plan-comments` evaluates `true`, this is requested as additional feature by @Wirone on top of `atlantis cancel` (see https://github.com/runatlantis/atlantis/pull/6215#issuecomment-4385996755).

## why
When running a large amount of plans it can be quite annoying if the PR gets spammed with all the `atlantis cancel` errors.

Some other ideas to solve this problem could be to add a `Suppress` property to the `ProjectCommandOutput` that can be filled based on the flag.

## tests
Added an unit test covering this scenario, will do manual testing later and update this PR.

<TBD>

## references
https://github.com/runatlantis/atlantis/pull/6215#issuecomment-4385996755