### PR TITLE
docs: document cancel command in allow-commands and atlantis help

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -4,3 +4,7 @@
 https://www.freepik.com/
 https://www.flaticon.com/
 https://medium.com/
+https://gitlab.com/gitlab-org/gitlab/-/blob/master/fixtures/emojis/digests.json
+
+# These sites intermittently time out for the link checker
+https://grafana.com/docs/pyroscope/

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -54,17 +54,17 @@ Values are chosen in this order:
 ### `--allow-commands` <Badge text="v0.27.0+" type="info"/>
 
 ```bash
-atlantis server --allow-commands=version,plan,apply,unlock,approve_policies
+atlantis server --allow-commands=version,plan,apply,unlock,approve_policies,cancel
 # or
-ATLANTIS_ALLOW_COMMANDS='version,plan,apply,unlock,approve_policies'
+ATLANTIS_ALLOW_COMMANDS='version,plan,apply,unlock,approve_policies,cancel'
 ```
 
-List of allowed commands to be run on the Atlantis server, Defaults to `version,plan,apply,unlock,approve_policies`
+List of allowed commands to be run on the Atlantis server, Defaults to `version,plan,apply,unlock,approve_policies,cancel`
 
 Notes:
 
 - Accepts a comma separated list, ex. `command1,command2`.
-- `version`, `plan`, `apply`, `unlock`, `approve_policies`, `import`, `state`, `policy_check` and `all` are available.
+- `version`, `plan`, `apply`, `unlock`, `approve_policies`, `cancel`, `import`, `state`, `policy_check` and `all` are available.
 - `policy_check` is an internal command that runs automatically after `plan` when [policy checking](policy-checking.md) is enabled. It must be explicitly allowlisted when using [`--gh-team-allowlist`](#gh-team-allowlist).
 - `all` is a special keyword that allows all commands. If pass `all` then all other commands will be ignored.
 

--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -572,6 +572,7 @@ func (e *CommentParser) HelpComment() string {
 		AllowVersion         bool
 		AllowPlan            bool
 		AllowApply           bool
+		AllowCancel          bool
 		AllowUnlock          bool
 		AllowApprovePolicies bool
 		AllowImport          bool
@@ -581,6 +582,7 @@ func (e *CommentParser) HelpComment() string {
 		AllowVersion:         e.isAllowedCommand(command.Version.String()),
 		AllowPlan:            e.isAllowedCommand(command.Plan.String()),
 		AllowApply:           e.isAllowedCommand(command.Apply.String()),
+		AllowCancel:          e.isAllowedCommand(command.Cancel.String()),
 		AllowUnlock:          e.isAllowedCommand(command.Unlock.String()),
 		AllowApprovePolicies: e.isAllowedCommand(command.ApprovePolicies.String()),
 		AllowImport:          e.isAllowedCommand(command.Import.String()),
@@ -623,6 +625,10 @@ Commands:
 {{- if .AllowApply }}
   apply    Runs 'terraform apply' on all unapplied plans from this pull request.
            To only apply a specific plan, use the -d, -w and -p flags.
+{{- end }}
+{{- if .AllowCancel }}
+  cancel   Cancels all queued commands for this pull request.
+           Already running commands are not interrupted.
 {{- end }}
 {{- if .AllowUnlock }}
   unlock   Removes all atlantis locks and discards all plans for this PR.

--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -1073,6 +1073,8 @@ Commands:
            To plan a specific project, use the -d, -w and -p flags.
   apply    Runs 'terraform apply' on all unapplied plans from this pull request.
            To only apply a specific plan, use the -d, -w and -p flags.
+  cancel   Cancels all queued commands for this pull request.
+           Already running commands are not interrupted.
   unlock   Removes all atlantis locks and discards all plans for this PR.
            To unlock a specific plan you can use the Atlantis UI.
   approve_policies


### PR DESCRIPTION
## Summary

[PR #5813](https://github.com/runatlantis/atlantis/pull/5813) added the `atlantis cancel` command, set the code default for `--allow-commands` to include `cancel`, and documented the command in `using-atlantis.md`. Two surfaces were missed:

- **`server-configuration.md` → `--allow-commands`**: the examples, the stated default, and the list of available commands all omitted `cancel` — even though `cmd/server.go` (`DefaultAllowCommands`) already enables it by default.
- **`atlantis help`** (the `helpCommentTemplate` rendered into PR comments): never listed `cancel`, so a command that is enabled by default was undiscoverable from help.

This PR aligns both surfaces with the actual code behavior.

## Changes

- `runatlantis.io/docs/server-configuration.md`: add `cancel` to the `--allow-commands` examples, the documented default, and the available-commands list.
- `server/events/comment_parser.go`: add `cancel` to the `atlantis help` output, gated on `--allow-commands` (`AllowCancel`) just like the other commands.
- `server/events/comment_parser_test.go`: update the "all commands allowed" expected help output.

## Test plan

- [x] `go test ./server/events/ -run 'CommentParser' -count=1` passes
- [x] `go vet ./server/events/` clean
- [x] `gofmt -l` clean on touched files
- [ ] Render the docs site and confirm the `--allow-commands` section lists `cancel`