### PR TITLE
chore(docker): Update base image to latest Debian Trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89
 # what distro is the image being built for
 ARG ALPINE_TAG=3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
-ARG DEBIAN_TAG=12.13-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3
+ARG DEBIAN_TAG=13.15@sha256:28de0877c2189802884ccd20f15ee41c203573bd87bb6b883f5f46362d24c5c2
 # renovate: datasource=docker depName=golang versioning=docker
 ARG GOLANG_TAG=1.25.8-alpine@sha256:8e02eb337d9e0ea459e041f1ee5eece41cbb61f1d83e7d883a3e2fb4862063fa
 
@@ -56,22 +56,22 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM debian:${DEBIAN_TAG} AS debian-base
 
 # Define package versions for Debian
-# renovate: datasource=repology depName=debian_12/ca-certificates versioning=loose
-ENV DEBIAN_CA_CERTIFICATES_VERSION="20230311+deb12u1"
-# renovate: datasource=repology depName=debian_12/curl versioning=loose
-ENV DEBIAN_CURL_VERSION="7.88.1-10+deb12u14"
-# renovate: datasource=repology depName=debian_12/git versioning=loose
-ENV DEBIAN_GIT_VERSION="1:2.39.5-0+deb12u3"
-# renovate: datasource=repology depName=debian_12/unzip versioning=loose
-ENV DEBIAN_UNZIP_VERSION="6.0-28"
-# renovate: datasource=repology depName=debian_12/openssh-server versioning=loose
-ENV DEBIAN_OPENSSH_SERVER_VERSION="1:9.2p1-2+deb12u10"
-# renovate: datasource=repology depName=debian_12/dumb-init versioning=loose
-ENV DEBIAN_DUMB_INIT_VERSION="1.2.5-2"
-# renovate: datasource=repology depName=debian_12/gnupg versioning=loose
-ENV DEBIAN_GNUPG_VERSION="2.2.40-1.1+deb12u2"
-# renovate: datasource=repology depName=debian_12/openssl versioning=loose
-ENV DEBIAN_OPENSSL_VERSION="3.0.20-1~deb12u1"
+# renovate: datasource=repology depName=debian_13/ca-certificates versioning=loose
+ENV DEBIAN_CA_CERTIFICATES_VERSION="20250419"
+# renovate: datasource=repology depName=debian_13/curl versioning=loose
+ENV DEBIAN_CURL_VERSION="8.14.1-2+deb13u3"
+# renovate: datasource=repology depName=debian_13/git versioning=loose
+ENV DEBIAN_GIT_VERSION="1:2.47.3-0+deb13u1"
+# renovate: datasource=repology depName=debian_13/unzip versioning=loose
+ENV DEBIAN_UNZIP_VERSION="6.0-29"
+# renovate: datasource=repology depName=debian_13/openssh-server versioning=loose
+ENV DEBIAN_OPENSSH_SERVER_VERSION="1:10.0p1-7+deb13u4"
+# renovate: datasource=repology depName=debian_13/dumb-init versioning=loose
+ENV DEBIAN_DUMB_INIT_VERSION="1.2.5-3"
+# renovate: datasource=repology depName=debian_13/gnupg versioning=loose
+ENV DEBIAN_GNUPG_VERSION="2.4.7-21+deb13u1"
+# renovate: datasource=repology depName=debian_13/openssl versioning=loose
+ENV DEBIAN_OPENSSL_VERSION="3.5.6-1~deb13u2"
 
 # Set up the 'atlantis' user and adjust permissions. User with uid 1000 is for backwards compatibility
 RUN groupadd --gid 1000 atlantis && \
@@ -276,8 +276,8 @@ ENV DEFAULT_CONFTEST_VERSION=${DEFAULT_CONFTEST_VERSION}
 # trees, not the entire image). Post-pass: if getcap still reports any
 # "path = cap_set" line under that scope, the build fails. Strip may use
 # 2>/dev/null and setcap || true; verification is the hard guarantee.
-# renovate: datasource=repology depName=debian_12/libcap2-bin versioning=loose
-ENV DEBIAN_LIBCAP2_BIN_VERSION="1:2.66-4+deb12u3+b1"
+# renovate: datasource=repology depName=debian_13/libcap2-bin versioning=loose
+ENV DEBIAN_LIBCAP2_BIN_VERSION="1:2.75-10+deb13u1+b1"
 # hadolint ignore=DL4006
 RUN fcap_scan_dirs="/bin /sbin /usr /opt /lib /lib64" && \
     apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89
 # what distro is the image being built for
 ARG ALPINE_TAG=3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
-ARG DEBIAN_TAG=13.15-slim@sha256:28de0877c2189802884ccd20f15ee41c203573bd87bb6b883f5f46362d24c5c2
+ARG DEBIAN_TAG=13.5-slim@sha256:28de0877c2189802884ccd20f15ee41c203573bd87bb6b883f5f46362d24c5c2
 # renovate: datasource=docker depName=golang versioning=docker
 ARG GOLANG_TAG=1.25.8-alpine@sha256:8e02eb337d9e0ea459e041f1ee5eece41cbb61f1d83e7d883a3e2fb4862063fa
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -186,7 +186,7 @@ COPY --from=deps /usr/bin/git-lfs /usr/bin/git-lfs
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 # renovate: datasource=repology depName=alpine_3_23/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20260413-r0"
+ENV CA_CERTIFICATES_VERSION="20260611-r0"
 # renovate: datasource=repology depName=alpine_3_23/curl versioning=loose
 ENV CURL_VERSION="8.19.0-r0"
 # renovate: datasource=repology depName=alpine_3_23/git versioning=loose

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89
 # what distro is the image being built for
 ARG ALPINE_TAG=3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
-ARG DEBIAN_TAG=13.15@sha256:28de0877c2189802884ccd20f15ee41c203573bd87bb6b883f5f46362d24c5c2
+ARG DEBIAN_TAG=13.15-slim@sha256:28de0877c2189802884ccd20f15ee41c203573bd87bb6b883f5f46362d24c5c2
 # renovate: datasource=docker depName=golang versioning=docker
 ARG GOLANG_TAG=1.25.8-alpine@sha256:8e02eb337d9e0ea459e041f1ee5eece41cbb61f1d83e7d883a3e2fb4862063fa
 


### PR DESCRIPTION
## What

- Updates the base Debian image from 12 (bookworm) to 13 (trixie).
- Updates pins of packages installed via `apt-get` to their trixie equivalent versions.
- Updates renovate comments to `debian_13`.

## Why

Resolves https://github.com/runatlantis/atlantis/issues/6571

## Tests

- Manual build via `docker build -t 'atlantis-debian' . --build-arg ATLANTIS_BASE_TAG_TYPE=debian`
- `docker scout compare --to registry://ghcr.io/runatlantis/atlantis:v0.44.0-debian local://atlantis-debian`:

<details>
<summary>docker scout results (abridged)</summary>

<img width="932" height="264" alt="image" src="https://github.com/user-attachments/assets/2775094b-d2db-45bd-96f5-5488075a155f" />

## Packages and Vulnerabilities

```
+   39 packages added
-   37 packages removed
⎌  176 packages changed (↑ 176 upgraded, ↓ 0 downgraded)
     444 packages unchanged

+ 3 vulnerabilities added
- 47 vulnerabilities removed
```
</details>

## References

Upgrading:
- https://www.debian.org/releases/trixie/release-notes/upgrading.html

Debian release notes:
- 12.14: https://www.debian.org/News/2026/2026051602
- 13.0: https://www.debian.org/releases/trixie/release-notes/index.en.html
- 13.1: https://www.debian.org/News/2025/20250906
- 13.2: https://www.debian.org/News/2025/20251115
- 13.3: https://www.debian.org/News/2026/20260110
- 13.4: https://www.debian.org/News/2026/20260314
- 13.5: https://www.debian.org/News/2026/20260516