### PR TITLE
fix(vcs): show "up to date" in apply status when plan has no changes

### DIFF
--- a/server/controllers/api_controller.go
+++ b/server/controllers/api_controller.go
@@ -257,13 +257,13 @@ func (a *APIController) apiPlan(request *APIRequest, ctx *command.Context) (*com
 		// When silence is enabled and no projects are found, don't set any VCS status
 		if !a.SilenceVCSStatusNoProjects {
 			ctx.Log.Debug("setting VCS status to success with no projects found")
-			if err := a.CommitStatusUpdater.UpdateCombinedCount(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.SuccessCommitStatus, command.Plan, 0, 0); err != nil {
+			if err := a.CommitStatusUpdater.UpdateCombinedCount(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.SuccessCommitStatus, command.Plan, models.ProjectCounts{}); err != nil {
 				ctx.Log.Warn("unable to update plan status: %s", err)
 			}
-			if err := a.CommitStatusUpdater.UpdateCombinedCount(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.SuccessCommitStatus, command.PolicyCheck, 0, 0); err != nil {
+			if err := a.CommitStatusUpdater.UpdateCombinedCount(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.SuccessCommitStatus, command.PolicyCheck, models.ProjectCounts{}); err != nil {
 				ctx.Log.Warn("unable to update policy check status: %s", err)
 			}
-			if err := a.CommitStatusUpdater.UpdateCombinedCount(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.SuccessCommitStatus, command.Apply, 0, 0); err != nil {
+			if err := a.CommitStatusUpdater.UpdateCombinedCount(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.SuccessCommitStatus, command.Apply, models.ProjectCounts{}); err != nil {
 				ctx.Log.Warn("unable to update apply status: %s", err)
 			}
 		} else {
@@ -305,13 +305,13 @@ func (a *APIController) apiApply(request *APIRequest, ctx *command.Context) (*co
 		// When silence is enabled and no projects are found, don't set any VCS status
 		if !a.SilenceVCSStatusNoProjects {
 			ctx.Log.Debug("setting VCS status to success with no projects found")
-			if err := a.CommitStatusUpdater.UpdateCombinedCount(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.SuccessCommitStatus, command.Plan, 0, 0); err != nil {
+			if err := a.CommitStatusUpdater.UpdateCombinedCount(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.SuccessCommitStatus, command.Plan, models.ProjectCounts{}); err != nil {
 				ctx.Log.Warn("unable to update plan status: %s", err)
 			}
-			if err := a.CommitStatusUpdater.UpdateCombinedCount(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.SuccessCommitStatus, command.PolicyCheck, 0, 0); err != nil {
+			if err := a.CommitStatusUpdater.UpdateCombinedCount(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.SuccessCommitStatus, command.PolicyCheck, models.ProjectCounts{}); err != nil {
 				ctx.Log.Warn("unable to update policy check status: %s", err)
 			}
-			if err := a.CommitStatusUpdater.UpdateCombinedCount(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.SuccessCommitStatus, command.Apply, 0, 0); err != nil {
+			if err := a.CommitStatusUpdater.UpdateCombinedCount(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.SuccessCommitStatus, command.Apply, models.ProjectCounts{}); err != nil {
 				ctx.Log.Warn("unable to update apply status: %s", err)
 			}
 		} else {

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -144,7 +144,7 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 				if pullStatus == nil {
 					// default to 0/0
 					ctx.Log.Debug("setting VCS status to 0/0 success as no previous state was found")
-					if err := a.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.Apply, 0, 0); err != nil {
+					if err := a.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.Apply, models.ProjectCounts{}); err != nil {
 						ctx.Log.Warn("unable to update commit status: %s", err)
 					}
 					return
@@ -157,7 +157,7 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 				// the Atlantis status to be passing for all pull requests.
 				// Does not apply to skipped runs for specific projects
 				ctx.Log.Debug("setting VCS status to success with no projects found")
-				if err := a.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.Apply, 0, 0); err != nil {
+				if err := a.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.Apply, models.ProjectCounts{}); err != nil {
 					ctx.Log.Warn("unable to update commit status: %s", err)
 				}
 			}
@@ -199,9 +199,11 @@ func (a *ApplyCommandRunner) isParallelEnabled(projectCmds []command.ProjectCont
 func (a *ApplyCommandRunner) updateCommitStatus(ctx *command.Context, pullStatus models.PullStatus) {
 	var numSuccess int
 	var numErrored int
+	var numNoChanges int
 	status := models.SuccessCommitStatus
 
-	numSuccess = pullStatus.StatusCount(models.AppliedPlanStatus) + pullStatus.StatusCount(models.PlannedNoChangesPlanStatus)
+	numNoChanges = pullStatus.StatusCount(models.PlannedNoChangesPlanStatus)
+	numSuccess = pullStatus.StatusCount(models.AppliedPlanStatus) + numNoChanges
 	numErrored = pullStatus.StatusCount(models.ErroredApplyStatus)
 
 	if numErrored > 0 {
@@ -218,8 +220,7 @@ func (a *ApplyCommandRunner) updateCommitStatus(ctx *command.Context, pullStatus
 		ctx.Pull,
 		status,
 		command.Apply,
-		numSuccess,
-		len(pullStatus.Projects),
+		models.ProjectCounts{Success: numSuccess, Total: len(pullStatus.Projects), Errored: numErrored, NoChanges: numNoChanges},
 	); err != nil {
 		ctx.Log.Warn("unable to update commit status: %s", err)
 	}

--- a/server/events/apply_command_runner_test.go
+++ b/server/events/apply_command_runner_test.go
@@ -232,8 +232,7 @@ func TestApplyCommandRunner_IsSilenced(t *testing.T) {
 					Any[models.PullRequest](),
 					Eq[models.CommitStatus](models.SuccessCommitStatus),
 					Eq[command.Name](command.Apply),
-					Eq(c.ExpVCSStatusSucc),
-					Eq(c.ExpVCSStatusTotal),
+					Eq(models.ProjectCounts{Success: c.ExpVCSStatusSucc, Total: c.ExpVCSStatusTotal}),
 				)
 			} else {
 				commitUpdater.VerifyWasCalled(Never()).UpdateCombinedCount(
@@ -242,8 +241,7 @@ func TestApplyCommandRunner_IsSilenced(t *testing.T) {
 					Any[models.PullRequest](),
 					Any[models.CommitStatus](),
 					Eq[command.Name](command.Apply),
-					Any[int](),
-					Any[int](),
+					Any[models.ProjectCounts](),
 				)
 			}
 		})
@@ -554,4 +552,70 @@ func TestApplyCommandRunner_ExecutionOrder(t *testing.T) {
 			)
 		})
 	}
+}
+
+func TestApplyCommandRunner_NoChangesCount(t *testing.T) {
+	logger := logging.NewNoopLogger(t)
+	RegisterMockTestingT(t)
+
+	tmp := t.TempDir()
+	db, err := boltdb.New(tmp)
+	t.Cleanup(func() { db.Close() })
+	Ok(t, err)
+
+	setup(t, func(tc *TestConfig) {
+		tc.SilenceNoProjects = true
+		tc.database = db
+	})
+
+	scopeNull := metricstest.NewLoggingScope(t, logger, "atlantis")
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num}
+
+	// Seed the DB: one applied project and one project that planned with no changes.
+	_, err = db.UpdatePullWithResults(modelPull, []command.ProjectResult{
+		{
+			Command:    command.Apply,
+			RepoRelDir: "dir1",
+			Workspace:  "default",
+		},
+		{
+			Command:    command.Plan,
+			RepoRelDir: "dir2",
+			Workspace:  "default",
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PlanSuccess: &models.PlanSuccess{
+					TerraformOutput: "No changes. Infrastructure is up-to-date.",
+				},
+			},
+		},
+	})
+	Ok(t, err)
+
+	pull := &github.PullRequest{State: github.Ptr("open")}
+	When(githubGetter.GetPullRequest(logger, testdata.GithubRepo, testdata.Pull.Num)).ThenReturn(pull, nil)
+	When(eventParsing.ParseGithubPull(logger, pull)).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+
+	// Target a dir that has no new projects so the runner re-reads the existing pull status.
+	cmd := &events.CommentCommand{Name: command.Apply, RepoRelDir: "nomatch"}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    scopeNull,
+		Pull:     modelPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).ThenReturn([]command.ProjectContext{}, nil)
+
+	applyCommandRunner.Run(ctx, cmd)
+
+	// Verify that NoChanges=1 is passed correctly (not Any[int]()).
+	commitUpdater.VerifyWasCalledOnce().UpdateCombinedCount(
+		Any[logging.SimpleLogging](),
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Any[models.CommitStatus](),
+		Eq[command.Name](command.Apply),
+		Eq(models.ProjectCounts{Success: 2, Total: 2, NoChanges: 1}),
+	)
 }

--- a/server/events/approve_policies_command_runner.go
+++ b/server/events/approve_policies_command_runner.go
@@ -68,7 +68,7 @@ func (a *ApprovePoliciesCommandRunner) Run(ctx *command.Context, cmd *CommentCom
 			// with 0/0 projects approve_policies successfully because some users require
 			// the Atlantis status to be passing for all pull requests.
 			ctx.Log.Debug("setting VCS status to success with no projects found")
-			if err := a.commitStatusUpdater.UpdateCombinedCount(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.SuccessCommitStatus, command.PolicyCheck, 0, 0); err != nil {
+			if err := a.commitStatusUpdater.UpdateCombinedCount(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.SuccessCommitStatus, command.PolicyCheck, models.ProjectCounts{}); err != nil {
 				ctx.Log.Warn("unable to update commit status: %s", err)
 			}
 		}
@@ -104,7 +104,7 @@ func (a *ApprovePoliciesCommandRunner) updateCommitStatus(ctx *command.Context, 
 		status = models.FailedCommitStatus
 	}
 
-	if err := a.commitStatusUpdater.UpdateCombinedCount(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, status, command.PolicyCheck, numSuccess, len(pullStatus.Projects)); err != nil {
+	if err := a.commitStatusUpdater.UpdateCombinedCount(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, status, command.PolicyCheck, models.ProjectCounts{Success: numSuccess, Total: len(pullStatus.Projects), Errored: numErrored}); err != nil {
 		ctx.Log.Warn("unable to update commit status: %s", err)
 	}
 }

--- a/server/events/command_runner_internal_test.go
+++ b/server/events/command_runner_internal_test.go
@@ -14,11 +14,13 @@ import (
 
 func TestApplyUpdateCommitStatus(t *testing.T) {
 	cases := map[string]struct {
-		cmd           command.Name
-		pullStatus    models.PullStatus
-		expStatus     models.CommitStatus
-		expNumSuccess int
-		expNumTotal   int
+		cmd             command.Name
+		pullStatus      models.PullStatus
+		expStatus       models.CommitStatus
+		expNumSuccess   int
+		expNumTotal     int
+		expNumErrored   int
+		expNumNoChanges int
 	}{
 		"apply, one pending": {
 			cmd: command.Apply,
@@ -70,6 +72,7 @@ func TestApplyUpdateCommitStatus(t *testing.T) {
 			expStatus:     models.FailedCommitStatus,
 			expNumSuccess: 1,
 			expNumTotal:   3,
+			expNumErrored: 1,
 		},
 		"apply, one planned no changes": {
 			cmd: command.Apply,
@@ -83,9 +86,27 @@ func TestApplyUpdateCommitStatus(t *testing.T) {
 					},
 				},
 			},
-			expStatus:     models.SuccessCommitStatus,
-			expNumSuccess: 2,
-			expNumTotal:   2,
+			expStatus:       models.SuccessCommitStatus,
+			expNumSuccess:   2,
+			expNumTotal:     2,
+			expNumNoChanges: 1,
+		},
+		"apply, one planned no changes and one pending": {
+			cmd: command.Apply,
+			pullStatus: models.PullStatus{
+				Projects: []models.ProjectStatus{
+					{
+						Status: models.PlannedNoChangesPlanStatus,
+					},
+					{
+						Status: models.PlannedPlanStatus,
+					},
+				},
+			},
+			expStatus:       models.PendingCommitStatus,
+			expNumSuccess:   1,
+			expNumTotal:     2,
+			expNumNoChanges: 1,
 		},
 	}
 
@@ -100,8 +121,7 @@ func TestApplyUpdateCommitStatus(t *testing.T) {
 			Equals(t, models.PullRequest{}, csu.CalledPull)
 			Equals(t, c.expStatus, csu.CalledStatus)
 			Equals(t, c.cmd, csu.CalledCommand)
-			Equals(t, c.expNumSuccess, csu.CalledNumSuccess)
-			Equals(t, c.expNumTotal, csu.CalledNumTotal)
+			Equals(t, models.ProjectCounts{Success: c.expNumSuccess, Total: c.expNumTotal, Errored: c.expNumErrored, NoChanges: c.expNumNoChanges}, csu.CalledCounts)
 		})
 	}
 }
@@ -113,6 +133,7 @@ func TestPlanUpdatePlanCommitStatus(t *testing.T) {
 		expStatus     models.CommitStatus
 		expNumSuccess int
 		expNumTotal   int
+		expNumErrored int
 	}{
 		"single plan success": {
 			cmd: command.Plan,
@@ -148,6 +169,7 @@ func TestPlanUpdatePlanCommitStatus(t *testing.T) {
 			expStatus:     models.FailedCommitStatus,
 			expNumSuccess: 3,
 			expNumTotal:   4,
+			expNumErrored: 1,
 		},
 	}
 
@@ -162,8 +184,7 @@ func TestPlanUpdatePlanCommitStatus(t *testing.T) {
 			Equals(t, models.PullRequest{}, csu.CalledPull)
 			Equals(t, c.expStatus, csu.CalledStatus)
 			Equals(t, c.cmd, csu.CalledCommand)
-			Equals(t, c.expNumSuccess, csu.CalledNumSuccess)
-			Equals(t, c.expNumTotal, csu.CalledNumTotal)
+			Equals(t, models.ProjectCounts{Success: c.expNumSuccess, Total: c.expNumTotal, Errored: c.expNumErrored}, csu.CalledCounts)
 		})
 	}
 }
@@ -176,6 +197,8 @@ func TestPlanUpdateApplyCommitStatus(t *testing.T) {
 		doNotCallUpdateApply bool // In certain situations, we don't expect updateCommitStatus to call the underlying commitStatusUpdater code at all
 		expNumSuccess        int
 		expNumTotal          int
+		expNumErrored        int
+		expNumNoChanges      int
 	}{
 		"all plans success with no changes": {
 			cmd: command.Apply,
@@ -189,9 +212,10 @@ func TestPlanUpdateApplyCommitStatus(t *testing.T) {
 					},
 				},
 			},
-			expStatus:     models.SuccessCommitStatus,
-			expNumSuccess: 2,
-			expNumTotal:   2,
+			expStatus:       models.SuccessCommitStatus,
+			expNumSuccess:   2,
+			expNumTotal:     2,
+			expNumNoChanges: 2,
 		},
 		"one plan, one plan success with no changes": {
 			cmd: command.Apply,
@@ -239,9 +263,31 @@ func TestPlanUpdateApplyCommitStatus(t *testing.T) {
 					},
 				},
 			},
+			expStatus:       models.FailedCommitStatus,
+			expNumSuccess:   2,
+			expNumTotal:     3,
+			expNumErrored:   1,
+			expNumNoChanges: 1,
+		},
+		"one apply error, one pending plan": {
+			cmd: command.Apply,
+			pullStatus: models.PullStatus{
+				Projects: []models.ProjectStatus{
+					{
+						Status: models.ErroredApplyStatus,
+					},
+					{
+						Status: models.AppliedPlanStatus,
+					},
+					{
+						Status: models.PlannedPlanStatus,
+					},
+				},
+			},
 			expStatus:     models.FailedCommitStatus,
-			expNumSuccess: 2,
+			expNumSuccess: 1,
 			expNumTotal:   3,
+			expNumErrored: 1,
 		},
 	}
 
@@ -260,31 +306,142 @@ func TestPlanUpdateApplyCommitStatus(t *testing.T) {
 				Equals(t, models.PullRequest{}, csu.CalledPull)
 				Equals(t, c.expStatus, csu.CalledStatus)
 				Equals(t, c.cmd, csu.CalledCommand)
-				Equals(t, c.expNumSuccess, csu.CalledNumSuccess)
-				Equals(t, c.expNumTotal, csu.CalledNumTotal)
+				Equals(t, models.ProjectCounts{Success: c.expNumSuccess, Total: c.expNumTotal, Errored: c.expNumErrored, NoChanges: c.expNumNoChanges}, csu.CalledCounts)
 			}
 		})
 	}
 }
 
-type MockCSU struct {
-	CalledRepo       models.Repo
-	CalledPull       models.PullRequest
-	CalledStatus     models.CommitStatus
-	CalledCommand    command.Name
-	CalledNumSuccess int
-	CalledNumTotal   int
-	Called           bool
+func TestPlanUpdateApplyCommitStatus_GitLabPendingWithNoChanges(t *testing.T) {
+	csu := &MockCSU{}
+	runner := &PlanCommandRunner{
+		commitStatusUpdater: csu,
+		PendingApplyStatus:  true,
+	}
+	pullStatus := models.PullStatus{
+		Projects: []models.ProjectStatus{
+			{
+				Status: models.PlannedNoChangesPlanStatus,
+			},
+			{
+				Status: models.PlannedPlanStatus,
+			},
+		},
+	}
+	ctx := &command.Context{
+		Log: logging.NewNoopLogger(t),
+		Pull: models.PullRequest{
+			BaseRepo: models.Repo{
+				VCSHost: models.VCSHost{
+					Type: models.Gitlab,
+				},
+			},
+		},
+	}
+
+	runner.updateCommitStatus(ctx, pullStatus, command.Apply)
+
+	Equals(t, true, csu.Called)
+	Equals(t, models.PendingCommitStatus, csu.CalledStatus)
+	Equals(t, command.Apply, csu.CalledCommand)
+	Equals(t, models.ProjectCounts{Success: 1, Total: 2, NoChanges: 1}, csu.CalledCounts)
 }
 
-func (m *MockCSU) UpdateCombinedCount(_ logging.SimpleLogging, repo models.Repo, pull models.PullRequest, status models.CommitStatus, command command.Name, numSuccess int, numTotal int) error {
+func TestPolicyCheckUpdateCommitStatus(t *testing.T) {
+	cases := map[string]struct {
+		pullStatus    models.PullStatus
+		expStatus     models.CommitStatus
+		expNumSuccess int
+		expNumTotal   int
+		expNumErrored int
+	}{
+		"all policy checks passed": {
+			pullStatus: models.PullStatus{
+				Projects: []models.ProjectStatus{
+					{
+						Status: models.PassedPolicyCheckStatus,
+					},
+					{
+						Status: models.PassedPolicyCheckStatus,
+					},
+				},
+			},
+			expStatus:     models.SuccessCommitStatus,
+			expNumSuccess: 2,
+			expNumTotal:   2,
+		},
+		"one policy check failed, one untouched project": {
+			pullStatus: models.PullStatus{
+				Projects: []models.ProjectStatus{
+					{
+						Status: models.ErroredPolicyCheckStatus,
+					},
+					{
+						Status: models.PlannedPlanStatus,
+					},
+				},
+			},
+			expStatus:     models.FailedCommitStatus,
+			expNumTotal:   2,
+			expNumErrored: 1,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			csu := &MockCSU{}
+			runner := &PolicyCheckCommandRunner{
+				commitStatusUpdater: csu,
+			}
+			runner.updateCommitStatus(&command.Context{}, c.pullStatus)
+			Equals(t, models.Repo{}, csu.CalledRepo)
+			Equals(t, models.PullRequest{}, csu.CalledPull)
+			Equals(t, c.expStatus, csu.CalledStatus)
+			Equals(t, command.PolicyCheck, csu.CalledCommand)
+			Equals(t, models.ProjectCounts{Success: c.expNumSuccess, Total: c.expNumTotal, Errored: c.expNumErrored}, csu.CalledCounts)
+		})
+	}
+}
+
+func TestApprovePoliciesUpdateCommitStatus(t *testing.T) {
+	pullStatus := models.PullStatus{
+		Projects: []models.ProjectStatus{
+			{
+				Status: models.ErroredPolicyCheckStatus,
+			},
+			{
+				Status: models.PlannedPlanStatus,
+			},
+		},
+	}
+	csu := &MockCSU{}
+	runner := &ApprovePoliciesCommandRunner{
+		commitStatusUpdater: csu,
+	}
+
+	runner.updateCommitStatus(&command.Context{}, pullStatus)
+
+	Equals(t, models.FailedCommitStatus, csu.CalledStatus)
+	Equals(t, command.PolicyCheck, csu.CalledCommand)
+	Equals(t, models.ProjectCounts{Total: 2, Errored: 1}, csu.CalledCounts)
+}
+
+type MockCSU struct {
+	CalledRepo    models.Repo
+	CalledPull    models.PullRequest
+	CalledStatus  models.CommitStatus
+	CalledCommand command.Name
+	CalledCounts  models.ProjectCounts
+	Called        bool
+}
+
+func (m *MockCSU) UpdateCombinedCount(_ logging.SimpleLogging, repo models.Repo, pull models.PullRequest, status models.CommitStatus, command command.Name, counts models.ProjectCounts) error {
 	m.Called = true
 	m.CalledRepo = repo
 	m.CalledPull = pull
 	m.CalledStatus = status
 	m.CalledCommand = command
-	m.CalledNumSuccess = numSuccess
-	m.CalledNumTotal = numTotal
+	m.CalledCounts = counts
 	return nil
 }
 

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -424,8 +424,7 @@ func TestRunCommentCommandPlan_NoProjects_SilenceEnabled(t *testing.T) {
 		Any[models.PullRequest](),
 		Eq[models.CommitStatus](models.SuccessCommitStatus),
 		Eq[command.Name](command.Plan),
-		Eq(0),
-		Eq(0),
+		Eq(models.ProjectCounts{}),
 	)
 }
 
@@ -448,8 +447,7 @@ func TestRunCommentCommandPlan_NoProjectsTarget_SilenceEnabled(t *testing.T) {
 		Any[models.PullRequest](),
 		Eq[models.CommitStatus](models.SuccessCommitStatus),
 		Eq[command.Name](command.Plan),
-		Eq(0),
-		Eq(0),
+		Eq(models.ProjectCounts{}),
 	)
 }
 
@@ -546,7 +544,7 @@ func TestRunCommentCommand_DisableAutoplan(t *testing.T) {
 				CommandName: command.Plan,
 			},
 		}, nil)
-	When(commitUpdater.UpdateCombinedCount(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Any[models.CommitStatus](), Any[command.Name](), Any[int](), Any[int]())).ThenReturn(nil)
+	When(commitUpdater.UpdateCombinedCount(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Any[models.CommitStatus](), Any[command.Name](), Any[models.ProjectCounts]())).ThenReturn(nil)
 	ch.RunAutoplanCommand(testdata.GithubRepo, testdata.GithubRepo, modelPull, testdata.User)
 	projectCommandBuilder.VerifyWasCalled(Never()).BuildAutoplanCommands(Any[*command.Context]())
 }

--- a/server/events/commit_status_updater.go
+++ b/server/events/commit_status_updater.go
@@ -26,9 +26,9 @@ type CommitStatusUpdater interface {
 	// UpdateCombined updates the combined status of the head commit of pull.
 	// A combined status represents all the projects modified in the pull.
 	UpdateCombined(logger logging.SimpleLogging, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName command.Name) error
-	// UpdateCombinedCount updates the combined status to reflect the
-	// numSuccess out of numTotal.
-	UpdateCombinedCount(logger logging.SimpleLogging, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName command.Name, numSuccess int, numTotal int) error
+	// UpdateCombinedCount updates the combined status to reflect the counts
+	// of project outcomes. counts.NoChanges is only meaningful for command.Apply.
+	UpdateCombinedCount(logger logging.SimpleLogging, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName command.Name, counts models.ProjectCounts) error
 
 	UpdatePreWorkflowHook(logger logging.SimpleLogging, pull models.PullRequest, status models.CommitStatus, hookDescription string, runtimeDescription string, url string) error
 	UpdatePostWorkflowHook(logger logging.SimpleLogging, pull models.PullRequest, status models.CommitStatus, hookDescription string, runtimeDescription string, url string) error
@@ -59,20 +59,60 @@ func (d *DefaultCommitStatusUpdater) UpdateCombined(logger logging.SimpleLogging
 	return d.Client.UpdateStatus(logger, repo, pull, status, src, descripWords, "")
 }
 
-func (d *DefaultCommitStatusUpdater) UpdateCombinedCount(logger logging.SimpleLogging, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName command.Name, numSuccess int, numTotal int) error {
+func (d *DefaultCommitStatusUpdater) UpdateCombinedCount(logger logging.SimpleLogging, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName command.Name, counts models.ProjectCounts) error {
 	src := truncateContext(fmt.Sprintf("%s/%s", d.StatusName, cmdName.String()))
-	cmdVerb := "unknown"
 
+	var descrip string
 	switch cmdName {
-	case command.Plan:
-		cmdVerb = "planned"
-	case command.PolicyCheck:
-		cmdVerb = "policies checked"
 	case command.Apply:
-		cmdVerb = "applied"
+		switch {
+		case status == models.FailedCommitStatus:
+			descrip = fmt.Sprintf("%d/%d projects failed to apply.", counts.Errored, counts.Total)
+		case status == models.PendingCommitStatus:
+			applied := counts.Success - counts.NoChanges
+			if counts.NoChanges > 0 {
+				descrip = fmt.Sprintf("%d/%d projects applied (%d up to date).", applied, counts.Total, counts.NoChanges)
+			} else {
+				descrip = fmt.Sprintf("%d/%d projects applied.", applied, counts.Total)
+			}
+		case counts.NoChanges > 0 && counts.NoChanges == counts.Total:
+			descrip = fmt.Sprintf("%d/%d projects up to date.", counts.NoChanges, counts.Total)
+		case counts.NoChanges > 0 && counts.Success > counts.NoChanges:
+			applied := counts.Success - counts.NoChanges
+			descrip = fmt.Sprintf("%d/%d projects applied successfully (%d up to date).", applied, counts.Total, counts.NoChanges)
+		default:
+			descrip = fmt.Sprintf("%d/%d projects applied successfully.", counts.Success, counts.Total)
+		}
+	case command.Plan:
+		switch status {
+		case models.FailedCommitStatus:
+			descrip = fmt.Sprintf("%d/%d projects failed to plan.", counts.Total-counts.Success, counts.Total)
+		case models.PendingCommitStatus:
+			descrip = fmt.Sprintf("%d/%d projects planned.", counts.Success, counts.Total)
+		default:
+			descrip = fmt.Sprintf("%d/%d projects planned successfully.", counts.Success, counts.Total)
+		}
+	case command.PolicyCheck:
+		switch status {
+		case models.FailedCommitStatus:
+			descrip = fmt.Sprintf("%d/%d projects failed policy checks.", counts.Errored, counts.Total)
+		case models.PendingCommitStatus:
+			descrip = fmt.Sprintf("%d/%d projects had policies checked.", counts.Success, counts.Total)
+		default:
+			descrip = fmt.Sprintf("%d/%d projects had policies checked successfully.", counts.Success, counts.Total)
+		}
+	default:
+		switch status {
+		case models.FailedCommitStatus:
+			descrip = fmt.Sprintf("%d/%d projects failed.", counts.Total-counts.Success, counts.Total)
+		case models.PendingCommitStatus:
+			descrip = fmt.Sprintf("%d/%d projects completed.", counts.Success, counts.Total)
+		default:
+			descrip = fmt.Sprintf("%d/%d projects succeeded.", counts.Success, counts.Total)
+		}
 	}
 
-	return d.Client.UpdateStatus(logger, repo, pull, status, src, fmt.Sprintf("%d/%d projects %s successfully.", numSuccess, numTotal, cmdVerb), "")
+	return d.Client.UpdateStatus(logger, repo, pull, status, src, descrip, "")
 }
 
 func (d *DefaultCommitStatusUpdater) UpdateProject(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus, url string, result *command.ProjectCommandOutput) error {

--- a/server/events/commit_status_updater_test.go
+++ b/server/events/commit_status_updater_test.go
@@ -126,6 +126,7 @@ func TestUpdateCombinedCount(t *testing.T) {
 		command    command.Name
 		numSuccess int
 		numTotal   int
+		numErrored int
 		expDescrip string
 	}{
 		{
@@ -133,14 +134,14 @@ func TestUpdateCombinedCount(t *testing.T) {
 			command:    command.Plan,
 			numSuccess: 0,
 			numTotal:   2,
-			expDescrip: "0/2 projects planned successfully.",
+			expDescrip: "0/2 projects planned.",
 		},
 		{
 			status:     models.FailedCommitStatus,
 			command:    command.Plan,
 			numSuccess: 1,
 			numTotal:   2,
-			expDescrip: "1/2 projects planned successfully.",
+			expDescrip: "1/2 projects failed to plan.",
 		},
 		{
 			status:     models.SuccessCommitStatus,
@@ -151,17 +152,34 @@ func TestUpdateCombinedCount(t *testing.T) {
 		},
 		{
 			status:     models.FailedCommitStatus,
+			command:    command.PolicyCheck,
+			numSuccess: 0,
+			numTotal:   2,
+			numErrored: 1,
+			expDescrip: "1/2 projects failed policy checks.",
+		},
+		{
+			status:     models.FailedCommitStatus,
 			command:    command.Apply,
 			numSuccess: 0,
 			numTotal:   2,
-			expDescrip: "0/2 projects applied successfully.",
+			numErrored: 2,
+			expDescrip: "2/2 projects failed to apply.",
+		},
+		{
+			status:     models.FailedCommitStatus,
+			command:    command.Apply,
+			numSuccess: 1,
+			numTotal:   3,
+			numErrored: 1,
+			expDescrip: "1/3 projects failed to apply.",
 		},
 		{
 			status:     models.PendingCommitStatus,
 			command:    command.Apply,
 			numSuccess: 1,
 			numTotal:   2,
-			expDescrip: "1/2 projects applied successfully.",
+			expDescrip: "1/2 projects applied.",
 		},
 		{
 			status:     models.SuccessCommitStatus,
@@ -177,10 +195,68 @@ func TestUpdateCombinedCount(t *testing.T) {
 			RegisterMockTestingT(t)
 			client := mocks.NewMockClient()
 			s := events.DefaultCommitStatusUpdater{Client: client, StatusName: "atlantis-test"}
-			err := s.UpdateCombinedCount(logger, models.Repo{}, models.PullRequest{}, c.status, c.command, c.numSuccess, c.numTotal)
+			err := s.UpdateCombinedCount(logger, models.Repo{}, models.PullRequest{}, c.status, c.command, models.ProjectCounts{Success: c.numSuccess, Total: c.numTotal, Errored: c.numErrored})
 			Ok(t, err)
 
 			expSrc := fmt.Sprintf("%s/%s", s.StatusName, c.command)
+			client.VerifyWasCalledOnce().UpdateStatus(logger, models.Repo{}, models.PullRequest{}, c.status, expSrc, c.expDescrip, "")
+		})
+	}
+}
+
+func TestUpdateCombinedCountNoChanges(t *testing.T) {
+	logger := logging.NewNoopLogger(t)
+	cases := []struct {
+		name         string
+		status       models.CommitStatus
+		numSuccess   int
+		numTotal     int
+		numNoChanges int
+		expDescrip   string
+	}{
+		{
+			name:         "all up to date",
+			status:       models.SuccessCommitStatus,
+			numSuccess:   2,
+			numTotal:     2,
+			numNoChanges: 2,
+			expDescrip:   "2/2 projects up to date.",
+		},
+		{
+			name:         "mixed: applied and no-change",
+			status:       models.SuccessCommitStatus,
+			numSuccess:   3,
+			numTotal:     3,
+			numNoChanges: 1,
+			expDescrip:   "2/3 projects applied successfully (1 up to date).",
+		},
+		{
+			name:         "pending: no-change and unapplied",
+			status:       models.PendingCommitStatus,
+			numSuccess:   1,
+			numTotal:     2,
+			numNoChanges: 1,
+			expDescrip:   "0/2 projects applied (1 up to date).",
+		},
+		{
+			name:         "pending: applied, no-change, and unapplied",
+			status:       models.PendingCommitStatus,
+			numSuccess:   2,
+			numTotal:     3,
+			numNoChanges: 1,
+			expDescrip:   "1/3 projects applied (1 up to date).",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			RegisterMockTestingT(t)
+			client := mocks.NewMockClient()
+			s := events.DefaultCommitStatusUpdater{Client: client, StatusName: "atlantis-test"}
+			err := s.UpdateCombinedCount(logger, models.Repo{}, models.PullRequest{}, c.status, command.Apply, models.ProjectCounts{Success: c.numSuccess, Total: c.numTotal, NoChanges: c.numNoChanges})
+			Ok(t, err)
+
+			expSrc := fmt.Sprintf("%s/apply", s.StatusName)
 			client.VerifyWasCalledOnce().UpdateStatus(logger, models.Repo{}, models.PullRequest{}, c.status, expSrc, c.expDescrip, "")
 		})
 	}
@@ -193,12 +269,12 @@ func TestUpdateCombinedCountTruncatesLongContext(t *testing.T) {
 	s := events.DefaultCommitStatusUpdater{Client: client, StatusName: strings.Repeat("a", 260)}
 	originalSrc := fmt.Sprintf("%s/%s", s.StatusName, command.Plan)
 
-	err := s.UpdateCombinedCount(logger, models.Repo{}, models.PullRequest{}, models.PendingCommitStatus, command.Plan, 0, 2)
+	err := s.UpdateCombinedCount(logger, models.Repo{}, models.PullRequest{}, models.PendingCommitStatus, command.Plan, models.ProjectCounts{Total: 2})
 	Ok(t, err)
 
 	_, _, _, _, src, _, _ := client.VerifyWasCalledOnce().UpdateStatus(
 		Any[logging.SimpleLogging](), Eq(models.Repo{}), Eq(models.PullRequest{}),
-		Eq(models.PendingCommitStatus), Any[string](), Eq("0/2 projects planned successfully."), Eq("")).GetCapturedArguments()
+		Eq(models.PendingCommitStatus), Any[string](), Eq("0/2 projects planned."), Eq("")).GetCapturedArguments()
 	assertTruncatedStatusContext(t, src, originalSrc)
 }
 

--- a/server/events/mocks/mock_commit_status_updater.go
+++ b/server/events/mocks/mock_commit_status_updater.go
@@ -42,11 +42,11 @@ func (mock *MockCommitStatusUpdater) UpdateCombined(logger logging.SimpleLogging
 	return _ret0
 }
 
-func (mock *MockCommitStatusUpdater) UpdateCombinedCount(logger logging.SimpleLogging, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName command.Name, numSuccess int, numTotal int) error {
+func (mock *MockCommitStatusUpdater) UpdateCombinedCount(logger logging.SimpleLogging, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName command.Name, counts models.ProjectCounts) error {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockCommitStatusUpdater().")
 	}
-	_params := []pegomock.Param{logger, repo, pull, status, cmdName, numSuccess, numTotal}
+	_params := []pegomock.Param{logger, repo, pull, status, cmdName, counts}
 	_result := pegomock.GetGenericMockFrom(mock).Invoke("UpdateCombinedCount", _params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
 	var _ret0 error
 	if len(_result) != 0 {
@@ -177,8 +177,8 @@ func (c *MockCommitStatusUpdater_UpdateCombined_OngoingVerification) GetAllCaptu
 	return
 }
 
-func (verifier *VerifierMockCommitStatusUpdater) UpdateCombinedCount(logger logging.SimpleLogging, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName command.Name, numSuccess int, numTotal int) *MockCommitStatusUpdater_UpdateCombinedCount_OngoingVerification {
-	_params := []pegomock.Param{logger, repo, pull, status, cmdName, numSuccess, numTotal}
+func (verifier *VerifierMockCommitStatusUpdater) UpdateCombinedCount(logger logging.SimpleLogging, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName command.Name, counts models.ProjectCounts) *MockCommitStatusUpdater_UpdateCombinedCount_OngoingVerification {
+	_params := []pegomock.Param{logger, repo, pull, status, cmdName, counts}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "UpdateCombinedCount", _params, verifier.timeout)
 	return &MockCommitStatusUpdater_UpdateCombinedCount_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -188,12 +188,12 @@ type MockCommitStatusUpdater_UpdateCombinedCount_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockCommitStatusUpdater_UpdateCombinedCount_OngoingVerification) GetCapturedArguments() (logging.SimpleLogging, models.Repo, models.PullRequest, models.CommitStatus, command.Name, int, int) {
-	logger, repo, pull, status, cmdName, numSuccess, numTotal := c.GetAllCapturedArguments()
-	return logger[len(logger)-1], repo[len(repo)-1], pull[len(pull)-1], status[len(status)-1], cmdName[len(cmdName)-1], numSuccess[len(numSuccess)-1], numTotal[len(numTotal)-1]
+func (c *MockCommitStatusUpdater_UpdateCombinedCount_OngoingVerification) GetCapturedArguments() (logging.SimpleLogging, models.Repo, models.PullRequest, models.CommitStatus, command.Name, models.ProjectCounts) {
+	logger, repo, pull, status, cmdName, counts := c.GetAllCapturedArguments()
+	return logger[len(logger)-1], repo[len(repo)-1], pull[len(pull)-1], status[len(status)-1], cmdName[len(cmdName)-1], counts[len(counts)-1]
 }
 
-func (c *MockCommitStatusUpdater_UpdateCombinedCount_OngoingVerification) GetAllCapturedArguments() (_param0 []logging.SimpleLogging, _param1 []models.Repo, _param2 []models.PullRequest, _param3 []models.CommitStatus, _param4 []command.Name, _param5 []int, _param6 []int) {
+func (c *MockCommitStatusUpdater_UpdateCombinedCount_OngoingVerification) GetAllCapturedArguments() (_param0 []logging.SimpleLogging, _param1 []models.Repo, _param2 []models.PullRequest, _param3 []models.CommitStatus, _param4 []command.Name, _param5 []models.ProjectCounts) {
 	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(_params) > 0 {
 		if len(_params) > 0 {
@@ -227,15 +227,9 @@ func (c *MockCommitStatusUpdater_UpdateCombinedCount_OngoingVerification) GetAll
 			}
 		}
 		if len(_params) > 5 {
-			_param5 = make([]int, len(c.methodInvocations))
+			_param5 = make([]models.ProjectCounts, len(c.methodInvocations))
 			for u, param := range _params[5] {
-				_param5[u] = param.(int)
-			}
-		}
-		if len(_params) > 6 {
-			_param6 = make([]int, len(c.methodInvocations))
-			for u, param := range _params[6] {
-				_param6[u] = param.(int)
+				_param5[u] = param.(models.ProjectCounts)
 			}
 		}
 	}

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -703,6 +703,17 @@ func (p PullStatus) StatusCount(status ProjectPlanStatus) int {
 	return c
 }
 
+// ProjectCounts holds the success/failure counts for a set of project operations.
+// For command.Apply: Errored counts projects with apply errors. NoChanges is a
+// subset of Success (projects that were already up to date count as successful).
+// NoChanges is ignored for all other commands.
+type ProjectCounts struct {
+	Success   int
+	Total     int
+	Errored   int
+	NoChanges int
+}
+
 // ProjectStatus is the status of a specific project.
 type ProjectStatus struct {
 	Workspace   string

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -129,13 +129,13 @@ func (p *PlanCommandRunner) runAutoplan(ctx *command.Context) {
 			// with 0/0 projects planned/policy_checked/applied successfully because some users require
 			// the Atlantis status to be passing for all pull requests.
 			ctx.Log.Debug("setting VCS status to success with no projects found")
-			if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.Plan, 0, 0); err != nil {
+			if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.Plan, models.ProjectCounts{}); err != nil {
 				ctx.Log.Warn("unable to update commit status: %s", err)
 			}
-			if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.PolicyCheck, 0, 0); err != nil {
+			if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.PolicyCheck, models.ProjectCounts{}); err != nil {
 				ctx.Log.Warn("unable to update commit status: %s", err)
 			}
-			if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.Apply, 0, 0); err != nil {
+			if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.Apply, models.ProjectCounts{}); err != nil {
 				ctx.Log.Warn("unable to update commit status: %s", err)
 			}
 		} else {
@@ -233,7 +233,7 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 				if pullStatus == nil {
 					// default to 0/0
 					ctx.Log.Debug("setting VCS status to 0/0 success as no previous state was found")
-					if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.Plan, 0, 0); err != nil {
+					if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.Plan, models.ProjectCounts{}); err != nil {
 						ctx.Log.Warn("unable to update commit status: %s", err)
 					}
 					return
@@ -246,13 +246,13 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 				// the Atlantis status to be passing for all pull requests.
 				// Does not apply to skipped runs for specific projects
 				ctx.Log.Debug("setting VCS status to success with no projects found")
-				if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.Plan, 0, 0); err != nil {
+				if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.Plan, models.ProjectCounts{}); err != nil {
 					ctx.Log.Warn("unable to update commit status: %s", err)
 				}
-				if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.PolicyCheck, 0, 0); err != nil {
+				if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.PolicyCheck, models.ProjectCounts{}); err != nil {
 					ctx.Log.Warn("unable to update commit status: %s", err)
 				}
-				if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.Apply, 0, 0); err != nil {
+				if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.Apply, models.ProjectCounts{}); err != nil {
 					ctx.Log.Warn("unable to update commit status: %s", err)
 				}
 			}
@@ -314,7 +314,7 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 		// with 0/0 projects planned/policy_checked/applied successfully because some users require
 		// the Atlantis status to be passing for all pull requests.
 		ctx.Log.Debug("setting VCS status to success with no projects found")
-		if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.PolicyCheck, 0, 0); err != nil {
+		if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.PolicyCheck, models.ProjectCounts{}); err != nil {
 			ctx.Log.Warn("unable to update commit status: %s", err)
 		}
 	}
@@ -331,6 +331,7 @@ func (p *PlanCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 func (p *PlanCommandRunner) updateCommitStatus(ctx *command.Context, pullStatus models.PullStatus, commandName command.Name) {
 	var numSuccess int
 	var numErrored int
+	var numNoChanges int
 	status := models.SuccessCommitStatus
 
 	switch commandName {
@@ -345,7 +346,8 @@ func (p *PlanCommandRunner) updateCommitStatus(ctx *command.Context, pullStatus 
 			status = models.FailedCommitStatus
 		}
 	case command.Apply:
-		numSuccess = pullStatus.StatusCount(models.AppliedPlanStatus) + pullStatus.StatusCount(models.PlannedNoChangesPlanStatus)
+		numNoChanges = pullStatus.StatusCount(models.PlannedNoChangesPlanStatus)
+		numSuccess = pullStatus.StatusCount(models.AppliedPlanStatus) + numNoChanges
 		numErrored = pullStatus.StatusCount(models.ErroredApplyStatus)
 
 		if numErrored > 0 {
@@ -375,8 +377,7 @@ func (p *PlanCommandRunner) updateCommitStatus(ctx *command.Context, pullStatus 
 		ctx.Pull,
 		status,
 		commandName,
-		numSuccess,
-		len(pullStatus.Projects),
+		models.ProjectCounts{Success: numSuccess, Total: len(pullStatus.Projects), Errored: numErrored, NoChanges: numNoChanges},
 	); err != nil {
 		ctx.Log.Warn("unable to update commit status: %s", err)
 	}

--- a/server/events/plan_command_runner_test.go
+++ b/server/events/plan_command_runner_test.go
@@ -147,8 +147,7 @@ func TestPlanCommandRunner_IsSilenced(t *testing.T) {
 					Any[models.PullRequest](),
 					Eq[models.CommitStatus](models.SuccessCommitStatus),
 					Eq[command.Name](command.Plan),
-					Eq(c.ExpVCSStatusSucc),
-					Eq(c.ExpVCSStatusTotal),
+					Eq(models.ProjectCounts{Success: c.ExpVCSStatusSucc, Total: c.ExpVCSStatusTotal}),
 				)
 			} else {
 				commitUpdater.VerifyWasCalled(Never()).UpdateCombinedCount(
@@ -157,8 +156,7 @@ func TestPlanCommandRunner_IsSilenced(t *testing.T) {
 					Any[models.PullRequest](),
 					Any[models.CommitStatus](),
 					Eq[command.Name](command.Plan),
-					Any[int](),
-					Any[int](),
+					Any[models.ProjectCounts](),
 				)
 			}
 		})
@@ -562,9 +560,10 @@ func TestPlanCommandRunner_AtlantisApplyStatus(t *testing.T) {
 		ProjectContexts        []command.ProjectContext
 		ProjectCommandOutput   []command.ProjectCommandOutput
 		PrevPlanStored         bool // stores a previous "No changes" plan in the database
-		DoNotUpdateApply       bool // certain circumtances we want to skip the call to update apply
+		DoNotUpdateApply       bool // certain circumstances we want to skip the call to update apply
 		ExpVCSApplyStatusTotal int
 		ExpVCSApplyStatusSucc  int
+		ExpVCSApplyNoChanges   int
 	}{
 		{
 			Description: "When planning with changes, do not change the apply status",
@@ -600,6 +599,7 @@ func TestPlanCommandRunner_AtlantisApplyStatus(t *testing.T) {
 			},
 			ExpVCSApplyStatusTotal: 1,
 			ExpVCSApplyStatusSucc:  1,
+			ExpVCSApplyNoChanges:   1,
 		},
 		{
 			Description: "When planning with no changes and previous plan with no changes do not set the apply status",
@@ -637,6 +637,7 @@ func TestPlanCommandRunner_AtlantisApplyStatus(t *testing.T) {
 			PrevPlanStored:         true,
 			ExpVCSApplyStatusTotal: 2,
 			ExpVCSApplyStatusSucc:  2,
+			ExpVCSApplyNoChanges:   2,
 		},
 		{
 			Description: "When planning again with changes following a previous 'No changes' plan do not set the apply status",
@@ -713,6 +714,7 @@ func TestPlanCommandRunner_AtlantisApplyStatus(t *testing.T) {
 			PrevPlanStored:         true,
 			ExpVCSApplyStatusTotal: 2,
 			ExpVCSApplyStatusSucc:  2,
+			ExpVCSApplyNoChanges:   2,
 		},
 	}
 
@@ -781,8 +783,7 @@ func TestPlanCommandRunner_AtlantisApplyStatus(t *testing.T) {
 					Any[models.PullRequest](),
 					Any[models.CommitStatus](),
 					Eq[command.Name](command.Apply),
-					AnyInt(),
-					AnyInt(),
+					Any[models.ProjectCounts](),
 				)
 			} else {
 				commitUpdater.VerifyWasCalledOnce().UpdateCombinedCount(
@@ -791,8 +792,7 @@ func TestPlanCommandRunner_AtlantisApplyStatus(t *testing.T) {
 					Any[models.PullRequest](),
 					Eq[models.CommitStatus](ExpCommitStatus),
 					Eq[command.Name](command.Apply),
-					Eq(c.ExpVCSApplyStatusSucc),
-					Eq(c.ExpVCSApplyStatusTotal),
+					Eq(models.ProjectCounts{Success: c.ExpVCSApplyStatusSucc, Total: c.ExpVCSApplyStatusTotal, NoChanges: c.ExpVCSApplyNoChanges}),
 				)
 			}
 		})
@@ -857,8 +857,7 @@ func TestPlanCommandRunner_SilenceFlagsClearsPendingStatus(t *testing.T) {
 			Any[models.PullRequest](),
 			Any[models.CommitStatus](),
 			Any[command.Name](),
-			Any[int](),
-			Any[int](),
+			Any[models.ProjectCounts](),
 		)
 	})
 }
@@ -965,6 +964,7 @@ func TestPlanCommandRunner_PendingApplyStatus(t *testing.T) {
 		ExpApplyStatus         models.CommitStatus
 		ExpVCSApplyStatusTotal int
 		ExpVCSApplyStatusSucc  int
+		ExpVCSApplyNoChanges   int
 		ExpShouldUpdateStatus  bool
 	}{
 		{
@@ -1023,6 +1023,7 @@ func TestPlanCommandRunner_PendingApplyStatus(t *testing.T) {
 			ExpApplyStatus:         models.SuccessCommitStatus,
 			ExpVCSApplyStatusTotal: 1,
 			ExpVCSApplyStatusSucc:  1,
+			ExpVCSApplyNoChanges:   1,
 			ExpShouldUpdateStatus:  true,
 		},
 		{
@@ -1099,8 +1100,7 @@ func TestPlanCommandRunner_PendingApplyStatus(t *testing.T) {
 					Any[models.PullRequest](),
 					Eq[models.CommitStatus](c.ExpApplyStatus),
 					Eq[command.Name](command.Apply),
-					Eq(c.ExpVCSApplyStatusSucc),
-					Eq(c.ExpVCSApplyStatusTotal),
+					Eq(models.ProjectCounts{Success: c.ExpVCSApplyStatusSucc, Total: c.ExpVCSApplyStatusTotal, NoChanges: c.ExpVCSApplyNoChanges}),
 				)
 			} else {
 				// Verify that UpdateCombinedCount was NOT called for Apply command
@@ -1110,8 +1110,7 @@ func TestPlanCommandRunner_PendingApplyStatus(t *testing.T) {
 					Any[models.PullRequest](),
 					Any[models.CommitStatus](),
 					Eq[command.Name](command.Apply),
-					Any[int](),
-					Any[int](),
+					Any[models.ProjectCounts](),
 				)
 			}
 		})

--- a/server/events/policy_check_command_runner.go
+++ b/server/events/policy_check_command_runner.go
@@ -48,7 +48,7 @@ func (p *PolicyCheckCommandRunner) Run(ctx *command.Context, cmds []command.Proj
 			// with 0/0 projects policy_checked successfully because some users require
 			// the Atlantis status to be passing for all pull requests.
 			ctx.Log.Debug("setting VCS status to success with no projects found")
-			if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.SuccessCommitStatus, command.PolicyCheck, 0, 0); err != nil {
+			if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.SuccessCommitStatus, command.PolicyCheck, models.ProjectCounts{}); err != nil {
 				ctx.Log.Warn("unable to update commit status: %s", err)
 			}
 		}
@@ -93,7 +93,7 @@ func (p *PolicyCheckCommandRunner) updateCommitStatus(ctx *command.Context, pull
 		status = models.FailedCommitStatus
 	}
 
-	if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, status, command.PolicyCheck, numSuccess, len(pullStatus.Projects)); err != nil {
+	if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, status, command.PolicyCheck, models.ProjectCounts{Success: numSuccess, Total: len(pullStatus.Projects), Errored: numErrored}); err != nil {
 		ctx.Log.Warn("unable to update commit status: %s", err)
 	}
 }


### PR DESCRIPTION
## what
  - Extend CommitStatusUpdater.UpdateCombinedCount to surface "no changes" project outcomes in the apply commit status description, distinguishing between projects that were applied vs. those whose plan already showed no infrastructure changes
  - Replace the three positional int parameters (numSuccess, numTotal, numNoChanges) with a single models.ProjectCounts struct to eliminate argument-order errors at call sites and make the API easier to extend
  - Fix UpdateCombinedCount to generate status-aware descriptions — previously the description always said "successfully" regardless of whether the commit status was failed or pending; now each command produces distinct wording per outcome:
    - Apply success (all up to date): "2/2 projects up to date."
    - Apply success (mixed): "1/2 projects applied successfully (1 up to date)."
    - Apply success (all applied): "2/2 projects applied successfully."
    - Apply failed: "1/2 projects failed to apply."
    - Apply pending: "1/2 projects applied."
    - Same failed/pending/success distinction for plan and policy_check

## why
When terraform plan returns "No changes. Your infrastructure matches the configuration.", Atlantis was setting the atlantis/apply commit status to "N/N projects applied successfully." — even though terraform apply never ran. This made it impossible to tell from the PR whether an apply had actually executed.


## tests
  - TestUpdateCombinedCount — expected descriptions updated for FailedCommitStatus and PendingCommitStatus cases; verifies the new wording for plan and apply across all three status values
  - TestUpdateCombinedCountNoChanges — covers "all up to date" and "mixed applied/no-change" apply success cases
  - TestApplyCommandRunner_NoChangesCount (new) — seeds the DB with one applied project and one no-changes project (via a plan with no-changes output), then asserts ProjectCounts{Success: 2, Total: 2, NoChanges: 1} is passed to UpdateCombinedCount, validating
  end-to-end propagation of the no-changes count
  - All existing assertions in plan_command_runner_test.go, apply_command_runner_test.go, command_runner_test.go, and command_runner_internal_test.go updated to use models.ProjectCounts matchers
  - go test ./server/events/ ./server/events/models/ ./server/controllers/ passes

## references
atlantis in progress showing
> 1/1 projects applied successfully

even though nothing will or has been applied (applies are disabled on my instance):
<img width="1026" height="680" alt="Screenshot 2026-05-22 at 10 03 41 AM" src="https://github.com/user-attachments/assets/2cf0c808-017f-49e9-bcc0-49c6d75f9c0e" />
