### PR TITLE
feat: add reconfigure comment command

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -162,7 +162,7 @@ const (
 	DefaultADHostname                   = "dev.azure.com"
 	DefaultAutoDiscoverMode             = "auto"
 	DefaultAutoplanFileList             = "**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl"
-	DefaultAllowCommands                = "version,plan,apply,unlock,approve_policies,cancel"
+	DefaultAllowCommands                = "version,plan,reconfigure,apply,unlock,approve_policies,cancel"
 	DefaultBlockedExtraArgs             = "-chdir,--chdir,-plugin-dir,--plugin-dir"
 	DefaultCheckoutStrategy             = CheckoutStrategyBranch
 	DefaultCheckoutDepth                = 0

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -54,17 +54,17 @@ Values are chosen in this order:
 ### `--allow-commands` <Badge text="v0.27.0+" type="info"/>
 
 ```bash
-atlantis server --allow-commands=version,plan,apply,unlock,approve_policies
+atlantis server --allow-commands=version,plan,reconfigure,apply,unlock,approve_policies,cancel
 # or
-ATLANTIS_ALLOW_COMMANDS='version,plan,apply,unlock,approve_policies'
+ATLANTIS_ALLOW_COMMANDS='version,plan,reconfigure,apply,unlock,approve_policies,cancel'
 ```
 
-List of allowed commands to be run on the Atlantis server, Defaults to `version,plan,apply,unlock,approve_policies`
+List of allowed commands to be run on the Atlantis server, Defaults to `version,plan,reconfigure,apply,unlock,approve_policies,cancel`
 
 Notes:
 
 - Accepts a comma separated list, ex. `command1,command2`.
-- `version`, `plan`, `apply`, `unlock`, `approve_policies`, `import`, `state`, `policy_check` and `all` are available.
+- `version`, `plan`, `reconfigure`, `apply`, `unlock`, `approve_policies`, `cancel`, `import`, `state`, `policy_check` and `all` are available.
 - `policy_check` is an internal command that runs automatically after `plan` when [policy checking](policy-checking.md) is enabled. It must be explicitly allowlisted when using [`--gh-team-allowlist`](#gh-team-allowlist).
 - `all` is a special keyword that allows all commands. If pass `all` then all other commands will be ignored.
 

--- a/runatlantis.io/docs/using-atlantis.md
+++ b/runatlantis.io/docs/using-atlantis.md
@@ -94,6 +94,40 @@ atlantis plan -d dir -- -var foo='bar'
 
 If you always need to append a certain flag, see [Custom Workflow Use Cases](custom-workflows.md#adding-extra-arguments-to-terraform-commands).
 
+---
+
+## atlantis reconfigure
+
+```bash
+atlantis reconfigure [--verbose]
+```
+
+### Explanation
+
+Deletes this pull request's local Atlantis workspace, clears stale Atlantis plan state, releases Atlantis locks for the pull request, and then runs a normal unqualified `atlantis plan` from the current pull request head.
+
+This is useful when an idle pull request was already planned before the Atlantis server's default Terraform version changed. A normal `atlantis plan` can reuse an existing local checkout and Terraform initialization state; `atlantis reconfigure` forces Atlantis to rebuild that local PR workspace before planning.
+
+::: warning NOTE
+`atlantis reconfigure` invalidates previous plans for the pull request. Run `atlantis apply` only after the new plan has completed successfully.
+:::
+
+### Examples
+
+```bash
+# Rebuild the local PR workspace and run plan for modified projects.
+atlantis reconfigure
+
+# Include Atlantis logs in the resulting comment.
+atlantis reconfigure --verbose
+```
+
+### Options
+
+* `--verbose` Append Atlantis log to comment.
+
+Scoped flags such as `-d`, `-w`, `-p`, and Terraform extra args after `--` are not supported. Use `atlantis plan` for project-scoped planning.
+
 ### Automatic Environment Variable Files
 
 Atlantis automatically includes workspace-specific variable files if they exist in your repository. This feature helps reduce duplication across different environments and workspaces.

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1650,8 +1650,19 @@ func setupE2E(t *testing.T, repoDir string, opt setupOption) (events_controllers
 		projectCommandRunner,
 	)
 
+	reconfigureCommandRunner := events.NewReconfigureCommandRunner(
+		workingDir,
+		locker,
+		lockingClient,
+		database,
+		pullUpdater,
+		projectCmdOutputHandler,
+		cancellationTracker,
+	)
+
 	commentCommandRunnerByCmd := map[command.Name]events.CommentCommandRunner{
 		command.Plan:            planCommandRunner,
+		command.Reconfigure:     reconfigureCommandRunner,
 		command.Apply:           applyCommandRunner,
 		command.ApprovePolicies: approvePoliciesCommandRunner,
 		command.Unlock:          unlockCommandRunner,

--- a/server/events/command/name.go
+++ b/server/events/command/name.go
@@ -19,6 +19,8 @@ const (
 	Apply Name = iota
 	// Plan is a command to run terraform plan.
 	Plan
+	// Reconfigure is a command to delete local PR workspace/cache state before running terraform plan.
+	Reconfigure
 	// Unlock is a command to discard previous plans as well as the atlantis locks.
 	Unlock
 	// PolicyCheck is a command to run conftest test.
@@ -47,6 +49,7 @@ type ArgCount struct {
 var AllCommentCommands = []Name{
 	Version,
 	Plan,
+	Reconfigure,
 	Apply,
 	Cancel,
 	Unlock,
@@ -68,6 +71,8 @@ func (c Name) String() string {
 		return "apply"
 	case Plan, Autoplan:
 		return "plan"
+	case Reconfigure:
+		return "reconfigure"
 	case Unlock:
 		return "unlock"
 	case PolicyCheck:
@@ -145,6 +150,8 @@ func ParseCommandName(name string) (Name, error) {
 		return Apply, nil
 	case "plan":
 		return Plan, nil
+	case "reconfigure":
+		return Reconfigure, nil
 	case "unlock":
 		return Unlock, nil
 	case "policy_check":

--- a/server/events/command/name_test.go
+++ b/server/events/command/name_test.go
@@ -38,6 +38,7 @@ func TestName_String(t *testing.T) {
 	}{
 		{command.Apply, "apply"},
 		{command.Plan, "plan"},
+		{command.Reconfigure, "reconfigure"},
 		{command.Unlock, "unlock"},
 		{command.PolicyCheck, "policy_check"},
 		{command.ApprovePolicies, "approve_policies"},
@@ -61,6 +62,7 @@ func TestName_DefaultUsage(t *testing.T) {
 	}{
 		{command.Apply, "apply"},
 		{command.Plan, "plan"},
+		{command.Reconfigure, "reconfigure"},
 		{command.Unlock, "unlock"},
 		{command.PolicyCheck, "policy_check"},
 		{command.ApprovePolicies, "approve_policies"},
@@ -84,6 +86,7 @@ func TestName_SubCommands(t *testing.T) {
 	}{
 		{c: command.Apply},
 		{c: command.Plan},
+		{c: command.Reconfigure},
 		{c: command.Unlock},
 		{c: command.PolicyCheck},
 		{c: command.ApprovePolicies},
@@ -109,6 +112,7 @@ func TestName_CommandArgCount(t *testing.T) {
 	}{
 		{c: command.Apply, want: &command.ArgCount{}},
 		{c: command.Plan, want: &command.ArgCount{}},
+		{c: command.Reconfigure, want: &command.ArgCount{}},
 		{c: command.Unlock, want: &command.ArgCount{}},
 		{c: command.PolicyCheck, want: &command.ArgCount{}},
 		{c: command.ApprovePolicies, want: &command.ArgCount{}},
@@ -176,6 +180,7 @@ func TestParseCommandName(t *testing.T) {
 	}{
 		{command.Apply, "apply"},
 		{command.Plan, "plan"},
+		{command.Reconfigure, "reconfigure"},
 		{command.Unlock, "unlock"},
 		{command.PolicyCheck, "policy_check"},
 		{command.ApprovePolicies, "approve_policies"},

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -365,6 +365,16 @@ func (c *DefaultCommandRunner) RunCommentCommand(baseRepo models.Repo, maybeHead
 		return
 	}
 
+	if cmd.Name == command.Reconfigure {
+		planVerbose := cmd.Verbose
+		reconfigureRunner := buildCommentCommandRunner(c, command.Reconfigure)
+		reconfigureRunner.Run(ctx, cmd)
+		if ctx.CommandHasErrors {
+			return
+		}
+		cmd = &CommentCommand{Name: command.Plan, Verbose: planVerbose}
+	}
+
 	// Only set pending status if silence is not enabled
 	// The command runners will handle the final status decision based on project results
 	if !c.SilenceVCSStatusNoProjects {

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -57,6 +57,7 @@ var planCommandRunner *events.PlanCommandRunner
 var applyLockChecker *lockingmocks.MockApplyLockChecker
 var lockingLocker *lockingmocks.MockLocker
 var applyCommandRunner *events.ApplyCommandRunner
+var reconfigureCommandRunner *events.ReconfigureCommandRunner
 var unlockCommandRunner *events.UnlockCommandRunner
 var importCommandRunner *events.ImportCommandRunner
 var preWorkflowHooksCommandRunner events.PreWorkflowHooksCommandRunner
@@ -192,6 +193,16 @@ func setup(t *testing.T, options ...func(testConfig *TestConfig)) *vcsmocks.Mock
 		pullReqStatusFetcher,
 	)
 
+	reconfigureCommandRunner = events.NewReconfigureCommandRunner(
+		workingDir,
+		events.NewDefaultWorkingDirLocker(),
+		lockingLocker,
+		testConfig.database,
+		pullUpdater,
+		nil,
+		cancellationTracker,
+	)
+
 	approvePoliciesCommandRunner = events.NewApprovePoliciesCommandRunner(
 		commitUpdater,
 		projectCommandBuilder,
@@ -228,6 +239,7 @@ func setup(t *testing.T, options ...func(testConfig *TestConfig)) *vcsmocks.Mock
 
 	commentCommandRunnerByCmd := map[command.Name]events.CommentCommandRunner{
 		command.Plan:            planCommandRunner,
+		command.Reconfigure:     reconfigureCommandRunner,
 		command.Apply:           applyCommandRunner,
 		command.ApprovePolicies: approvePoliciesCommandRunner,
 		command.Unlock:          unlockCommandRunner,
@@ -965,6 +977,53 @@ func TestRunGenericPlanCommand_DeletePlans(t *testing.T) {
 	testdata.Pull.BaseRepo = testdata.GithubRepo
 	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan})
 	pendingPlanFinder.VerifyWasCalledOnce().DeletePlans(tmp)
+}
+
+func TestRunCommentCommand_ReconfigureCleansThenRunsPlan(t *testing.T) {
+	setup(t)
+	tmp := t.TempDir()
+	pull := &github.PullRequest{State: github.Ptr("open")}
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num}
+	projectCtx := command.ProjectContext{
+		CommandName:         command.Plan,
+		ExecutionOrderGroup: 0,
+		ProjectName:         "default",
+		Workspace:           "default",
+		BaseRepo:            testdata.GithubRepo,
+		Pull:                modelPull,
+	}
+	_, err := dbUpdater.Database.UpdatePullWithResults(modelPull, []command.ProjectResult{
+		{
+			ProjectName: "old",
+			RepoRelDir:  "old",
+			Workspace:   "default",
+			Command:     command.Plan,
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PlanSuccess: &models.PlanSuccess{},
+			},
+		},
+	})
+	Ok(t, err)
+
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+	When(workingDir.Delete(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull))).ThenReturn(nil)
+	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(tmp, nil)
+	When(projectCommandBuilder.BuildPlanCommands(Any[*command.Context](), Any[*events.CommentCommand]())).
+		ThenReturn([]command.ProjectContext{projectCtx}, nil)
+	When(projectCommandRunner.Plan(projectCtx)).ThenReturn(command.ProjectCommandOutput{PlanSuccess: &models.PlanSuccess{}})
+
+	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Reconfigure, Verbose: true})
+
+	workingDir.(*mocks.MockWorkingDir).VerifyWasCalledOnce().Delete(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull))
+	pendingPlanFinder.VerifyWasCalledOnce().DeletePlans(tmp)
+	_, planCmd := projectCommandBuilder.VerifyWasCalledOnce().BuildPlanCommands(Any[*command.Context](), Any[*events.CommentCommand]()).GetCapturedArguments()
+	Equals(t, command.Plan, planCmd.Name)
+	Assert(t, planCmd.Verbose, "expected reconfigure --verbose to carry into synthesized plan")
+	Equals(t, "", planCmd.RepoRelDir)
+	Equals(t, "", planCmd.Workspace)
+	Equals(t, "", planCmd.ProjectName)
+	cancellationTracker.VerifyWasCalled(Times(2)).Clear(modelPull)
 }
 
 func TestRunSpecificPlanCommandDoesnt_DeletePlans(t *testing.T) {

--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -138,8 +138,8 @@ type CommentParseResult struct {
 // Valid commands contain:
 //   - The initial "executable" name, 'run' or 'atlantis' or '@GithubUser'
 //     where GithubUser is the API user Atlantis is running as.
-//   - Then a command: 'plan', 'apply', 'unlock', 'version, 'approve_policies',
-//     or 'help'.
+//   - Then a command: 'plan', 'reconfigure', 'apply', 'unlock', 'version,
+//     'approve_policies', or 'help'.
 //   - Then optional flags, then an optional separator '--' followed by optional
 //     extra flags to be appended to the terraform plan/apply command.
 //
@@ -149,6 +149,7 @@ type CommentParseResult struct {
 // - @GithubUser plan -w staging
 // - atlantis plan -w staging -d dir --verbose
 // - atlantis plan --verbose -- -key=value -key2 value2
+// - atlantis reconfigure
 // - atlantis unlock
 // - atlantis version
 // - atlantis approve_policies
@@ -255,6 +256,11 @@ func (e *CommentParser) Parse(rawComment string, vcsHost models.VCSHostType) Com
 		flagSet.StringVarP(&dir, dirFlagLong, dirFlagShort, "", "Which directory to run plan in relative to root of repo, ex. 'child/dir'.")
 		flagSet.StringVarP(&project, projectFlagLong, projectFlagShort, "", "Which project to run plan for. Refers to the name of the project configured in a repo config file. Cannot be used at same time as workspace or dir flags.")
 		flagSet.BoolVarP(&verbose, verboseFlagLong, verboseFlagShort, false, "Append Atlantis log to comment.")
+	case command.Reconfigure.String():
+		name = command.Reconfigure
+		flagSet = pflag.NewFlagSet(command.Reconfigure.String(), pflag.ContinueOnError)
+		flagSet.SetOutput(io.Discard)
+		flagSet.BoolVarP(&verbose, verboseFlagLong, verboseFlagShort, false, "Append Atlantis log to comment.")
 	case command.Apply.String():
 		name = command.Apply
 		flagSet = pflag.NewFlagSet(command.Apply.String(), pflag.ContinueOnError)
@@ -313,6 +319,9 @@ func (e *CommentParser) Parse(rawComment string, vcsHost models.VCSHostType) Com
 	subName, extraArgs, errResult := e.parseArgs(name, args, flagSet)
 	if errResult != "" {
 		return CommentParseResult{CommentResponse: errResult}
+	}
+	if name == command.Reconfigure && len(extraArgs) > 0 {
+		return CommentParseResult{CommentResponse: e.errMarkdown(fmt.Sprintf("unknown argument(s) - %s", strings.Join(extraArgs, " ")), name.DefaultUsage(), flagSet)}
 	}
 
 	dir, err = e.validateDir(dir)
@@ -571,6 +580,7 @@ func (e *CommentParser) HelpComment() string {
 		ExecutableName       string
 		AllowVersion         bool
 		AllowPlan            bool
+		AllowReconfigure     bool
 		AllowApply           bool
 		AllowUnlock          bool
 		AllowApprovePolicies bool
@@ -580,6 +590,7 @@ func (e *CommentParser) HelpComment() string {
 		ExecutableName:       e.ExecutableName,
 		AllowVersion:         e.isAllowedCommand(command.Version.String()),
 		AllowPlan:            e.isAllowedCommand(command.Plan.String()),
+		AllowReconfigure:     e.isAllowedCommand(command.Reconfigure.String()),
 		AllowApply:           e.isAllowedCommand(command.Apply.String()),
 		AllowUnlock:          e.isAllowedCommand(command.Unlock.String()),
 		AllowApprovePolicies: e.isAllowedCommand(command.ApprovePolicies.String()),
@@ -606,6 +617,11 @@ Examples:
   # run plan in the root directory passing the -target flag to terraform
   {{ .ExecutableName }} plan -d . -- -target=resource
 {{- end }}
+{{- if .AllowReconfigure }}
+
+  # delete this pull request's local Atlantis workspace and run plan again
+  {{ .ExecutableName }} reconfigure
+{{- end }}
 {{- if .AllowApply }}
 
   # apply all unapplied plans from this pull request
@@ -619,6 +635,10 @@ Commands:
 {{- if .AllowPlan }}
   plan     Runs 'terraform plan' for the changes in this pull request.
            To plan a specific project, use the -d, -w and -p flags.
+{{- end }}
+{{- if .AllowReconfigure }}
+  reconfigure
+           Deletes this pull request's local Atlantis workspace and runs plan again.
 {{- end }}
 {{- if .AllowApply }}
   apply    Runs 'terraform apply' on all unapplied plans from this pull request.

--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -54,10 +54,10 @@ func TestNewCommentParser(t *testing.T) {
 			name: "comment un-available commands filtered",
 			args: args{
 				// PolicyCheck and Autoplan cannot be used on comment command, so filtered
-				allowCommands: []command.Name{command.Plan, command.Apply, command.Unlock, command.PolicyCheck, command.ApprovePolicies, command.Autoplan, command.Version, command.Import},
+				allowCommands: []command.Name{command.Plan, command.Reconfigure, command.Apply, command.Unlock, command.PolicyCheck, command.ApprovePolicies, command.Autoplan, command.Version, command.Import},
 			},
 			want: &events.CommentParser{
-				AllowCommands:    []command.Name{command.Version, command.Plan, command.Apply, command.Unlock, command.ApprovePolicies, command.Import},
+				AllowCommands:    []command.Name{command.Version, command.Plan, command.Reconfigure, command.Apply, command.Unlock, command.ApprovePolicies, command.Import},
 				BlockedExtraArgs: nil,
 			},
 		},
@@ -318,6 +318,8 @@ func TestParse_SubcommandUsage(t *testing.T) {
 	}{
 		{"atlantis plan -h", "plan"},
 		{"atlantis plan --help", "plan"},
+		{"atlantis reconfigure -h", "reconfigure"},
+		{"atlantis reconfigure --help", "reconfigure"},
 		{"atlantis apply -h", "apply"},
 		{"atlantis apply --help", "apply"},
 		{"atlantis approve_policies -h", "approve_policies"},
@@ -334,6 +336,38 @@ func TestParse_SubcommandUsage(t *testing.T) {
 			"For comment %q expected CommentResponse %q to contain %q", c, r.CommentResponse, exp)
 		Assert(t, !strings.Contains(r.CommentResponse, "Error:"),
 			"For comment %q expected CommentResponse %q to not contain %q", c, r.CommentResponse, "Error: ")
+	}
+}
+
+func TestParse_Reconfigure(t *testing.T) {
+	for _, comment := range []string{
+		"atlantis reconfigure",
+		"atlantis reconfigure --verbose",
+	} {
+		t.Run(comment, func(t *testing.T) {
+			r := commentParser.Parse(comment, models.Github)
+
+			Equals(t, "", r.CommentResponse)
+			Equals(t, command.Reconfigure, r.Command.Name)
+			Equals(t, "", r.Command.RepoRelDir)
+			Equals(t, "", r.Command.Workspace)
+			Equals(t, "", r.Command.ProjectName)
+			Equals(t, []string(nil), r.Command.Flags)
+			Equals(t, strings.Contains(comment, "--verbose"), r.Command.Verbose)
+		})
+	}
+}
+
+func TestParse_ReconfigureRejectsArgs(t *testing.T) {
+	for _, comment := range []string{
+		"atlantis reconfigure -d .",
+		"atlantis reconfigure -- -target=resource",
+		"atlantis reconfigure unexpected",
+	} {
+		t.Run(comment, func(t *testing.T) {
+			r := commentParser.Parse(comment, models.Github)
+			Assert(t, strings.Contains(r.CommentResponse, "Error:"), "expected error for %q but got %q", comment, r.CommentResponse)
+		})
 	}
 }
 
@@ -1062,6 +1096,9 @@ Examples:
   # run plan in the root directory passing the -target flag to terraform
   atlantis plan -d . -- -target=resource
 
+  # delete this pull request's local Atlantis workspace and run plan again
+  atlantis reconfigure
+
   # apply all unapplied plans from this pull request
   atlantis apply
 
@@ -1071,6 +1108,8 @@ Examples:
 Commands:
   plan     Runs 'terraform plan' for the changes in this pull request.
            To plan a specific project, use the -d, -w and -p flags.
+  reconfigure
+           Deletes this pull request's local Atlantis workspace and runs plan again.
   apply    Runs 'terraform apply' on all unapplied plans from this pull request.
            To only apply a specific plan, use the -d, -w and -p flags.
   unlock   Removes all atlantis locks and discards all plans for this PR.

--- a/server/events/reconfigure_command_runner.go
+++ b/server/events/reconfigure_command_runner.go
@@ -1,0 +1,103 @@
+// Copyright 2026 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package events
+
+import (
+	"fmt"
+
+	"github.com/runatlantis/atlantis/server/core/db"
+	"github.com/runatlantis/atlantis/server/core/locking"
+	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/jobs"
+)
+
+// ReconfigureCommandRunner deletes a pull request's local Atlantis workspace
+// state before DefaultCommandRunner continues with a normal plan command.
+type ReconfigureCommandRunner struct {
+	WorkingDir               WorkingDir       `validate:"required"`
+	WorkingDirLocker         WorkingDirLocker `validate:"required"`
+	Locker                   locking.Locker   `validate:"required"`
+	Database                 db.Database      `validate:"required"`
+	PullUpdater              *PullUpdater     `validate:"required"`
+	LogStreamResourceCleaner ResourceCleaner
+	CancellationTracker      CancellationTracker
+}
+
+func NewReconfigureCommandRunner(
+	workingDir WorkingDir,
+	workingDirLocker WorkingDirLocker,
+	locker locking.Locker,
+	database db.Database,
+	pullUpdater *PullUpdater,
+	logStreamResourceCleaner ResourceCleaner,
+	cancellationTracker CancellationTracker,
+) *ReconfigureCommandRunner {
+	return &ReconfigureCommandRunner{
+		WorkingDir:               workingDir,
+		WorkingDirLocker:         workingDirLocker,
+		Locker:                   locker,
+		Database:                 database,
+		PullUpdater:              pullUpdater,
+		LogStreamResourceCleaner: logStreamResourceCleaner,
+		CancellationTracker:      cancellationTracker,
+	}
+}
+
+func (r *ReconfigureCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
+	unlockFn, err := r.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, "", "", "", command.Reconfigure)
+	if err != nil {
+		r.fail(ctx, cmd, err)
+		return
+	}
+	defer unlockFn()
+
+	pullStatus, err := r.Database.GetPullStatus(ctx.Pull)
+	if err != nil {
+		ctx.Log.Err("retrieving pull status: %s", err)
+	}
+	r.cleanupLogStreams(ctx.Pull, pullStatus)
+
+	if err := r.WorkingDir.Delete(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull); err != nil {
+		r.fail(ctx, cmd, fmt.Errorf("deleting pull request workspace: %w", err))
+		return
+	}
+
+	if _, err := r.Locker.UnlockByPull(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num); err != nil {
+		r.fail(ctx, cmd, fmt.Errorf("deleting locks: %w", err))
+		return
+	}
+
+	if err := r.Database.DeletePullStatus(ctx.Pull); err != nil {
+		r.fail(ctx, cmd, fmt.Errorf("deleting pull status from db: %w", err))
+		return
+	}
+
+	if r.CancellationTracker != nil {
+		r.CancellationTracker.Clear(ctx.Pull)
+	}
+	ctx.PullStatus = nil
+}
+
+func (r *ReconfigureCommandRunner) cleanupLogStreams(pull models.PullRequest, pullStatus *models.PullStatus) {
+	if r.LogStreamResourceCleaner == nil || pullStatus == nil {
+		return
+	}
+
+	for _, project := range pullStatus.Projects {
+		r.LogStreamResourceCleaner.CleanUp(jobs.PullInfo{
+			PullNum:      pull.Num,
+			Repo:         pull.BaseRepo.Name,
+			RepoFullName: pull.BaseRepo.FullName,
+			ProjectName:  project.ProjectName,
+			Path:         project.RepoRelDir,
+			Workspace:    project.Workspace,
+		})
+	}
+}
+
+func (r *ReconfigureCommandRunner) fail(ctx *command.Context, cmd *CommentCommand, err error) {
+	ctx.CommandHasErrors = true
+	r.PullUpdater.updatePull(ctx, cmd, command.Result{Error: err})
+}

--- a/server/events/reconfigure_command_runner_test.go
+++ b/server/events/reconfigure_command_runner_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package events_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	. "github.com/petergtz/pegomock/v4"
+	dbmocks "github.com/runatlantis/atlantis/server/core/db/mocks"
+	lockingmocks "github.com/runatlantis/atlantis/server/core/locking/mocks"
+	"github.com/runatlantis/atlantis/server/events"
+	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/events/mocks"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/events/models/testdata"
+	vcsmocks "github.com/runatlantis/atlantis/server/events/vcs/mocks"
+	"github.com/runatlantis/atlantis/server/jobs"
+	"github.com/runatlantis/atlantis/server/logging"
+	. "github.com/runatlantis/atlantis/testing"
+	"go.uber.org/mock/gomock"
+)
+
+func TestReconfigureCommandRunner_RunCleansPullState(t *testing.T) {
+	RegisterMockTestingT(t)
+	ctrl := gomock.NewController(t)
+	database := dbmocks.NewMockDatabase(ctrl)
+	locker := lockingmocks.NewMockLocker(ctrl)
+	workingDir := mocks.NewMockWorkingDir()
+	resourceCleaner := mocks.NewMockResourceCleaner()
+	cancellationTracker := mocks.NewMockCancellationTracker()
+	pullUpdater := reconfigurePullUpdater()
+	runner := events.NewReconfigureCommandRunner(
+		workingDir,
+		events.NewDefaultWorkingDirLocker(),
+		locker,
+		database,
+		pullUpdater,
+		resourceCleaner,
+		cancellationTracker,
+	)
+	pull := reconfigurePull()
+	pullStatus := &models.PullStatus{
+		Projects: []models.ProjectStatus{
+			{ProjectName: "app", RepoRelDir: "app", Workspace: "default"},
+			{ProjectName: "db", RepoRelDir: "db", Workspace: "prod"},
+		},
+	}
+	ctx := &command.Context{
+		Log:        logging.NewNoopLogger(t),
+		Pull:       pull,
+		PullStatus: pullStatus,
+	}
+
+	database.EXPECT().GetPullStatus(pull).Return(pullStatus, nil)
+	When(workingDir.Delete(Any[logging.SimpleLogging](), Eq(pull.BaseRepo), Eq(pull))).ThenReturn(nil)
+	locker.EXPECT().UnlockByPull(pull.BaseRepo.FullName, pull.Num).Return(nil, nil)
+	database.EXPECT().DeletePullStatus(pull).Return(nil)
+
+	runner.Run(ctx, &events.CommentCommand{Name: command.Reconfigure})
+
+	workingDir.VerifyWasCalledOnce().Delete(Any[logging.SimpleLogging](), Eq(pull.BaseRepo), Eq(pull))
+	resourceCleaner.VerifyWasCalled(Times(2)).CleanUp(Any[jobs.PullInfo]())
+	cancellationTracker.VerifyWasCalledOnce().Clear(pull)
+	Assert(t, ctx.PullStatus == nil, "expected reconfigure to clear stale pull status from command context")
+	Assert(t, !ctx.CommandHasErrors, "expected reconfigure to succeed")
+}
+
+func TestReconfigureCommandRunner_RunStopsWhenPullIsLocked(t *testing.T) {
+	RegisterMockTestingT(t)
+	ctrl := gomock.NewController(t)
+	database := dbmocks.NewMockDatabase(ctrl)
+	locker := lockingmocks.NewMockLocker(ctrl)
+	workingDir := mocks.NewMockWorkingDir()
+	vcsClient := vcsmocks.NewMockClient()
+	pullUpdater := reconfigurePullUpdaterWithClient(vcsClient)
+	workingDirLocker := events.NewDefaultWorkingDirLocker()
+	pull := reconfigurePull()
+	_, err := workingDirLocker.TryLock(pull.BaseRepo.FullName, pull.Num, "default", ".", "app", command.Plan)
+	Ok(t, err)
+	runner := events.NewReconfigureCommandRunner(
+		workingDir,
+		workingDirLocker,
+		locker,
+		database,
+		pullUpdater,
+		nil,
+		nil,
+	)
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: pull,
+	}
+
+	runner.Run(ctx, &events.CommentCommand{Name: command.Reconfigure})
+
+	workingDir.VerifyWasCalled(Never()).Delete(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest]())
+	_, _, _, comment, _ := vcsClient.VerifyWasCalledOnce().CreateComment(
+		Any[logging.SimpleLogging](), Eq(pull.BaseRepo), Eq(pull.Num), Any[string](), Eq(command.Reconfigure.String())).GetCapturedArguments()
+	Assert(t, strings.Contains(comment, "currently locked by"), "expected lock error comment, got %q", comment)
+	Assert(t, ctx.CommandHasErrors, "expected reconfigure to stop on active pull lock")
+}
+
+func TestReconfigureCommandRunner_RunStopsOnWorkspaceDeleteFailure(t *testing.T) {
+	RegisterMockTestingT(t)
+	ctrl := gomock.NewController(t)
+	database := dbmocks.NewMockDatabase(ctrl)
+	locker := lockingmocks.NewMockLocker(ctrl)
+	workingDir := mocks.NewMockWorkingDir()
+	vcsClient := vcsmocks.NewMockClient()
+	pullUpdater := reconfigurePullUpdaterWithClient(vcsClient)
+	pull := reconfigurePull()
+	runner := events.NewReconfigureCommandRunner(
+		workingDir,
+		events.NewDefaultWorkingDirLocker(),
+		locker,
+		database,
+		pullUpdater,
+		nil,
+		nil,
+	)
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: pull,
+	}
+
+	database.EXPECT().GetPullStatus(pull).Return(nil, nil)
+	When(workingDir.Delete(Any[logging.SimpleLogging](), Eq(pull.BaseRepo), Eq(pull))).ThenReturn(errors.New("boom"))
+
+	runner.Run(ctx, &events.CommentCommand{Name: command.Reconfigure})
+
+	_, _, _, comment, _ := vcsClient.VerifyWasCalledOnce().CreateComment(
+		Any[logging.SimpleLogging](), Eq(pull.BaseRepo), Eq(pull.Num), Any[string](), Eq(command.Reconfigure.String())).GetCapturedArguments()
+	Assert(t, strings.Contains(comment, "deleting pull request workspace: boom"), "expected delete error comment, got %q", comment)
+	Assert(t, ctx.CommandHasErrors, "expected reconfigure to stop on delete failure")
+}
+
+func reconfigurePullUpdater() *events.PullUpdater {
+	return reconfigurePullUpdaterWithClient(vcsmocks.NewMockClient())
+}
+
+func reconfigurePullUpdaterWithClient(vcsClient *vcsmocks.MockClient) *events.PullUpdater {
+	return &events.PullUpdater{
+		VCSClient:        vcsClient,
+		MarkdownRenderer: events.NewMarkdownRenderer(false, false, false, false, false, false, "", "atlantis", false, false),
+	}
+}
+
+func reconfigurePull() models.PullRequest {
+	pull := testdata.Pull
+	pull.BaseRepo = testdata.GithubRepo
+	return pull
+}

--- a/server/events/working_dir_locker.go
+++ b/server/events/working_dir_locker.go
@@ -48,6 +48,24 @@ func (d *DefaultWorkingDirLocker) TryLock(repoFullName string, pullNum int, work
 	defer d.mutex.Unlock()
 
 	workspaceKey := d.workspaceKey(repoFullName, pullNum, workspace, path, projectName)
+	pullKey := d.pullKey(repoFullName, pullNum)
+
+	if cmdName == command.Reconfigure && workspaceKey == pullKey {
+		if currentLock, exists := d.findPullLock(pullKey); exists {
+			return func() {}, fmt.Errorf("cannot run %q: this pull request is currently locked by %q.\n"+
+				"Wait until the previous command is complete and try again", cmdName, currentLock)
+		}
+		d.locks[pullKey] = cmdName
+		return func() {
+			d.unlock(repoFullName, pullNum, workspace, path, projectName)
+		}, nil
+	}
+
+	if currentLock, exists := d.locks[pullKey]; exists {
+		return func() {}, fmt.Errorf("cannot run %q: this pull request is currently locked by %q.\n"+
+			"Wait until the previous command is complete and try again", cmdName, currentLock)
+	}
+
 	if currentLock, exists := d.locks[workspaceKey]; exists {
 		return func() {}, fmt.Errorf("cannot run %q: the %s workspace at path %s is currently locked for this pull request by %q.\n"+
 			"Wait until the previous command is complete and try again", cmdName, workspace, path, currentLock)
@@ -64,9 +82,10 @@ func (d *DefaultWorkingDirLocker) UnlockByPull(repoFullName string, pullNum int)
 	defer d.mutex.Unlock()
 
 	// Find and remove all locks for this pull request
-	prefix := fmt.Sprintf("%s/%d/", repoFullName, pullNum)
+	pullKey := d.pullKey(repoFullName, pullNum)
+	prefix := pullKey + "/"
 	for key := range d.locks {
-		if strings.HasPrefix(key, prefix) {
+		if key == pullKey || strings.HasPrefix(key, prefix) {
 			delete(d.locks, key)
 		}
 	}
@@ -83,4 +102,22 @@ func (d *DefaultWorkingDirLocker) unlock(repoFullName string, pullNum int, works
 
 func (d *DefaultWorkingDirLocker) workspaceKey(repo string, pull int, workspace string, path string, projectName string) string {
 	return strings.TrimRight(fmt.Sprintf("%s/%d/%s/%s/%s", repo, pull, workspace, path, projectName), "/")
+}
+
+func (d *DefaultWorkingDirLocker) pullKey(repo string, pull int) string {
+	return fmt.Sprintf("%s/%d", repo, pull)
+}
+
+func (d *DefaultWorkingDirLocker) findPullLock(pullKey string) (command.Name, bool) {
+	if currentLock, exists := d.locks[pullKey]; exists {
+		return currentLock, true
+	}
+
+	prefix := pullKey + "/"
+	for key, currentLock := range d.locks {
+		if strings.HasPrefix(key, prefix) {
+			return currentLock, true
+		}
+	}
+	return -1, false
 }

--- a/server/events/working_dir_locker_test.go
+++ b/server/events/working_dir_locker_test.go
@@ -215,3 +215,60 @@ func TestUnlockDifferentProjectNames(t *testing.T) {
 	_, err = locker.TryLock(repo, 1, workspace, path, newProjectName, cmd)
 	Ok(t, err)
 }
+
+func TestTryLockReconfigureConflictsWithWorkspaceLocks(t *testing.T) {
+	locker := events.NewDefaultWorkingDirLocker()
+
+	_, err := locker.TryLock(repo, 1, workspace, path, projectName, command.Plan)
+	Ok(t, err)
+
+	_, err = locker.TryLock(repo, 1, "", "", "", command.Reconfigure)
+	ErrEquals(t, "cannot run \"reconfigure\": this pull request is currently locked by \"plan\".\n"+
+		"Wait until the previous command is complete and try again", err)
+}
+
+func TestTryLockWorkspaceConflictsWithReconfigure(t *testing.T) {
+	locker := events.NewDefaultWorkingDirLocker()
+
+	unlockFn, err := locker.TryLock(repo, 1, "", "", "", command.Reconfigure)
+	Ok(t, err)
+
+	_, err = locker.TryLock(repo, 1, workspace, path, projectName, command.Plan)
+	ErrEquals(t, "cannot run \"plan\": this pull request is currently locked by \"reconfigure\".\n"+
+		"Wait until the previous command is complete and try again", err)
+
+	unlockFn()
+	_, err = locker.TryLock(repo, 1, workspace, path, projectName, command.Plan)
+	Ok(t, err)
+}
+
+func TestTryLockReconfigureDifferentRepoAndPull(t *testing.T) {
+	locker := events.NewDefaultWorkingDirLocker()
+
+	_, err := locker.TryLock(repo, 1, "", "", "", command.Reconfigure)
+	Ok(t, err)
+
+	_, err = locker.TryLock("owner/newrepo", 1, workspace, path, projectName, command.Plan)
+	Ok(t, err)
+
+	_, err = locker.TryLock(repo, 2, workspace, path, projectName, command.Plan)
+	Ok(t, err)
+}
+
+func TestUnlockByPullReleasesReconfigureLockForSamePullOnly(t *testing.T) {
+	locker := events.NewDefaultWorkingDirLocker()
+
+	_, err := locker.TryLock(repo, 1, "", "", "", command.Reconfigure)
+	Ok(t, err)
+	_, err = locker.TryLock(repo, 2, "", "", "", command.Reconfigure)
+	Ok(t, err)
+
+	locker.UnlockByPull(repo, 1)
+
+	_, err = locker.TryLock(repo, 1, workspace, path, projectName, command.Plan)
+	Ok(t, err)
+
+	_, err = locker.TryLock(repo, 2, workspace, path, projectName, command.Plan)
+	ErrEquals(t, "cannot run \"plan\": this pull request is currently locked by \"reconfigure\".\n"+
+		"Wait until the previous command is complete and try again", err)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -865,8 +865,19 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		userConfig.SilenceNoProjects,
 	)
 
+	reconfigureCommandRunner := events.NewReconfigureCommandRunner(
+		workingDir,
+		workingDirLocker,
+		lockingClient,
+		database,
+		pullUpdater,
+		projectCmdOutputHandler,
+		cancellationTracker,
+	)
+
 	commentCommandRunnerByCmd := map[command.Name]events.CommentCommandRunner{
 		command.Plan:            planCommandRunner,
+		command.Reconfigure:     reconfigureCommandRunner,
 		command.Apply:           applyCommandRunner,
 		command.ApprovePolicies: approvePoliciesCommandRunner,
 		command.Unlock:          unlockCommandRunner,

--- a/server/user_config_test.go
+++ b/server/user_config_test.go
@@ -25,23 +25,23 @@ func TestUserConfig_ToAllowCommandNames(t *testing.T) {
 	}{
 		{
 			name:          "full commands can be parsed by comma",
-			allowCommands: "apply,plan,cancel,unlock,policy_check,approve_policies,version,import,state",
+			allowCommands: "apply,plan,reconfigure,cancel,unlock,policy_check,approve_policies,version,import,state",
 			want: []command.Name{
-				command.Apply, command.Plan, command.Cancel, command.Unlock, command.PolicyCheck, command.ApprovePolicies, command.Version, command.Import, command.State,
+				command.Apply, command.Plan, command.Reconfigure, command.Cancel, command.Unlock, command.PolicyCheck, command.ApprovePolicies, command.Version, command.Import, command.State,
 			},
 		},
 		{
 			name:          "all",
 			allowCommands: "all",
 			want: []command.Name{
-				command.Version, command.Plan, command.Apply, command.Cancel, command.Unlock, command.ApprovePolicies, command.Import, command.State,
+				command.Version, command.Plan, command.Reconfigure, command.Apply, command.Cancel, command.Unlock, command.ApprovePolicies, command.Import, command.State,
 			},
 		},
 		{
 			name:          "all with others returns same with all result",
 			allowCommands: "all,plan",
 			want: []command.Name{
-				command.Version, command.Plan, command.Apply, command.Cancel, command.Unlock, command.ApprovePolicies, command.Import, command.State,
+				command.Version, command.Plan, command.Reconfigure, command.Apply, command.Cancel, command.Unlock, command.ApprovePolicies, command.Import, command.State,
 			},
 		},
 		{


### PR DESCRIPTION
## what

- Add an `atlantis reconfigure` PR comment command.
- The command deletes the PR-local Atlantis workspace, clears stale plan status and locks, then runs a normal unqualified `atlantis plan` from the current PR head.
- Add PR-level working directory locking so reconfigure cannot delete a workspace while another command is active for the same pull request.
- Document the command and include it in the default `--allow-commands` list.

## why

- Issue https://github.com/runatlantis/atlantis/issues/5135 describes idle PRs retaining stale local Terraform initialization/cache state after the Atlantis default Terraform version changes.
- A normal unqualified plan can reuse an existing local PR workspace, so operators need an explicit command that forces Atlantis to rebuild that workspace before planning again.
- This intentionally invalidates older applyable plans for the PR so the next apply can only use plans generated after reconfiguration.

## tests

- [x] `go test ./server/events -run 'TestReconfigure|TestRunCommentCommand_Reconfigure|TestTryLockReconfigure|TestTryLockWorkspaceConflictsWithReconfigure|TestUnlockByPullReleasesReconfigure'`
- [x] `go test ./server/events/...`
- [x] `go test ./server ./cmd`
- [x] `make test`
- [x] `git diff --check`
- [x] `goimports -l` over touched Go files

## references

- Closes https://github.com/runatlantis/atlantis/issues/5135