### PR TITLE
feat: add --disable-automerge-label flag

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -72,6 +72,7 @@ const (
 	DisableApplyAllFlag              = "disable-apply-all"
 	DisableAutoplanFlag              = "disable-autoplan"
 	DisableAutoplanLabelFlag         = "disable-autoplan-label"
+	DisableAutomergeLabelFlag        = "disable-automerge-label"
 	DisableMarkdownFoldingFlag       = "disable-markdown-folding"
 	DisableRepoLockingFlag           = "disable-repo-locking"
 	DisableGlobalApplyLockFlag       = "disable-global-apply-lock"
@@ -303,6 +304,10 @@ var stringFlags = map[string]stringFlag{
 	},
 	DisableAutoplanLabelFlag: {
 		description:  "Pull request label to disable atlantis auto planning feature only if present.",
+		defaultValue: "",
+	},
+	DisableAutomergeLabelFlag: {
+		description:  "Pull request label to disable atlantis automerge feature only if present.",
 		defaultValue: "",
 	},
 	DisableUnlockLabelFlag: {

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -161,6 +161,7 @@ var testFlags = map[string]any{
 	WriteGitCredsFlag:                true,
 	DisableAutoplanFlag:              true,
 	DisableAutoplanLabelFlag:         "no-auto-plan",
+	DisableAutomergeLabelFlag:        "no-auto-merge",
 	DisableUnlockLabelFlag:           "do-not-unlock",
 	EnablePolicyChecksFlag:           false,
 	EnableRegExpCmdFlag:              false,

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -486,6 +486,19 @@ ATLANTIS_DISABLE_APPLY_ALL=true
 Disable `atlantis apply` command so a specific project/workspace/directory has to
 be specified for applies.
 
+### `--disable-automerge-label` <Badge text="v0.45.0+" type="info"/>
+
+```bash
+atlantis server --disable-automerge-label="no-auto-merge"
+# or
+ATLANTIS_DISABLE_AUTOMERGE_LABEL="no-auto-merge"
+```
+
+Disable atlantis automerge only on pull requests with the specified label.
+Defaults to an empty string, so no label disables automerge by default.
+This flag has no effect unless automerge is enabled with `--automerge` or
+repo-level `automerge: true`.
+
 ### `--disable-autoplan` <Badge text="v0.15.0+" type="info"/>
 
 ```bash

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1439,6 +1439,7 @@ func setupE2E(t *testing.T, repoDir string, opt setupOption) (events_controllers
 	parallelPoolSize := 1
 	silenceNoProjects := false
 
+	disableAutomergeLabel := "no-auto-merge"
 	disableUnlockLabel := "do-not-unlock"
 
 	statusUpdater := runtimemocks.NewMockStatusUpdater()
@@ -1630,6 +1631,7 @@ func setupE2E(t *testing.T, repoDir string, opt setupOption) (events_controllers
 		silenceNoProjects,
 		false,
 		e2ePullReqStatusFetcher,
+		disableAutomergeLabel,
 	)
 
 	approvePoliciesCommandRunner := events.NewApprovePoliciesCommandRunner(

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -4,6 +4,8 @@
 package events
 
 import (
+	"slices"
+
 	"github.com/runatlantis/atlantis/server/core/db"
 	"github.com/runatlantis/atlantis/server/core/locking"
 	"github.com/runatlantis/atlantis/server/events/command"
@@ -27,6 +29,7 @@ func NewApplyCommandRunner(
 	SilenceNoProjects bool,
 	silenceVCSStatusNoProjects bool,
 	pullReqStatusFetcher vcs.PullReqStatusFetcher,
+	disableAutomergeLabel string,
 ) *ApplyCommandRunner {
 	return &ApplyCommandRunner{
 		vcsClient:                  vcsClient,
@@ -44,23 +47,25 @@ func NewApplyCommandRunner(
 		SilenceNoProjects:          SilenceNoProjects,
 		silenceVCSStatusNoProjects: silenceVCSStatusNoProjects,
 		pullReqStatusFetcher:       pullReqStatusFetcher,
+		disableAutomergeLabel:      disableAutomergeLabel,
 	}
 }
 
 type ApplyCommandRunner struct {
-	DisableApplyAll      bool
-	Database             db.Database
-	locker               locking.ApplyLockChecker
-	vcsClient            vcs.Client
-	commitStatusUpdater  CommitStatusUpdater
-	prjCmdBuilder        ProjectApplyCommandBuilder
-	prjCmdRunner         ProjectApplyCommandRunner
-	cancellationTracker  CancellationTracker
-	autoMerger           *AutoMerger
-	pullUpdater          *PullUpdater
-	dbUpdater            *DBUpdater
-	parallelPoolSize     int
-	pullReqStatusFetcher vcs.PullReqStatusFetcher
+	DisableApplyAll       bool
+	Database              db.Database
+	locker                locking.ApplyLockChecker
+	vcsClient             vcs.Client
+	commitStatusUpdater   CommitStatusUpdater
+	prjCmdBuilder         ProjectApplyCommandBuilder
+	prjCmdRunner          ProjectApplyCommandRunner
+	cancellationTracker   CancellationTracker
+	autoMerger            *AutoMerger
+	pullUpdater           *PullUpdater
+	dbUpdater             *DBUpdater
+	parallelPoolSize      int
+	pullReqStatusFetcher  vcs.PullReqStatusFetcher
+	disableAutomergeLabel string
 	// SilenceNoProjects is whether Atlantis should respond to PRs if no projects
 	// are found
 	SilenceNoProjects bool
@@ -207,6 +212,16 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 	a.updateCommitStatus(ctx, pullStatus)
 
 	if a.autoMerger.automergeEnabled(projectCmds) && !cmd.AutoMergeDisabled {
+		if len(a.disableAutomergeLabel) > 0 {
+			labels, err := a.vcsClient.GetPullLabels(ctx.Log, baseRepo, pull)
+			if err != nil {
+				ctx.Log.Err("unable to get pull request labels so not automerging, error %s", err)
+				return
+			} else if slices.Contains(labels, a.disableAutomergeLabel) {
+				ctx.Log.Info("pull/merge request has disable automerge label %q so not automerging", a.disableAutomergeLabel)
+				return
+			}
+		}
 		a.autoMerger.automerge(ctx, pullStatus, a.autoMerger.deleteSourceBranchOnMergeEnabled(projectCmds), cmd.AutoMergeMethod)
 	}
 }

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -73,6 +73,7 @@ type TestConfig struct {
 	discardApprovalOnPlan      bool
 	database                   db.Database
 	DisableUnlockLabel         string
+	DisableAutomergeLabel      string
 	PendingApplyStatus         bool
 	applyLockCheckerReturn     locking.ApplyCommandLock
 	applyLockCheckerErr        error
@@ -206,6 +207,7 @@ func setup(t *testing.T, options ...func(testConfig *TestConfig)) *vcsmocks.Mock
 		testConfig.SilenceNoProjects,
 		testConfig.silenceVCSStatusNoProjects,
 		pullReqStatusFetcher,
+		testConfig.DisableAutomergeLabel,
 	)
 
 	approvePoliciesCommandRunner = events.NewApprovePoliciesCommandRunner(
@@ -1453,15 +1455,7 @@ func TestApplyMergeablityWhenPolicyCheckFails(t *testing.T) {
 func TestApplyWithAutoMerge_VSCMerge(t *testing.T) {
 	t.Log("if \"atlantis apply\" is run with automerge then a VCS merge is performed")
 
-	vcsClient := setup(t)
-	pull := &github.PullRequest{
-		State: github.Ptr("open"),
-	}
-	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState}
-	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(pull, nil)
-	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
-	autoMerger.GlobalAutomerge = true
-	defer func() { autoMerger.GlobalAutomerge = false }()
+	vcsClient, modelPull := setupApplyWithAutoMerge(t)
 
 	pullOptions := models.PullRequestOptions{
 		DeleteSourceBranchOnMerge: false,
@@ -1475,19 +1469,9 @@ func TestApplyWithAutoMerge_UsesGlobalMergeMethod(t *testing.T) {
 	t.Log("if \"atlantis apply\" is run with automerge and no --auto-merge-method" +
 		" comment flag, the server-side default merge method is used")
 
-	vcsClient := setup(t)
-	pull := &github.PullRequest{
-		State: github.Ptr("open"),
-	}
-	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState}
-	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(pull, nil)
-	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
-	autoMerger.GlobalAutomerge = true
+	vcsClient, modelPull := setupApplyWithAutoMerge(t)
 	autoMerger.GlobalAutomergeMethod = "squash"
-	defer func() {
-		autoMerger.GlobalAutomerge = false
-		autoMerger.GlobalAutomergeMethod = ""
-	}()
+	t.Cleanup(func() { autoMerger.GlobalAutomergeMethod = "" })
 
 	pullOptions := models.PullRequestOptions{
 		DeleteSourceBranchOnMerge: false,
@@ -1502,19 +1486,9 @@ func TestApplyWithAutoMerge_CommentFlagOverridesGlobalMergeMethod(t *testing.T) 
 	t.Log("if \"atlantis apply\" is run with automerge and a --auto-merge-method" +
 		" comment flag, the comment flag overrides the server-side default")
 
-	vcsClient := setup(t)
-	pull := &github.PullRequest{
-		State: github.Ptr("open"),
-	}
-	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState}
-	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(pull, nil)
-	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
-	autoMerger.GlobalAutomerge = true
+	vcsClient, modelPull := setupApplyWithAutoMerge(t)
 	autoMerger.GlobalAutomergeMethod = "squash"
-	defer func() {
-		autoMerger.GlobalAutomerge = false
-		autoMerger.GlobalAutomergeMethod = ""
-	}()
+	t.Cleanup(func() { autoMerger.GlobalAutomergeMethod = "" })
 
 	pullOptions := models.PullRequestOptions{
 		DeleteSourceBranchOnMerge: false,
@@ -1523,6 +1497,75 @@ func TestApplyWithAutoMerge_CommentFlagOverridesGlobalMergeMethod(t *testing.T) 
 
 	ch.RunCommentCommand(testdata.GithubRepo, &testdata.GithubRepo, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Apply, AutoMergeMethod: "rebase"})
 	vcsClient.VerifyWasCalledOnce().MergePull(Any[logging.SimpleLogging](), Eq(modelPull), Eq(pullOptions))
+}
+
+func TestApplyWithAutoMerge_DisableAutomergeLabelStillMergesWhenLabelMissing(t *testing.T) {
+	t.Log("if disable-automerge-label is configured but the pull request does not have that label, automerge is performed")
+
+	disableAutomergeLabel := "no-auto-merge"
+	vcsClient, modelPull := setupApplyWithAutoMerge(t, func(testConfig *TestConfig) {
+		testConfig.DisableAutomergeLabel = disableAutomergeLabel
+	})
+	When(vcsClient.GetPullLabels(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull))).ThenReturn([]string{"safe-to-merge"}, nil)
+
+	pullOptions := models.PullRequestOptions{
+		DeleteSourceBranchOnMerge: false,
+	}
+
+	ch.RunCommentCommand(testdata.GithubRepo, &testdata.GithubRepo, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Apply})
+
+	vcsClient.VerifyWasCalledOnce().GetPullLabels(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull))
+	vcsClient.VerifyWasCalledOnce().MergePull(Any[logging.SimpleLogging](), Eq(modelPull), Eq(pullOptions))
+}
+
+func TestApplyWithAutoMerge_DisableAutomergeLabelSkipsMergeWhenLabelPresent(t *testing.T) {
+	t.Log("if disable-automerge-label is configured and the pull request has that label, automerge is not performed")
+
+	disableAutomergeLabel := "no-auto-merge"
+	vcsClient, modelPull := setupApplyWithAutoMerge(t, func(testConfig *TestConfig) {
+		testConfig.DisableAutomergeLabel = disableAutomergeLabel
+	})
+	When(vcsClient.GetPullLabels(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull))).ThenReturn([]string{disableAutomergeLabel, "need-help"}, nil)
+
+	ch.RunCommentCommand(testdata.GithubRepo, &testdata.GithubRepo, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Apply})
+
+	vcsClient.VerifyWasCalledOnce().GetPullLabels(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull))
+	vcsClient.VerifyWasCalled(Never()).MergePull(Any[logging.SimpleLogging](), Any[models.PullRequest](), Any[models.PullRequestOptions]())
+}
+
+func TestApplyWithAutoMerge_DisableAutomergeLabelSkipsMergeWhenLabelsCannotBeFetched(t *testing.T) {
+	t.Log("if disable-automerge-label is configured and pull request labels cannot be fetched, automerge is not performed")
+
+	disableAutomergeLabel := "no-auto-merge"
+	vcsClient, modelPull := setupApplyWithAutoMerge(t, func(testConfig *TestConfig) {
+		testConfig.DisableAutomergeLabel = disableAutomergeLabel
+	})
+	When(vcsClient.GetPullLabels(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull))).ThenReturn(nil, errors.New("err"))
+
+	ch.RunCommentCommand(testdata.GithubRepo, &testdata.GithubRepo, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Apply})
+
+	vcsClient.VerifyWasCalledOnce().GetPullLabels(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull))
+	vcsClient.VerifyWasCalled(Never()).MergePull(Any[logging.SimpleLogging](), Any[models.PullRequest](), Any[models.PullRequestOptions]())
+}
+
+func setupApplyWithAutoMerge(t *testing.T, options ...func(testConfig *TestConfig)) (*vcsmocks.MockClient, models.PullRequest) {
+	t.Helper()
+
+	vcsClient := setup(t, options...)
+	pull := &github.PullRequest{
+		State: github.Ptr("open"),
+	}
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState}
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+	autoMerger.GlobalAutomerge = true
+	autoMerger.GlobalAutomergeMethod = ""
+	t.Cleanup(func() {
+		autoMerger.GlobalAutomerge = false
+		autoMerger.GlobalAutomergeMethod = ""
+	})
+
+	return vcsClient, modelPull
 }
 
 func TestRunApply_DiscardedProjects(t *testing.T) {

--- a/server/server.go
+++ b/server/server.go
@@ -846,6 +846,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		userConfig.SilenceNoProjects,
 		userConfig.SilenceVCSStatusNoProjects,
 		pullReqStatusFetcher,
+		userConfig.DisableAutomergeLabel,
 	)
 
 	approvePoliciesCommandRunner := events.NewApprovePoliciesCommandRunner(

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -43,6 +43,7 @@ type UserConfig struct {
 	DisableApplyAll             bool   `mapstructure:"disable-apply-all"`
 	DisableAutoplan             bool   `mapstructure:"disable-autoplan"`
 	DisableAutoplanLabel        string `mapstructure:"disable-autoplan-label"`
+	DisableAutomergeLabel       string `mapstructure:"disable-automerge-label"`
 	DisableMarkdownFolding      bool   `mapstructure:"disable-markdown-folding"`
 	DisableRepoLocking          bool   `mapstructure:"disable-repo-locking"`
 	DisableGlobalApplyLock      bool   `mapstructure:"disable-global-apply-lock"`


### PR DESCRIPTION
## what

- Add a new --disable-automerge-label server configuration flag, analogous to the existing --disable-autoplan-label
- When configured, Atlantis skips automerge after a successful atlantis apply if the PR/MR has the specified label
- Fail closed when Atlantis cannot fetch PR/MR labels before automerge, so label lookup errors do not bypass the configured opt-out
- Document a consistent no-auto-merge example label

## why

- On long-lived or iterative PRs with multiple rounds of atlantis apply, remembering to pass --auto-merge-disabled every time is error-prone
- Forgetting the flag can result in an unintended merge, requiring a new branch/PR to continue work
- A label-based approach is persistent for the PR lifetime, visible in the VCS UI, and consistent with how --disable-autoplan-label already works
- Supersedes #6532 because the original fork has maintainer edits disabled; original PR author is @Vince-Chenal and the commit author is preserved

## tests

- [x] git diff --check
- [x] make check-fmt
- [x] go test ./server/events -run TestApplyWithAutoMerge -count=1
- [x] go test ./server/events ./cmd -count=1
- [x] npm run website:build

## references

- Supersedes #6532
- closes #3181
