### PR TITLE
fix: scope regex project plans with restrict file list

### DIFF
--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -640,7 +640,7 @@ The flag will only allow the regexes listed in the [`allowed_regexp_prefixes`](r
 
 This will not work with `-d` yet and to use `-p` the repo projects must be defined in the repo `atlantis.yaml` file.
 
-This will bypass `--restrict-file-list` if regex is used, normal commands will still be blocked if necessary.
+When `--restrict-file-list` is enabled, regex project plans are limited to matching projects with files modified in the pull request. Without `--restrict-file-list`, regex project commands can still run against all matching projects.
 
 ::: warning SECURITY WARNING
 It's not supposed to be used with `--disable-apply-all`.
@@ -1409,8 +1409,7 @@ ATLANTIS_RESTRICT_FILE_LIST=true
 ```
 
 `--restrict-file-list` will block plan requests from projects outside the files modified in the pull request.
-This will not block plan requests with regex if using the `--enable-regexp-cmd` flag, in these cases commands
-like `atlantis plan -p .*` will still work if used. normal commands will still be blocked if necessary.
+When `--enable-regexp-cmd` is also enabled, regex project plans such as `atlantis plan -p .*` are scoped to matching projects with files modified in the pull request.
 Defaults to `false`.
 
 ### `--silence-allowlist-errors` <Badge text="v0.28.0+" type="info"/>

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -855,6 +855,8 @@ func (p *DefaultProjectCommandBuilder) buildProjectPlanCommand(ctx *command.Cont
 		if err != nil {
 			return nil, err
 		}
+		var restrictedRegexProjects []valid.Project
+		var restrictedRegexRepoCfg *valid.RepoCfg
 
 		if p.IncludeGitUntrackedFiles {
 			ctx.Log.Debug(("'include-git-untracked-files' option is set, getting untracked files"))
@@ -884,7 +886,6 @@ func (p *DefaultProjectCommandBuilder) buildProjectPlanCommand(ctx *command.Cont
 
 		if cmd.ProjectName != "" {
 			ctx.Log.Debug("Command project name specified: %s", cmd.ProjectName)
-			var notFoundFiles = []string{}
 			var repoConfig valid.RepoCfg
 
 			repoConfig, err = p.ParserValidator.ParseRepoCfg(defaultRepoDir, p.GlobalCfg, ctx.Pull.BaseRepo.ID(), ctx.Pull.BaseBranch)
@@ -892,24 +893,32 @@ func (p *DefaultProjectCommandBuilder) buildProjectPlanCommand(ctx *command.Cont
 				return pcc, err
 			}
 			repoCfgProjects := repoConfig.FindProjectsByName(cmd.ProjectName)
-
-			for _, f := range modifiedFiles {
-				foundDir := false
-
-				for _, p := range repoCfgProjects {
-					if filepath.Dir(f) == p.Dir {
-						foundDir = true
-					}
-				}
-
-				if !foundDir {
-					notFoundFiles = append(notFoundFiles, filepath.Dir(f))
-				}
-			}
+			notFoundFiles := modifiedFilesOutsideProjects(modifiedFiles, repoCfgProjects)
 
 			if len(notFoundFiles) > 0 {
 				return pcc, fmt.Errorf("the following directories are present in the pull request but not in the requested project:\n%s", strings.Join(notFoundFiles, "\n"))
 			}
+			if p.EnableRegExpCmd && len(repoCfgProjects) > 1 {
+				restrictedRegexProjects = filterProjectsByModifiedFiles(repoCfgProjects, modifiedFiles)
+				if len(restrictedRegexProjects) == 0 {
+					return pcc, fmt.Errorf("no modified files match requested project %q", cmd.ProjectName)
+				}
+				restrictedRegexRepoCfg = &repoConfig
+			}
+		}
+		if restrictedRegexRepoCfg != nil {
+			return p.buildProjectCommandCtxWithCfg(
+				ctx,
+				command.Plan,
+				"",
+				cmd.Flags,
+				defaultRepoDir,
+				repoRelDir,
+				workspace,
+				cmd.Verbose,
+				restrictedRegexProjects,
+				restrictedRegexRepoCfg,
+			)
 		}
 	}
 
@@ -1146,6 +1155,19 @@ func (p *DefaultProjectCommandBuilder) buildProjectCommandCtx(ctx *command.Conte
 	if err != nil {
 		return []command.ProjectContext{}, err
 	}
+	return p.buildProjectCommandCtxWithCfg(ctx, cmd, subCmd, commentFlags, repoDir, repoRelDir, workspace, verbose, matchingProjects, repoCfgPtr)
+}
+
+func (p *DefaultProjectCommandBuilder) buildProjectCommandCtxWithCfg(ctx *command.Context,
+	cmd command.Name,
+	subCmd string,
+	commentFlags []string,
+	repoDir string,
+	repoRelDir string,
+	workspace string,
+	verbose bool,
+	matchingProjects []valid.Project,
+	repoCfgPtr *valid.RepoCfg) ([]command.ProjectContext, error) {
 	var projCtxs []command.ProjectContext
 	var projCfg valid.MergedProjectCfg
 	automerge := p.EnableAutoMerge
@@ -1245,6 +1267,37 @@ func (p *DefaultProjectCommandBuilder) buildProjectCommandCtx(ctx *command.Conte
 	})
 
 	return projCtxs, nil
+}
+
+func modifiedFilesOutsideProjects(modifiedFiles []string, projects []valid.Project) []string {
+	projectDirs := make(map[string]struct{}, len(projects))
+	for _, project := range projects {
+		projectDirs[filepath.Clean(project.Dir)] = struct{}{}
+	}
+
+	var notFoundFiles []string
+	for _, file := range modifiedFiles {
+		dir := filepath.Clean(filepath.Dir(file))
+		if _, ok := projectDirs[dir]; !ok {
+			notFoundFiles = append(notFoundFiles, filepath.Dir(file))
+		}
+	}
+	return notFoundFiles
+}
+
+func filterProjectsByModifiedFiles(projects []valid.Project, modifiedFiles []string) []valid.Project {
+	modifiedDirs := make(map[string]struct{}, len(modifiedFiles))
+	for _, file := range modifiedFiles {
+		modifiedDirs[filepath.Clean(filepath.Dir(file))] = struct{}{}
+	}
+
+	var filtered []valid.Project
+	for _, project := range projects {
+		if _, ok := modifiedDirs[filepath.Clean(project.Dir)]; ok {
+			filtered = append(filtered, project)
+		}
+	}
+	return filtered
 }
 
 // validateWorkspaceAllowed returns an error if repoCfg defines projects in

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -849,14 +849,14 @@ func (p *DefaultProjectCommandBuilder) buildProjectPlanCommand(ctx *command.Cont
 		return pcc, ErrIgnoredTargetedDir
 	}
 
+	var restrictedRegexProjects []valid.Project
+	var restrictedRegexRepoCfg *valid.RepoCfg
 	if p.RestrictFileList {
 		ctx.Log.Debug("'restrict-file-list' option is set, checking modified files")
 		modifiedFiles, err := p.VCSClient.GetModifiedFiles(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull)
 		if err != nil {
 			return nil, err
 		}
-		var restrictedRegexProjects []valid.Project
-		var restrictedRegexRepoCfg *valid.RepoCfg
 
 		if p.IncludeGitUntrackedFiles {
 			ctx.Log.Debug(("'include-git-untracked-files' option is set, getting untracked files"))
@@ -906,20 +906,6 @@ func (p *DefaultProjectCommandBuilder) buildProjectPlanCommand(ctx *command.Cont
 				restrictedRegexRepoCfg = &repoConfig
 			}
 		}
-		if restrictedRegexRepoCfg != nil {
-			return p.buildProjectCommandCtxWithCfg(
-				ctx,
-				command.Plan,
-				"",
-				cmd.Flags,
-				defaultRepoDir,
-				repoRelDir,
-				workspace,
-				cmd.Verbose,
-				restrictedRegexProjects,
-				restrictedRegexRepoCfg,
-			)
-		}
 	}
 
 	if DefaultWorkspace != workspace {
@@ -928,6 +914,20 @@ func (p *DefaultProjectCommandBuilder) buildProjectPlanCommand(ctx *command.Cont
 		if err != nil {
 			return pcc, err
 		}
+	}
+	if restrictedRegexRepoCfg != nil {
+		return p.buildProjectCommandCtxWithCfg(
+			ctx,
+			command.Plan,
+			"",
+			cmd.Flags,
+			defaultRepoDir,
+			repoRelDir,
+			workspace,
+			cmd.Verbose,
+			restrictedRegexProjects,
+			restrictedRegexRepoCfg,
+		)
 	}
 
 	return p.buildProjectCommandCtx(

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -1828,6 +1828,7 @@ func TestDefaultProjectCommandBuilder_BuildSinglePlanApplyCommand_WithRestrictFi
 		ExpNoProjects      bool
 		ExpSkipFileList    bool
 		ExpProjectNames    []string
+		ExpCloneWorkspaces []string
 	}{
 		{
 			Description: "planning a file outside of the changed files",
@@ -1975,6 +1976,42 @@ projects:
 			ExpProjectNames: []string{"cicd/shared"},
 		},
 		{
+			Description: "planning a regexp project with non-default workspace clones the workspace before returning",
+			Cmd: events.CommentCommand{
+				Name:        command.Plan,
+				Workspace:   "staging",
+				ProjectName: ".*/shared",
+			},
+			EnableRegExpCmd: true,
+			AtlantisYAML: `
+version: 3
+projects:
+- name: athens/shared
+  dir: layers/athens/shared
+  workspace: staging
+- name: cicd/shared
+  dir: layers/cicd/shared
+  workspace: staging
+`,
+			DirectoryStructure: map[string]any{
+				"layers": map[string]any{
+					"athens": map[string]any{
+						"shared": map[string]any{
+							"main.tf": nil,
+						},
+					},
+					"cicd": map[string]any{
+						"shared": map[string]any{
+							"main.tf": nil,
+						},
+					},
+				},
+			},
+			ModifiedFiles:      []string{"layers/cicd/shared/main.tf"},
+			ExpProjectNames:    []string{"cicd/shared"},
+			ExpCloneWorkspaces: []string{"default", "staging"},
+		},
+		{
 			Description: "planning a regexp project outside of the changed files",
 			Cmd: events.CommentCommand{
 				Name:        command.Plan,
@@ -2083,6 +2120,10 @@ projects:
 				return
 			}
 			Ok(t, err)
+			if len(c.ExpCloneWorkspaces) > 0 {
+				_, _, _, cloneWorkspaces := workingDir.VerifyWasCalled(Times(len(c.ExpCloneWorkspaces))).Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Any[string]()).GetAllCapturedArguments()
+				Equals(t, c.ExpCloneWorkspaces, cloneWorkspaces)
+			}
 			if len(c.ExpProjectNames) == 0 {
 				Equals(t, 1, len(actCtxs))
 				return

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -1823,9 +1823,11 @@ func TestDefaultProjectCommandBuilder_BuildSinglePlanApplyCommand_WithRestrictFi
 		DirectoryStructure map[string]any
 		ModifiedFiles      []string
 		Cmd                events.CommentCommand
+		EnableRegExpCmd    bool
 		ExpErr             string
 		ExpNoProjects      bool
 		ExpSkipFileList    bool
+		ExpProjectNames    []string
 	}{
 		{
 			Description: "planning a file outside of the changed files",
@@ -1939,6 +1941,72 @@ projects:
 			},
 			ModifiedFiles: []string{"directory-1/main.tf"},
 		},
+		{
+			Description: "planning a regexp project only includes changed matching projects",
+			Cmd: events.CommentCommand{
+				Name:        command.Plan,
+				Workspace:   "default",
+				ProjectName: ".*/shared",
+			},
+			EnableRegExpCmd: true,
+			AtlantisYAML: `
+version: 3
+projects:
+- name: athens/shared
+  dir: layers/athens/shared
+- name: cicd/shared
+  dir: layers/cicd/shared
+`,
+			DirectoryStructure: map[string]any{
+				"layers": map[string]any{
+					"athens": map[string]any{
+						"shared": map[string]any{
+							"main.tf": nil,
+						},
+					},
+					"cicd": map[string]any{
+						"shared": map[string]any{
+							"main.tf": nil,
+						},
+					},
+				},
+			},
+			ModifiedFiles:   []string{"layers/cicd/shared/main.tf"},
+			ExpProjectNames: []string{"cicd/shared"},
+		},
+		{
+			Description: "planning a regexp project outside of the changed files",
+			Cmd: events.CommentCommand{
+				Name:        command.Plan,
+				Workspace:   "default",
+				ProjectName: "athens/.*",
+			},
+			EnableRegExpCmd: true,
+			AtlantisYAML: `
+version: 3
+projects:
+- name: athens/shared
+  dir: layers/athens/shared
+- name: cicd/shared
+  dir: layers/cicd/shared
+`,
+			DirectoryStructure: map[string]any{
+				"layers": map[string]any{
+					"athens": map[string]any{
+						"shared": map[string]any{
+							"main.tf": nil,
+						},
+					},
+					"cicd": map[string]any{
+						"shared": map[string]any{
+							"main.tf": nil,
+						},
+					},
+				},
+			},
+			ModifiedFiles: []string{"layers/cicd/shared/main.tf"},
+			ExpErr:        "the following directories are present in the pull request but not in the requested project:\nlayers/cicd/shared",
+		},
 	}
 
 	logger := logging.NewNoopLogger(t)
@@ -1980,7 +2048,7 @@ projects:
 				&events.DefaultPendingPlanFinder{},
 				&events.CommentParser{ExecutableName: "atlantis"},
 				userConfig.SkipCloneNoChanges,
-				userConfig.EnableRegExpCmd,
+				c.EnableRegExpCmd,
 				userConfig.EnableAutoMerge,
 				userConfig.EnableParallelPlan,
 				userConfig.EnableParallelApply,
@@ -2015,9 +2083,94 @@ projects:
 				return
 			}
 			Ok(t, err)
-			Equals(t, 1, len(actCtxs))
+			if len(c.ExpProjectNames) == 0 {
+				Equals(t, 1, len(actCtxs))
+				return
+			}
+			var actProjectNames []string
+			for _, actCtx := range actCtxs {
+				actProjectNames = append(actProjectNames, actCtx.ProjectName)
+			}
+			sort.Strings(actProjectNames)
+			Equals(t, c.ExpProjectNames, actProjectNames)
 		})
 	}
+}
+
+func TestDefaultProjectCommandBuilder_BuildPlanCommand_RegExpProjectWithoutRestrictFileList(t *testing.T) {
+	RegisterMockTestingT(t)
+	logger := logging.NewNoopLogger(t)
+	scope := metricstest.NewLoggingScope(t, logger, "atlantis")
+	tmpDir := DirStructure(t, map[string]any{
+		"layers": map[string]any{
+			"athens": map[string]any{
+				"shared": map[string]any{
+					"main.tf": nil,
+				},
+			},
+			"cicd": map[string]any{
+				"shared": map[string]any{
+					"main.tf": nil,
+				},
+			},
+		},
+	})
+	err := os.WriteFile(filepath.Join(tmpDir, valid.DefaultAtlantisFile), []byte(`
+version: 3
+projects:
+- name: athens/shared
+  dir: layers/athens/shared
+- name: cicd/shared
+  dir: layers/cicd/shared
+`), 0600)
+	Ok(t, err)
+
+	workingDir := mocks.NewMockWorkingDir()
+	When(workingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](),
+		Any[string]())).ThenReturn(tmpDir, nil)
+	When(workingDir.GetWorkingDir(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).ThenReturn(tmpDir, nil)
+
+	builder := events.NewProjectCommandBuilder(
+		false,
+		&config.ParserValidator{},
+		&events.DefaultProjectFinder{},
+		vcsmocks.NewMockClient(),
+		workingDir,
+		events.NewDefaultWorkingDirLocker(),
+		valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{AllowAllRepoSettings: true}),
+		&events.DefaultPendingPlanFinder{},
+		&events.CommentParser{ExecutableName: "atlantis"},
+		defaultUserConfig.SkipCloneNoChanges,
+		true,
+		defaultUserConfig.EnableAutoMerge,
+		defaultUserConfig.EnableParallelPlan,
+		defaultUserConfig.EnableParallelApply,
+		defaultUserConfig.AutoDetectModuleFiles,
+		defaultUserConfig.AutoplanFileList,
+		false,
+		defaultUserConfig.SilenceNoProjects,
+		defaultUserConfig.IncludeGitUntrackedFiles,
+		defaultUserConfig.AutoDiscoverMode,
+		scope,
+		tfclientmocks.NewMockClient(),
+	)
+
+	actCtxs, err := builder.BuildPlanCommands(&command.Context{
+		Log:   logger,
+		Scope: scope,
+	}, &events.CommentCommand{
+		Name:        command.Plan,
+		Workspace:   "default",
+		ProjectName: ".*/shared",
+	})
+
+	Ok(t, err)
+	var actProjectNames []string
+	for _, actCtx := range actCtxs {
+		actProjectNames = append(actProjectNames, actCtx.ProjectName)
+	}
+	sort.Strings(actProjectNames)
+	Equals(t, []string{"athens/shared", "cicd/shared"}, actProjectNames)
 }
 
 func TestDefaultProjectCommandBuilder_BuildPlanCommands(t *testing.T) {


### PR DESCRIPTION
Summary:
- Scope regex `-p` plan matches to modified project directories when `--restrict-file-list` is enabled.
- Preserve unrestricted regex project behavior when `--restrict-file-list` is disabled.
- Update server configuration docs for the new regex/restrict-file-list interaction.

Closes #6555
