### PR TITLE
feat: Add a possibility to define a default merge method

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -51,6 +51,7 @@ const (
 	AtlantisURLFlag                  = "atlantis-url"
 	AutoDiscoverModeFlag             = "autodiscover-mode"
 	AutomergeFlag                    = "automerge"
+	AutomergeMethodFlag              = "automerge-method"
 	ParallelPlanFlag                 = "parallel-plan"
 	ParallelApplyFlag                = "parallel-apply"
 	AutoplanModules                  = "autoplan-modules"
@@ -239,6 +240,11 @@ var stringFlags = map[string]stringFlag{
 			"means projects will be discovered when no explicit projects are defined in repo config. Also supports 'enabled' (always " +
 			"discover projects) and 'disabled' (never discover projects).",
 		defaultValue: DefaultAutoDiscoverMode,
+	},
+	AutomergeMethodFlag: {
+		description: "Default merge method to use when automerging pull requests, unless overridden by the --auto-merge-method comment flag. " +
+			"Valid values are 'merge', 'rebase', and 'squash'. Currently only implemented for GitHub.",
+		defaultValue: "",
 	},
 	AutoplanModulesFromProjects: {
 		description: "Comma separated list of file patterns to select projects Atlantis will index for module dependencies." +
@@ -713,6 +719,10 @@ var int64Flags = map[string]int64Flag{
 // ValidLogLevels are the valid log levels that can be set
 var ValidLogLevels = []string{"debug", "info", "warn", "error"}
 
+// ValidAutomergeMethods are the valid merge methods that can be set for the
+// automerge-method flag.
+var ValidAutomergeMethods = []string{"merge", "rebase", "squash"}
+
 type stringFlag struct {
 	description  string
 	defaultValue string
@@ -1036,6 +1046,10 @@ func (s *ServerCmd) validate(userConfig server.UserConfig) error {
 	if checkoutStrategy != CheckoutStrategyBranch && checkoutStrategy != CheckoutStrategyMerge {
 		return fmt.Errorf("invalid checkout strategy: not one of %s or %s",
 			CheckoutStrategyBranch, CheckoutStrategyMerge)
+	}
+
+	if userConfig.AutomergeMethod != "" && !slices.Contains(ValidAutomergeMethods, userConfig.AutomergeMethod) {
+		return fmt.Errorf("invalid --%s: must be one of %v", AutomergeMethodFlag, ValidAutomergeMethods)
 	}
 
 	if (userConfig.SSLKeyFile == "") != (userConfig.SSLCertFile == "") {

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -61,6 +61,7 @@ var testFlags = map[string]any{
 	APISecretFlag:                    "",
 	AutoDiscoverModeFlag:             "auto",
 	AutomergeFlag:                    true,
+	AutomergeMethodFlag:              "squash",
 	AutoplanFileListFlag:             "**/*.tf,**/*.yml",
 	BitbucketApiUserFlag:             "bitbucket-api-user",
 	BitbucketBaseURLFlag:             "https://bitbucket-base-url.com",
@@ -487,6 +488,55 @@ func TestExecute_ValidateCheckoutStrategy(t *testing.T) {
 	}, t)
 	err := c.Execute()
 	ErrEquals(t, "invalid checkout strategy: not one of branch or merge", err)
+}
+
+func TestExecute_ValidateAutomergeMethod(t *testing.T) {
+	cases := []struct {
+		description string
+		method      string
+		expectErr   string
+	}{
+		{
+			"empty method uses VCS default",
+			"",
+			"",
+		},
+		{
+			"merge",
+			"merge",
+			"",
+		},
+		{
+			"rebase",
+			"rebase",
+			"",
+		},
+		{
+			"squash",
+			"squash",
+			"",
+		},
+		{
+			"invalid method",
+			"fast-forward",
+			"invalid --automerge-method: must be one of [merge rebase squash]",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.description, func(t *testing.T) {
+			c := setupWithDefaults(map[string]any{
+				AutomergeMethodFlag: testCase.method,
+			}, t)
+
+			err := c.Execute()
+			if testCase.expectErr != "" {
+				ErrEquals(t, testCase.expectErr, err)
+			} else {
+				Ok(t, err)
+			}
+		})
+	}
 }
 
 func TestExecute_ValidateSSLConfig(t *testing.T) {

--- a/runatlantis.io/docs/automerging.md
+++ b/runatlantis.io/docs/automerging.md
@@ -31,8 +31,16 @@ command with the `--auto-merge-disabled` option.
 
 ## How to set the merge method for automerge
 
-If automerge is enabled, you can use the `--auto-merge-method` option
-for the `atlantis apply` command to specify which merge method use.
+If automerge is enabled, you can set a default merge method with the
+`--automerge-method` server flag or `ATLANTIS_AUTOMERGE_METHOD` environment
+variable.
+
+```shell
+atlantis server --automerge-method <method>
+```
+
+You can override the server default for a single `atlantis apply` command with
+the `--auto-merge-method` option.
 
 ```shell
 atlantis apply --auto-merge-method <method>

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -152,6 +152,19 @@ ATLANTIS_AUTOMERGE=true
 Automatically merge pull requests after all plans have been successfully applied.
 Defaults to `false`. See [Automerging](automerging.md) for more details.
 
+### `--automerge-method`
+
+```bash
+atlantis server --automerge-method="squash"
+# or
+ATLANTIS_AUTOMERGE_METHOD="squash"
+```
+
+Default merge method to use when automerging pull requests. Valid values are
+`merge`, `rebase`, and `squash`. When not set, the VCS provider's default merge
+method is used. This can be overridden per command with the `--auto-merge-method`
+comment flag. Currently only implemented for GitHub.
+
 ### `--autoplan-file-list` <Badge text="v0.15.0+" type="info"/>
 
 ```bash

--- a/server/events/automerger.go
+++ b/server/events/automerger.go
@@ -12,8 +12,9 @@ import (
 )
 
 type AutoMerger struct {
-	VCSClient       vcs.Client
-	GlobalAutomerge bool
+	VCSClient             vcs.Client
+	GlobalAutomerge       bool
+	GlobalAutomergeMethod string
 }
 
 func (c *AutoMerger) automerge(ctx *command.Context, pullStatus models.PullStatus, deleteSourceBranchOnMerge bool, mergeMethod string) {
@@ -29,6 +30,12 @@ func (c *AutoMerger) automerge(ctx *command.Context, pullStatus models.PullStatu
 	if err := c.VCSClient.CreateComment(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull.Num, automergeComment, command.Apply.String()); err != nil {
 		ctx.Log.Err("failed to comment about automerge: %s", err)
 		// Commenting isn't required so continue.
+	}
+
+	// Fall back to the server-side default merge method when the comment
+	// command didn't specify one with --auto-merge-method.
+	if mergeMethod == "" {
+		mergeMethod = c.GlobalAutomergeMethod
 	}
 
 	// Make the API call to perform the merge.

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -1151,6 +1151,60 @@ func TestApplyWithAutoMerge_VSCMerge(t *testing.T) {
 	vcsClient.VerifyWasCalledOnce().MergePull(Any[logging.SimpleLogging](), Eq(modelPull), Eq(pullOptions))
 }
 
+func TestApplyWithAutoMerge_UsesGlobalMergeMethod(t *testing.T) {
+	t.Log("if \"atlantis apply\" is run with automerge and no --auto-merge-method" +
+		" comment flag, the server-side default merge method is used")
+
+	vcsClient := setup(t)
+	pull := &github.PullRequest{
+		State: github.Ptr("open"),
+	}
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState}
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+	autoMerger.GlobalAutomerge = true
+	autoMerger.GlobalAutomergeMethod = "squash"
+	defer func() {
+		autoMerger.GlobalAutomerge = false
+		autoMerger.GlobalAutomergeMethod = ""
+	}()
+
+	pullOptions := models.PullRequestOptions{
+		DeleteSourceBranchOnMerge: false,
+		MergeMethod:               "squash",
+	}
+
+	ch.RunCommentCommand(testdata.GithubRepo, &testdata.GithubRepo, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Apply})
+	vcsClient.VerifyWasCalledOnce().MergePull(Any[logging.SimpleLogging](), Eq(modelPull), Eq(pullOptions))
+}
+
+func TestApplyWithAutoMerge_CommentFlagOverridesGlobalMergeMethod(t *testing.T) {
+	t.Log("if \"atlantis apply\" is run with automerge and a --auto-merge-method" +
+		" comment flag, the comment flag overrides the server-side default")
+
+	vcsClient := setup(t)
+	pull := &github.PullRequest{
+		State: github.Ptr("open"),
+	}
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState}
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+	autoMerger.GlobalAutomerge = true
+	autoMerger.GlobalAutomergeMethod = "squash"
+	defer func() {
+		autoMerger.GlobalAutomerge = false
+		autoMerger.GlobalAutomergeMethod = ""
+	}()
+
+	pullOptions := models.PullRequestOptions{
+		DeleteSourceBranchOnMerge: false,
+		MergeMethod:               "rebase",
+	}
+
+	ch.RunCommentCommand(testdata.GithubRepo, &testdata.GithubRepo, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Apply, AutoMergeMethod: "rebase"})
+	vcsClient.VerifyWasCalledOnce().MergePull(Any[logging.SimpleLogging](), Eq(modelPull), Eq(pullOptions))
+}
+
 func TestRunApply_DiscardedProjects(t *testing.T) {
 	t.Log("if \"atlantis apply\" is run with automerge and at least one project" +
 		" has a discarded plan, automerge should not take place")

--- a/server/server.go
+++ b/server/server.go
@@ -776,8 +776,9 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	}
 
 	autoMerger := &events.AutoMerger{
-		VCSClient:       vcsClient,
-		GlobalAutomerge: userConfig.Automerge,
+		VCSClient:             vcsClient,
+		GlobalAutomerge:       userConfig.Automerge,
+		GlobalAutomergeMethod: userConfig.AutomergeMethod,
 	}
 
 	projectOutputWrapper := &events.ProjectOutputWrapper{

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -23,6 +23,7 @@ type UserConfig struct {
 	AtlantisURL                 string `mapstructure:"atlantis-url"`
 	AutoDiscoverModeFlag        string `mapstructure:"autodiscover-mode"`
 	Automerge                   bool   `mapstructure:"automerge"`
+	AutomergeMethod             string `mapstructure:"automerge-method"`
 	AutoplanFileList            string `mapstructure:"autoplan-file-list"`
 	AutoplanModules             bool   `mapstructure:"autoplan-modules"`
 	AutoplanModulesFromProjects string `mapstructure:"autoplan-modules-from-projects"`


### PR DESCRIPTION
## Summary

- Add an optional `--automerge-method` / `ATLANTIS_AUTOMERGE_METHOD` server default for automerge merge method.
- Preserve the per-apply `--auto-merge-method` override and leave unset behavior at the VCS provider default.
- Document the server default in the automerging and server configuration docs.

## Notes

Currently only GitHub implements merge method handling.
