### PR TITLE
fix: color changed lines inside heredoc/multiline-string diffs

### DIFF
--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -534,7 +534,7 @@ func (p *PlanSuccess) NoChanges() bool {
 
 // Diff Markdown regexes
 var (
-	diffKeywordRegex  = regexp.MustCompile(`(?m)^( +)([-+~]\s)([a-zA-Z_][\w]*\s*)(\s=\s|\s->\s|\(known after apply\)|\{)(.*)`)
+	diffKeywordRegex  = regexp.MustCompile(`(?m)^( +)([-+~]\s)(\s*[a-zA-Z_][\w]*\s*)(\s=\s|\s->\s|\(known after apply\)|\{)(.*)`)
 	diffResourceRegex = regexp.MustCompile(`(?m)^( +)([-+~]\s)((?:resource|data|module)\s+.+\{.*)`)
 	diffHeredocRegex  = regexp.MustCompile(`(?m)^( +)([-+~]\s)(<<)(.*)`)
 	diffColonRegex    = regexp.MustCompile(`(?m)^( +)([-+~]\s)( {4,}[a-zA-Z_][\w-]*:.*)`)

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -534,13 +534,14 @@ func (p *PlanSuccess) NoChanges() bool {
 
 // Diff Markdown regexes
 var (
-	// diffKeywordRegex matches an attribute-style diff line. Group 3 captures any
-	// indentation between the marker and the attribute name (preserved when the
-	// marker is moved to column 0); group 4 is the whitespace-free keyword/name.
+	// diffKeywordRegex matches an attribute-style diff line. Group 3 captures
+	// optional heredoc/multiline-string indentation between the marker and the
+	// attribute name (preserved when the marker is moved to column 0); group 4 is
+	// the whitespace-free keyword/name.
 	// The leading indentation lets changes inside heredoc/multiline-string bodies
 	// (where Terraform keeps the line's own indentation after the gutter marker)
 	// still be matched and colored.
-	diffKeywordRegex  = regexp.MustCompile(`(?m)^( +)([-+~]\s)(\s*)([a-zA-Z_][\w]*\s*)(\s=\s|\s->\s|\(known after apply\)|\{)(.*)`)
+	diffKeywordRegex  = regexp.MustCompile(`(?m)^( +)([-+~]\s)( {4,})?([a-zA-Z_][\w]*\s*)(\s=\s|\s->\s|\(known after apply\)|\{)(.*)`)
 	diffResourceRegex = regexp.MustCompile(`(?m)^( +)([-+~]\s)((?:resource|data|module)\s+.+\{.*)`)
 	diffHeredocRegex  = regexp.MustCompile(`(?m)^( +)([-+~]\s)(<<)(.*)`)
 	diffColonRegex    = regexp.MustCompile(`(?m)^( +)([-+~]\s)( {4,}[a-zA-Z_][\w-]*:.*)`)

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -608,7 +608,8 @@ func diffMarkdownHeredocStart(line string) (string, int, int, bool) {
 }
 
 func isDiffMarkdownHeredocEnd(line string, delimiter string, indent int) bool {
-	return line == strings.Repeat(" ", indent)+delimiter
+	terminator := strings.Repeat(" ", indent) + delimiter
+	return line == terminator || strings.HasPrefix(line, terminator+" -> ")
 }
 
 func formatHeredocDiffMarkdownLine(line string, diffMarkerIndent int) string {

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -534,7 +534,13 @@ func (p *PlanSuccess) NoChanges() bool {
 
 // Diff Markdown regexes
 var (
-	diffKeywordRegex  = regexp.MustCompile(`(?m)^( +)([-+~]\s)(\s*[a-zA-Z_][\w]*\s*)(\s=\s|\s->\s|\(known after apply\)|\{)(.*)`)
+	// diffKeywordRegex matches an attribute-style diff line. Group 3 captures any
+	// indentation between the marker and the attribute name (preserved when the
+	// marker is moved to column 0); group 4 is the whitespace-free keyword/name.
+	// The leading indentation lets changes inside heredoc/multiline-string bodies
+	// (where Terraform keeps the line's own indentation after the gutter marker)
+	// still be matched and colored.
+	diffKeywordRegex  = regexp.MustCompile(`(?m)^( +)([-+~]\s)(\s*)([a-zA-Z_][\w]*\s*)(\s=\s|\s->\s|\(known after apply\)|\{)(.*)`)
 	diffResourceRegex = regexp.MustCompile(`(?m)^( +)([-+~]\s)((?:resource|data|module)\s+.+\{.*)`)
 	diffHeredocRegex  = regexp.MustCompile(`(?m)^( +)([-+~]\s)(<<)(.*)`)
 	diffColonRegex    = regexp.MustCompile(`(?m)^( +)([-+~]\s)( {4,}[a-zA-Z_][\w-]*:.*)`)
@@ -544,7 +550,7 @@ var (
 
 // DiffMarkdownFormattedTerraformOutput formats the Terraform output to match diff markdown format
 func (p PlanSuccess) DiffMarkdownFormattedTerraformOutput() string {
-	formattedTerraformOutput := diffKeywordRegex.ReplaceAllString(p.TerraformOutput, "$2$1$3$4$5")
+	formattedTerraformOutput := diffKeywordRegex.ReplaceAllString(p.TerraformOutput, "$2$1$3$4$5$6")
 	formattedTerraformOutput = diffResourceRegex.ReplaceAllString(formattedTerraformOutput, "$2$1$3")
 	formattedTerraformOutput = diffHeredocRegex.ReplaceAllString(formattedTerraformOutput, "$2$1$3$4")
 	formattedTerraformOutput = diffColonRegex.ReplaceAllString(formattedTerraformOutput, "$2$1$3")

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -534,31 +534,83 @@ func (p *PlanSuccess) NoChanges() bool {
 
 // Diff Markdown regexes
 var (
-	// diffKeywordRegex matches an attribute-style diff line. Group 3 captures
-	// optional heredoc/multiline-string indentation between the marker and the
-	// attribute name (preserved when the marker is moved to column 0); group 4 is
-	// the whitespace-free keyword/name.
-	// The leading indentation lets changes inside heredoc/multiline-string bodies
-	// (where Terraform keeps the line's own indentation after the gutter marker)
-	// still be matched and colored.
-	diffKeywordRegex  = regexp.MustCompile(`(?m)^( +)([-+~]\s)( {4,})?([a-zA-Z_][\w]*\s*)(\s=\s|\s->\s|\(known after apply\)|\{)(.*)`)
-	diffResourceRegex = regexp.MustCompile(`(?m)^( +)([-+~]\s)((?:resource|data|module)\s+.+\{.*)`)
-	diffHeredocRegex  = regexp.MustCompile(`(?m)^( +)([-+~]\s)(<<)(.*)`)
-	diffColonRegex    = regexp.MustCompile(`(?m)^( +)([-+~]\s)( {4,}[a-zA-Z_][\w-]*:.*)`)
-	diffListRegex     = regexp.MustCompile(`(?m)^( +)([-+~]\s)(".*",)`)
-	diffTildeRegex    = regexp.MustCompile(`(?m)^~`)
+	diffKeywordRegex            = regexp.MustCompile(`(?m)^( +)([-+~]\s)([a-zA-Z_][\w]*\s*)(\s=\s|\s->\s|\(known after apply\)|\{)(.*)`)
+	diffResourceRegex           = regexp.MustCompile(`(?m)^( +)([-+~]\s)((?:resource|data|module)\s+.+\{.*)`)
+	diffHeredocRegex            = regexp.MustCompile(`(?m)^( +)([-+~]\s)(<<)(.*)`)
+	diffColonRegex              = regexp.MustCompile(`(?m)^( +)([-+~]\s)( {4,}[a-zA-Z_][\w-]*:.*)`)
+	diffListRegex               = regexp.MustCompile(`(?m)^( +)([-+~]\s)(".*",)`)
+	diffTildeRegex              = regexp.MustCompile(`(?m)^~`)
+	diffLineMarkerRegex         = regexp.MustCompile(`^( +)([-+~])\s`)
+	diffHeredocStartRegex       = regexp.MustCompile(`<<-?([a-zA-Z_][\w]*)`)
+	diffHeredocContentLineRegex = regexp.MustCompile(`^( +)([-+~]\s)(.*)`)
 )
 
 // DiffMarkdownFormattedTerraformOutput formats the Terraform output to match diff markdown format
 func (p PlanSuccess) DiffMarkdownFormattedTerraformOutput() string {
-	formattedTerraformOutput := diffKeywordRegex.ReplaceAllString(p.TerraformOutput, "$2$1$3$4$5$6")
-	formattedTerraformOutput = diffResourceRegex.ReplaceAllString(formattedTerraformOutput, "$2$1$3")
-	formattedTerraformOutput = diffHeredocRegex.ReplaceAllString(formattedTerraformOutput, "$2$1$3$4")
-	formattedTerraformOutput = diffColonRegex.ReplaceAllString(formattedTerraformOutput, "$2$1$3")
-	formattedTerraformOutput = diffListRegex.ReplaceAllString(formattedTerraformOutput, "$2$1$3")
-	formattedTerraformOutput = diffTildeRegex.ReplaceAllString(formattedTerraformOutput, "!")
+	lines := strings.Split(p.TerraformOutput, "\n")
+	heredocDelimiter := ""
+	heredocDiffMarkerIndent := -1
 
-	return strings.TrimSpace(formattedTerraformOutput)
+	for i, line := range lines {
+		if heredocDelimiter != "" {
+			if strings.TrimSpace(line) == heredocDelimiter {
+				heredocDelimiter = ""
+				heredocDiffMarkerIndent = -1
+				continue
+			}
+
+			if heredocDiffMarkerIndent >= 0 {
+				lines[i] = formatHeredocDiffMarkdownLine(line, heredocDiffMarkerIndent)
+			}
+			continue
+		}
+
+		if delimiter, diffMarkerIndent, ok := diffMarkdownHeredocStart(line); ok {
+			heredocDelimiter = delimiter
+			heredocDiffMarkerIndent = diffMarkerIndent
+		}
+
+		lines[i] = formatDiffMarkdownLine(line)
+	}
+
+	return strings.TrimSpace(strings.Join(lines, "\n"))
+}
+
+func formatDiffMarkdownLine(line string) string {
+	formattedLine := diffKeywordRegex.ReplaceAllString(line, "$2$1$3$4$5")
+	formattedLine = diffResourceRegex.ReplaceAllString(formattedLine, "$2$1$3")
+	formattedLine = diffHeredocRegex.ReplaceAllString(formattedLine, "$2$1$3$4")
+	formattedLine = diffColonRegex.ReplaceAllString(formattedLine, "$2$1$3")
+	formattedLine = diffListRegex.ReplaceAllString(formattedLine, "$2$1$3")
+	formattedLine = diffTildeRegex.ReplaceAllString(formattedLine, "!")
+
+	return formattedLine
+}
+
+func diffMarkdownHeredocStart(line string) (string, int, bool) {
+	heredocMatch := diffHeredocStartRegex.FindStringSubmatch(line)
+	if heredocMatch == nil {
+		return "", -1, false
+	}
+
+	markerMatch := diffLineMarkerRegex.FindStringSubmatch(line)
+	if markerMatch == nil || markerMatch[2] != "~" {
+		return heredocMatch[1], -1, true
+	}
+
+	// Terraform renders per-line diffs inside changed multiline strings four
+	// spaces deeper than the attribute marker. Added/deleted heredocs print their
+	// content normally, so only ~ heredocs should enable this inner gutter.
+	return heredocMatch[1], len(markerMatch[1]) + 4, true
+}
+
+func formatHeredocDiffMarkdownLine(line string, diffMarkerIndent int) string {
+	matches := diffHeredocContentLineRegex.FindStringSubmatch(line)
+	if matches == nil || len(matches[1]) != diffMarkerIndent {
+		return line
+	}
+
+	return diffTildeRegex.ReplaceAllString(matches[2]+matches[1]+matches[3], "!")
 }
 
 // Stats returns plan change stats and contextual information.

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -540,8 +540,7 @@ var (
 	diffColonRegex              = regexp.MustCompile(`(?m)^( +)([-+~]\s)( {4,}[a-zA-Z_][\w-]*:.*)`)
 	diffListRegex               = regexp.MustCompile(`(?m)^( +)([-+~]\s)(".*",)`)
 	diffTildeRegex              = regexp.MustCompile(`(?m)^~`)
-	diffLineMarkerRegex         = regexp.MustCompile(`^( +)([-+~])\s`)
-	diffHeredocStartRegex       = regexp.MustCompile(`<<-?([a-zA-Z_][\w]*)`)
+	diffHeredocStartRegex       = regexp.MustCompile(`^( *)([-+~]\s)?[a-zA-Z_][\w]*\s*=\s<<-?([a-zA-Z_][\w]*)\s*$`)
 	diffHeredocContentLineRegex = regexp.MustCompile(`^( +)([-+~]\s)(.*)`)
 )
 
@@ -549,12 +548,14 @@ var (
 func (p PlanSuccess) DiffMarkdownFormattedTerraformOutput() string {
 	lines := strings.Split(p.TerraformOutput, "\n")
 	heredocDelimiter := ""
+	heredocTerminatorIndent := -1
 	heredocDiffMarkerIndent := -1
 
 	for i, line := range lines {
 		if heredocDelimiter != "" {
-			if strings.TrimSpace(line) == heredocDelimiter {
+			if isDiffMarkdownHeredocEnd(line, heredocDelimiter, heredocTerminatorIndent) {
 				heredocDelimiter = ""
+				heredocTerminatorIndent = -1
 				heredocDiffMarkerIndent = -1
 				continue
 			}
@@ -565,8 +566,9 @@ func (p PlanSuccess) DiffMarkdownFormattedTerraformOutput() string {
 			continue
 		}
 
-		if delimiter, diffMarkerIndent, ok := diffMarkdownHeredocStart(line); ok {
+		if delimiter, terminatorIndent, diffMarkerIndent, ok := diffMarkdownHeredocStart(line); ok {
 			heredocDelimiter = delimiter
+			heredocTerminatorIndent = terminatorIndent
 			heredocDiffMarkerIndent = diffMarkerIndent
 		}
 
@@ -587,21 +589,26 @@ func formatDiffMarkdownLine(line string) string {
 	return formattedLine
 }
 
-func diffMarkdownHeredocStart(line string) (string, int, bool) {
+func diffMarkdownHeredocStart(line string) (string, int, int, bool) {
 	heredocMatch := diffHeredocStartRegex.FindStringSubmatch(line)
 	if heredocMatch == nil {
-		return "", -1, false
+		return "", -1, -1, false
 	}
 
-	markerMatch := diffLineMarkerRegex.FindStringSubmatch(line)
-	if markerMatch == nil || markerMatch[2] != "~" {
-		return heredocMatch[1], -1, true
+	delimiter := heredocMatch[3]
+	terminatorIndent := len(heredocMatch[1]) + len(heredocMatch[2])
+	if !strings.HasPrefix(heredocMatch[2], "~") {
+		return delimiter, terminatorIndent, -1, true
 	}
 
 	// Terraform renders per-line diffs inside changed multiline strings four
 	// spaces deeper than the attribute marker. Added/deleted heredocs print their
 	// content normally, so only ~ heredocs should enable this inner gutter.
-	return heredocMatch[1], len(markerMatch[1]) + 4, true
+	return delimiter, terminatorIndent, len(heredocMatch[1]) + 4, true
+}
+
+func isDiffMarkdownHeredocEnd(line string, delimiter string, indent int) bool {
+	return line == strings.Repeat(" ", indent)+delimiter
 }
 
 func formatHeredocDiffMarkdownLine(line string, diffMarkerIndent int) string {

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -534,14 +534,15 @@ func (p *PlanSuccess) NoChanges() bool {
 
 // Diff Markdown regexes
 var (
-	diffKeywordRegex            = regexp.MustCompile(`(?m)^( +)([-+~]\s)([a-zA-Z_][\w]*\s*)(\s=\s|\s->\s|\(known after apply\)|\{)(.*)`)
-	diffResourceRegex           = regexp.MustCompile(`(?m)^( +)([-+~]\s)((?:resource|data|module)\s+.+\{.*)`)
-	diffHeredocRegex            = regexp.MustCompile(`(?m)^( +)([-+~]\s)(<<)(.*)`)
-	diffColonRegex              = regexp.MustCompile(`(?m)^( +)([-+~]\s)( {4,}[a-zA-Z_][\w-]*:.*)`)
-	diffListRegex               = regexp.MustCompile(`(?m)^( +)([-+~]\s)(".*",)`)
-	diffTildeRegex              = regexp.MustCompile(`(?m)^~`)
-	diffHeredocStartRegex       = regexp.MustCompile(`^( *)([-+~]\s)?[a-zA-Z_][\w]*\s*=\s<<-?([a-zA-Z_][\w]*)\s*$`)
-	diffHeredocContentLineRegex = regexp.MustCompile(`^( +)([-+~]\s)(.*)`)
+	diffKeywordRegex                  = regexp.MustCompile(`(?m)^( +)([-+~]\s)([a-zA-Z_][\w]*\s*)(\s=\s|\s->\s|\(known after apply\)|\{)(.*)`)
+	diffResourceRegex                 = regexp.MustCompile(`(?m)^( +)([-+~]\s)((?:resource|data|module)\s+.+\{.*)`)
+	diffHeredocRegex                  = regexp.MustCompile(`(?m)^( +)([-+~]\s)(<<)(.*)`)
+	diffColonRegex                    = regexp.MustCompile(`(?m)^( +)([-+~]\s)( {4,}[a-zA-Z_][\w-]*:.*)`)
+	diffListRegex                     = regexp.MustCompile(`(?m)^( +)([-+~]\s)(".*",)`)
+	diffTildeRegex                    = regexp.MustCompile(`(?m)^~`)
+	diffHeredocAttributeStartRegex    = regexp.MustCompile(`^( *)([-+~]\s)?[a-zA-Z_][\w]*\s*=\s<<-?([a-zA-Z_][\w]*)\s*$`)
+	diffHeredocCollectionElementRegex = regexp.MustCompile(`^( *)([-+~]\s)<<-?([a-zA-Z_][\w]*)\s*$`)
+	diffHeredocContentLineRegex       = regexp.MustCompile(`^( +)([-+~]\s)(.*)`)
 )
 
 // DiffMarkdownFormattedTerraformOutput formats the Terraform output to match diff markdown format
@@ -590,26 +591,34 @@ func formatDiffMarkdownLine(line string) string {
 }
 
 func diffMarkdownHeredocStart(line string) (string, int, int, bool) {
-	heredocMatch := diffHeredocStartRegex.FindStringSubmatch(line)
-	if heredocMatch == nil {
-		return "", -1, -1, false
+	if heredocMatch := diffHeredocAttributeStartRegex.FindStringSubmatch(line); heredocMatch != nil {
+		// Attribute heredoc content diff markers render two spaces deeper than the
+		// terminator. Collection element content diff markers align with it.
+		return diffMarkdownHeredocState(heredocMatch[1], heredocMatch[2], heredocMatch[3], len(heredocMatch[1])+4)
 	}
 
-	delimiter := heredocMatch[3]
-	terminatorIndent := len(heredocMatch[1]) + len(heredocMatch[2])
-	if !strings.HasPrefix(heredocMatch[2], "~") {
+	if heredocMatch := diffHeredocCollectionElementRegex.FindStringSubmatch(line); heredocMatch != nil {
+		return diffMarkdownHeredocState(heredocMatch[1], heredocMatch[2], heredocMatch[3], len(heredocMatch[1])+len(heredocMatch[2]))
+	}
+
+	return "", -1, -1, false
+}
+
+func diffMarkdownHeredocState(indent string, marker string, delimiter string, diffMarkerIndent int) (string, int, int, bool) {
+	terminatorIndent := len(indent) + len(marker)
+	if !strings.HasPrefix(marker, "~") {
 		return delimiter, terminatorIndent, -1, true
 	}
 
-	// Terraform renders per-line diffs inside changed multiline strings four
-	// spaces deeper than the attribute marker. Added/deleted heredocs print their
-	// content normally, so only ~ heredocs should enable this inner gutter.
-	return delimiter, terminatorIndent, len(heredocMatch[1]) + 4, true
+	return delimiter, terminatorIndent, diffMarkerIndent, true
 }
 
 func isDiffMarkdownHeredocEnd(line string, delimiter string, indent int) bool {
 	terminator := strings.Repeat(" ", indent) + delimiter
-	return line == terminator || strings.HasPrefix(line, terminator+" -> ")
+	return line == terminator ||
+		line == terminator+"," ||
+		strings.HasPrefix(line, terminator+" -> ") ||
+		strings.HasPrefix(line, terminator+", -> ")
 }
 
 func formatHeredocDiffMarkdownLine(line string, diffMarkerIndent int) string {

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -592,13 +592,11 @@ func formatDiffMarkdownLine(line string) string {
 
 func diffMarkdownHeredocStart(line string) (string, int, int, bool) {
 	if heredocMatch := diffHeredocAttributeStartRegex.FindStringSubmatch(line); heredocMatch != nil {
-		// Attribute heredoc content diff markers render two spaces deeper than the
-		// terminator. Collection element content diff markers align with it.
 		return diffMarkdownHeredocState(heredocMatch[1], heredocMatch[2], heredocMatch[3], len(heredocMatch[1])+4)
 	}
 
 	if heredocMatch := diffHeredocCollectionElementRegex.FindStringSubmatch(line); heredocMatch != nil {
-		return diffMarkdownHeredocState(heredocMatch[1], heredocMatch[2], heredocMatch[3], len(heredocMatch[1])+len(heredocMatch[2]))
+		return diffMarkdownHeredocState(heredocMatch[1], heredocMatch[2], heredocMatch[3], len(heredocMatch[1])+len(heredocMatch[2])+2)
 	}
 
 	return "", -1, -1, false
@@ -610,6 +608,8 @@ func diffMarkdownHeredocState(indent string, marker string, delimiter string, di
 		return delimiter, terminatorIndent, -1, true
 	}
 
+	// Terraform renders changed heredoc content diff markers two spaces deeper
+	// than the heredoc terminator.
 	return delimiter, terminatorIndent, diffMarkerIndent, true
 }
 

--- a/server/events/models/models_test.go
+++ b/server/events/models/models_test.go
@@ -1611,6 +1611,41 @@ Plan: 1 to add, 0 to change, 0 to destroy.`,
         EOT
     }`,
 		},
+		{
+			// Regression test: changes inside a heredoc / multiline-string attribute.
+			// Terraform renders a line-by-line string diff with the marker in a gutter,
+			// preserving the line's own indentation after it. The marker must be pulled
+			// to column 0 so the diff highlighter colors it.
+			"heredoc multiline-string attribute diff",
+			`  # module.ogc.nomad_job.ogc will be updated in-place
+  ~ resource "nomad_job" "ogc" {
+        id      = "ogc"
+      ~ jobspec = <<-EOT
+            job "ogc" {
+              group "ogc" {
+                config {
+          -         image        = "registry/ogc:5.224.0"
+          +         image        = "registry/ogc:5.226.0"
+                  }
+              }
+            }
+        EOT
+    }`,
+			`# module.ogc.nomad_job.ogc will be updated in-place
+!   resource "nomad_job" "ogc" {
+        id      = "ogc"
+!       jobspec = <<-EOT
+            job "ogc" {
+              group "ogc" {
+                config {
+-                   image        = "registry/ogc:5.224.0"
++                   image        = "registry/ogc:5.226.0"
+                  }
+              }
+            }
+        EOT
+    }`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/events/models/models_test.go
+++ b/server/events/models/models_test.go
@@ -1742,6 +1742,27 @@ Plan: 1 to add, 0 to change, 0 to destroy.`,
         }
     }`,
 		},
+		{
+			"heredoc terminator with terraform suffix exits heredoc mode",
+			`  # terraform_data.example will be updated in-place
+  ~ resource "terraform_data" "example" {
+      ~ output = <<-EOT
+          old
+        EOT -> (known after apply)
+      + triggers_replace = [
+          + "changed",
+        ]
+    }`,
+			`# terraform_data.example will be updated in-place
+!   resource "terraform_data" "example" {
+!       output = <<-EOT
+          old
+        EOT -> (known after apply)
++       triggers_replace = [
++           "changed",
+        ]
+    }`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/events/models/models_test.go
+++ b/server/events/models/models_test.go
@@ -1770,8 +1770,8 @@ Plan: 1 to add, 0 to change, 0 to destroy.`,
       ~ input = [
           ~ <<-EOT
               first
-            - old
-            + new
+              - old
+              + new
             EOT,
         ]
       + triggers_replace = [
@@ -1783,8 +1783,8 @@ Plan: 1 to add, 0 to change, 0 to destroy.`,
 !       input = [
 !           <<-EOT
               first
--             old
-+             new
+-               old
++               new
             EOT,
         ]
 +       triggers_replace = [

--- a/server/events/models/models_test.go
+++ b/server/events/models/models_test.go
@@ -1575,6 +1575,52 @@ Plan: 1 to add, 0 to change, 0 to destroy.`,
     }`,
 		},
 		{
+			// Regression test for https://github.com/runatlantis/atlantis/issues/6419
+			// Spaced YAML list scalars inside a heredoc must not be mistaken for
+			// Terraform diff markers.
+			"argocd application with spaced yaml key=value list item in heredoc",
+			`  # argocd_application.example will be updated in-place
+  ~ resource "argocd_application" "example" {
+        id   = "my-app"
+      ~ metadata {
+          ~ resource_version = "12345" -> (known after apply)
+        }
+        spec = <<-EOT
+            destination:
+              namespace: default
+              server: https://kubernetes.default.svc
+            source:
+              repoURL: https://github.com/example/repo
+            syncPolicy:
+              automated:
+                prune: true
+                selfHeal: true
+              syncOptions:
+              -   ServerSideApply = true
+        EOT
+    }`,
+			`# argocd_application.example will be updated in-place
+!   resource "argocd_application" "example" {
+        id   = "my-app"
+!       metadata {
+!           resource_version = "12345" -> (known after apply)
+        }
+        spec = <<-EOT
+            destination:
+              namespace: default
+              server: https://kubernetes.default.svc
+            source:
+              repoURL: https://github.com/example/repo
+            syncPolicy:
+              automated:
+                prune: true
+                selfHeal: true
+              syncOptions:
+              -   ServerSideApply = true
+        EOT
+    }`,
+		},
+		{
 			"cloudformation stack with extra-spaced yaml list items in heredoc",
 			`  + resource "aws_cloudformation_stack" "conditions" {
       + id            = (known after apply)

--- a/server/events/models/models_test.go
+++ b/server/events/models/models_test.go
@@ -1763,6 +1763,35 @@ Plan: 1 to add, 0 to change, 0 to destroy.`,
         ]
     }`,
 		},
+		{
+			"collection element heredoc diff",
+			`  # terraform_data.example will be updated in-place
+  ~ resource "terraform_data" "example" {
+      ~ input = [
+          ~ <<-EOT
+              first
+            - old
+            + new
+            EOT,
+        ]
+      + triggers_replace = [
+          + "changed",
+        ]
+    }`,
+			`# terraform_data.example will be updated in-place
+!   resource "terraform_data" "example" {
+!       input = [
+!           <<-EOT
+              first
+-             old
++             new
+            EOT,
+        ]
++       triggers_replace = [
++           "changed",
+        ]
+    }`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/events/models/models_test.go
+++ b/server/events/models/models_test.go
@@ -1700,6 +1700,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.`,
       ~ jobspec = <<-EOT
             syncOptions:
               -   ServerSideApply = true
+            EOT
             job "ogc" {
               group "ogc" {
           -   image = "registry/ogc:5.224.0"
@@ -1714,6 +1715,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.`,
 !       jobspec = <<-EOT
             syncOptions:
               -   ServerSideApply = true
+            EOT
             job "ogc" {
               group "ogc" {
 -             image = "registry/ogc:5.224.0"
@@ -1721,6 +1723,23 @@ Plan: 1 to add, 0 to change, 0 to destroy.`,
               }
             }
         EOT
+    }`,
+		},
+		{
+			"quoted heredoc-like string does not enter heredoc mode",
+			`  # null_resource.example will be updated in-place
+  ~ resource "null_resource" "example" {
+      ~ cmd      = "cat <<EOF" -> "cat <<EOF --changed"
+      ~ triggers = {
+          + changed = "true"
+        }
+    }`,
+			`# null_resource.example will be updated in-place
+!   resource "null_resource" "example" {
+!       cmd      = "cat <<EOF" -> "cat <<EOF --changed"
+!       triggers = {
++           changed = "true"
+        }
     }`,
 		},
 	}

--- a/server/events/models/models_test.go
+++ b/server/events/models/models_test.go
@@ -1692,6 +1692,37 @@ Plan: 1 to add, 0 to change, 0 to destroy.`,
         EOT
     }`,
 		},
+		{
+			"heredoc multiline-string attribute diff with short indentation",
+			`  # module.ogc.nomad_job.ogc will be updated in-place
+  ~ resource "nomad_job" "ogc" {
+        id      = "ogc"
+      ~ jobspec = <<-EOT
+            syncOptions:
+              -   ServerSideApply = true
+            job "ogc" {
+              group "ogc" {
+          -   image = "registry/ogc:5.224.0"
+          +   image = "registry/ogc:5.226.0"
+              }
+            }
+        EOT
+    }`,
+			`# module.ogc.nomad_job.ogc will be updated in-place
+!   resource "nomad_job" "ogc" {
+        id      = "ogc"
+!       jobspec = <<-EOT
+            syncOptions:
+              -   ServerSideApply = true
+            job "ogc" {
+              group "ogc" {
+-             image = "registry/ogc:5.224.0"
++             image = "registry/ogc:5.226.0"
+              }
+            }
+        EOT
+    }`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## what

allow optional leading whitespace before the attribute name in `diffkeywordregex` so that `+`/`-` markers terraform places inside a changed heredoc / multiline-string body are pulled to column 0 and therefore color-coded by github/gitlab diff highlighting.

```diff
- diffkeywordregex  = regexp.mustcompile(`(?m)^( +)([-+~]\s)([a-za-z_][\w]*\s*)(\s=\s|\s->\s|\(known after apply\)|\{)(.*)`)
+ diffkeywordregex  = regexp.mustcompile(`(?m)^( +)([-+~]\s)(\s*[a-za-z_][\w]*\s*)(\s=\s|\s->\s|\(known after apply\)|\{)(.*)`)
```

adds a regression test covering a heredoc string diff (`server/events/models/models_test.go`).

## why

regression since v0.42.0 (#6069). terraform renders a line-by-line diff of a changed multiline string, keeping the line's own indentation **after** the gutter marker:

```
          -         image        = "registry/ogc:5.224.0"
```

the current `[a-za-z_][\w]*\s*` name group requires the name immediately after `marker + space`, so these lines no longer match and the marker stays indented → the highlighter (anchored to `^[+-]`) leaves them uncolored. pre-v0.42 used `(.*)` which matched them. adding `\s*` restores that for genuine attribute-style lines.

## tests

- all existing `testdiffmarkdownformattedterraformoutput` cases still pass, including the false-positive guards:
  - `- serversideapply=true` (yaml `key=value`, #6419) — still not colored (`=` ≠ ` = `).
  - `-   fn::equals:` / `-   !ref x` / `-   ""` (extra-spaced yaml, #6069) — still not colored.
- new case `heredoc multiline-string attribute diff` asserts the in-heredoc `image` change is pulled to column 0.

## references

closes #6560


