### PR TITLE
fix: detect OpenTofu versions with project distribution

### DIFF
--- a/runatlantis.io/docs/repo-level-atlantis-yaml.md
+++ b/runatlantis.io/docs/repo-level-atlantis-yaml.md
@@ -278,6 +278,8 @@ projects:
 ```
 
 Atlantis will automatically download and use this distribution. Valid values are `terraform` and `opentofu`.
+If `terraform_version` is omitted and the project uses a `required_version` constraint, Atlantis resolves that
+constraint against the selected distribution.
 
 ### Terraform Versions
 

--- a/runatlantis.io/docs/terraform-versions.md
+++ b/runatlantis.io/docs/terraform-versions.md
@@ -58,6 +58,9 @@ See [Terraform `required_version`](https://developer.hashicorp.com/terraform/lan
 ::: tip NOTE
 Atlantis will automatically download the latest version that fulfills the constraint specified.
 A `terraform_version` specified in the `atlantis.yaml` file takes precedence over both the [`--default-tf-version`](server-configuration.md#default-tf-version) flag and the `required_version` in the terraform hcl.
+When a project sets `terraform_distribution`, Atlantis resolves the `required_version`
+constraint against that distribution. For example, an OpenTofu project resolves to an
+OpenTofu version instead of a Terraform version.
 :::
 
 ::: tip NOTE

--- a/server/core/terraform/tfclient/mocks/mock_terraform_client.go
+++ b/server/core/terraform/tfclient/mocks/mock_terraform_client.go
@@ -28,11 +28,11 @@ func NewMockClient(options ...pegomock.Option) *MockClient {
 func (mock *MockClient) SetFailHandler(fh pegomock.FailHandler) { mock.fail = fh }
 func (mock *MockClient) FailHandler() pegomock.FailHandler      { return mock.fail }
 
-func (mock *MockClient) DetectVersion(log logging.SimpleLogging, projectDirectory string) *go_version.Version {
+func (mock *MockClient) DetectVersion(log logging.SimpleLogging, d terraform.Distribution, projectDirectory string) *go_version.Version {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockClient().")
 	}
-	_params := []pegomock.Param{log, projectDirectory}
+	_params := []pegomock.Param{log, d, projectDirectory}
 	_result := pegomock.GetGenericMockFrom(mock).Invoke("DetectVersion", _params, []reflect.Type{reflect.TypeOf((**go_version.Version)(nil)).Elem()})
 	var _ret0 *go_version.Version
 	if len(_result) != 0 {
@@ -114,8 +114,8 @@ type VerifierMockClient struct {
 	timeout                time.Duration
 }
 
-func (verifier *VerifierMockClient) DetectVersion(log logging.SimpleLogging, projectDirectory string) *MockClient_DetectVersion_OngoingVerification {
-	_params := []pegomock.Param{log, projectDirectory}
+func (verifier *VerifierMockClient) DetectVersion(log logging.SimpleLogging, d terraform.Distribution, projectDirectory string) *MockClient_DetectVersion_OngoingVerification {
+	_params := []pegomock.Param{log, d, projectDirectory}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "DetectVersion", _params, verifier.timeout)
 	return &MockClient_DetectVersion_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -125,12 +125,12 @@ type MockClient_DetectVersion_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockClient_DetectVersion_OngoingVerification) GetCapturedArguments() (logging.SimpleLogging, string) {
-	log, projectDirectory := c.GetAllCapturedArguments()
-	return log[len(log)-1], projectDirectory[len(projectDirectory)-1]
+func (c *MockClient_DetectVersion_OngoingVerification) GetCapturedArguments() (logging.SimpleLogging, terraform.Distribution, string) {
+	log, d, projectDirectory := c.GetAllCapturedArguments()
+	return log[len(log)-1], d[len(d)-1], projectDirectory[len(projectDirectory)-1]
 }
 
-func (c *MockClient_DetectVersion_OngoingVerification) GetAllCapturedArguments() (_param0 []logging.SimpleLogging, _param1 []string) {
+func (c *MockClient_DetectVersion_OngoingVerification) GetAllCapturedArguments() (_param0 []logging.SimpleLogging, _param1 []terraform.Distribution, _param2 []string) {
 	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(_params) > 0 {
 		if len(_params) > 0 {
@@ -140,9 +140,15 @@ func (c *MockClient_DetectVersion_OngoingVerification) GetAllCapturedArguments()
 			}
 		}
 		if len(_params) > 1 {
-			_param1 = make([]string, len(c.methodInvocations))
+			_param1 = make([]terraform.Distribution, len(c.methodInvocations))
 			for u, param := range _params[1] {
-				_param1[u] = param.(string)
+				_param1[u] = param.(terraform.Distribution)
+			}
+		}
+		if len(_params) > 2 {
+			_param2 = make([]string, len(c.methodInvocations))
+			for u, param := range _params[2] {
+				_param2[u] = param.(string)
 			}
 		}
 	}

--- a/server/core/terraform/tfclient/terraform_client.go
+++ b/server/core/terraform/tfclient/terraform_client.go
@@ -44,7 +44,9 @@ type Client interface {
 	// EnsureVersion makes sure that terraform version `v` is available to use
 	EnsureVersion(log logging.SimpleLogging, d terraform.Distribution, v *version.Version) error
 
-	// DetectVersion extracts required_version from Terraform configuration in the specified project directory. Returns nil if unable to determine the version.
+	// DetectVersion extracts required_version from Terraform/OpenTofu configuration in the specified project directory.
+	// Non-exact constraints are resolved using the provided distribution, or the client default distribution when nil.
+	// Returns nil if unable to determine the version.
 	DetectVersion(log logging.SimpleLogging, d terraform.Distribution, projectDirectory string) *version.Version
 }
 
@@ -287,9 +289,10 @@ func (c *DefaultClient) ExtractExactRegex(log logging.SimpleLogging, version str
 	return tfVersions
 }
 
-// DetectVersion extracts required_version from Terraform configuration in the specified project directory. Returns nil if unable to determine the version.
-// It will also try to evaluate non-exact matches by passing the Constraints to the hc-install Releases API, which will return a list of available versions.
-// It will then select the highest version that satisfies the constraint.
+// DetectVersion extracts required_version from Terraform/OpenTofu configuration in the specified project directory.
+// If downloads are allowed, non-exact constraints are resolved against the provided distribution, or the client
+// default distribution when nil, and the highest satisfying version is selected.
+// Returns nil if unable to determine the version.
 func (c *DefaultClient) DetectVersion(log logging.SimpleLogging, d terraform.Distribution, projectDirectory string) *version.Version {
 	module, diags := tfconfig.LoadModule(projectDirectory)
 	if diags.HasErrors() {

--- a/server/core/terraform/tfclient/terraform_client.go
+++ b/server/core/terraform/tfclient/terraform_client.go
@@ -44,8 +44,8 @@ type Client interface {
 	// EnsureVersion makes sure that terraform version `v` is available to use
 	EnsureVersion(log logging.SimpleLogging, d terraform.Distribution, v *version.Version) error
 
-	// DetectVersion Extracts required_version from Terraform configuration in the specified project directory. Returns nil if unable to determine the version.
-	DetectVersion(log logging.SimpleLogging, projectDirectory string) *version.Version
+	// DetectVersion extracts required_version from Terraform configuration in the specified project directory. Returns nil if unable to determine the version.
+	DetectVersion(log logging.SimpleLogging, d terraform.Distribution, projectDirectory string) *version.Version
 }
 
 type DefaultClient struct {
@@ -290,7 +290,7 @@ func (c *DefaultClient) ExtractExactRegex(log logging.SimpleLogging, version str
 // DetectVersion extracts required_version from Terraform configuration in the specified project directory. Returns nil if unable to determine the version.
 // It will also try to evaluate non-exact matches by passing the Constraints to the hc-install Releases API, which will return a list of available versions.
 // It will then select the highest version that satisfies the constraint.
-func (c *DefaultClient) DetectVersion(log logging.SimpleLogging, projectDirectory string) *version.Version {
+func (c *DefaultClient) DetectVersion(log logging.SimpleLogging, d terraform.Distribution, projectDirectory string) *version.Version {
 	module, diags := tfconfig.LoadModule(projectDirectory)
 	if diags.HasErrors() {
 		log.Err("trying to detect required version: %s", diags.Error())
@@ -319,7 +319,7 @@ func (c *DefaultClient) DetectVersion(log logging.SimpleLogging, projectDirector
 		return version
 	}
 
-	downloadVersion, err := c.distribution.ResolveConstraint(context.Background(), requiredVersionSetting)
+	downloadVersion, err := c.effectiveDistribution(d).ResolveConstraint(context.Background(), requiredVersionSetting)
 	if err != nil {
 		log.Err("%s", err)
 		return nil

--- a/server/core/terraform/tfclient/terraform_client_test.go
+++ b/server/core/terraform/tfclient/terraform_client_test.go
@@ -1033,7 +1033,7 @@ terraform {
 			tmpDir := DirStructure(t, testCase.DirStructure)
 
 			for project, expectedVersion := range testCase.Exp {
-				detectedVersion := c.DetectVersion(logger, filepath.Join(tmpDir, project))
+				detectedVersion := c.DetectVersion(logger, nil, filepath.Join(tmpDir, project))
 
 				expectNil := expectedVersion == "" || (!testCase.IsExact && !downloadsAllowed)
 				if expectNil {
@@ -1052,6 +1052,75 @@ terraform {
 		runDetectVersionTestCase(t, name+": Downloads Allowed", testCase, true)
 		runDetectVersionTestCase(t, name+": Downloads Disabled", testCase, false)
 	}
+}
+
+type constraintResolvingDistribution struct {
+	binName         string
+	resolvedVersion string
+	constraints     []string
+}
+
+func (d *constraintResolvingDistribution) BinName() string {
+	return d.binName
+}
+
+func (*constraintResolvingDistribution) Downloader() terraform.Downloader {
+	return nil
+}
+
+func (d *constraintResolvingDistribution) ResolveConstraint(_ context.Context, constraintStr string) (*version.Version, error) {
+	d.constraints = append(d.constraints, constraintStr)
+	return version.NewVersion(d.resolvedVersion)
+}
+
+func TestDetectVersion_UsesDistributionOverride(t *testing.T) {
+	logger := logging.NewNoopLogger(t)
+	tmp, binDir, cacheDir := mkSubDirs(t)
+	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
+	Ok(t, writeExecutable(filepath.Join(tmp, "terraform"), "echo '\nTerraform v0.11.10\n'"))
+	defer tempSetEnv(t, "PATH", fmt.Sprintf("%s:%s", tmp, os.Getenv("PATH")))()
+	defaultDistribution := &constraintResolvingDistribution{
+		binName:         "terraform",
+		resolvedVersion: "1.15.7",
+	}
+	opentofuDistribution := &constraintResolvingDistribution{
+		binName:         "tofu",
+		resolvedVersion: "1.12.3",
+	}
+	c, err := tfclient.NewTestClient(
+		logger,
+		defaultDistribution,
+		binDir,
+		cacheDir,
+		"",
+		"",
+		"",
+		cmd.DefaultTFVersionFlag,
+		cmd.DefaultTFDownloadURL,
+		true,
+		true,
+		projectCmdOutputHandler,
+	)
+	Ok(t, err)
+
+	tmpDir := DirStructure(t, map[string]any{
+		"project1": map[string]any{
+			"main.tf": `terraform {
+  required_version = ">= 1.5"
+}
+`,
+		},
+	})
+
+	detectedDefault := c.DetectVersion(logger, nil, filepath.Join(tmpDir, "project1"))
+	Assert(t, detectedDefault != nil, "TerraformVersion is nil.")
+	Equals(t, "1.15.7", detectedDefault.String())
+	Equals(t, []string{">= 1.5"}, defaultDistribution.constraints)
+
+	detectedOpenTofu := c.DetectVersion(logger, opentofuDistribution, filepath.Join(tmpDir, "project1"))
+	Assert(t, detectedOpenTofu != nil, "TerraformVersion is nil.")
+	Equals(t, "1.12.3", detectedOpenTofu.String())
+	Equals(t, []string{">= 1.5"}, opentofuDistribution.constraints)
 }
 
 func TestExtractExactRegex(t *testing.T) {

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	. "github.com/petergtz/pegomock/v4"
+	"github.com/runatlantis/atlantis/server/core/terraform"
 	tfclientmocks "github.com/runatlantis/atlantis/server/core/terraform/tfclient/mocks"
 	"github.com/runatlantis/atlantis/server/metrics/metricstest"
 
@@ -3187,11 +3188,19 @@ projects:
   terraform_version: v0.12.6
 `
 
+	opentofuAtlantisYamlContent := `
+version: 3
+projects:
+- dir: project1
+  terraform_distribution: opentofu
+`
+
 	type testCase struct {
-		DirStructure  map[string]any
-		AtlantisYAML  string
-		ModifiedFiles []string
-		Exp           map[string]string
+		DirStructure    map[string]any
+		AtlantisYAML    string
+		ModifiedFiles   []string
+		Exp             map[string]string
+		ExpDistribution map[string]string
 	}
 
 	testCases := make(map[string]testCase)
@@ -3251,6 +3260,22 @@ projects:
 		},
 	}
 
+	testCases["opentofu project detects version with opentofu distribution"] = testCase{
+		DirStructure: map[string]any{
+			"project1": map[string]any{
+				"main.tf": baseVersionConfig,
+			},
+			valid.DefaultAtlantisFile: opentofuAtlantisYamlContent,
+		},
+		ModifiedFiles: []string{"project1/main.tf"},
+		Exp: map[string]string{
+			"project1": "0.12.8",
+		},
+		ExpDistribution: map[string]string{
+			"project1": "tofu",
+		},
+	}
+
 	logger := logging.NewNoopLogger(t)
 	scope := metricstest.NewLoggingScope(t, logger, "atlantis")
 	userConfig := defaultUserConfig
@@ -3274,8 +3299,12 @@ projects:
 			}
 
 			terraformClient := tfclientmocks.NewMockClient()
-			When(terraformClient.DetectVersion(Any[logging.SimpleLogging](), Any[string]())).Then(func(params []Param) ReturnValues {
-				projectName := filepath.Base(params[1].(string))
+			detectedDistributions := map[string]string{}
+			When(terraformClient.DetectVersion(Any[logging.SimpleLogging](), Any[terraform.Distribution](), Any[string]())).Then(func(params []Param) ReturnValues {
+				projectName := filepath.Base(params[2].(string))
+				if params[1] != nil {
+					detectedDistributions[projectName] = params[1].(terraform.Distribution).BinName()
+				}
 				testVersion := testCase.Exp[projectName]
 				if testVersion != "" {
 					v, _ := version.NewVersion(testVersion)
@@ -3330,6 +3359,9 @@ projects:
 				} else {
 					Assert(t, actCtx.TerraformVersion == nil, "TerraformVersion is supposed to be nil.")
 				}
+			}
+			for project, expDistribution := range testCase.ExpDistribution {
+				Equals(t, expDistribution, detectedDistributions[project])
 			}
 		})
 	}

--- a/server/events/project_command_context_builder.go
+++ b/server/events/project_command_context_builder.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/core/terraform"
 	"github.com/runatlantis/atlantis/server/core/terraform/tfclient"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
@@ -125,11 +126,7 @@ func (cb *DefaultProjectCommandContextBuilder) BuildProjectContext(
 		}
 	}
 
-	// If TerraformVersion not defined in config file look for a
-	// terraform.require_version block.
-	if prjCfg.TerraformVersion == nil {
-		prjCfg.TerraformVersion = terraformClient.DetectVersion(ctx.Log, filepath.Join(repoDir, prjCfg.RepoRelDir))
-	}
+	detectProjectTerraformVersion(ctx, &prjCfg, repoDir, terraformClient)
 
 	projectCmdContext := newProjectCommandContext(
 		ctx,
@@ -180,11 +177,7 @@ func (cb *PolicyCheckProjectCommandContextBuilder) BuildProjectContext(
 		ctx.Log.Debug("PolicyChecks are disabled on this repository")
 	}
 
-	// If TerraformVersion not defined in config file look for a
-	// terraform.require_version block.
-	if prjCfg.TerraformVersion == nil {
-		prjCfg.TerraformVersion = terraformClient.DetectVersion(ctx.Log, filepath.Join(repoDir, prjCfg.RepoRelDir))
-	}
+	detectProjectTerraformVersion(ctx, &prjCfg, repoDir, terraformClient)
 
 	projectCmds = cb.ProjectCommandContextBuilder.BuildProjectContext(
 		ctx,
@@ -229,6 +222,20 @@ func (cb *PolicyCheckProjectCommandContextBuilder) BuildProjectContext(
 	}
 
 	return
+}
+
+func detectProjectTerraformVersion(ctx *command.Context, prjCfg *valid.MergedProjectCfg, repoDir string, terraformClient tfclient.Client) {
+	// If TerraformVersion is not defined in the repo config, look for a
+	// required_version setting in the project's Terraform/OpenTofu config.
+	if prjCfg.TerraformVersion != nil {
+		return
+	}
+
+	var tfDistribution terraform.Distribution
+	if prjCfg.TerraformDistribution != nil {
+		tfDistribution = terraform.NewDistribution(*prjCfg.TerraformDistribution)
+	}
+	prjCfg.TerraformVersion = terraformClient.DetectVersion(ctx.Log, tfDistribution, filepath.Join(repoDir, prjCfg.RepoRelDir))
 }
 
 // newProjectCommandContext is a initializer method that handles constructing the


### PR DESCRIPTION
Summary:
- Resolve autodetected `required_version` constraints with a project's `terraform_distribution` override.
- Cover OpenTofu version detection so mixed Terraform/OpenTofu deployments do not resolve Terraform-only versions for tofu.
- Document the distribution-aware version detection behavior.

References:
- Fixes #6553
