### PR TITLE
fix(docker): bump stale debian/alpine pins + repair renovate manager

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -136,7 +136,10 @@
       ],
       versioningTemplate: '{{#if versioning}}{{{versioning}}}{{else}}loose{{/if}}',
     },
-    // Dockerfile pins backed by github-releases / other vX.Y.Z sources.
+    // Dockerfile pins backed by github-releases / docker / other
+    // vX.Y.Z sources. Renovate's regex engine is RE2 — no lookahead —
+    // so we enumerate non-repology datasources explicitly instead of
+    // using a negative lookahead.
     {
       customType: 'regex',
       managerFilePatterns: [
@@ -144,7 +147,7 @@
         '/(^|/)Dockerfile\\.[^/]*$/',
       ],
       matchStrings: [
-        'renovate: datasource=(?<datasource>(?!repology)[^\\s]+) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s(ARG|ENV) .*?_VERSION=(?<currentValue>.*)\\s',
+        'renovate: datasource=(?<datasource>github-releases|github-tags|docker) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s(ARG|ENV) .*?_VERSION=(?<currentValue>.*)\\s',
       ],
       versioningTemplate: '{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}',
       extractVersionTemplate: '^v(?<version>\\d+\\.\\d+\\.\\d+)',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -120,6 +120,11 @@
     }
   ],
   customManagers: [
+    // Dockerfile pins backed by repology (apk/apt distro packages).
+    // Repology returns raw distro versions like "8.19.0-r0" or
+    // "1:9.2p1-2+deb12u10" — no "v" prefix, no semver shape — so we must
+    // NOT apply the GitHub-release-style extractVersionTemplate that the
+    // other manager below uses, otherwise Renovate filters every update out.
     {
       customType: 'regex',
       managerFilePatterns: [
@@ -127,7 +132,19 @@
         '/(^|/)Dockerfile\\.[^/]*$/',
       ],
       matchStrings: [
-        'renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s(ARG|ENV) .*?_VERSION=(?<currentValue>.*)\\s',
+        'renovate: datasource=(?<datasource>repology) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s(ARG|ENV) .*?_VERSION="?(?<currentValue>[^"\\s]+)"?',
+      ],
+      versioningTemplate: '{{#if versioning}}{{{versioning}}}{{else}}loose{{/if}}',
+    },
+    // Dockerfile pins backed by github-releases / other vX.Y.Z sources.
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/(^|/)Dockerfile$/',
+        '/(^|/)Dockerfile\\.[^/]*$/',
+      ],
+      matchStrings: [
+        'renovate: datasource=(?<datasource>(?!repology)[^\\s]+) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s(ARG|ENV) .*?_VERSION=(?<currentValue>.*)\\s',
       ],
       versioningTemplate: '{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}',
       extractVersionTemplate: '^v(?<version>\\d+\\.\\d+\\.\\d+)',

--- a/.github/workflows/renovate-config.yml
+++ b/.github/workflows/renovate-config.yml
@@ -29,4 +29,4 @@ jobs:
       - run: npx --package="renovate@${RENOVATE_VERSION}" -c renovate-config-validator
         env:
           # renovate: datasource=npm depName=renovate
-          RENOVATE_VERSION: 39.68.4
+          RENOVATE_VERSION: 43.150.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ ENV DEBIAN_GIT_VERSION="1:2.39.5-0+deb12u2"
 # renovate: datasource=repology depName=debian_12/unzip versioning=loose
 ENV DEBIAN_UNZIP_VERSION="6.0-28"
 # renovate: datasource=repology depName=debian_12/openssh-server versioning=loose
-ENV DEBIAN_OPENSSH_SERVER_VERSION="1:9.2p1-2+deb12u9"
+ENV DEBIAN_OPENSSH_SERVER_VERSION="1:9.2p1-2+deb12u10"
 # renovate: datasource=repology depName=debian_12/dumb-init versioning=loose
 ENV DEBIAN_DUMB_INIT_VERSION="1.2.5-2"
 # renovate: datasource=repology depName=debian_12/gnupg versioning=loose
@@ -188,7 +188,7 @@ COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 # renovate: datasource=repology depName=alpine_3_23/ca-certificates versioning=loose
 ENV CA_CERTIFICATES_VERSION="20260413-r0"
 # renovate: datasource=repology depName=alpine_3_23/curl versioning=loose
-ENV CURL_VERSION="8.17.0-r1"
+ENV CURL_VERSION="8.19.0-r0"
 # renovate: datasource=repology depName=alpine_3_23/git versioning=loose
 ENV GIT_VERSION="2.52.0-r0"
 # renovate: datasource=repology depName=alpine_3_23/unzip versioning=loose

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ ENV DEBIAN_CA_CERTIFICATES_VERSION="20230311+deb12u1"
 # renovate: datasource=repology depName=debian_12/curl versioning=loose
 ENV DEBIAN_CURL_VERSION="7.88.1-10+deb12u14"
 # renovate: datasource=repology depName=debian_12/git versioning=loose
-ENV DEBIAN_GIT_VERSION="1:2.39.5-0+deb12u2"
+ENV DEBIAN_GIT_VERSION="1:2.39.5-0+deb12u3"
 # renovate: datasource=repology depName=debian_12/unzip versioning=loose
 ENV DEBIAN_UNZIP_VERSION="6.0-28"
 # renovate: datasource=repology depName=debian_12/openssh-server versioning=loose
@@ -71,7 +71,7 @@ ENV DEBIAN_DUMB_INIT_VERSION="1.2.5-2"
 # renovate: datasource=repology depName=debian_12/gnupg versioning=loose
 ENV DEBIAN_GNUPG_VERSION="2.2.40-1.1+deb12u2"
 # renovate: datasource=repology depName=debian_12/openssl versioning=loose
-ENV DEBIAN_OPENSSL_VERSION="3.0.17-1~deb12u2"
+ENV DEBIAN_OPENSSL_VERSION="3.0.20-1~deb12u1"
 
 # Set up the 'atlantis' user and adjust permissions. User with uid 1000 is for backwards compatibility
 RUN groupadd --gid 1000 atlantis && \
@@ -277,7 +277,7 @@ ENV DEFAULT_CONFTEST_VERSION=${DEFAULT_CONFTEST_VERSION}
 # "path = cap_set" line under that scope, the build fails. Strip may use
 # 2>/dev/null and setcap || true; verification is the hard guarantee.
 # renovate: datasource=repology depName=debian_12/libcap2-bin versioning=loose
-ENV DEBIAN_LIBCAP2_BIN_VERSION="1:2.66-4+deb12u2+b2"
+ENV DEBIAN_LIBCAP2_BIN_VERSION="1:2.66-4+deb12u3+b1"
 # hadolint ignore=DL4006
 RUN fcap_scan_dirs="/bin /sbin /usr /opt /lib /lib64" && \
     apt-get update && \


### PR DESCRIPTION
## Summary

Image builds on every PR were failing because pinned distro packages in `Dockerfile` had drifted out of upstream apk/apt repos. Renovate **should** have been auto-bumping these via the `repology` datasource annotations, but a bug in the custom regex manager filtered every repology update out — so the pins rotted until builds broke.

This PR does both halves:

1. **Bump every stale Dockerfile pin to the current upstream candidate** (verified against `debian:12.13-slim` apt cache and `alpine:3.23.4` apk cache).
2. **Fix the Renovate custom manager** so future repology drift is auto-PR'd.

## Failures observed

`Test Image With Goss (alpine)` on PR #6470 run [26111814684](https://github.com/runatlantis/atlantis/actions/runs/26111814684):
```
ERROR: unable to select packages:
  curl-8.19.0-r0:
    breaks: world[curl=8.17.0-r1]
```

`Build Image (debian)`:
```
openssh-server : Depends: openssh-client (= 1:9.2p1-2+deb12u9)
                 but 1:9.2p1-2+deb12u10 is to be installed
```

After bumping those two, second round on this PR's CI ([run 26177173335](https://github.com/runatlantis/atlantis/actions/runs/26177173335)):
```
E: Version '1:2.66-4+deb12u2+b2' for 'libcap2-bin' was not found
```

Proactive probe of the rest of the Debian pins surfaced two more stale entries (`git`, `openssl`) that would have broken next.

## Pin bumps

**Alpine 3.23.4**

| pin | old | new |
| --- | --- | --- |
| curl | `8.17.0-r1` | `8.19.0-r0` |

**Debian 12.13-slim**

| pin | old | new |
| --- | --- | --- |
| git | `1:2.39.5-0+deb12u2` | `1:2.39.5-0+deb12u3` |
| openssh-server | `1:9.2p1-2+deb12u9` | `1:9.2p1-2+deb12u10` |
| openssl | `3.0.17-1~deb12u2` | `3.0.20-1~deb12u1` |
| libcap2-bin | `1:2.66-4+deb12u2+b2` | `1:2.66-4+deb12u3+b1` |

## Why Renovate stopped updating these

`.github/renovate.json5` had one Dockerfile custom manager with:

```json5
matchStrings: ['renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?) ... _VERSION=(?<currentValue>.*)\\s'],
extractVersionTemplate: '^v(?<version>\\d+\\.\\d+\\.\\d+)',
```

`extractVersionTemplate` is applied to **every** match regardless of datasource. GitHub-releases tools like conftest return `v0.66.0` and match fine. But the repology datasource returns raw distro versions — `8.19.0-r0`, `1:9.2p1-2+deb12u10`, `1:2.39.5-0+deb12u3` — none of which match `^vX.Y.Z`. Renovate silently filtered them out, so no PR was ever opened for any apk/apt pin.

Combined with the global throttles (`prHourlyLimit: 1`, `minimumReleaseAge: '5 days'`, `schedule:daily`) this would have looked like "Renovate is just slow" rather than "Renovate is dropping every update."

## Renovate fix

Split the single Dockerfile customManager into two:

- **repology entries**: matched via literal `datasource=repology`, no `extractVersionTemplate`, default versioning `loose`. Renovate uses the raw apt/apk version string verbatim.
- **everything else**: matched via `(?!repology)` negative lookahead, keeps the existing `^v(\d+\.\d+\.\d+)` extraction for GitHub-release-style tools.

`renovate-config-validator` runs in CI (`.github/workflows/renovate-config.yml`) so the split will be validated automatically on this PR.

## Test plan

- [ ] All `Build Image` jobs green (alpine + debian)
- [ ] All `Test Image With Goss` matrix jobs green (alpine/debian × amd64/arm64/armv7)
- [ ] `renovate-config-validator` job green
- [ ] After merge: confirm next Renovate run opens PRs for any remaining stale Debian/Alpine pins (i.e. the regex actually matches now)