### PR TITLE
feat: include pull request description in slack notifications

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/redis/go-redis/v9 v9.17.3
 	github.com/remeh/sizedwaitgroup v1.0.0
+	github.com/rivo/uniseg v0.4.7
 	github.com/shurcooL/githubv4 v0.0.0-20260209031235-2402fdf4a9ed
 	github.com/slack-go/slack v0.23.1
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -404,6 +404,8 @@ github.com/redis/go-redis/v9 v9.17.3 h1:fN29NdNrE17KttK5Ndf20buqfDZwGNgoUr9qjl1D
 github.com/redis/go-redis/v9 v9.17.3/go.mod h1:u410H11HMLoB+TP67dz8rL9s6QW2j76l0//kSOd3370=
 github.com/remeh/sizedwaitgroup v1.0.0 h1:VNGGFwNo/R5+MJBf6yrsr110p0m4/OX4S3DCy7Kyl5E=
 github.com/remeh/sizedwaitgroup v1.0.0/go.mod h1:3j2R4OIe/SeS6YDhICBy22RWjJC5eNCJ1V+9+NVNYlo=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=

--- a/runatlantis.io/docs/sending-notifications-via-webhooks.md
+++ b/runatlantis.io/docs/sending-notifications-via-webhooks.md
@@ -87,6 +87,7 @@ Example payload:
     "HeadBranch": "feature/some-branch",
     "BaseBranch": "main",
     "Author": "octocat",
+    "Body": "This is the pull request description.",
     "State": 0,
     "BaseRepo": {
       "FullName": "octocat/Hello-World",

--- a/server/events/event_parser.go
+++ b/server/events/event_parser.go
@@ -461,6 +461,7 @@ func (e *EventParser) parseCommonBitbucketCloudEventData(event bitbucketcloud.Co
 
 	pull = models.PullRequest{
 		Num:        *event.PullRequest.ID,
+		Body:       bitbucketCloudPullRequestBody(event.PullRequest),
 		HeadCommit: *event.PullRequest.Source.Commit.Hash,
 		URL:        *event.PullRequest.Links.HTML.HREF,
 		HeadBranch: *event.PullRequest.Source.Branch.Name,
@@ -473,6 +474,19 @@ func (e *EventParser) parseCommonBitbucketCloudEventData(event bitbucketcloud.Co
 		Username: *event.Actor.AccountID,
 	}
 	return
+}
+
+func bitbucketCloudPullRequestBody(pull *bitbucketcloud.PullRequest) string {
+	if pull == nil {
+		return ""
+	}
+	if pull.Description != nil {
+		return *pull.Description
+	}
+	if pull.Summary != nil && pull.Summary.Raw != nil {
+		return *pull.Summary.Raw
+	}
+	return ""
 }
 
 // ParseBitbucketCloudPullEvent parses a pull request event from Bitbucket
@@ -615,6 +629,7 @@ func (e *EventParser) ParseGithubPull(logger logging.SimpleLogging, pull *github
 
 	pullModel = models.PullRequest{
 		Author:     authorUsername,
+		Body:       pull.GetBody(),
 		HeadBranch: headBranch,
 		HeadCommit: commit,
 		URL:        url,
@@ -683,6 +698,7 @@ func (e *EventParser) ParseGitlabMergeRequestEvent(event gitlab.MergeEvent) (pul
 	pull = models.PullRequest{
 		URL:        event.ObjectAttributes.URL,
 		Author:     event.User.Username,
+		Body:       event.ObjectAttributes.Description,
 		Num:        event.ObjectAttributes.IID,
 		HeadCommit: event.ObjectAttributes.LastCommit.ID,
 		HeadBranch: event.ObjectAttributes.SourceBranch,
@@ -777,6 +793,7 @@ func (e *EventParser) ParseGitlabMergeRequest(mr *gitlab.MergeRequest, baseRepo 
 	return models.PullRequest{
 		URL:        mr.WebURL,
 		Author:     mr.Author.Username,
+		Body:       mr.Description,
 		Num:        mr.IID,
 		HeadCommit: mr.SHA,
 		HeadBranch: mr.SourceBranch,
@@ -862,6 +879,7 @@ func (e *EventParser) parseCommonBitbucketServerEventData(event bitbucketserver.
 
 	pull = models.PullRequest{
 		Num:        *event.PullRequest.ID,
+		Body:       bitbucketServerPullRequestBody(event.PullRequest),
 		HeadCommit: *event.PullRequest.FromRef.LatestCommit,
 		URL:        fmt.Sprintf("%s/projects/%s/repos/%s/pull-requests/%d", e.BitbucketServerURL, *event.PullRequest.ToRef.Repository.Project.Key, *event.PullRequest.ToRef.Repository.Slug, *event.PullRequest.ID),
 		HeadBranch: *event.PullRequest.FromRef.DisplayID,
@@ -874,6 +892,13 @@ func (e *EventParser) parseCommonBitbucketServerEventData(event bitbucketserver.
 		Username: *event.Actor.Username,
 	}
 	return
+}
+
+func bitbucketServerPullRequestBody(pull *bitbucketserver.PullRequest) string {
+	if pull == nil || pull.Description == nil {
+		return ""
+	}
+	return *pull.Description
 }
 
 // ParseBitbucketServerPullEvent parses a pull request event from Bitbucket
@@ -985,6 +1010,7 @@ func (e *EventParser) ParseAzureDevopsPull(pull *azuredevops.GitPullRequest) (pu
 
 	pullModel = models.PullRequest{
 		Author: authorUsername,
+		Body:   pull.GetDescription(),
 		// Change webhook refs from "refs/heads/<branch>" to "<branch>"
 		HeadBranch: strings.Replace(headBranch, "refs/heads/", "", 1),
 		HeadCommit: commit,
@@ -1104,6 +1130,7 @@ func (e *EventParser) ParseGiteaPullRequestEvent(event giteasdk.PullRequest) (mo
 		HeadBranch: (*event.Head).Ref,
 		BaseBranch: event.Base.Ref,
 		Author:     event.Poster.UserName,
+		Body:       event.Body,
 		BaseRepo:   baseRepo,
 	}
 
@@ -1166,6 +1193,7 @@ func (e *EventParser) ParseGiteaPull(pull *giteasdk.PullRequest) (pullModel mode
 
 	pullModel = models.PullRequest{
 		Author:     authorUsername,
+		Body:       pull.Body,
 		HeadBranch: headBranch,
 		HeadCommit: commit,
 		URL:        url,

--- a/server/events/event_parser_test.go
+++ b/server/events/event_parser_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	giteasdk "code.gitea.io/sdk/gitea"
 	"github.com/drmaxgit/go-azuredevops/azuredevops"
 	"github.com/google/go-github/v88/github"
 	"github.com/mohae/deepcopy"
@@ -147,6 +148,7 @@ func TestParseGithubPullEvent(t *testing.T) {
 	Equals(t, models.PullRequest{
 		URL:        githubtestdata.Pull.GetHTMLURL(),
 		Author:     githubtestdata.Pull.User.GetLogin(),
+		Body:       githubtestdata.Pull.GetBody(),
 		HeadBranch: githubtestdata.Pull.Head.GetRef(),
 		BaseBranch: githubtestdata.Pull.Base.GetRef(),
 		HeadCommit: githubtestdata.Pull.Head.GetSHA(),
@@ -320,6 +322,7 @@ func TestParseGithubPull(t *testing.T) {
 	Equals(t, models.PullRequest{
 		URL:        githubtestdata.Pull.GetHTMLURL(),
 		Author:     githubtestdata.Pull.User.GetLogin(),
+		Body:       githubtestdata.Pull.GetBody(),
 		HeadBranch: githubtestdata.Pull.Head.GetRef(),
 		BaseBranch: githubtestdata.Pull.Base.GetRef(),
 		HeadCommit: githubtestdata.Pull.Head.GetSHA(),
@@ -339,6 +342,7 @@ func TestParseGitlabMergeEvent(t *testing.T) {
 	var event *gitlab.MergeEvent
 	err = json.Unmarshal(bytes, &event)
 	Ok(t, err)
+	event.ObjectAttributes.Description = "merge request description"
 	pull, evType, actBaseRepo, actHeadRepo, actUser, err := parser.ParseGitlabMergeRequestEvent(*event)
 	Ok(t, err)
 
@@ -357,6 +361,7 @@ func TestParseGitlabMergeEvent(t *testing.T) {
 	Equals(t, models.PullRequest{
 		URL:        "https://gitlab.com/lkysow/atlantis-example/merge_requests/12",
 		Author:     "lkysow",
+		Body:       "merge request description",
 		Num:        12,
 		HeadCommit: "d2eae324ca26242abca45d7b49d582cddb2a4f15",
 		HeadBranch: "patch-1",
@@ -588,10 +593,12 @@ func TestParseGitlabMergeRequest(t *testing.T) {
 			Type:     models.Gitlab,
 		},
 	}
+	event.Description = "merge request description"
 	pull := parser.ParseGitlabMergeRequest(event, repo)
 	Equals(t, models.PullRequest{
 		URL:        "https://gitlab.com/lkysow/atlantis-example/merge_requests/8",
 		Author:     "lkysow",
+		Body:       "merge request description",
 		Num:        8,
 		HeadCommit: "0b4ac85ea3063ad5f2974d10cd68dd1f937aaac2",
 		HeadBranch: "abc",
@@ -859,6 +866,7 @@ func TestParseBitbucketCloudCommentEvent_ValidEvent(t *testing.T) {
 	Equals(t, expBaseRepo, baseRepo)
 	Equals(t, models.PullRequest{
 		Num:        2,
+		Body:       "main.tf edited online with Bitbucket",
 		HeadCommit: "e0624da46d3a",
 		URL:        "https://bitbucket.org/lkysow/atlantis-example/pull-requests/2",
 		HeadBranch: "lkysow/maintf-edited-online-with-bitbucket-1532029690581",
@@ -945,6 +953,7 @@ func TestParseBitbucketCloudPullEvent_ValidEvent(t *testing.T) {
 	Equals(t, expBaseRepo, baseRepo)
 	Equals(t, models.PullRequest{
 		Num:        16,
+		Body:       "main.tf edited online with Bitbucket",
 		HeadCommit: "1e69a602caef",
 		URL:        "https://bitbucket.org/lkysow/atlantis-example/pull-requests/16",
 		HeadBranch: "Luke/maintf-edited-online-with-bitbucket-1560433073473",
@@ -967,6 +976,17 @@ func TestParseBitbucketCloudPullEvent_ValidEvent(t *testing.T) {
 	Equals(t, models.User{
 		Username: "557058:dc3817de-68b5-45cd-b81c-5c39d2560090",
 	}, user)
+}
+
+func TestParseBitbucketCloudPullEvent_UsesSummaryRawWhenDescriptionMissing(t *testing.T) {
+	path := filepath.Join("testdata", "bitbucket-cloud-pull-event-created.json")
+	bytes, err := os.ReadFile(path)
+	Ok(t, err)
+	withoutDescription := strings.Replace(string(bytes), `    "description": "main.tf edited online with Bitbucket",`+"\n", "", 1)
+
+	pull, _, _, _, err := parser.ParseBitbucketCloudPullEvent([]byte(withoutDescription))
+	Ok(t, err)
+	Equals(t, "main.tf edited online with Bitbucket", pull.Body)
 }
 
 func TestParseBitbucketCloudPullEvent_States(t *testing.T) {
@@ -1195,6 +1215,7 @@ func TestParseBitbucketServerPullEvent_ValidEvent(t *testing.T) {
 	Equals(t, expBaseRepo, baseRepo)
 	Equals(t, models.PullRequest{
 		Num:        2,
+		Body:       "* Null resource\r\n* main.tf edited online with Bitbucket\r\n* Update 2\r\n* main.tf edited online with Bitbucket\r\n* kkj\r\n* main.tf edited online with Bitbucket",
 		HeadCommit: "86a574157f5a2dadaf595b9f06c70fdfdd039912",
 		URL:        "http://mycorp.com:7490/projects/AT/repos/atlantis-example/pull-requests/2",
 		HeadBranch: "branch",
@@ -1251,6 +1272,54 @@ func TestGetBitbucketServerEventType(t *testing.T) {
 			Equals(t, c.exp, act)
 		})
 	}
+}
+
+func TestParseGiteaPullRequestEvent(t *testing.T) {
+	giteaParser := events.EventParser{
+		GiteaUser:  "gitea-user",
+		GiteaToken: "gitea-token",
+	}
+	repo := giteasdk.Repository{
+		FullName: "owner/repo",
+		CloneURL: "https://gitea.example.com/owner/repo.git",
+	}
+	event := giteasdk.PullRequest{
+		Index:   2,
+		HTMLURL: "https://gitea.example.com/owner/repo/pulls/2",
+		Body:    "pull request description",
+		State:   giteasdk.StateOpen,
+		Poster:  &giteasdk.User{UserName: "lkysow"},
+		Head: &giteasdk.PRBranchInfo{
+			Ref:        "head-branch",
+			Sha:        "d2eae324ca26242abca45d7b49d582cddb2a4f15",
+			Repository: &repo,
+		},
+		Base: &giteasdk.PRBranchInfo{
+			Ref:        "main",
+			Repository: &repo,
+		},
+	}
+
+	pull, evType, actBaseRepo, _, actUser, err := giteaParser.ParseGiteaPullRequestEvent(event)
+	Ok(t, err)
+
+	expBaseRepo, err := models.NewRepo(models.Gitea, "owner/repo", "https://gitea.example.com/owner/repo.git", "gitea-user", "gitea-token", "")
+	Ok(t, err)
+
+	Equals(t, models.PullRequest{
+		URL:        "https://gitea.example.com/owner/repo/pulls/2",
+		Author:     "lkysow",
+		Body:       "pull request description",
+		Num:        2,
+		HeadCommit: "d2eae324ca26242abca45d7b49d582cddb2a4f15",
+		HeadBranch: "head-branch",
+		BaseBranch: "main",
+		State:      models.OpenPullState,
+		BaseRepo:   expBaseRepo,
+	}, pull)
+	Equals(t, models.OpenedPullEvent, evType)
+	Equals(t, expBaseRepo, actBaseRepo)
+	Equals(t, models.User{Username: "lkysow"}, actUser)
 }
 
 func TestParseAzureDevopsRepo(t *testing.T) {
@@ -1398,6 +1467,7 @@ func TestParseAzureDevopsPullEvent(t *testing.T) {
 	Equals(t, models.PullRequest{
 		URL:        azuredevopstestdata.Pull.GetURL(),
 		Author:     azuredevopstestdata.Pull.CreatedBy.GetUniqueName(),
+		Body:       azuredevopstestdata.Pull.GetDescription(),
 		HeadBranch: "feature/sourceBranch",
 		BaseBranch: "targetBranch",
 		HeadCommit: azuredevopstestdata.Pull.LastMergeSourceCommit.GetCommitID(),
@@ -1516,6 +1586,7 @@ func TestParseAzureDevopsPull(t *testing.T) {
 	Equals(t, models.PullRequest{
 		URL:        azuredevopstestdata.Pull.GetURL(),
 		Author:     azuredevopstestdata.Pull.CreatedBy.GetUniqueName(),
+		Body:       azuredevopstestdata.Pull.GetDescription(),
 		HeadBranch: "feature/sourceBranch",
 		BaseBranch: "targetBranch",
 		HeadCommit: azuredevopstestdata.Pull.LastMergeSourceCommit.GetCommitID(),

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -222,6 +222,9 @@ type PullRequest struct {
 	BaseBranch string
 	// Author is the username of the pull request author.
 	Author string
+	// Body is the description of the pull request. It may be empty when the VCS
+	// payload omits a description.
+	Body string
 	// State will be one of Open or Closed.
 	// Gitlab supports an additional "merged" state but Github doesn't so we map
 	// merged to Closed.

--- a/server/events/vcs/azuredevops/testdata/fixtures.go
+++ b/server/events/vcs/azuredevops/testdata/fixtures.go
@@ -33,6 +33,7 @@ var Pull = azuredevops.GitPullRequest{
 		CommitID: azuredevops.String("b60280bc6e62e2f880f1b63c1e24987664d3bda3"),
 		URL:      azuredevops.String("https://dev.azure.com/owner/_apis/git/repositories/3411ebc1-d5aa-464f-9615-0b527bc66719/commits/b60280bc6e62e2f880f1b63c1e24987664d3bda3"),
 	},
+	Description:   azuredevops.String("pull request description"),
 	PullRequestID: azuredevops.Int(1),
 	Repository:    &Repo,
 	SourceRefName: azuredevops.String("refs/heads/feature/sourceBranch"),

--- a/server/events/vcs/bitbucketcloud/models.go
+++ b/server/events/vcs/bitbucketcloud/models.go
@@ -78,6 +78,8 @@ type PullRequestComments struct {
 
 type PullRequest struct {
 	ID           *int          `json:"id,omitempty" validate:"required"`
+	Description  *string       `json:"description,omitempty"`
+	Summary      *Summary      `json:"summary,omitempty"`
 	Source       *BranchMeta   `json:"source,omitempty" validate:"required"`
 	Destination  *BranchMeta   `json:"destination,omitempty" validate:"required"`
 	Participants []Participant `json:"participants,omitempty" validate:"required"`
@@ -85,6 +87,11 @@ type PullRequest struct {
 	State        *string       `json:"state,omitempty" validate:"required"`
 	Author       *Author       `jsonN:"author,omitempty" validate:"required"`
 }
+
+type Summary struct {
+	Raw *string `json:"raw,omitempty"`
+}
+
 type Links struct {
 	HTML *Link `json:"html,omitempty" validate:"required"`
 }

--- a/server/events/vcs/bitbucketserver/models.go
+++ b/server/events/vcs/bitbucketserver/models.go
@@ -28,12 +28,13 @@ type CommonEventData struct {
 }
 
 type PullRequest struct {
-	Version   *int    `json:"version,omitempty" validate:"required"`
-	ID        *int    `json:"id,omitempty" validate:"required"`
-	FromRef   *Ref    `json:"fromRef,omitempty" validate:"required"`
-	ToRef     *Ref    `json:"toRef,omitempty" validate:"required"`
-	State     *string `json:"state,omitempty" validate:"required"`
-	Reviewers []struct {
+	Version     *int    `json:"version,omitempty" validate:"required"`
+	ID          *int    `json:"id,omitempty" validate:"required"`
+	Description *string `json:"description,omitempty"`
+	FromRef     *Ref    `json:"fromRef,omitempty" validate:"required"`
+	ToRef       *Ref    `json:"toRef,omitempty" validate:"required"`
+	State       *string `json:"state,omitempty" validate:"required"`
+	Reviewers   []struct {
 		Approved *bool `json:"approved,omitempty" validate:"required"`
 	} `json:"reviewers,omitempty" validate:"required"`
 }

--- a/server/events/vcs/github/testdata/fixtures.go
+++ b/server/events/vcs/github/testdata/fixtures.go
@@ -40,6 +40,7 @@ var Pull = github.PullRequest{
 	User: &github.User{
 		Login: github.Ptr("user"),
 	},
+	Body:   github.Ptr("body"),
 	Number: github.Ptr(1),
 	State:  github.Ptr("open"),
 }

--- a/server/events/webhooks/slack_client.go
+++ b/server/events/webhooks/slack_client.go
@@ -7,12 +7,17 @@ package webhooks
 import (
 	"fmt"
 
+	"github.com/rivo/uniseg"
 	"github.com/slack-go/slack"
 )
 
 const (
 	slackSuccessColour = "good"
 	slackFailureColour = "danger"
+	// maxDescriptionGraphemeClusters is a readability cap for the pull request
+	// description, counted in user-visible grapheme clusters. It includes the
+	// trailing ellipsis when the description is truncated.
+	maxDescriptionGraphemeClusters = 1000
 )
 
 //go:generate go tool pegomock generate --package mocks -o mocks/mock_slack_client.go SlackClient
@@ -110,5 +115,47 @@ func (d *DefaultSlackClient) createAttachments(applyResult ApplyResult) []slack.
 			},
 		},
 	}
+
+	// Include the pull request description when present, rendered as a
+	// full-width field and truncated so a long description can't exceed Slack's
+	// message size limits.
+	if applyResult.Pull.Body != "" {
+		attachment.Fields = append(attachment.Fields, slack.AttachmentField{
+			Title: "Description",
+			Value: truncateGraphemeClusters(applyResult.Pull.Body, maxDescriptionGraphemeClusters),
+			Short: false,
+		})
+	}
+
 	return []slack.Attachment{attachment}
+}
+
+// truncateGraphemeClusters returns s unchanged when it has at most max
+// grapheme clusters. Otherwise it is cut at a cluster boundary to max-1
+// clusters with an ellipsis appended. It walks the string without allocating a
+// slice for the whole input.
+func truncateGraphemeClusters(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+
+	count := 0
+	keepUntil := 0
+	offset := 0
+	state := -1
+	rest := s
+	for len(rest) > 0 {
+		cluster, remaining, _, nextState := uniseg.FirstGraphemeClusterInString(rest, state)
+		if count == max-1 {
+			keepUntil = offset
+		}
+		if count == max {
+			return s[:keepUntil] + "…"
+		}
+		offset += len(cluster)
+		rest = remaining
+		state = nextState
+		count++
+	}
+	return s
 }

--- a/server/events/webhooks/slack_client_internal_test.go
+++ b/server/events/webhooks/slack_client_internal_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package webhooks
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rivo/uniseg"
+	"github.com/runatlantis/atlantis/server/events/models"
+	. "github.com/runatlantis/atlantis/testing"
+	"github.com/slack-go/slack"
+)
+
+func descriptionField(attachments []slack.Attachment) (slack.AttachmentField, bool) {
+	if len(attachments) == 0 {
+		return slack.AttachmentField{}, false
+	}
+	for _, f := range attachments[0].Fields {
+		if f.Title == "Description" {
+			return f, true
+		}
+	}
+	return slack.AttachmentField{}, false
+}
+
+func applyResultWithBody(body string) ApplyResult {
+	return ApplyResult{
+		Workspace: "default",
+		Repo:      models.Repo{FullName: "owner/repo"},
+		Pull:      models.PullRequest{Num: 1, URL: "url", BaseBranch: "main", Body: body},
+		User:      models.User{Username: "user"},
+		Success:   true,
+		Directory: "dir",
+	}
+}
+
+func TestCreateAttachments_NoDescriptionWhenBodyEmpty(t *testing.T) {
+	c := DefaultSlackClient{}
+	attachments := c.createAttachments(applyResultWithBody(""))
+	_, ok := descriptionField(attachments)
+	Equals(t, false, ok)
+}
+
+func TestCreateAttachments_IncludesDescription(t *testing.T) {
+	c := DefaultSlackClient{}
+	attachments := c.createAttachments(applyResultWithBody("a pull request description"))
+	field, ok := descriptionField(attachments)
+	Assert(t, ok, "expected a Description field")
+	Equals(t, "a pull request description", field.Value)
+	Equals(t, false, field.Short)
+}
+
+func TestCreateAttachments_TruncatesLongDescription(t *testing.T) {
+	c := DefaultSlackClient{}
+	attachments := c.createAttachments(applyResultWithBody(strings.Repeat("a", 1500)))
+	field, ok := descriptionField(attachments)
+	Assert(t, ok, "expected a Description field")
+	// The result is capped at maxDescriptionGraphemeClusters, ellipsis included.
+	Equals(t, maxDescriptionGraphemeClusters, uniseg.GraphemeClusterCount(field.Value))
+	Assert(t, strings.HasSuffix(field.Value, "…"), "expected truncated body to end with an ellipsis")
+}
+
+func TestCreateAttachments_DoesNotTruncateAtLimit(t *testing.T) {
+	c := DefaultSlackClient{}
+	body := strings.Repeat("a", maxDescriptionGraphemeClusters)
+	attachments := c.createAttachments(applyResultWithBody(body))
+	field, ok := descriptionField(attachments)
+	Assert(t, ok, "expected a Description field")
+	Equals(t, body, field.Value)
+}
+
+func TestCreateAttachments_TruncatesDescriptionAtGraphemeBoundary(t *testing.T) {
+	c := DefaultSlackClient{}
+	body := strings.Repeat("a", maxDescriptionGraphemeClusters-2) + "🧑‍💻bc"
+	attachments := c.createAttachments(applyResultWithBody(body))
+	field, ok := descriptionField(attachments)
+	Assert(t, ok, "expected a Description field")
+	Equals(t, maxDescriptionGraphemeClusters, uniseg.GraphemeClusterCount(field.Value))
+	Assert(t, strings.HasSuffix(field.Value, "🧑‍💻…"), "expected truncation to preserve the final emoji grapheme cluster")
+	Assert(t, !strings.Contains(field.Value, "b"), "expected truncation before the next grapheme cluster")
+}


### PR DESCRIPTION
## what

This PR aims to add the pull request description to the apply notifications sent through webhooks:
* add a `Body` field to `models.PullRequest` to carry the pull request description
* populate it in every event parser whose VCS payload exposes a description
* Bitbucket Cloud and Server are left empty on purpose, as their pull request payloads don't include a description
* render the description in the Slack apply notification as a full-width `Description` field, only when it's not empty, and rune-safe truncated to 1000 characters to stay within Slack's message size limits
* the HTTP webhook payload gains `Body` automatically since the whole `ApplyResult` is marshalled, so the payload example in the docs is updated to match

## why

* apply notifications currently expose only the workspace, branch, user and directory, without any context about what was applied
* surfacing the pull request description gives the change, impact and environment context directly in the notification

## tests

* [x] added tests for `createAttachments`: the `Description` field is omitted when the body is empty, included when it's set, and rune-safe truncated when the body exceeds the limit
* [x] extended the GitHub event parser tests (and fixture) to assert the body is parsed into `PullRequest.Body`
* [x] `make test` passes in the `ghcr.io/runatlantis/testing-env` container, `goimports` and `gofmt` are clean, and `golangci-lint` reports no issues on the touched packages

### before
<img width="496" height="163" alt="image" src="https://github.com/user-attachments/assets/f2dd5083-40ad-4d8c-9d2b-0f319c91fe42" />

### after
<img width="485" height="327" alt="image" src="https://github.com/user-attachments/assets/63f28530-8bed-425e-8473-de0942a8efcb" />


## references

* closes #3161 