### PR TITLE
chore: Remove check-lint from Makefile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@
 ⚠️ **Known failing test:** `TestNewServer_GitHubUser` in server/server_test.go - pre-existing, ignore it
 
 **Lint/Format:** `make check-fmt` (ALWAYS works) • `make fmt` (auto-format)
-⚠️ **Known issue:** `make lint` and `make check-lint` fail with Go 1.25+ version mismatch. Use `make check-fmt` locally, CI handles linting.
+⚠️ **Known issue:** `make lint` fail with Go 1.25+ version mismatch. Use `make check-fmt` locally, CI handles linting.
 
 **Mocks:** `make go-generate` (regenerate after interface changes) • `make regen-mocks` (delete & regenerate all)
 
@@ -63,7 +63,6 @@
 
 ## Known Issues
 
-1. **golangci-lint Go 1.25+ incompatibility:** `make lint`/`make check-lint` fail. Use `make check-fmt` locally; CI handles linting.
 2. **TestNewServer_GitHubUser fails:** Pre-existing in main. Ignore it.
 3. **E2E tests skip on forks:** Expected (no secrets). Maintainers run them.
 4. **Website needs npm install first:** Always run `npm install` before `npm run website:*` commands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@
 ⚠️ **Known failing test:** `TestNewServer_GitHubUser` in server/server_test.go - pre-existing, ignore it
 
 **Lint/Format:** `make check-fmt` (ALWAYS works) • `make fmt` (auto-format)
-⚠️ **Known issue:** `make lint` fail with Go 1.25+ version mismatch. Use `make check-fmt` locally, CI handles linting.
+⚠️ **Known issue:** `make lint` fails with Go 1.25+ version mismatch. Use `make check-fmt` locally, CI handles linting.
 
 **Mocks:** `make go-generate` (regenerate after interface changes) • `make regen-mocks` (delete & regenerate all)
 

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,6 @@ IMAGE_NAME := runatlantis/atlantis
 
 .DEFAULT_GOAL := help
 
-# renovate: datasource=github-releases depName=golangci/golangci-lint
-GOLANGCI_LINT_VERSION := v1.64.4
-
 .PHONY: help
 help: ## List targets & descriptions
 	@cat Makefile* | grep -E '^[a-zA-Z\/_-]+:.*?## .*$$' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -93,11 +90,6 @@ fmt: ## Run goimports (which also formats)
 .PHONY: lint
 lint: ## Run linter locally
 	golangci-lint run
-
-.PHONY: check-lint
-check-lint: ## Run linter in CI/CD. If running locally use 'lint'
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin $(GOLANGCI_LINT_VERSION)
-	./bin/golangci-lint run -j 4 --timeout 5m
 
 .PHONY: check-fmt
 check-fmt: ## Fail if not formatted


### PR DESCRIPTION
## what

Remove check-lint from Makefile

## why

This command in the make was explicitly documented to be for CI. However, CI hasn't relied on `make check-lint` since #3026.

The only other reference in the repo was in AGENTS.md, which I cleaned up.

In particular, the variable `GOLANGCI_LINT_VERSION` can and did diverge from the version in CI, which led me to this issue.

## tests

N/A

## references

N/A

