### PR TITLE
docs: clarify GitHub App merge checkout behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,13 +61,15 @@
 
 **Terraform execution:** Modify `server/core/terraform/tfclient/terraform_client.go` or `server/core/runtime/*_step_runner.go` (uses `hashicorp/hc-install`)
 
+**GitHub App merge checkout:** In `server/events/working_dir.go`, `CheckoutMerge` with `GithubAppEnabled` and a PR number fetches `pull/<n>/head` from `origin` and intentionally skips the `source` remote. Preserve this fork-safe behavior when changing clone, fetch, or divergence logic.
+
 ## Known Issues
 
-2. **TestNewServer_GitHubUser fails:** Pre-existing in main. Ignore it.
-3. **E2E tests skip on forks:** Expected (no secrets). Maintainers run them.
-4. **Website needs npm install first:** Always run `npm install` before `npm run website:*` commands.
-5. **docker-compose needs atlantis.env:** Create file per CONTRIBUTING.md template for local webhook testing.
-6. **E2E GitHub tests require GitHub App secrets:** CI needs `ATLANTISBOT_GH_APP_ID`, `ATLANTISBOT_GH_APP_KEY`, `ATLANTISBOT_GH_APP_SLUG` secrets configured. PAT auth (`ATLANTISBOT_GITHUB_USERNAME`/`ATLANTISBOT_GITHUB_TOKEN`) is deprecated due to org 2FA requirements (#6311).
+1. **TestNewServer_GitHubUser fails:** Pre-existing in main. Ignore it.
+2. **E2E tests skip on forks:** Expected (no secrets). Maintainers run them.
+3. **Website needs npm install first:** Always run `npm install` before `npm run website:*` commands.
+4. **docker-compose needs atlantis.env:** Create file per CONTRIBUTING.md template for local webhook testing.
+5. **E2E GitHub tests require GitHub App secrets:** CI needs `ATLANTISBOT_GH_APP_ID`, `ATLANTISBOT_GH_APP_KEY`, `ATLANTISBOT_GH_APP_SLUG` secrets configured. PAT auth (`ATLANTISBOT_GITHUB_USERNAME`/`ATLANTISBOT_GITHUB_TOKEN`) is deprecated due to org 2FA requirements (#6311).
 
 ## Code Style
 

--- a/runatlantis.io/docs/checkout-strategy.md
+++ b/runatlantis.io/docs/checkout-strategy.md
@@ -49,6 +49,15 @@ In the case of transient errors when updating the merged branch, Atlantis will
 error for safety to avoid using a stale branch.
 :::
 
+:::tip NOTE
+When Atlantis is authenticated as a GitHub App and uses the `merge` checkout
+strategy for a GitHub pull request, it fetches the pull request head from the
+base repository's `pull/<PR number>/head` ref on `origin`. It does not create or
+update a separate `source` remote for the pull request's head repository. This
+avoids fetching forks that the GitHub App installation cannot access. The
+non-GitHub App checkout path still uses the `source` remote.
+:::
+
 :::warning
 Atlantis only performs this merge during the `terraform plan` phase. If another
 commit is pushed to `main` **after** Atlantis runs `plan`, nothing will happen.


### PR DESCRIPTION
Summary:
- Document GitHub App merge checkout behavior for fork PRs in the checkout strategy docs.
- Capture the same working-dir invariant in AGENTS.md and fix the Known Issues numbering drift.

References:
- Follow-up to #6568
