### PR TITLE
feat: add --disable-automerge-label flag

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -70,6 +70,7 @@ const (
 	DisableApplyAllFlag              = "disable-apply-all"
 	DisableAutoplanFlag              = "disable-autoplan"
 	DisableAutoplanLabelFlag         = "disable-autoplan-label"
+	DisableAutomergeLabelFlag        = "disable-automerge-label"
 	DisableMarkdownFoldingFlag       = "disable-markdown-folding"
 	DisableRepoLockingFlag           = "disable-repo-locking"
 	DisableGlobalApplyLockFlag       = "disable-global-apply-lock"
@@ -293,6 +294,10 @@ var stringFlags = map[string]stringFlag{
 	},
 	DisableAutoplanLabelFlag: {
 		description:  "Pull request label to disable atlantis auto planning feature only if present.",
+		defaultValue: "",
+	},
+	DisableAutomergeLabelFlag: {
+		description:  "Pull request label to disable atlantis automerge feature only if present.",
 		defaultValue: "",
 	},
 	DisableUnlockLabelFlag: {

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -157,6 +157,7 @@ var testFlags = map[string]any{
 	WriteGitCredsFlag:                true,
 	DisableAutoplanFlag:              true,
 	DisableAutoplanLabelFlag:         "no-auto-plan",
+	DisableAutomergeLabelFlag:        "no-auto-merge",
 	DisableUnlockLabelFlag:           "do-not-unlock",
 	EnablePolicyChecksFlag:           false,
 	EnableRegExpCmdFlag:              false,

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -473,6 +473,16 @@ ATLANTIS_DISABLE_APPLY_ALL=true
 Disable `atlantis apply` command so a specific project/workspace/directory has to
 be specified for applies.
 
+### `--disable-automerge-label`
+
+```bash
+atlantis server --disable-automerge-label="no-automerge"
+# or
+ATLANTIS_DISABLE_AUTOMERGE_LABEL="no-automerge"
+```
+
+Disable atlantis automerge only on pull requests with the specified label.
+
 ### `--disable-autoplan` <Badge text="v0.15.0+" type="info"/>
 
 ```bash

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1439,6 +1439,7 @@ func setupE2E(t *testing.T, repoDir string, opt setupOption) (events_controllers
 	parallelPoolSize := 1
 	silenceNoProjects := false
 
+	disableAutomergeLabel := "no-auto-merge"
 	disableUnlockLabel := "do-not-unlock"
 
 	statusUpdater := runtimemocks.NewMockStatusUpdater()
@@ -1630,6 +1631,7 @@ func setupE2E(t *testing.T, repoDir string, opt setupOption) (events_controllers
 		silenceNoProjects,
 		false,
 		e2ePullReqStatusFetcher,
+		disableAutomergeLabel,
 	)
 
 	approvePoliciesCommandRunner := events.NewApprovePoliciesCommandRunner(

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -4,6 +4,8 @@
 package events
 
 import (
+	"slices"
+
 	"github.com/runatlantis/atlantis/server/core/db"
 	"github.com/runatlantis/atlantis/server/core/locking"
 	"github.com/runatlantis/atlantis/server/events/command"
@@ -27,6 +29,7 @@ func NewApplyCommandRunner(
 	SilenceNoProjects bool,
 	silenceVCSStatusNoProjects bool,
 	pullReqStatusFetcher vcs.PullReqStatusFetcher,
+	disableAutomergeLabel string,
 ) *ApplyCommandRunner {
 	return &ApplyCommandRunner{
 		vcsClient:                  vcsClient,
@@ -44,23 +47,25 @@ func NewApplyCommandRunner(
 		SilenceNoProjects:          SilenceNoProjects,
 		silenceVCSStatusNoProjects: silenceVCSStatusNoProjects,
 		pullReqStatusFetcher:       pullReqStatusFetcher,
+		disableAutomergeLabel:      disableAutomergeLabel,
 	}
 }
 
 type ApplyCommandRunner struct {
-	DisableApplyAll      bool
-	Database             db.Database
-	locker               locking.ApplyLockChecker
-	vcsClient            vcs.Client
-	commitStatusUpdater  CommitStatusUpdater
-	prjCmdBuilder        ProjectApplyCommandBuilder
-	prjCmdRunner         ProjectApplyCommandRunner
-	cancellationTracker  CancellationTracker
-	autoMerger           *AutoMerger
-	pullUpdater          *PullUpdater
-	dbUpdater            *DBUpdater
-	parallelPoolSize     int
-	pullReqStatusFetcher vcs.PullReqStatusFetcher
+	DisableApplyAll       bool
+	Database              db.Database
+	locker                locking.ApplyLockChecker
+	vcsClient             vcs.Client
+	commitStatusUpdater   CommitStatusUpdater
+	prjCmdBuilder         ProjectApplyCommandBuilder
+	prjCmdRunner          ProjectApplyCommandRunner
+	cancellationTracker   CancellationTracker
+	autoMerger            *AutoMerger
+	pullUpdater           *PullUpdater
+	dbUpdater             *DBUpdater
+	parallelPoolSize      int
+	pullReqStatusFetcher  vcs.PullReqStatusFetcher
+	disableAutomergeLabel string
 	// SilenceNoProjects is whether Atlantis should respond to PRs if no projects
 	// are found
 	SilenceNoProjects bool
@@ -177,6 +182,15 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 	a.updateCommitStatus(ctx, pullStatus)
 
 	if a.autoMerger.automergeEnabled(projectCmds) && !cmd.AutoMergeDisabled {
+		if len(a.disableAutomergeLabel) > 0 {
+			labels, err := a.vcsClient.GetPullLabels(ctx.Log, baseRepo, pull)
+			if err != nil {
+				ctx.Log.Err("Unable to get pull request labels: %s. Proceeding with automerge.", err)
+			} else if slices.Contains(labels, a.disableAutomergeLabel) {
+				ctx.Log.Info("Pull/merge request has disable automerge label '%s' so not automerging.", a.disableAutomergeLabel)
+				return
+			}
+		}
 		a.autoMerger.automerge(ctx, pullStatus, a.autoMerger.deleteSourceBranchOnMergeEnabled(projectCmds), cmd.AutoMergeMethod)
 	}
 }

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -72,6 +72,7 @@ type TestConfig struct {
 	discardApprovalOnPlan      bool
 	database                   db.Database
 	DisableUnlockLabel         string
+	DisableAutomergeLabel      string
 	PendingApplyStatus         bool
 	applyLockCheckerReturn     locking.ApplyCommandLock
 	applyLockCheckerErr        error
@@ -190,6 +191,7 @@ func setup(t *testing.T, options ...func(testConfig *TestConfig)) *vcsmocks.Mock
 		testConfig.SilenceNoProjects,
 		testConfig.silenceVCSStatusNoProjects,
 		pullReqStatusFetcher,
+		testConfig.DisableAutomergeLabel,
 	)
 
 	approvePoliciesCommandRunner = events.NewApprovePoliciesCommandRunner(

--- a/server/server.go
+++ b/server/server.go
@@ -839,6 +839,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		userConfig.SilenceNoProjects,
 		userConfig.SilenceVCSStatusNoProjects,
 		pullReqStatusFetcher,
+		userConfig.DisableAutomergeLabel,
 	)
 
 	approvePoliciesCommandRunner := events.NewApprovePoliciesCommandRunner(

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -42,6 +42,7 @@ type UserConfig struct {
 	DisableApplyAll             bool   `mapstructure:"disable-apply-all"`
 	DisableAutoplan             bool   `mapstructure:"disable-autoplan"`
 	DisableAutoplanLabel        string `mapstructure:"disable-autoplan-label"`
+	DisableAutomergeLabel       string `mapstructure:"disable-automerge-label"`
 	DisableMarkdownFolding      bool   `mapstructure:"disable-markdown-folding"`
 	DisableRepoLocking          bool   `mapstructure:"disable-repo-locking"`
 	DisableGlobalApplyLock      bool   `mapstructure:"disable-global-apply-lock"`


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

- Add a new `--disable-automerge-label` server configuration flag (analogous to the existing `--disable-autoplan-label`)
- When configured, if a PR/MR carries the specified label, Atlantis skips automerge after a successful `atlantis apply`
- This provides a persistent, per-PR mechanism to opt out of automerge without requiring `--auto-merge-disabled` on every apply command

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

- On long-lived or iterative PRs with multiple rounds of `atlantis apply`, remembering to pass `--auto-merge-disabled` every time is error-prone
- Forgetting the flag can result in an unintended merge, requiring a new branch/PR to continue work
- A label-based approach is persistent for the PR lifetime, visible in the VCS UI, and consistent with how `--disable-autoplan-label` already works

## tests

<!--
- [ ] I have tested my changes by ...
-->

- [x] Validated the feature in an enterprise environment with real PRs

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

- closes https://github.com/runatlantis/atlantis/issues/3181