### PR TITLE
fix(github): Skip unused "source" remote on GitHub App path

### DIFF
--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -269,12 +269,17 @@ func (w *FileWorkspace) recheckDiverged(logger logging.SimpleLogging, p models.P
 		{
 			"git", "remote", "set-url", "origin", p.BaseRepo.CloneURL,
 		},
-		{
-			"git", "remote", "set-url", prSourceRemote, headRepo.CloneURL,
-		},
-		{
-			"git", "remote", "update",
-		},
+	}
+	if w.usesPRSourceRemote(p) {
+		cmds = append(cmds,
+			[]string{"git", "remote", "set-url", prSourceRemote, headRepo.CloneURL},
+			[]string{"git", "remote", "update"},
+		)
+	} else {
+		// On the GitHub App path the source (fork) remote isn't used to fetch the
+		// PR head, so only refresh origin. This avoids fetching a possibly
+		// inaccessible fork, which would fail and make us assume divergence.
+		cmds = append(cmds, []string{"git", "remote", "update", "origin"})
 	}
 
 	for _, args := range cmds {
@@ -467,8 +472,15 @@ func (w *FileWorkspace) remoteHasBranch(logger logging.SimpleLogging, c wrappedG
 // Locks are acquired by the caller.
 func (w *FileWorkspace) updateToRef(logger logging.SimpleLogging, c wrappedGitContext, targetRef string) error {
 
-	// We use both `<prSourceRemote>` and `origin` remotes, update them both
-	if err := w.wrappedGit(logger, c, "fetch", "--all"); err != nil {
+	// We use both `<prSourceRemote>` and `origin` remotes, update them both.
+	// On the GitHub App path the source (fork) remote isn't used to fetch the PR
+	// head (mergeToBaseBranch fetches pull/<n>/head from origin), so only update
+	// origin and avoid fetching a possibly inaccessible fork.
+	fetchArgs := []string{"fetch", "--all"}
+	if !w.usesPRSourceRemote(c.pr) {
+		fetchArgs = []string{"fetch", "origin"}
+	}
+	if err := w.wrappedGit(logger, c, fetchArgs...); err != nil {
 		return err
 	}
 
@@ -529,6 +541,17 @@ func (w *FileWorkspace) isBranchAtTargetRef(logger logging.SimpleLogging, c wrap
 	return strings.HasPrefix(currCommit, targetRef), nil
 }
 
+// usesPRSourceRemote reports whether the "source" remote (the PR's head repo,
+// e.g. a fork) is actually used to fetch the PR head. On the GitHub App path
+// mergeToBaseBranch fetches "pull/<n>/head" from origin instead (see
+// GithubAppEnabled handling there), so the source remote is never used and we
+// skip creating/updating it. Fetching the head repo otherwise only slows down
+// "git remote update"/"git fetch --all" and, when the App installation can't
+// read the fork, fails and makes recheckDiverged spuriously assume divergence.
+func (w *FileWorkspace) usesPRSourceRemote(p models.PullRequest) bool {
+	return !w.GithubAppEnabled || p.Num <= 0
+}
+
 func (w *FileWorkspace) forceClone(logger logging.SimpleLogging, c wrappedGitContext) error {
 	err := os.RemoveAll(c.dir)
 	if err != nil {
@@ -569,8 +592,10 @@ func (w *FileWorkspace) forceClone(logger logging.SimpleLogging, c wrappedGitCon
 		}
 	}
 
-	if err := w.wrappedGit(logger, c, "remote", "add", prSourceRemote, headCloneURL); err != nil {
-		return err
+	if w.usesPRSourceRemote(c.pr) {
+		if err := w.wrappedGit(logger, c, "remote", "add", prSourceRemote, headCloneURL); err != nil {
+			return err
+		}
 	}
 	if w.GpgNoSigningEnabled {
 		if err := w.wrappedGit(logger, c, "config", "--local", "commit.gpgsign", "false"); err != nil {

--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -167,6 +167,66 @@ func TestClone_CheckoutMergeNoneExisting(t *testing.T) {
 	Equals(t, expLsOutput, actLsOutput)
 }
 
+// Test that on the GitHub App path (GithubAppEnabled && pr.Num > 0) the merge
+// is performed by fetching pull/<n>/head from origin and the "source" (fork)
+// remote is never created, since it isn't used to fetch the PR head.
+func TestClone_CheckoutMergeGithubAppNoSourceRemote(t *testing.T) {
+	// Initialize the git repo.
+	repoDir := initRepo(t)
+
+	// Add a commit to branch 'branch' that's not on main.
+	runCmd(t, repoDir, "git", "checkout", "branch")
+	runCmd(t, repoDir, "touch", "branch-file")
+	runCmd(t, repoDir, "git", "add", "branch-file")
+	runCmd(t, repoDir, "git", "commit", "-m", "branch-commit")
+	branchCommit := runCmd(t, repoDir, "git", "rev-parse", "HEAD")
+
+	// Now switch back to main and advance the main branch by another commit.
+	runCmd(t, repoDir, "git", "checkout", "main")
+	runCmd(t, repoDir, "touch", "main-file")
+	runCmd(t, repoDir, "git", "add", "main-file")
+	runCmd(t, repoDir, "git", "commit", "-m", "main-commit")
+	mainCommit := runCmd(t, repoDir, "git", "rev-parse", "HEAD")
+
+	// On the GitHub App path the head is fetched as pull/<n>/head from origin,
+	// so expose the branch commit under that ref in the origin repo.
+	runCmd(t, repoDir, "git", "update-ref", "refs/pull/1/head", strings.TrimSpace(branchCommit))
+
+	logger := logging.NewNoopLogger(t)
+	dataDir := t.TempDir()
+
+	overrideURL := fmt.Sprintf("file://%s", repoDir)
+	wd := &events.FileWorkspace{
+		DataDir:                     dataDir,
+		CheckoutMerge:               true,
+		CheckoutDepth:               50,
+		TestingOverrideHeadCloneURL: overrideURL,
+		TestingOverrideBaseCloneURL: overrideURL,
+		GpgNoSigningEnabled:         true,
+		GithubAppEnabled:            true,
+	}
+
+	cloneDir, err := wd.Clone(logger, models.Repo{}, models.PullRequest{
+		BaseRepo:   models.Repo{},
+		HeadBranch: "branch",
+		BaseBranch: "main",
+		Num:        1,
+	}, "default")
+	Ok(t, err)
+
+	// The merge should still produce a merge commit whose parents are the base
+	// (main) and the head (branch) commits.
+	actBaseCommit := runCmd(t, cloneDir, "git", "rev-parse", "HEAD~1")
+	actHeadCommit := runCmd(t, cloneDir, "git", "rev-parse", "HEAD^2")
+	Equals(t, mainCommit, actBaseCommit)
+	Equals(t, branchCommit, actHeadCommit)
+
+	// The "source" remote must not have been created on the GitHub App path.
+	remotes := runCmd(t, cloneDir, "git", "remote")
+	Assert(t, !strings.Contains(remotes, "source"), "expected no \"source\" remote on the GitHub App path, got remotes: %q", remotes)
+	Assert(t, strings.Contains(remotes, "origin"), "expected \"origin\" remote, got remotes: %q", remotes)
+}
+
 // Test that if we're using the merge method and the repo is already cloned at
 // the right commit, then we don't reclone.
 func TestClone_CheckoutMergeNoReclone(t *testing.T) {


### PR DESCRIPTION
### what

- Add `usesPRSourceRemote()` and use it to skip the `source` remote (the PR's head repo, i.e. the fork) whenever Atlantis runs on the GitHub App path (`GithubAppEnabled && pr.Num > 0`)
- `forceClone` no longer runs `git remote add source`; `recheckDiverged` no longer runs `git remote set-url source` and scopes `git remote update` to `origin`; `updateToRef` scopes `git fetch --all` to `git fetch origin`
- The non-App (user/PAT) checkout-merge strategy still creates and uses `source` unchanged

### why

- A GitHub App installation is scoped to the repositories it's installed on. It does **not** get access to a contributor's **fork**, even when the fork owner is a member of the same organization — the fork lives under a personal account that the App is not installed on. So Atlantis cannot authenticate to the fork at all.
- On the GitHub App path the merge already fetches `pull/<n>/head` from `origin` (see `mergeToBaseBranch`), so the `source` remote (which points at the fork) is **never used** to fetch the PR head — creating and updating it is pure dead weight.
- But the existing code still adds the `source` remote and then fetches it via `git remote update` / `git fetch --all`. For any **fork-based PR** that fetch hits the inaccessible fork and **fails** — so the current functionality is broken for fork PRs on the App path.
- `recheckDiverged` treats that failure as divergence (logs a warning and returns `true`), so **every plan re-runs the full merge** and repeatedly pays the cost of the failing/slow fork fetch (e.g. an ~88s `git remote update`).
- Skipping the `source` remote on the App path removes the doomed fork fetch, speeds up `git remote update`, and lets divergence be detected correctly. The PR head still comes from `origin`'s `pull/<n>/head`, which the App **can** read on the base repo.

### workaround (no code change)

The same failing fork fetch can be avoided at runtime — without this patch — by telling git to skip the `source` remote during `git fetch --all` / `git remote update`. Set these in the Atlantis environment:

```
GIT_CONFIG_COUNT=1
GIT_CONFIG_KEY_0=remote.source.skipFetchAll
GIT_CONFIG_VALUE_0=true
```

This sets `remote.source.skipFetchAll=true` for every git invocation, so the inaccessible fork is no longer fetched. It's a useful mitigation for existing/older releases, but it still creates the unused `source` remote — this PR removes the work entirely on the App path.

### tests

- Added `TestClone_CheckoutMergeGithubAppNoSourceRemote`: with `GithubAppEnabled` and a PR number set, the merge fetches `pull/<n>/head` from `origin` and asserts the `source` remote is never created (and `origin` still exists)
- Existing working-dir tests exercise the non-App path, so that behavior is unchanged