### PR TITLE
feat: support OpenTofu .tofu/.tofu.json version auto-detection

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -170,7 +170,7 @@ const (
 	DefaultADBasicPassword              = ""
 	DefaultADHostname                   = "dev.azure.com"
 	DefaultAutoDiscoverMode             = "auto"
-	DefaultAutoplanFileList             = "**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl"
+	DefaultAutoplanFileList             = "**/*.tf,**/*.tf.json,**/*.tfvars,**/*.tfvars.json,**/*.tofu,**/*.tofu.json,**/terragrunt.hcl,**/.terraform.lock.hcl"
 	DefaultAllowCommands                = "version,plan,apply,unlock,approve_policies,cancel"
 	DefaultBlockedExtraArgs             = "-chdir,--chdir,-plugin-dir,--plugin-dir"
 	DefaultCheckoutStrategy             = CheckoutStrategyBranch

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -1375,3 +1375,10 @@ func TestSanitizeKubernetesServiceLinks_UDPIgnored(t *testing.T) {
 	Ok(t, err)
 	Equals(t, DefaultRedisPort, passedConfig.RedisPort)
 }
+
+func TestDefaultAutoplanFileList_ContainsExpectedPatterns(t *testing.T) {
+	// Pin the public server default independently of the constant.
+	// If a pattern is accidentally removed, this test fails.
+	expected := "**/*.tf,**/*.tf.json,**/*.tfvars,**/*.tfvars.json,**/*.tofu,**/*.tofu.json,**/terragrunt.hcl,**/.terraform.lock.hcl"
+	Equals(t, expected, DefaultAutoplanFileList)
+}

--- a/runatlantis.io/docs/autoplanning.md
+++ b/runatlantis.io/docs/autoplanning.md
@@ -6,11 +6,11 @@ run `terraform plan` in the directories it thinks hold modified Terraform projec
 The algorithm it uses is as follows:
 
 1. Get list of all modified files in pull request
-1. Filter to those containing `.tf`
+1. Filter to those matching the configured [`--autoplan-file-list`](server-configuration.md#autoplan-file-list) (default includes `.tf`, `.tf.json`, `.tfvars`, `.tofu`, `.tofu.json`, etc.)
 1. Get the directories that those files are in
 1. If the directory path doesn't contain `modules/` then try to run `plan` in that directory
 1. If it does contain `modules/` look at the directory one level above `modules/`. If it
-contains a `main.tf` run plan in that directory, otherwise ignore the change (see below for exceptions).
+contains a supported project indicator file (`*.tf`, `*.tf.json`, `*.tofu`, `*.tofu.json`, or `terragrunt.hcl`) run plan in that directory, otherwise ignore the change (see below for exceptions).
 
 ## Example
 

--- a/runatlantis.io/docs/repo-level-atlantis-yaml.md
+++ b/runatlantis.io/docs/repo-level-atlantis-yaml.md
@@ -218,6 +218,7 @@ Note:
 - The paths are relative to the project's directory.
 - `when_modified` will be used by both automatic and manually run plans.
 - `when_modified` will continue to work for manually run plans even when autoplan is disabled.
+- The default `when_modified` includes `**/*.tf*`, `**/*.tofu`, `**/*.tofu.json`, `**/terragrunt.hcl`, and `**/.terraform.lock.hcl`. Custom `when_modified` overrides these defaults entirely.
 
 ### Supporting Terraform Workspaces
 
@@ -511,7 +512,9 @@ when_modified: ["*.tf", "terragrunt.hcl", ".terraform.lock.hcl"]
 | Key           | Type            | Default        | Required | Description                                                                                                                                                                                                                                                     |
 | ------------- | --------------- | -------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | enabled       | boolean         | `true`         | no       | Whether autoplanning is enabled for this project.                                                                                                                                                                                                               |
-| when_modified | array\[string\] | `["**/*.tf*"]` | no       | Uses [.dockerignore](https://docs.docker.com/engine/reference/builder/#dockerignore-file) syntax. If any modified file in the pull request matches, this project will be planned. See [Autoplanning](autoplanning.md). Paths are relative to the project's dir. |
+| when_modified | array\[string\] | see below      | no       | Uses [.dockerignore](https://docs.docker.com/engine/reference/builder/#dockerignore-file) syntax. If any modified file in the pull request matches, this project will be planned. See [Autoplanning](autoplanning.md). Paths are relative to the project's dir. |
+
+Default `when_modified` patterns: `["**/*.tf*", "**/*.tofu", "**/*.tofu.json", "**/terragrunt.hcl", "**/.terraform.lock.hcl"]`. Custom `when_modified` values override these defaults entirely. The default is global (not distribution-aware).
 
 ### RepoLocks
 

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -181,9 +181,10 @@ Notes:
 - Accepts a comma separated list, ex. `pattern1,pattern2`.
 - Patterns use the [`.dockerignore` syntax](https://docs.docker.com/engine/reference/builder/#dockerignore-file)
 - List of file patterns will be used by both automatic and manually run plans.
-- When not set, defaults to all `.tf`, `.tfvars`, `.tfvars.json`, `terragrunt.hcl` and `.terraform.lock.hcl` files
-   (`--autoplan-file-list='**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl'`).
+- When not set, defaults to all `.tf`, `.tf.json`, `.tfvars`, `.tfvars.json`, `.tofu`, `.tofu.json`, `terragrunt.hcl` and `.terraform.lock.hcl` files
+   (`--autoplan-file-list='**/*.tf,**/*.tf.json,**/*.tfvars,**/*.tfvars.json,**/*.tofu,**/*.tofu.json,**/terragrunt.hcl,**/.terraform.lock.hcl'`).
 - Setting `--autoplan-file-list` will override the defaults. You **must** add `**/*.tf` and other defaults if you want to include them.
+- The default is global (not distribution-aware). Both Terraform and OpenTofu installs will match `.tofu` changes. If you do not use OpenTofu, you can override the default to exclude `.tofu` patterns.
 - A custom [Workflow](repo-level-atlantis-yaml.md#configuring-planning) that uses autoplan `when_modified` will ignore this value.
 
 Examples:
@@ -211,6 +212,10 @@ Defaults to `false`. When set to `true`, Atlantis will trace the local modules o
 Included project are projects with files included by `--autoplan-file-list`.
 After tracing, Atlantis will plan any project that includes a changed module. This is equivalent to setting
 `--autoplan-modules-from-projects` to the value of `--autoplan-file-list`. See below.
+
+::: tip NOTE
+Module dependency indexing uses Terraform config inspection and may not fully support `.tofu` / `.tofu.json` files. Module calls defined only in `.tofu` files or shared module directories containing only `.tofu` files may not be traced. Direct file-change autoplanning for `.tofu` projects works regardless. Use explicit `autoplan.when_modified` patterns as a workaround. See [OpenTofu .tofu file support](terraform-versions.md#opentofu-tofu-file-support) for details.
+:::
 
 ### `--autoplan-modules-from-projects` <Badge text="v0.26.0+" type="info"/>
 

--- a/runatlantis.io/docs/terraform-versions.md
+++ b/runatlantis.io/docs/terraform-versions.md
@@ -63,6 +63,45 @@ constraint against that distribution. For example, an OpenTofu project resolves 
 OpenTofu version instead of a Terraform version.
 :::
 
+## OpenTofu `.tofu` file support
+
+When the effective distribution is OpenTofu, Atlantis reads `required_version`
+from `.tofu` and `.tofu.json` files in addition to `.tf` and `.tf.json`. The effective
+distribution is OpenTofu when either:
+
+- A project sets `terraform_distribution: opentofu` in `atlantis.yaml`
+- The server default is `--default-tf-distribution=opentofu` and the project does not override it
+
+If a project explicitly sets `terraform_distribution: terraform`, Atlantis uses the
+Terraform version-detection path (`.tf` / `.tf.json` only) even if the server default is OpenTofu.
+
+OpenTofu file precedence is respected: a `.tofu` file overrides a same-basename `.tf`
+file, and `.tofu.json` overrides a same-basename `.tf.json` file. Files with different
+basenames both contribute constraints independently.
+
+Terraform distribution is unaffected and continues to read only `.tf` / `.tf.json` files.
+
+::: warning Known limitation
+Module autoplanning (`--autoplan-modules`) dependency indexing still relies on
+`terraform-config-inspect` and does not fully understand `.tofu` / `.tofu.json`:
+
+1. Module source blocks defined only in `.tofu` / `.tofu.json` files are not indexed.
+   Projects using these files for `module {}` blocks will not be planned when shared
+   modules change.
+2. Shared module directories containing only `.tofu` / `.tofu.json` files may not be
+   recognized as modules by the dependency index.
+
+Direct file-change autoplanning (without `--autoplan-modules`) is fully supported for
+`.tofu` projects. As a workaround for module dependencies, include shared module paths
+in explicit `autoplan.when_modified` patterns, or keep module source declarations in
+`.tf` files until full `.tofu` module indexing is implemented.
+
+Additionally, Terraform Cloud workspace detection (`cloud { workspaces { ... } }`) still
+scans only `.tf` files. If your workspace config is defined only in `.tofu` / `.tofu.json`,
+Atlantis may fall back to the default workspace. Workaround: keep workspace config in a
+`.tf` file, or configure the workspace explicitly in `atlantis.yaml`.
+:::
+
 ::: tip NOTE
 The Atlantis [latest docker image](https://github.com/runatlantis/atlantis/pkgs/container/atlantis/9854680?tag=latest) tends to have recent versions of Terraform, but there may be a delay as new versions are released. The highest version of Terraform allowed in your code is the version specified by `DEFAULT_TERRAFORM_VERSION` in the image your server is running.
 :::

--- a/server/core/config/raw/autoplan.go
+++ b/server/core/config/raw/autoplan.go
@@ -13,6 +13,8 @@ import (
 // autoplan behavior for changes inside existing projects.
 var terraformAutoplanIndicators = []string{
 	"*.tf*",
+	"*.tofu",
+	"*.tofu.json",
 	"terragrunt.hcl",
 	".terraform.lock.hcl",
 }

--- a/server/core/config/raw/autoplan_test.go
+++ b/server/core/config/raw/autoplan_test.go
@@ -153,5 +153,5 @@ func TestAutoplan_ToValid(t *testing.T) {
 }
 
 func TestDefaultAutoPlanWhenModified(t *testing.T) {
-	Equals(t, []string{"**/*.tf*", "**/terragrunt.hcl", "**/.terraform.lock.hcl"}, raw.DefaultAutoPlanWhenModified())
+	Equals(t, []string{"**/*.tf*", "**/*.tofu", "**/*.tofu.json", "**/terragrunt.hcl", "**/.terraform.lock.hcl"}, raw.DefaultAutoPlanWhenModified())
 }

--- a/server/core/config/raw/project.go
+++ b/server/core/config/raw/project.go
@@ -26,10 +26,12 @@ const (
 )
 
 // terraformProjectIndicators are configuration files that suggest a directory
-// should be treated as a Terraform/Terragrunt project.
+// should be treated as a Terraform/Terragrunt/OpenTofu project.
 var terraformProjectIndicators = []string{
 	"*.tf",
 	"*.tf.json",
+	"*.tofu",
+	"*.tofu.json",
 	"terragrunt.hcl",
 }
 

--- a/server/core/config/raw/project_test.go
+++ b/server/core/config/raw/project_test.go
@@ -764,6 +764,42 @@ func TestIsTerraformProjectDir(t *testing.T) {
 			},
 			exp: false,
 		},
+		{
+			description: ".tofu file",
+			files: map[string]string{
+				"main.tofu": "Some content",
+			},
+			exp: true,
+		},
+		{
+			description: ".tofu.json file",
+			files: map[string]string{
+				"main.tofu.json": "Some content",
+			},
+			exp: true,
+		},
+		{
+			description: ".tofu and .tf together",
+			files: map[string]string{
+				"main.tf":       "Some content",
+				"versions.tofu": "Some content",
+			},
+			exp: true,
+		},
+		{
+			description: "hidden .tofu file still matches indicator glob",
+			files: map[string]string{
+				".main.tofu": "Some content",
+			},
+			exp: true,
+		},
+		{
+			description: ".tofu in subdirectory only",
+			files: map[string]string{
+				"subdir/main.tofu": "Some content",
+			},
+			exp: false,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {

--- a/server/core/terraform/tfclient/export_test.go
+++ b/server/core/terraform/tfclient/export_test.go
@@ -1,0 +1,6 @@
+// Copyright 2025 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tfclient
+
+var DetectRequiredCoreFromTofuForTest = detectRequiredCoreFromTofu

--- a/server/core/terraform/tfclient/terraform_client.go
+++ b/server/core/terraform/tfclient/terraform_client.go
@@ -294,16 +294,13 @@ func (c *DefaultClient) ExtractExactRegex(log logging.SimpleLogging, version str
 // default distribution when nil, and the highest satisfying version is selected.
 // Returns nil if unable to determine the version.
 func (c *DefaultClient) DetectVersion(log logging.SimpleLogging, d terraform.Distribution, projectDirectory string) *version.Version {
-	module, diags := tfconfig.LoadModule(projectDirectory)
-	if diags.HasErrors() {
-		log.Err("trying to detect required version: %s", diags.Error())
-	}
+	requiredCore := c.detectRequiredCore(log, d, projectDirectory)
 
-	if len(module.RequiredCore) != 1 {
-		log.Info("cannot determine which version to use from terraform configuration, detected %d possibilities.", len(module.RequiredCore))
+	if len(requiredCore) != 1 {
+		log.Info("cannot determine which version to use from terraform configuration, detected %d possibilities.", len(requiredCore))
 		return nil
 	}
-	requiredVersionSetting := module.RequiredCore[0]
+	requiredVersionSetting := requiredCore[0]
 	log.Debug("Found required_version setting of %q", requiredVersionSetting)
 
 	if !c.downloadAllowed {
@@ -329,6 +326,33 @@ func (c *DefaultClient) DetectVersion(log logging.SimpleLogging, d terraform.Dis
 	}
 
 	return downloadVersion
+}
+
+// detectRequiredCore returns the required_version constraints from configuration files.
+// For OpenTofu distribution, it uses a local parser that supports .tofu/.tofu.json files
+// with proper precedence (.tofu overrides same-basename .tf). For Terraform distribution,
+// it uses hashicorp/terraform-config-inspect which only reads .tf/.tf.json files.
+func (c *DefaultClient) detectRequiredCore(log logging.SimpleLogging, d terraform.Distribution, projectDirectory string) []string {
+	dist := c.effectiveDistribution(d)
+	if dist.BinName() == "tofu" {
+		constraints, err := detectRequiredCoreFromTofu(projectDirectory)
+		if err != nil {
+			log.Err("trying to detect required version from OpenTofu config: %s", err)
+		}
+		if len(constraints) == 0 && err != nil {
+			return nil
+		}
+		return constraints
+	}
+
+	module, diags := tfconfig.LoadModule(projectDirectory)
+	if diags.HasErrors() {
+		log.Err("trying to detect required version: %s", diags.Error())
+	}
+	if module == nil {
+		return nil
+	}
+	return module.RequiredCore
 }
 
 // See Client.EnsureVersion.

--- a/server/core/terraform/tfclient/tofu_version.go
+++ b/server/core/terraform/tfclient/tofu_version.go
@@ -1,0 +1,197 @@
+// Copyright 2025 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tfclient
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+)
+
+// Schema matching terraform-config-inspect: terraform block with no labels.
+var tofuRootSchema = &hcl.BodySchema{
+	Blocks: []hcl.BlockHeaderSchema{
+		{Type: "terraform", LabelNames: nil},
+	},
+}
+
+var tofuTerraformBlockSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{Name: "required_version"},
+	},
+}
+
+// detectRequiredCoreFromTofu reads .tofu, .tofu.json, .tf, and .tf.json files
+// in the given directory, applying OpenTofu file precedence rules:
+//   - .tofu overrides same-basename .tf
+//   - .tofu.json overrides same-basename .tf.json
+//
+// Returns constraints found and any diagnostics encountered. When no constraints
+// are found and diagnostics exist, returns a non-nil error. When constraints are
+// recovered despite diagnostics, returns both so the caller can log warnings.
+func detectRequiredCoreFromTofu(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	tofuFiles := make(map[string]bool)
+	tofuJSONFiles := make(map[string]bool)
+
+	for _, e := range entries {
+		if e.IsDir() || isIgnoredFile(e.Name()) {
+			continue
+		}
+		name := e.Name()
+		if base, ok := strings.CutSuffix(name, ".tofu.json"); ok {
+			tofuJSONFiles[base] = true
+		} else if base, ok := strings.CutSuffix(name, ".tofu"); ok {
+			tofuFiles[base] = true
+		}
+	}
+
+	var filesToParse []string
+	for _, e := range entries {
+		if e.IsDir() || isIgnoredFile(e.Name()) {
+			continue
+		}
+		name := e.Name()
+		switch {
+		case strings.HasSuffix(name, ".tofu.json"):
+			filesToParse = append(filesToParse, filepath.Join(dir, name))
+		case strings.HasSuffix(name, ".tofu"):
+			filesToParse = append(filesToParse, filepath.Join(dir, name))
+		case strings.HasSuffix(name, ".tf.json"):
+			base, _ := strings.CutSuffix(name, ".tf.json")
+			if !tofuJSONFiles[base] {
+				filesToParse = append(filesToParse, filepath.Join(dir, name))
+			}
+		case strings.HasSuffix(name, ".tf"):
+			base, _ := strings.CutSuffix(name, ".tf")
+			if !tofuFiles[base] {
+				filesToParse = append(filesToParse, filepath.Join(dir, name))
+			}
+		}
+	}
+
+	var constraints []string
+	var parseErrors []error
+	parser := hclparse.NewParser()
+
+	for _, path := range filesToParse {
+		found, parseErr := extractRequiredVersion(parser, path)
+		if parseErr != nil {
+			parseErrors = append(parseErrors, parseErr)
+		}
+		constraints = append(constraints, found...)
+	}
+
+	if len(constraints) == 0 && len(parseErrors) > 0 {
+		return nil, errors.Join(parseErrors...)
+	}
+
+	if len(parseErrors) > 0 {
+		return constraints, errors.Join(parseErrors...)
+	}
+
+	return constraints, nil
+}
+
+// isIgnoredFile returns true if the filename should be skipped (editor swap
+// files, hidden files, etc.). Matches terraform-config-inspect behavior.
+func isIgnoredFile(name string) bool {
+	return strings.HasPrefix(name, ".") ||
+		strings.HasSuffix(name, "~") ||
+		(strings.HasPrefix(name, "#") && strings.HasSuffix(name, "#"))
+}
+
+// extractRequiredVersion parses either native HCL or HCL JSON format files
+// using the HCL parser (matching terraform-config-inspect behavior) and
+// extracts required_version from zero-label terraform {} blocks.
+func extractRequiredVersion(parser *hclparse.Parser, path string) ([]string, error) {
+	var file *hcl.File
+	var diags hcl.Diagnostics
+
+	if strings.HasSuffix(path, ".json") {
+		file, diags = parser.ParseJSONFile(path)
+	} else {
+		file, diags = parser.ParseHCLFile(path)
+	}
+
+	if file == nil {
+		if diags.HasErrors() {
+			return nil, fmt.Errorf("%s: %s", path, diags.Error())
+		}
+		return nil, nil
+	}
+
+	content, _, contentDiags := file.Body.PartialContent(tofuRootSchema)
+	diags = append(diags, contentDiags...)
+
+	if content == nil {
+		if diags.HasErrors() {
+			return nil, fmt.Errorf("%s: %s", path, diags.Error())
+		}
+		return nil, nil
+	}
+
+	var constraints []string
+	var valueErrors []error
+
+	for _, block := range content.Blocks {
+		if block.Type != "terraform" {
+			continue
+		}
+
+		innerContent, _, innerDiags := block.Body.PartialContent(tofuTerraformBlockSchema)
+		diags = append(diags, innerDiags...)
+
+		if innerContent == nil {
+			continue
+		}
+
+		attr, defined := innerContent.Attributes["required_version"]
+		if !defined {
+			continue
+		}
+
+		val, valDiags := attr.Expr.Value(nil)
+		if valDiags.HasErrors() {
+			valueErrors = append(valueErrors, fmt.Errorf("%s: required_version: %s", path, valDiags.Error()))
+			continue
+		}
+		if val.IsNull() || !val.IsKnown() {
+			valueErrors = append(valueErrors, fmt.Errorf("%s: required_version must be a string literal", path))
+			continue
+		}
+
+		strVal, convErr := convert.Convert(val, cty.String)
+		if convErr != nil {
+			valueErrors = append(valueErrors, fmt.Errorf("%s: required_version: %s", path, convErr))
+			continue
+		}
+		constraints = append(constraints, strVal.AsString())
+	}
+
+	var allErrs []error
+	allErrs = append(allErrs, valueErrors...)
+	if diags.HasErrors() {
+		allErrs = append(allErrs, fmt.Errorf("%s: %s", path, diags.Error()))
+	}
+
+	if len(constraints) == 0 && len(allErrs) > 0 {
+		return nil, errors.Join(allErrs...)
+	}
+	if len(allErrs) > 0 {
+		return constraints, errors.Join(allErrs...)
+	}
+	return constraints, nil
+}

--- a/server/core/terraform/tfclient/tofu_version_test.go
+++ b/server/core/terraform/tfclient/tofu_version_test.go
@@ -1,0 +1,684 @@
+// Copyright 2025 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tfclient_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	. "github.com/petergtz/pegomock/v4"
+	"github.com/runatlantis/atlantis/cmd"
+	"github.com/runatlantis/atlantis/server/core/terraform"
+	"github.com/runatlantis/atlantis/server/core/terraform/mocks"
+	"github.com/runatlantis/atlantis/server/core/terraform/tfclient"
+	jobmocks "github.com/runatlantis/atlantis/server/jobs/mocks"
+	"github.com/runatlantis/atlantis/server/logging"
+	. "github.com/runatlantis/atlantis/testing"
+)
+
+func newTestClientForTofu(t *testing.T, downloadsAllowed bool) *tfclient.DefaultClient {
+	t.Helper()
+	RegisterMockTestingT(t)
+	_, binDir, cacheDir := mkSubDirs(t)
+	projectCmdOutputHandler := jobmocks.NewMockProjectCommandOutputHandler()
+	mockDownloader := mocks.NewMockDownloader()
+	distribution := terraform.NewDistributionTerraformWithDownloader(mockDownloader)
+
+	c, err := tfclient.NewTestClient(
+		logger(t), distribution, binDir, cacheDir,
+		"", "", "1.0.0", cmd.DefaultTFVersionFlag, cmd.DefaultTFDownloadURL,
+		downloadsAllowed, true, projectCmdOutputHandler,
+	)
+	Ok(t, err)
+	return c
+}
+
+func logger(t *testing.T) logging.SimpleLogging {
+	t.Helper()
+	return logging.NewNoopLogger(t)
+}
+
+func opentofuDist(version string) *constraintResolvingDistribution {
+	return &constraintResolvingDistribution{
+		binName:         "tofu",
+		resolvedVersion: version,
+	}
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	Ok(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0600))
+}
+
+func makeProjectDir(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "project")
+	Ok(t, os.MkdirAll(dir, 0700))
+	return dir
+}
+
+// recordingLogger captures Err log messages for assertion in production-path tests.
+type recordingLogger struct {
+	logging.SimpleLogging
+	errMessages []string
+}
+
+func newRecordingLogger(t *testing.T) *recordingLogger {
+	return &recordingLogger{SimpleLogging: logging.NewNoopLogger(t)}
+}
+
+func (l *recordingLogger) Err(format string, a ...any) {
+	l.errMessages = append(l.errMessages, fmt.Sprintf(format, a...))
+	l.SimpleLogging.Err(format, a...)
+}
+
+func (l *recordingLogger) hasErrContaining(substr string) bool {
+	for _, msg := range l.errMessages {
+		if strings.Contains(msg, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// --- Theme 1: OpenTofu .tofu file detection ---
+
+func TestDetectVersion_OpenTofu_TofuFileOnly(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu", `terraform { required_version = "1.12.1" }`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected != nil, "expected version detected from .tofu file")
+	Equals(t, "1.12.1", detected.String())
+}
+
+func TestDetectVersion_Terraform_IgnoresTofuFile(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu", `terraform { required_version = "1.12.1" }`)
+
+	detected := c.DetectVersion(logger(t), nil, dir)
+	Assert(t, detected == nil, "Terraform distribution must not read .tofu files")
+}
+
+func TestDetectVersion_Terraform_TfFileUnchanged(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tf", `terraform { required_version = "= 1.5.7" }`)
+
+	detected := c.DetectVersion(logger(t), nil, dir)
+	Assert(t, detected != nil, "existing .tf behavior should be unchanged")
+	Equals(t, "1.5.7", detected.String())
+}
+
+func TestDetectVersion_OpenTofu_TfFileAlone(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tf", `terraform { required_version = "1.10.0" }`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.10.0"), dir)
+	Assert(t, detected != nil, "OpenTofu should still read .tf files")
+	Equals(t, "1.10.0", detected.String())
+}
+
+// --- Theme 6: Same-basename precedence ---
+
+func TestDetectVersion_OpenTofu_TofuOverridesSameBasenameTf(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tf", `terraform { required_version = "1.10.0" }`)
+	writeFile(t, dir, "versions.tofu", `terraform { required_version = "1.12.1" }`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected != nil, "expected .tofu to override same-basename .tf")
+	Equals(t, "1.12.1", detected.String())
+}
+
+func TestDetectVersion_OpenTofu_TofuJSON_OverridesSameBasenameTfJSON(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tf.json", `{"terraform":{"required_version":"1.10.0"}}`)
+	writeFile(t, dir, "versions.tofu.json", `{"terraform":{"required_version":"1.12.1"}}`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected != nil, "expected .tofu.json to override same-basename .tf.json")
+	Equals(t, "1.12.1", detected.String())
+}
+
+func TestDetectVersion_OpenTofu_UnrelatedTfAndTofu_BothContribute(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	// Different basenames: both should contribute, giving 2 constraints → nil
+	writeFile(t, dir, "main.tofu", `terraform { required_version = "1.12.1" }`)
+	writeFile(t, dir, "other.tf", `terraform { required_version = "1.11.5" }`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected == nil, "multiple constraints from different basenames should return nil")
+}
+
+func TestDetectVersion_OpenTofu_SameBasenameSuppressesOnlyThatBasename(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	// versions.tofu overrides versions.tf, but other.tf is unrelated and contributes
+	writeFile(t, dir, "versions.tf", `terraform { required_version = "1.10.0" }`)
+	writeFile(t, dir, "versions.tofu", `terraform { required_version = "1.12.1" }`)
+	writeFile(t, dir, "other.tf", `terraform { required_version = "1.11.5" }`)
+
+	// Result: "1.12.1" from versions.tofu + "1.11.5" from other.tf → 2 constraints → nil
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected == nil, "same-basename suppression should not suppress unrelated .tf files")
+}
+
+// --- Theme 1 continued: .tofu.json ---
+
+func TestDetectVersion_OpenTofu_TofuJSON(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu.json", `{"terraform":{"required_version":"1.12.1"}}`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected != nil, "expected version from .tofu.json")
+	Equals(t, "1.12.1", detected.String())
+}
+
+// --- Theme 1: Constraint resolution ---
+
+func TestDetectVersion_OpenTofu_ConstraintResolution(t *testing.T) {
+	c := newTestClientForTofu(t, true)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu", `terraform { required_version = ">= 1.8" }`)
+
+	dist := opentofuDist("1.12.3")
+	detected := c.DetectVersion(logger(t), dist, dir)
+	Assert(t, detected != nil, "expected constraint resolution")
+	Equals(t, "1.12.3", detected.String())
+	Equals(t, []string{">= 1.8"}, dist.constraints)
+}
+
+func TestDetectVersion_OpenTofu_MultipleConstraints_ReturnsNil(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "a.tofu", `terraform { required_version = "1.12.0" }`)
+	writeFile(t, dir, "b.tofu", `terraform { required_version = "1.12.1" }`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected == nil, "multiple constraints should return nil")
+}
+
+// --- Theme 7 + Theme 1 (P1): Crash safety / Invalid values ---
+
+func TestDetectVersion_OpenTofu_NullRequiredVersion(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu", `terraform { required_version = null }`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected == nil, "null required_version should not panic, returns nil")
+}
+
+func TestDetectVersion_OpenTofu_NumericRequiredVersion(t *testing.T) {
+	// Numeric values are implicitly converted to string for compatibility
+	// with gohcl.DecodeExpression behavior in terraform-config-inspect.
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu", `terraform { required_version = 1.12 }`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12"), dir)
+	Assert(t, detected != nil, "numeric required_version should be accepted via implicit conversion")
+}
+
+func TestDetectVersion_OpenTofu_BoolRequiredVersion(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu", `terraform { required_version = true }`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected == nil, "bool required_version should not panic")
+}
+
+func TestDetectVersion_OpenTofu_ListRequiredVersion(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu", `terraform { required_version = ["1.12.0"] }`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected == nil, "list required_version should not panic")
+}
+
+func TestDetectVersion_OpenTofu_VariableReference(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu", `
+variable "version" { default = "1.12.0" }
+terraform { required_version = var.version }
+`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected == nil, "variable reference should not panic, returns nil")
+}
+
+func TestDetectVersion_OpenTofu_ConditionalNull(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu", `terraform { required_version = true ? null : "1.12.0" }`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected == nil, "conditional with null should not panic")
+}
+
+// --- Theme 7: Malformed files ---
+
+func TestDetectVersion_OpenTofu_MalformedTofuFile(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu", `this is not valid HCL {{{`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected == nil, "malformed .tofu should not panic")
+}
+
+func TestDetectVersion_OpenTofu_MalformedTofuJSON(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu.json", `{not valid json`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected == nil, "malformed .tofu.json should not panic")
+}
+
+func TestDetectVersion_OpenTofu_MalformedPlusValid(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "bad.tofu", `this is not valid HCL {{{`)
+	writeFile(t, dir, "good.tofu", `terraform { required_version = "1.12.1" }`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected != nil, "valid file should still be detected despite malformed sibling")
+	Equals(t, "1.12.1", detected.String())
+}
+
+func TestDetectVersion_OpenTofu_AllMalformed_LogsError(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu", `this is not valid HCL {{{`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected == nil, "all-malformed should return nil and log error")
+}
+
+func TestDetectVersion_OpenTofu_MissingDirectory(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), "/nonexistent/path/xyz")
+	Assert(t, detected == nil, "missing directory should not panic")
+}
+
+// --- Theme 4: Ignored files ---
+
+func TestDetectVersion_OpenTofu_IgnoresHiddenFiles(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, ".versions.tofu", `terraform { required_version = "1.12.1" }`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected == nil, "hidden .tofu file should be ignored")
+}
+
+func TestDetectVersion_OpenTofu_IgnoresBackupFiles(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu~", `terraform { required_version = "1.12.1" }`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected == nil, "backup file (~) should be ignored")
+}
+
+func TestDetectVersion_OpenTofu_IgnoresEmacsFiles(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "#versions.tofu#", `terraform { required_version = "1.12.1" }`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected == nil, "emacs temp file should be ignored")
+}
+
+func TestDetectVersion_OpenTofu_IgnoredFileDoesNotConflict(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	// Ignored file has conflicting version; real file should win
+	writeFile(t, dir, ".versions.tofu", `terraform { required_version = "9.9.9" }`)
+	writeFile(t, dir, "versions.tofu", `terraform { required_version = "1.12.1" }`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected != nil, "real file should be detected despite ignored conflict")
+	Equals(t, "1.12.1", detected.String())
+}
+
+func TestDetectVersion_OpenTofu_IgnoresHiddenTfFile(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, ".versions.tf", `terraform { required_version = "1.10.0" }`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected == nil, "hidden .tf file should be ignored in OpenTofu mode")
+}
+
+// --- Finding 1: Labeled terraform blocks ---
+
+func TestDetectVersion_OpenTofu_LabeledTerraformBlock(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu", `terraform "invalid" { required_version = "1.12.0" }`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.0"), dir)
+	Assert(t, detected == nil, "labeled terraform block should be rejected")
+}
+
+func TestDetectVersion_OpenTofu_LabeledBlockIgnored_ValidBlockUsed(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu", `
+terraform "invalid" { required_version = "9.9.9" }
+terraform { required_version = "1.12.1" }
+`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected != nil, "valid unlabeled block should be used despite labeled sibling")
+	Equals(t, "1.12.1", detected.String())
+}
+
+// --- Finding 4: Partial file recovery ---
+
+func TestDetectVersion_OpenTofu_PartialFileRecovery(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu", `
+terraform {
+  required_version = "1.12.1"
+}
+
+this is invalid HCL later in the file
+`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected != nil, "should recover required_version from partial file")
+	Equals(t, "1.12.1", detected.String())
+}
+
+// --- Finding 9: JSON precedence pinned to same basename ---
+
+func TestDetectVersion_OpenTofu_JSONPrecedence_OnlySameBasename(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tf.json", `{"terraform":{"required_version":"1.11.5"}}`)
+	writeFile(t, dir, "versions.tofu.json", `{"terraform":{"required_version":"1.12.1"}}`)
+	writeFile(t, dir, "other.tf.json", `{"terraform":{"required_version":"1.10.0"}}`)
+
+	// versions.tofu.json overrides versions.tf.json, but other.tf.json contributes
+	// Result: "1.12.1" + "1.10.0" = 2 constraints → nil
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected == nil, "json precedence should only suppress same basename, not unrelated")
+}
+
+// --- Finding 3: Invalid JSON shapes ---
+
+func TestDetectVersion_OpenTofu_InvalidJSON_TerraformNotObject(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu.json", `{"terraform": true}`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected == nil, "terraform=true should be invalid shape")
+}
+
+func TestDetectVersion_OpenTofu_JSON_NumericVersion(t *testing.T) {
+	// HCL JSON semantics support implicit number→string conversion
+	// (same as gohcl.DecodeExpression in terraform-config-inspect).
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu.json", `{"terraform":{"required_version": 123}}`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("123"), dir)
+	Assert(t, detected != nil, "numeric JSON required_version should be accepted via HCL JSON conversion")
+}
+
+func TestDetectVersion_OpenTofu_InvalidJSON_VersionNull(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu.json", `{"terraform":{"required_version": null}}`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected == nil, "null JSON required_version should be rejected")
+}
+
+func TestDetectVersion_OpenTofu_InvalidJSON_VersionList(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu.json", `{"terraform":{"required_version": ["1.12.0"]}}`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected == nil, "list JSON required_version should be rejected")
+}
+
+// --- Finding 10: Lower-level helper diagnostics ---
+
+func TestDetectRequiredCoreFromTofu_MalformedOnly_ReturnsError(t *testing.T) {
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu", `this is not valid HCL {{{`)
+
+	constraints, err := tfclient.DetectRequiredCoreFromTofuForTest(dir)
+	Assert(t, err != nil, "malformed-only should return error")
+	Assert(t, len(constraints) == 0, "no constraints from malformed file")
+	Assert(t, strings.Contains(err.Error(), "versions.tofu"), "error should reference the file")
+}
+
+func TestDetectRequiredCoreFromTofu_MalformedJSON_ReturnsError(t *testing.T) {
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu.json", `{not valid json`)
+
+	constraints, err := tfclient.DetectRequiredCoreFromTofuForTest(dir)
+	Assert(t, err != nil, "malformed JSON should return error")
+	Assert(t, len(constraints) == 0, "no constraints from malformed JSON")
+}
+
+func TestDetectRequiredCoreFromTofu_InvalidValue_ReturnsError(t *testing.T) {
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu", `terraform { required_version = null }`)
+
+	constraints, err := tfclient.DetectRequiredCoreFromTofuForTest(dir)
+	Assert(t, err != nil, "invalid value with no valid constraints should return error")
+	Assert(t, len(constraints) == 0, "no constraints from null value")
+}
+
+func TestDetectRequiredCoreFromTofu_ValidPlusMalformed_RecoversValid(t *testing.T) {
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "bad.tofu", `this is not valid HCL {{{`)
+	writeFile(t, dir, "good.tofu", `terraform { required_version = "1.12.1" }`)
+
+	constraints, err := tfclient.DetectRequiredCoreFromTofuForTest(dir)
+	Equals(t, []string{"1.12.1"}, constraints)
+	// Diagnostics are still surfaced even when constraints are recovered
+	Assert(t, err != nil, "should surface diagnostics from malformed sibling")
+	Assert(t, strings.Contains(err.Error(), "bad.tofu"), "error should reference the malformed file")
+}
+
+// --- Finding 1 (JSON): HCL JSON array block form ---
+
+func TestDetectVersion_OpenTofu_JSON_ArrayBlockForm(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu.json", `{"terraform":[{"required_version":"1.12.1"}]}`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected != nil, "HCL JSON array block form should be accepted")
+	Equals(t, "1.12.1", detected.String())
+}
+
+func TestDetectVersion_OpenTofu_TfJSON_ArrayBlockForm(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tf.json", `{"terraform":[{"required_version":"1.12.1"}]}`)
+
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected != nil, "OpenTofu-mode .tf.json array block form should be accepted")
+	Equals(t, "1.12.1", detected.String())
+}
+
+// --- Finding 4: Cross-format precedence ---
+
+func TestDetectVersion_OpenTofu_CrossFormat_TofuDoesNotSuppressTfJSON(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	// .tofu should not suppress .tf.json (different format counterpart)
+	writeFile(t, dir, "versions.tofu", `terraform { required_version = "1.12.1" }`)
+	writeFile(t, dir, "versions.tf.json", `{"terraform":{"required_version":"1.12.4"}}`)
+
+	// Both contribute → multiple constraints → nil
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected == nil, ".tofu must not suppress .tf.json; multiple constraints → nil")
+}
+
+func TestDetectVersion_OpenTofu_CrossFormat_TofuJSONDoesNotSuppressTf(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	// .tofu.json should not suppress .tf (different format counterpart)
+	writeFile(t, dir, "versions.tofu.json", `{"terraform":{"required_version":"1.12.1"}}`)
+	writeFile(t, dir, "versions.tf", `terraform { required_version = "1.12.4" }`)
+
+	// Both contribute → multiple constraints → nil
+	detected := c.DetectVersion(logger(t), opentofuDist("1.12.1"), dir)
+	Assert(t, detected == nil, ".tofu.json must not suppress .tf; multiple constraints → nil")
+}
+
+// --- Finding 7: Assert exact numeric constraint value ---
+
+func TestDetectRequiredCoreFromTofu_NumericHCL_ExactValue(t *testing.T) {
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu", `terraform { required_version = 1.12 }`)
+
+	constraints, err := tfclient.DetectRequiredCoreFromTofuForTest(dir)
+	Assert(t, err == nil, "no error for numeric value")
+	Assert(t, len(constraints) == 1, "expected one constraint")
+	Equals(t, "1.12", constraints[0])
+}
+
+func TestDetectRequiredCoreFromTofu_NumericJSON_ExactValue(t *testing.T) {
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu.json", `{"terraform":{"required_version": 1.12}}`)
+
+	constraints, err := tfclient.DetectRequiredCoreFromTofuForTest(dir)
+	Assert(t, err == nil, "no error for JSON numeric value")
+	Assert(t, len(constraints) == 1, "expected one constraint")
+	Equals(t, "1.12", constraints[0])
+}
+
+// --- Finding 6: Terraform-mode .tofu.json exclusion ---
+
+func TestDetectVersion_Terraform_IgnoresTofuJSONFile(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu.json", `{"terraform":{"required_version":"1.12.1"}}`)
+
+	detected := c.DetectVersion(logger(t), nil, dir)
+	Assert(t, detected == nil, "Terraform distribution must not read .tofu.json files")
+}
+
+func TestDetectVersion_Terraform_TfPlusTofuJSON_IgnoresTofuJSON(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tf", `terraform { required_version = "= 1.5.7" }`)
+	writeFile(t, dir, "versions.tofu.json", `{"terraform":{"required_version":"1.12.1"}}`)
+
+	detected := c.DetectVersion(logger(t), nil, dir)
+	Assert(t, detected != nil, "Terraform should detect only from .tf")
+	Equals(t, "1.5.7", detected.String())
+}
+
+// --- Finding 1: Same-file diagnostics ---
+
+func TestDetectRequiredCoreFromTofu_PartialFile_ReturnsDiagnostics(t *testing.T) {
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu", `
+terraform {
+  required_version = "1.12.1"
+}
+
+this is invalid HCL after the valid block
+`)
+
+	constraints, err := tfclient.DetectRequiredCoreFromTofuForTest(dir)
+	Equals(t, []string{"1.12.1"}, constraints)
+	Assert(t, err != nil, "should surface diagnostics even when constraint recovered")
+	Assert(t, strings.Contains(err.Error(), "versions.tofu"), "diagnostic should reference file")
+}
+
+// --- Finding 3: Production-path DetectVersion diagnostics ---
+
+func TestDetectVersion_OpenTofu_MalformedOnly_LogsDiagnostics(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	rl := newRecordingLogger(t)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu", `this is not valid HCL {{{`)
+
+	detected := c.DetectVersion(rl, opentofuDist("1.12.1"), dir)
+	Assert(t, detected == nil, "malformed-only should return nil")
+	Assert(t, rl.hasErrContaining("versions.tofu"), "should log error referencing malformed file")
+}
+
+func TestDetectVersion_OpenTofu_MalformedJSON_LogsDiagnostics(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	rl := newRecordingLogger(t)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu.json", `{not valid json}`)
+
+	detected := c.DetectVersion(rl, opentofuDist("1.12.1"), dir)
+	Assert(t, detected == nil, "malformed JSON should return nil")
+	Assert(t, rl.hasErrContaining("versions.tofu.json"), "should log error referencing malformed JSON")
+}
+
+func TestDetectVersion_OpenTofu_ValidPlusMalformed_LogsDiagnostics(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	rl := newRecordingLogger(t)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "bad.tofu", `this is not valid HCL {{{`)
+	writeFile(t, dir, "good.tofu", `terraform { required_version = "1.12.1" }`)
+
+	detected := c.DetectVersion(rl, opentofuDist("1.12.1"), dir)
+	Assert(t, detected != nil, "should recover valid constraint")
+	Equals(t, "1.12.1", detected.String())
+	Assert(t, rl.hasErrContaining("bad.tofu"), "should log diagnostics for malformed sibling")
+}
+
+func TestDetectVersion_OpenTofu_PartialFile_LogsDiagnostics(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	rl := newRecordingLogger(t)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tofu", `
+terraform {
+  required_version = "1.12.1"
+}
+
+this is invalid HCL after
+`)
+
+	detected := c.DetectVersion(rl, opentofuDist("1.12.1"), dir)
+	Assert(t, detected != nil, "should recover constraint from partial file")
+	Equals(t, "1.12.1", detected.String())
+	Assert(t, rl.hasErrContaining("versions.tofu"), "should log diagnostics from partial parse")
+}
+
+// --- Terraform .tf.json regression ---
+
+func TestDetectVersion_Terraform_TfJSON(t *testing.T) {
+	c := newTestClientForTofu(t, false)
+	dir := makeProjectDir(t)
+	writeFile(t, dir, "versions.tf.json", `{"terraform":{"required_version":"1.2.3"}}`)
+
+	detected := c.DetectVersion(logger(t), nil, dir)
+	Assert(t, detected != nil, "Terraform distribution must still detect from .tf.json")
+	Equals(t, "1.2.3", detected.String())
+}

--- a/server/events/project_command_builder_internal_test.go
+++ b/server/events/project_command_builder_internal_test.go
@@ -601,7 +601,7 @@ projects:
 				EscapedCommentArgs:   []string{`\f\l\a\g`},
 				AutomergeEnabled:     false,
 				AutoplanEnabled:      true,
-				AutoplanWhenModified: []string{"**/*.tf*", "**/terragrunt.hcl", "**/.terraform.lock.hcl"},
+				AutoplanWhenModified: []string{"**/*.tf*", "**/*.tofu", "**/*.tofu.json", "**/terragrunt.hcl", "**/.terraform.lock.hcl"},
 				HeadRepo:             models.Repo{},
 				Log:                  logger,
 				Scope:                statsScope,

--- a/server/events/project_finder.go
+++ b/server/events/project_finder.go
@@ -5,7 +5,6 @@
 package events
 
 import (
-	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -340,8 +339,8 @@ func getProjectDirFromFs(files fs.FS, modifiedFilePath string) string {
 		modulesSplit := strings.SplitN(dirWithTrailingSlash, "modules/", 2)
 		modulesParent := modulesSplit[0]
 
-		// Now we check whether there is a main.tf in the parent.
-		if _, err := fs.Stat(files, filepath.Join(modulesParent, "main.tf")); errors.Is(err, fs.ErrNotExist) {
+		// Check whether the parent contains a Terraform/OpenTofu project file.
+		if !hasProjectIndicator(files, modulesParent) {
 			return ""
 		}
 		return path.Clean(modulesParent)
@@ -354,6 +353,35 @@ func getProjectDirFromFs(files fs.FS, modifiedFilePath string) string {
 
 func isModule(dir string) bool {
 	return strings.Contains("/"+dir+"/", "/modules/")
+}
+
+// hasProjectIndicator checks whether a directory in the given filesystem
+// contains a Terraform/OpenTofu/Terragrunt project file. Aligned with
+// raw.IsTerraformProjectDir indicators: *.tf, *.tf.json, *.tofu, *.tofu.json,
+// terragrunt.hcl.
+func hasProjectIndicator(files fs.FS, dir string) bool {
+	dir = path.Clean(dir)
+	if dir == "" {
+		dir = "."
+	}
+	entries, err := fs.ReadDir(files, dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.HasSuffix(name, ".tf") ||
+			strings.HasSuffix(name, ".tf.json") ||
+			strings.HasSuffix(name, ".tofu") ||
+			strings.HasSuffix(name, ".tofu.json") ||
+			name == "terragrunt.hcl" {
+			return true
+		}
+	}
+	return false
 }
 
 // unique de-duplicates strs.

--- a/server/events/project_finder_internal_test.go
+++ b/server/events/project_finder_internal_test.go
@@ -1,0 +1,109 @@
+// Copyright 2025 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package events
+
+import (
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	. "github.com/runatlantis/atlantis/testing"
+)
+
+func TestGetProjectDirFromFs_ModuleParentWithMainTf(t *testing.T) {
+	files := fstest.MapFS{
+		"project/main.tf":             &fstest.MapFile{},
+		"project/modules/foo/main.tf": &fstest.MapFile{},
+	}
+	result := getProjectDirFromFs(fs.FS(files), "project/modules/foo/main.tf")
+	Equals(t, "project", result)
+}
+
+func TestGetProjectDirFromFs_ModuleParentWithMainTofu(t *testing.T) {
+	files := fstest.MapFS{
+		"project/main.tofu":             &fstest.MapFile{},
+		"project/modules/foo/main.tofu": &fstest.MapFile{},
+	}
+	result := getProjectDirFromFs(fs.FS(files), "project/modules/foo/main.tofu")
+	Equals(t, "project", result)
+}
+
+func TestGetProjectDirFromFs_ModuleParentNoMainTfOrTofu(t *testing.T) {
+	files := fstest.MapFS{
+		"project/modules/foo/main.tofu": &fstest.MapFile{},
+	}
+	result := getProjectDirFromFs(fs.FS(files), "project/modules/foo/main.tofu")
+	Equals(t, "", result)
+}
+
+func TestGetProjectDirFromFs_NonModuleTofu(t *testing.T) {
+	files := fstest.MapFS{
+		"project/main.tofu": &fstest.MapFile{},
+	}
+	result := getProjectDirFromFs(fs.FS(files), "project/main.tofu")
+	Equals(t, "project", result)
+}
+
+func TestGetProjectDirFromFs_ModuleParentWithMainTofuJSON(t *testing.T) {
+	files := fstest.MapFS{
+		"project/main.tofu.json":             &fstest.MapFile{},
+		"project/modules/foo/main.tofu.json": &fstest.MapFile{},
+	}
+	result := getProjectDirFromFs(fs.FS(files), "project/modules/foo/main.tofu.json")
+	Equals(t, "project", result)
+}
+
+func TestGetProjectDirFromFs_ModuleParentTofuJSON_ChangedTofu(t *testing.T) {
+	files := fstest.MapFS{
+		"project/main.tofu.json":        &fstest.MapFile{},
+		"project/modules/foo/main.tofu": &fstest.MapFile{},
+	}
+	result := getProjectDirFromFs(fs.FS(files), "project/modules/foo/main.tofu")
+	Equals(t, "project", result)
+}
+
+func TestGetProjectDirFromFs_ModuleParentVersionsTofu(t *testing.T) {
+	files := fstest.MapFS{
+		"project/versions.tofu":         &fstest.MapFile{},
+		"project/modules/foo/main.tofu": &fstest.MapFile{},
+	}
+	result := getProjectDirFromFs(fs.FS(files), "project/modules/foo/main.tofu")
+	Equals(t, "project", result)
+}
+
+func TestGetProjectDirFromFs_ModuleParentVersionsTofuJSON(t *testing.T) {
+	files := fstest.MapFS{
+		"project/versions.tofu.json":         &fstest.MapFile{},
+		"project/modules/foo/main.tofu.json": &fstest.MapFile{},
+	}
+	result := getProjectDirFromFs(fs.FS(files), "project/modules/foo/main.tofu.json")
+	Equals(t, "project", result)
+}
+
+func TestGetProjectDirFromFs_ModuleParentNoIndicator(t *testing.T) {
+	files := fstest.MapFS{
+		"project/README.md":             &fstest.MapFile{},
+		"project/modules/foo/main.tofu": &fstest.MapFile{},
+	}
+	result := getProjectDirFromFs(fs.FS(files), "project/modules/foo/main.tofu")
+	Equals(t, "", result)
+}
+
+func TestGetProjectDirFromFs_ModuleParentTfJSON(t *testing.T) {
+	files := fstest.MapFS{
+		"project/versions.tf.json":    &fstest.MapFile{},
+		"project/modules/foo/main.tf": &fstest.MapFile{},
+	}
+	result := getProjectDirFromFs(fs.FS(files), "project/modules/foo/main.tf")
+	Equals(t, "project", result)
+}
+
+func TestGetProjectDirFromFs_ModuleParentTerragrunt(t *testing.T) {
+	files := fstest.MapFS{
+		"project/terragrunt.hcl":      &fstest.MapFile{},
+		"project/modules/foo/main.tf": &fstest.MapFile{},
+	}
+	result := getProjectDirFromFs(fs.FS(files), "project/modules/foo/main.tf")
+	Equals(t, "project", result)
+}


### PR DESCRIPTION
## Summary

Fixes #6542 — OpenTofu version auto-detection now works for `.tofu` / `.tofu.json` projects.

## Problem

`DetectVersion` uses `hashicorp/terraform-config-inspect` which only recognizes `.tf` and `.tf.json` files. OpenTofu officially supports `.tofu` and `.tofu.json` files, but Atlantis could not read `required_version` from them.

## Solution

Added a local OpenTofu-aware parser using HCL parsing (`ParseHCLFile` / `ParseJSONFile` with `PartialContent` schema — same approach as `terraform-config-inspect`) that:

- Reads `.tofu`, `.tofu.json`, `.tf`, and `.tf.json` when the effective distribution is OpenTofu
- Applies OpenTofu file precedence (`.tofu` overrides same-basename `.tf`; `.tofu.json` overrides same-basename `.tf.json`)
- Supports HCL JSON array block form for full `.tf.json` parity
- Implicit number→string conversion via cty (matching `gohcl.DecodeExpression`)
- Rejects null, unknown, bool, list values with diagnostics
- Rejects labeled `terraform "x" {}` blocks per config-inspect schema
- Supports partial-file recovery (valid constraint + later syntax error)
- Surfaces diagnostics even when constraints are recovered
- Ignores hidden files, editor backups (`~`), emacs temp files (`#...#`)

Terraform distribution is **completely unchanged** — still uses `tfconfig.LoadModule()` exclusively.

## Autoplan & Project Discovery

- Added `*.tofu`, `*.tofu.json` to default `autoplan.when_modified` patterns
- Added `**/*.tf.json`, `**/*.tofu`, `**/*.tofu.json` to server `--autoplan-file-list` default
- Added `*.tofu`, `*.tofu.json` to project discovery indicators
- Module-parent autodiscovery uses canonical project indicators (`*.tf`, `*.tf.json`, `*.tofu`, `*.tofu.json`, `terragrunt.hcl`)

## Changes

| Area | Files |
|------|-------|
| Parser | `server/core/terraform/tfclient/tofu_version.go` (new), `terraform_client.go`, `export_test.go` |
| Config | `server/core/config/raw/project.go`, `autoplan.go` |
| Discovery | `server/events/project_finder.go`, `project_finder_internal_test.go` |
| Server | `cmd/server.go` |
| Tests | `tofu_version_test.go` (50+ test cases), `autoplan_test.go`, `project_test.go`, `project_command_builder_internal_test.go`, `server_test.go` |
| Docs | `terraform-versions.md`, `autoplanning.md`, `server-configuration.md`, `repo-level-atlantis-yaml.md` |

## Test Coverage

- OpenTofu + `.tofu` file → detects version
- OpenTofu + `.tofu.json` (object and array block forms) → detects version
- OpenTofu + `.tf` file alone → still works
- Terraform + `.tofu` / `.tofu.json` → ignored (no behavior change)
- Terraform + `.tf.json` → still works (regression pinned)
- Same-basename precedence (`.tofu` overrides `.tf`, `.tofu.json` overrides `.tf.json`)
- Cross-format independence (`.tofu` does not suppress `.tf.json` and vice versa)
- Unrelated files both contribute → multiple constraints → nil
- Invalid values: null, bool, list, variable ref, conditional null, labeled blocks
- Numeric conversion: HCL `1.12` and JSON `1.12` accepted
- Malformed files: no panic, diagnostics surfaced
- Partial file recovery: valid constraint + later garbage → constraint recovered + diagnostics logged
- Ignored files: hidden (`.`), backup (`~`), emacs (`#...#`)
- Module-parent: `.tf`, `.tf.json`, `.tofu`, `.tofu.json`, `terragrunt.hcl` roots
- Server autoplan default pinned with literal assertion
- Project indicators: `.tofu`, `.tofu.json` directories detected

## Known Limitations (documented)

1. **Module autoplanning** (`--autoplan-modules`) dependency indexing still uses `terraform-config-inspect` — module calls in `.tofu` files and `.tofu`-only module directories may not be traced. Workaround: explicit `when_modified` patterns.
2. **Terraform Cloud workspace detection** still scans `.tf` only. Workaround: keep workspace config in `.tf` or configure explicitly in `atlantis.yaml`.
3. **Autoplan defaults are global** (not distribution-aware) — Terraform repos may match `.tofu` changes at the trigger layer, though Terraform version detection still ignores `.tofu`.

## Backward Compatibility

- Terraform distribution: zero change
- OpenTofu + existing `.tf` projects: works as before
- OpenTofu + `.tofu` projects: now detects `required_version`
- Autoplan: `.tofu`/`.tofu.json` changes now trigger plans by default
- Project discovery: `.tofu`-only directories recognized as projects
- Module-parent: any project indicator file accepted (broader than before)