### PR TITLE
feat(e2e): activate new fixture coverage from atlantis-tests#21001

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,1 +1,2 @@
 atlantis-tests
+e2e

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"time"
 )
 
@@ -17,133 +18,147 @@ type E2ETester struct {
 	vcsClient    VCSClient
 	hookID       int64
 	cloneDirRoot string
-	projectType  Project
+	testCase     TestCase
 }
 
 type E2EResult struct {
-	projectType    string
+	testCase       string
 	pullRequestURL string
+	branchName     string
 	testResult     string
+	err            error
 }
 
-var testFileData = `
-resource "null_resource" "hello" {
-}
-`
+const (
+	pollInterval = 2 * time.Second
+	maxPolls     = 30
+	initialWait  = 2 * time.Second
+)
 
-// nolint: gosec
 func (t *E2ETester) Start(ctx context.Context) (*E2EResult, error) {
-	cloneDir := fmt.Sprintf("%s/%s-test", t.cloneDirRoot, t.projectType.Name)
-	branchName := fmt.Sprintf("%s-%s", t.projectType.Name, time.Now().Format("20060102150405"))
-	testFileName := fmt.Sprintf("%s.tf", t.projectType.Name)
-	e2eResult := &E2EResult{}
-	e2eResult.projectType = t.projectType.Name
+	tc := t.testCase
+	cloneDir := fmt.Sprintf("%s/%s-test", t.cloneDirRoot, tc.Name)
+	branchName := fmt.Sprintf("e2e-%s-%s", tc.Name, time.Now().Format("20060102150405"))
 
-	// create the directory and parents if necessary
+	result := &E2EResult{
+		testCase:   tc.Name,
+		branchName: branchName,
+	}
+
 	log.Printf("creating dir %q", cloneDir)
 	if err := os.MkdirAll(cloneDir, 0700); err != nil {
-		return e2eResult, fmt.Errorf("failed to create dir %q prior to cloning, attempting to continue: %v", cloneDir, err)
+		return result, fmt.Errorf("failed to create dir %q: %v", cloneDir, err)
 	}
 
-	err := t.vcsClient.Clone(cloneDir)
-	if err != nil {
-		return e2eResult, err
+	if err := t.vcsClient.Clone(cloneDir); err != nil {
+		return result, err
 	}
 
-	// checkout a new branch for the project
 	log.Printf("checking out branch %q", branchName)
 	checkoutCmd := exec.Command("git", "checkout", "-b", branchName)
 	checkoutCmd.Dir = cloneDir
 	if output, err := checkoutCmd.CombinedOutput(); err != nil {
-		return e2eResult, fmt.Errorf("failed to git checkout branch %q: %v: %s", branchName, err, string(output))
+		return result, fmt.Errorf("failed to git checkout branch %q: %v: %s", branchName, err, string(output))
 	}
 
-	// write a file for running the tests
-	randomData := []byte(testFileData)
-	filePath := fmt.Sprintf("%s/%s/%s", cloneDir, t.projectType.Name, testFileName)
-	log.Printf("creating file to commit %q", filePath)
-	err = os.WriteFile(filePath, randomData, 0644)
-	if err != nil {
-		return e2eResult, fmt.Errorf("couldn't write file %s: %v", filePath, err)
+	// Determine file to mutate.
+	mutateFile := tc.MutateFile
+	if mutateFile == "" {
+		mutateFile = fmt.Sprintf("%s.tf", tc.Name)
+	}
+	filePath := filepath.Join(cloneDir, tc.Dir, mutateFile)
+
+	// Ensure parent directory exists (for cases writing to subdirs).
+	if err := os.MkdirAll(filepath.Dir(filePath), 0700); err != nil {
+		return result, fmt.Errorf("failed to create parent dir for %q: %v", filePath, err)
 	}
 
-	// add the file
-	log.Printf("git add file %q", filePath)
+	content := tc.MutateContent
+	if content == "" {
+		content = defaultMutateContent
+	}
+
+	log.Printf("writing mutation file %q", filePath)
+	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+		return result, fmt.Errorf("couldn't write file %s: %v", filePath, err)
+	}
+
+	log.Printf("git add %q", filePath)
 	addCmd := exec.Command("git", "add", filePath)
 	addCmd.Dir = cloneDir
 	if output, err := addCmd.CombinedOutput(); err != nil {
-		return e2eResult, fmt.Errorf("failed to git add file %q: %v: %s", filePath, err, string(output))
+		return result, fmt.Errorf("failed to git add file %q: %v: %s", filePath, err, string(output))
 	}
 
-	// commit the file
-	log.Printf("git commit file %q", filePath)
-	commitCmd := exec.Command("git", "commit", "-am", "test commit")
+	log.Printf("git commit")
+	commitCmd := exec.Command("git", "commit", "-am", fmt.Sprintf("e2e: %s", tc.Name))
 	commitCmd.Dir = cloneDir
 	if output, err := commitCmd.CombinedOutput(); err != nil {
-		return e2eResult, fmt.Errorf("failed to run git commit in %q: %v: %v", cloneDir, err, string(output))
+		return result, fmt.Errorf("failed to git commit in %q: %v: %s", cloneDir, err, string(output))
 	}
 
-	// push the branch to remote
 	log.Printf("git push branch %q", branchName)
 	pushCmd := exec.Command("git", "push", "origin", branchName)
 	pushCmd.Dir = cloneDir
 	if output, err := pushCmd.CombinedOutput(); err != nil {
-		return e2eResult, fmt.Errorf("failed to git push branch %q: %v: %s", branchName, err, string(output))
+		return result, fmt.Errorf("failed to git push branch %q: %v: %s", branchName, err, string(output))
 	}
 
-	// create a new pr
-	title := fmt.Sprintf("This is a test pull request for atlantis e2e test for %s project type", t.projectType.Name)
-	url, pullId, err := t.vcsClient.CreatePullRequest(ctx, title, branchName)
-
+	title := fmt.Sprintf("[E2E] %s", tc.Name)
+	url, pullID, err := t.vcsClient.CreatePullRequest(ctx, title, branchName)
 	if err != nil {
-		return e2eResult, err
+		return result, err
 	}
-
-	// set pull request url
-	e2eResult.pullRequestURL = url
-
+	result.pullRequestURL = url
 	log.Printf("created pull request %s", url)
 
-	// defer closing pull request and delete remote branch
 	defer func() {
-		err := cleanUp(ctx, t, pullId, branchName)
-		if err != nil {
-			log.Printf("Failed to cleanup: %v", err)
+		if cleanErr := cleanUp(ctx, t, pullID, branchName); cleanErr != nil {
+			log.Printf("cleanup failed: %v", cleanErr)
 		}
 	}()
 
-	// wait for atlantis to respond to webhook and autoplan.
-	time.Sleep(2 * time.Second)
+	// Wait for Atlantis to receive webhook and start processing.
+	time.Sleep(initialWait)
+
+	statusPrefix := tc.StatusPrefix
+	if statusPrefix == "" {
+		statusPrefix = "atlantis/plan"
+	}
 
 	state := "not started"
-	// waiting for atlantis run and finish
-	maxLoops := 20
 	i := 0
-	for ; i < maxLoops && t.vcsClient.IsAtlantisInProgress(state); i++ {
-		time.Sleep(2 * time.Second)
-		state, _ = t.vcsClient.GetAtlantisStatus(ctx, branchName)
+	for ; i < maxPolls && t.vcsClient.IsAtlantisInProgress(state); i++ {
+		time.Sleep(pollInterval)
+		state, _ = t.vcsClient.GetAtlantisStatus(ctx, branchName, statusPrefix, tc.ExpectedStatusCount)
 		if state == "" {
-			log.Println("atlantis run hasn't started")
+			log.Printf("[%s] atlantis run hasn't started yet", tc.Name)
 			continue
 		}
-		log.Printf("atlantis run is in %s state", state)
+		log.Printf("[%s] atlantis status: %s", tc.Name, state)
 	}
-	if i == maxLoops {
+	if i == maxPolls {
 		state = "timed out"
 	}
 
-	log.Printf("atlantis run finished with status %q", state)
-	e2eResult.testResult = state
-	// check if atlantis run was a success
-	if !t.vcsClient.DidAtlantisSucceed(state) {
-		return e2eResult, fmt.Errorf("atlantis run project type %q failed with %q status", t.projectType.Name, state)
+	log.Printf("[%s] final status: %q", tc.Name, state)
+	result.testResult = state
+
+	// Evaluate result against expectations.
+	if tc.ExpectFailure {
+		if !t.vcsClient.DidAtlantisFail(state) {
+			return result, fmt.Errorf("[%s] expected failure but got %q", tc.Name, state)
+		}
+	} else {
+		if !t.vcsClient.DidAtlantisSucceed(state) {
+			return result, fmt.Errorf("[%s] expected success but got %q", tc.Name, state)
+		}
 	}
 
-	return e2eResult, nil
+	return result, nil
 }
 
 func cleanUp(ctx context.Context, t *E2ETester, pullRequestNumber int, branchName string) error {
-	// clean up
 	err := t.vcsClient.ClosePullRequest(ctx, pullRequestNumber)
 	if err != nil {
 		return err

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 )
@@ -69,7 +70,6 @@ func (t *E2ETester) Start(ctx context.Context) (*E2EResult, error) {
 	}
 	filePath := filepath.Join(cloneDir, tc.Dir, mutateFile)
 
-	// Ensure parent directory exists (for cases writing to subdirs).
 	if err := os.MkdirAll(filepath.Dir(filePath), 0700); err != nil {
 		return result, fmt.Errorf("failed to create parent dir for %q: %v", filePath, err)
 	}
@@ -122,17 +122,13 @@ func (t *E2ETester) Start(ctx context.Context) (*E2EResult, error) {
 	// Wait for Atlantis to receive webhook and start processing.
 	time.Sleep(initialWait)
 
-	statusPrefix := tc.StatusPrefix
-	if statusPrefix == "" {
-		statusPrefix = "atlantis/plan"
-	}
-
+	// Poll aggregate "atlantis/plan" status until terminal.
 	state := "not started"
 	var statusErr error
 	i := 0
 	for ; i < maxPolls && t.vcsClient.IsAtlantisInProgress(state); i++ {
 		time.Sleep(pollInterval)
-		state, statusErr = t.vcsClient.GetAtlantisStatus(ctx, branchName, statusPrefix, tc.ExpectedStatusCount)
+		state, statusErr = t.vcsClient.GetAtlantisStatus(ctx, branchName)
 		if statusErr != nil {
 			log.Printf("[%s] error polling status: %v", tc.Name, statusErr)
 			continue
@@ -154,7 +150,7 @@ func (t *E2ETester) Start(ctx context.Context) (*E2EResult, error) {
 	log.Printf("[%s] final status: %q", tc.Name, state)
 	result.testResult = state
 
-	// Evaluate result against expectations.
+	// Evaluate aggregate result against expectations.
 	if tc.ExpectFailure {
 		if !t.vcsClient.DidAtlantisFail(state) {
 			return result, fmt.Errorf("[%s] expected failure but got %q", tc.Name, state)
@@ -162,6 +158,13 @@ func (t *E2ETester) Start(ctx context.Context) (*E2EResult, error) {
 	} else {
 		if !t.vcsClient.DidAtlantisSucceed(state) {
 			return result, fmt.Errorf("[%s] expected success but got %q", tc.Name, state)
+		}
+	}
+
+	// Assert per-project status contexts if configured.
+	if len(tc.ExpectedStatusContexts) > 0 {
+		if err := assertProjectStatuses(ctx, t.vcsClient, branchName, tc); err != nil {
+			return result, err
 		}
 	}
 
@@ -173,6 +176,56 @@ func (t *E2ETester) Start(ctx context.Context) (*E2EResult, error) {
 	}
 
 	return result, nil
+}
+
+// assertProjectStatuses verifies that the expected per-project status contexts
+// are present and (optionally) that no unexpected project statuses exist.
+func assertProjectStatuses(ctx context.Context, client VCSClient, branchName string, tc TestCase) error {
+	projectStatuses, err := client.GetProjectStatuses(ctx, branchName)
+	if err != nil {
+		return fmt.Errorf("[%s] failed to get project statuses: %v", tc.Name, err)
+	}
+
+	// GetProjectStatuses returns nil on GitLab (unsupported).
+	if projectStatuses == nil {
+		log.Printf("[%s] skipping project status assertion (not supported on this VCS)", tc.Name)
+		return nil
+	}
+
+	// Check all expected contexts are present and successful.
+	for _, expected := range tc.ExpectedStatusContexts {
+		state, ok := projectStatuses[expected]
+		if !ok {
+			var found []string
+			for k := range projectStatuses {
+				found = append(found, k)
+			}
+			sort.Strings(found)
+			return fmt.Errorf("[%s] expected status context %q not found. Found: %v",
+				tc.Name, expected, found)
+		}
+		if state != "success" {
+			return fmt.Errorf("[%s] status context %q has state %q, expected success",
+				tc.Name, expected, state)
+		}
+	}
+
+	// Check no unexpected project statuses appear.
+	if tc.ForbidExtraProjectStatuses {
+		expectedSet := make(map[string]bool)
+		for _, e := range tc.ExpectedStatusContexts {
+			expectedSet[e] = true
+		}
+		for ctx := range projectStatuses {
+			if !expectedSet[ctx] {
+				return fmt.Errorf("[%s] unexpected project status %q (expected only %v)",
+					tc.Name, ctx, tc.ExpectedStatusContexts)
+			}
+		}
+	}
+
+	log.Printf("[%s] project status contexts verified: %v", tc.Name, tc.ExpectedStatusContexts)
+	return nil
 }
 
 func assertCommentContains(ctx context.Context, client VCSClient, pullNumber int, caseName, expected string) error {

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -216,10 +216,10 @@ func assertProjectStatuses(ctx context.Context, client VCSClient, branchName str
 		for _, e := range tc.ExpectedStatusContexts {
 			expectedSet[e] = true
 		}
-		for ctx := range projectStatuses {
-			if !expectedSet[ctx] {
+		for statusCtx := range projectStatuses {
+			if !expectedSet[statusCtx] {
 				return fmt.Errorf("[%s] unexpected project status %q (expected only %v)",
-					tc.Name, ctx, tc.ExpectedStatusContexts)
+					tc.Name, statusCtx, tc.ExpectedStatusContexts)
 			}
 		}
 	}

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -127,10 +128,15 @@ func (t *E2ETester) Start(ctx context.Context) (*E2EResult, error) {
 	}
 
 	state := "not started"
+	var statusErr error
 	i := 0
 	for ; i < maxPolls && t.vcsClient.IsAtlantisInProgress(state); i++ {
 		time.Sleep(pollInterval)
-		state, _ = t.vcsClient.GetAtlantisStatus(ctx, branchName, statusPrefix, tc.ExpectedStatusCount)
+		state, statusErr = t.vcsClient.GetAtlantisStatus(ctx, branchName, statusPrefix, tc.ExpectedStatusCount)
+		if statusErr != nil {
+			log.Printf("[%s] error polling status: %v", tc.Name, statusErr)
+			continue
+		}
 		if state == "" {
 			log.Printf("[%s] atlantis run hasn't started yet", tc.Name)
 			continue
@@ -138,7 +144,11 @@ func (t *E2ETester) Start(ctx context.Context) (*E2EResult, error) {
 		log.Printf("[%s] atlantis status: %s", tc.Name, state)
 	}
 	if i == maxPolls {
-		state = "timed out"
+		if statusErr != nil {
+			state = fmt.Sprintf("timed out (last error: %v)", statusErr)
+		} else {
+			state = "timed out"
+		}
 	}
 
 	log.Printf("[%s] final status: %q", tc.Name, state)
@@ -155,7 +165,28 @@ func (t *E2ETester) Start(ctx context.Context) (*E2EResult, error) {
 		}
 	}
 
+	// Assert expected comment substring if configured.
+	if tc.ExpectedCommentSubstring != "" {
+		if err := assertCommentContains(ctx, t.vcsClient, pullID, tc.Name, tc.ExpectedCommentSubstring); err != nil {
+			return result, err
+		}
+	}
+
 	return result, nil
+}
+
+func assertCommentContains(ctx context.Context, client VCSClient, pullNumber int, caseName, expected string) error {
+	comments, err := client.GetPRComments(ctx, pullNumber)
+	if err != nil {
+		return fmt.Errorf("[%s] failed to fetch comments for marker assertion: %v", caseName, err)
+	}
+	for _, body := range comments {
+		if strings.Contains(body, expected) {
+			log.Printf("[%s] found expected marker in comment: %q", caseName, expected)
+			return nil
+		}
+	}
+	return fmt.Errorf("[%s] expected comment containing %q not found in %d comments", caseName, expected, len(comments))
 }
 
 func cleanUp(ctx context.Context, t *E2ETester, pullRequestNumber int, branchName string) error {

--- a/e2e/github.go
+++ b/e2e/github.go
@@ -218,9 +218,9 @@ func (g GithubClient) GetProjectStatuses(ctx context.Context, branchName string)
 
 	result := make(map[string]string)
 	for _, status := range combinedStatus.Statuses {
-		ctx := status.GetContext()
-		if strings.HasPrefix(ctx, projectStatusPrefix) {
-			result[ctx] = status.GetState()
+		statusCtx := status.GetContext()
+		if strings.HasPrefix(statusCtx, projectStatusPrefix) {
+			result[statusCtx] = status.GetState()
 		}
 	}
 	return result, nil

--- a/e2e/github.go
+++ b/e2e/github.go
@@ -191,8 +191,13 @@ func (g GithubClient) CreatePullRequest(ctx context.Context, title, branchName s
 }
 
 // GetAtlantisStatus checks all commit statuses matching the given prefix.
-// It returns "success" only when all matching statuses report success.
-// If expectedCount > 0, it waits until exactly that many statuses appear.
+// When expectedCount > 0, enforces exact match:
+//   - 0 matched → "" (not started)
+//   - fewer than expected → "pending"
+//   - more than expected → "unexpected_count" (terminal failure)
+//   - exactly expected → aggregate individual states
+//
+// When expectedCount == 0, at least one matching status must succeed.
 func (g GithubClient) GetAtlantisStatus(ctx context.Context, branchName string, statusPrefix string, expectedCount int) (string, error) {
 	combinedStatus, _, err := g.client.Repositories.GetCombinedStatus(ctx, g.ownerName, g.repoName, branchName, nil)
 	if err != nil {
@@ -210,9 +215,19 @@ func (g GithubClient) GetAtlantisStatus(ctx context.Context, branchName string, 
 		return "", nil
 	}
 
-	// If we expect a specific count, don't report terminal until we have them all.
-	if expectedCount > 0 && len(matched) < expectedCount {
-		return "pending", nil
+	if expectedCount > 0 {
+		if len(matched) < expectedCount {
+			return "pending", nil
+		}
+		if len(matched) > expectedCount {
+			var contexts []string
+			for _, s := range matched {
+				contexts = append(contexts, s.GetContext())
+			}
+			log.Printf("unexpected status count: got %d, expected %d. Contexts: %v",
+				len(matched), expectedCount, contexts)
+			return "unexpected_count", nil
+		}
 	}
 
 	hasFailure := false
@@ -237,6 +252,22 @@ func (g GithubClient) GetAtlantisStatus(ctx context.Context, branchName string, 
 	return "success", nil
 }
 
+// GetPRComments returns all issue comment bodies on the pull request.
+// Atlantis posts plan/apply output as issue comments on GitHub.
+func (g GithubClient) GetPRComments(ctx context.Context, pullNumber int) ([]string, error) {
+	comments, _, err := g.client.Issues.ListComments(ctx, g.ownerName, g.repoName, pullNumber, &github.IssueListCommentsOptions{
+		ListOptions: github.ListOptions{PerPage: 100},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing PR comments: %w", err)
+	}
+	var bodies []string
+	for _, c := range comments {
+		bodies = append(bodies, c.GetBody())
+	}
+	return bodies, nil
+}
+
 func (g GithubClient) ClosePullRequest(ctx context.Context, pullRequestNumber int) error {
 	_, _, err := g.client.PullRequests.Edit(ctx, g.ownerName, g.repoName, pullRequestNumber, &github.PullRequest{State: github.Ptr("closed")})
 	if err != nil {
@@ -255,7 +286,7 @@ func (g GithubClient) DeleteBranch(ctx context.Context, branchName string) error
 }
 
 func (g GithubClient) IsAtlantisInProgress(state string) bool {
-	for _, s := range []string{"success", "error", "failure"} {
+	for _, s := range []string{"success", "error", "failure", "unexpected_count"} {
 		if state == s {
 			return false
 		}
@@ -268,5 +299,5 @@ func (g GithubClient) DidAtlantisSucceed(state string) bool {
 }
 
 func (g GithubClient) DidAtlantisFail(state string) bool {
-	return state == "failure" || state == "error"
+	return state == "failure" || state == "error" || state == "unexpected_count"
 }

--- a/e2e/github.go
+++ b/e2e/github.go
@@ -24,7 +24,6 @@ type GithubClient struct {
 	ownerName string
 	repoName  string
 	token     string
-	// transport is set when using GitHub App auth; nil for PAT auth.
 	transport *ghinstallation.Transport
 }
 
@@ -38,12 +37,10 @@ func NewGithubClient() *GithubClient {
 		repoName = "atlantis-tests"
 	}
 
-	// Try GitHub App auth first
 	if appIDStr := os.Getenv("ATLANTIS_GH_APP_ID"); appIDStr != "" {
 		return newGithubAppClient(appIDStr, ownerName, repoName)
 	}
 
-	// Fall back to PAT auth
 	return newGithubPATClient(ownerName, repoName)
 }
 
@@ -57,7 +54,6 @@ func newGithubAppClient(appIDStr, ownerName, repoName string) *GithubClient {
 		log.Fatalf("ATLANTIS_GH_APP_KEY cannot be empty when ATLANTIS_GH_APP_ID is set")
 	}
 
-	// Create an app-level transport to look up the installation for this repo
 	appTransport, err := ghinstallation.NewAppsTransport(http.DefaultTransport, appID, []byte(appKey))
 	if err != nil {
 		log.Fatalf("creating GitHub App transport: %v", err)
@@ -85,7 +81,6 @@ func newGithubAppClient(appIDStr, ownerName, repoName string) *GithubClient {
 		log.Fatalf("creating GitHub App installation client: %v", err)
 	}
 
-	// Derive bot username from app slug
 	username := ""
 	if slug := os.Getenv("ATLANTIS_GH_APP_SLUG"); slug != "" {
 		username = fmt.Sprintf("%s[bot]", slug)
@@ -133,7 +128,6 @@ func newGithubPATClient(ownerName, repoName string) *GithubClient {
 func (g GithubClient) Clone(cloneDir string) error {
 	var repoURL string
 	if g.transport != nil {
-		// GitHub App auth: get a fresh installation token for git clone
 		token, err := g.transport.Token(context.Background())
 		if err != nil {
 			return fmt.Errorf("getting installation token for clone: %w", err)
@@ -157,7 +151,6 @@ func (g GithubClient) CreateAtlantisWebhook(ctx context.Context, hookURL string)
 		ContentType: &contentType,
 		URL:         &hookURL,
 	}
-	// create atlantis hook
 	atlantisHook := &github.Hook{
 		Events: []string{"issue_comment", "pull_request", "push"},
 		Config: hookConfig,
@@ -194,38 +187,65 @@ func (g GithubClient) CreatePullRequest(ctx context.Context, title, branchName s
 		return "", 0, fmt.Errorf("error while creating new pull request: %v", err)
 	}
 
-	// set pull request url
 	return pull.GetHTMLURL(), pull.GetNumber(), nil
-
 }
 
-func (g GithubClient) GetAtlantisStatus(ctx context.Context, branchName string) (string, error) {
-	// check repo status
+// GetAtlantisStatus checks all commit statuses matching the given prefix.
+// It returns "success" only when all matching statuses report success.
+// If expectedCount > 0, it waits until exactly that many statuses appear.
+func (g GithubClient) GetAtlantisStatus(ctx context.Context, branchName string, statusPrefix string, expectedCount int) (string, error) {
 	combinedStatus, _, err := g.client.Repositories.GetCombinedStatus(ctx, g.ownerName, g.repoName, branchName, nil)
 	if err != nil {
 		return "", err
 	}
 
+	var matched []*github.RepoStatus
 	for _, status := range combinedStatus.Statuses {
-		if status.GetContext() == "atlantis/plan" {
-			return status.GetState(), nil
+		if strings.HasPrefix(status.GetContext(), statusPrefix) {
+			matched = append(matched, status)
 		}
 	}
 
-	return "", nil
+	if len(matched) == 0 {
+		return "", nil
+	}
+
+	// If we expect a specific count, don't report terminal until we have them all.
+	if expectedCount > 0 && len(matched) < expectedCount {
+		return "pending", nil
+	}
+
+	hasFailure := false
+	hasPending := false
+	for _, s := range matched {
+		switch s.GetState() {
+		case "success":
+			continue
+		case "failure", "error":
+			hasFailure = true
+		default:
+			hasPending = true
+		}
+	}
+
+	if hasFailure {
+		return "failure", nil
+	}
+	if hasPending {
+		return "pending", nil
+	}
+	return "success", nil
 }
 
 func (g GithubClient) ClosePullRequest(ctx context.Context, pullRequestNumber int) error {
-	// clean up
 	_, _, err := g.client.PullRequests.Edit(ctx, g.ownerName, g.repoName, pullRequestNumber, &github.PullRequest{State: github.Ptr("closed")})
 	if err != nil {
 		return fmt.Errorf("error while closing new pull request: %v", err)
 	}
 	return nil
-
 }
-func (g GithubClient) DeleteBranch(ctx context.Context, branchName string) error {
 
+func (g GithubClient) DeleteBranch(ctx context.Context, branchName string) error {
 	deleteBranchName := fmt.Sprintf("%s/%s", "heads", branchName)
 	_, err := g.client.Git.DeleteRef(ctx, g.ownerName, g.repoName, deleteBranchName)
 	if err != nil {
@@ -245,4 +265,8 @@ func (g GithubClient) IsAtlantisInProgress(state string) bool {
 
 func (g GithubClient) DidAtlantisSucceed(state string) bool {
 	return state == "success"
+}
+
+func (g GithubClient) DidAtlantisFail(state string) bool {
+	return state == "failure" || state == "error"
 }

--- a/e2e/github.go
+++ b/e2e/github.go
@@ -190,70 +190,43 @@ func (g GithubClient) CreatePullRequest(ctx context.Context, title, branchName s
 	return pull.GetHTMLURL(), pull.GetNumber(), nil
 }
 
-// GetAtlantisStatus checks all commit statuses matching the given prefix.
-// When expectedCount > 0, enforces exact match:
-//   - 0 matched → "" (not started)
-//   - fewer than expected → "pending"
-//   - more than expected → "unexpected_count" (terminal failure)
-//   - exactly expected → aggregate individual states
-//
-// When expectedCount == 0, at least one matching status must succeed.
-func (g GithubClient) GetAtlantisStatus(ctx context.Context, branchName string, statusPrefix string, expectedCount int) (string, error) {
+// GetAtlantisStatus polls the aggregate "atlantis/plan" commit status.
+// Used only for the polling loop to detect terminal state.
+func (g GithubClient) GetAtlantisStatus(ctx context.Context, branchName string) (string, error) {
 	combinedStatus, _, err := g.client.Repositories.GetCombinedStatus(ctx, g.ownerName, g.repoName, branchName, nil)
 	if err != nil {
 		return "", err
 	}
 
-	var matched []*github.RepoStatus
 	for _, status := range combinedStatus.Statuses {
-		if strings.HasPrefix(status.GetContext(), statusPrefix) {
-			matched = append(matched, status)
+		if status.GetContext() == "atlantis/plan" {
+			return status.GetState(), nil
 		}
 	}
 
-	if len(matched) == 0 {
-		return "", nil
+	return "", nil
+}
+
+// GetProjectStatuses returns all per-project Atlantis plan status contexts
+// and their states. These have the form "atlantis/plan: <ProjectID>".
+// The aggregate "atlantis/plan" status is excluded.
+func (g GithubClient) GetProjectStatuses(ctx context.Context, branchName string) (map[string]string, error) {
+	combinedStatus, _, err := g.client.Repositories.GetCombinedStatus(ctx, g.ownerName, g.repoName, branchName, nil)
+	if err != nil {
+		return nil, err
 	}
 
-	if expectedCount > 0 {
-		if len(matched) < expectedCount {
-			return "pending", nil
-		}
-		if len(matched) > expectedCount {
-			var contexts []string
-			for _, s := range matched {
-				contexts = append(contexts, s.GetContext())
-			}
-			log.Printf("unexpected status count: got %d, expected %d. Contexts: %v",
-				len(matched), expectedCount, contexts)
-			return "unexpected_count", nil
+	result := make(map[string]string)
+	for _, status := range combinedStatus.Statuses {
+		ctx := status.GetContext()
+		if strings.HasPrefix(ctx, projectStatusPrefix) {
+			result[ctx] = status.GetState()
 		}
 	}
-
-	hasFailure := false
-	hasPending := false
-	for _, s := range matched {
-		switch s.GetState() {
-		case "success":
-			continue
-		case "failure", "error":
-			hasFailure = true
-		default:
-			hasPending = true
-		}
-	}
-
-	if hasFailure {
-		return "failure", nil
-	}
-	if hasPending {
-		return "pending", nil
-	}
-	return "success", nil
+	return result, nil
 }
 
 // GetPRComments returns all issue comment bodies on the pull request.
-// Atlantis posts plan/apply output as issue comments on GitHub.
 func (g GithubClient) GetPRComments(ctx context.Context, pullNumber int) ([]string, error) {
 	comments, _, err := g.client.Issues.ListComments(ctx, g.ownerName, g.repoName, pullNumber, &github.IssueListCommentsOptions{
 		ListOptions: github.ListOptions{PerPage: 100},
@@ -286,7 +259,7 @@ func (g GithubClient) DeleteBranch(ctx context.Context, branchName string) error
 }
 
 func (g GithubClient) IsAtlantisInProgress(state string) bool {
-	for _, s := range []string{"success", "error", "failure", "unexpected_count"} {
+	for _, s := range []string{"success", "error", "failure"} {
 		if state == s {
 			return false
 		}
@@ -299,5 +272,5 @@ func (g GithubClient) DidAtlantisSucceed(state string) bool {
 }
 
 func (g GithubClient) DidAtlantisFail(state string) bool {
-	return state == "failure" || state == "error" || state == "unexpected_count"
+	return state == "failure" || state == "error"
 }

--- a/e2e/gitlab.go
+++ b/e2e/gitlab.go
@@ -15,13 +15,12 @@ import (
 )
 
 type GitlabClient struct {
-	client    *gitlab.Client
-	username  string
-	ownerName string
-	repoName  string
-	token     string
-	projectId int
-	// A mapping from branch names to MR IDs
+	client     *gitlab.Client
+	username   string
+	ownerName  string
+	repoName   string
+	token      string
+	projectId  int
 	branchToMR map[string]int
 }
 
@@ -62,20 +61,16 @@ func NewGitlabClient() *GitlabClient {
 		projectId:  project.ID,
 		branchToMR: make(map[string]int),
 	}
-
 }
 
 func (g GitlabClient) Clone(cloneDir string) error {
-
 	repoURL := fmt.Sprintf("https://%s:%s@gitlab.com/%s/%s.git", g.username, g.token, g.ownerName, g.repoName)
 	cloneCmd := exec.Command("git", "clone", repoURL, cloneDir)
-	// git clone the repo
 	log.Printf("git cloning into %q", cloneDir)
 	if output, err := cloneCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to clone repository: %v: %s", err, string(output))
 	}
 	return nil
-
 }
 
 func (g GitlabClient) CreateAtlantisWebhook(ctx context.Context, hookURL string) (int64, error) {
@@ -102,7 +97,6 @@ func (g GitlabClient) DeleteAtlantisHook(ctx context.Context, hookID int64) erro
 }
 
 func (g GitlabClient) CreatePullRequest(ctx context.Context, title, branchName string) (string, int, error) {
-
 	mr, _, err := g.client.MergeRequests.CreateMergeRequest(g.projectId, &gitlab.CreateMergeRequestOptions{
 		Title:        gitlab.Ptr(title),
 		SourceBranch: gitlab.Ptr(branchName),
@@ -113,20 +107,21 @@ func (g GitlabClient) CreatePullRequest(ctx context.Context, title, branchName s
 	}
 	g.branchToMR[branchName] = mr.IID
 	return mr.WebURL, mr.IID, nil
-
 }
 
-func (g GitlabClient) GetAtlantisStatus(ctx context.Context, branchName string) (string, error) {
-
+// GetAtlantisStatus for GitLab uses pipeline status which already aggregates all jobs.
+// The statusPrefix and expectedCount params are accepted for interface compatibility
+// but GitLab pipelines inherently represent the aggregate result.
+func (g GitlabClient) GetAtlantisStatus(ctx context.Context, branchName string, statusPrefix string, expectedCount int) (string, error) {
 	pipelineInfos, _, err := g.client.MergeRequests.ListMergeRequestPipelines(g.projectId, g.branchToMR[branchName])
 	if err != nil {
 		return "", err
 	}
-	// Possible todo: determine which status in the pipeline we care about?
-	if len(pipelineInfos) != 1 {
-		return "", fmt.Errorf("unexpected pipelines: %d", len(pipelineInfos))
+	if len(pipelineInfos) == 0 {
+		return "", nil
 	}
-	pipelineInfo := pipelineInfos[0]
+	// Use the most recent pipeline.
+	pipelineInfo := pipelineInfos[len(pipelineInfos)-1]
 	pipeline, _, err := g.client.Pipelines.GetPipeline(g.projectId, pipelineInfo.ID)
 	if err != nil {
 		return "", err
@@ -136,7 +131,6 @@ func (g GitlabClient) GetAtlantisStatus(ctx context.Context, branchName string) 
 }
 
 func (g GitlabClient) ClosePullRequest(ctx context.Context, pullRequestNumber int) error {
-	// clean up
 	_, _, err := g.client.MergeRequests.UpdateMergeRequest(g.projectId, pullRequestNumber, &gitlab.UpdateMergeRequestOptions{
 		StateEvent: gitlab.Ptr("close"),
 	})
@@ -144,21 +138,17 @@ func (g GitlabClient) ClosePullRequest(ctx context.Context, pullRequestNumber in
 		return fmt.Errorf("error while closing new pull request: %v", err)
 	}
 	return nil
-
 }
+
 func (g GitlabClient) DeleteBranch(ctx context.Context, branchName string) error {
 	_, err := g.client.Branches.DeleteBranch(g.projectId, branchName)
-
 	if err != nil {
 		return fmt.Errorf("error while deleting branch %s: %v", branchName, err)
 	}
 	return nil
-
 }
 
 func (g GitlabClient) IsAtlantisInProgress(state string) bool {
-	// From https://docs.gitlab.com/api/pipelines/
-	// created, waiting_for_resource, preparing, pending, running, success, failed, canceled, skipped, manual, scheduled
 	for _, s := range []string{"success", "failed", "canceled", "skipped"} {
 		if state == s {
 			return false
@@ -169,4 +159,8 @@ func (g GitlabClient) IsAtlantisInProgress(state string) bool {
 
 func (g GitlabClient) DidAtlantisSucceed(state string) bool {
 	return state == "success"
+}
+
+func (g GitlabClient) DidAtlantisFail(state string) bool {
+	return state == "failed" || state == "canceled"
 }

--- a/e2e/gitlab.go
+++ b/e2e/gitlab.go
@@ -109,10 +109,9 @@ func (g GitlabClient) CreatePullRequest(ctx context.Context, title, branchName s
 	return mr.WebURL, mr.IID, nil
 }
 
-// GetAtlantisStatus for GitLab uses pipeline status which aggregates all jobs.
-// GitLab pipelines cannot distinguish per-project plan counts, so
-// expectedCount is ignored. Count-sensitive cases must use VCSGitHub.
-func (g GitlabClient) GetAtlantisStatus(ctx context.Context, branchName string, statusPrefix string, expectedCount int) (string, error) {
+// GetAtlantisStatus polls pipeline status for the merge request.
+// Selects the newest pipeline by highest ID to avoid stale results.
+func (g GitlabClient) GetAtlantisStatus(ctx context.Context, branchName string) (string, error) {
 	pipelineInfos, _, err := g.client.MergeRequests.ListMergeRequestPipelines(g.projectId, g.branchToMR[branchName])
 	if err != nil {
 		return "", err
@@ -120,10 +119,16 @@ func (g GitlabClient) GetAtlantisStatus(ctx context.Context, branchName string, 
 	if len(pipelineInfos) == 0 {
 		return "", nil
 	}
-	// GitLab returns pipelines newest-first (descending ID order).
-	// Use the first entry to get the most recent pipeline.
-	pipelineInfo := pipelineInfos[0]
-	pipeline, _, err := g.client.Pipelines.GetPipeline(g.projectId, pipelineInfo.ID)
+
+	// Select newest pipeline by highest ID (deterministic regardless of API ordering).
+	newest := pipelineInfos[0]
+	for _, p := range pipelineInfos[1:] {
+		if p.ID > newest.ID {
+			newest = p
+		}
+	}
+
+	pipeline, _, err := g.client.Pipelines.GetPipeline(g.projectId, newest.ID)
 	if err != nil {
 		return "", err
 	}
@@ -131,8 +136,14 @@ func (g GitlabClient) GetAtlantisStatus(ctx context.Context, branchName string, 
 	return pipeline.Status, nil
 }
 
+// GetProjectStatuses is not supported on GitLab.
+// GitLab uses aggregate pipeline status; per-project commit status contexts
+// are not available. Cases requiring project-level assertions must use VCSGitHub.
+func (g GitlabClient) GetProjectStatuses(ctx context.Context, branchName string) (map[string]string, error) {
+	return nil, nil
+}
+
 // GetPRComments returns all MR note bodies for the merge request.
-// Atlantis posts plan/apply output as MR notes on GitLab.
 func (g GitlabClient) GetPRComments(ctx context.Context, pullNumber int) ([]string, error) {
 	notes, _, err := g.client.Notes.ListMergeRequestNotes(g.projectId, pullNumber, &gitlab.ListMergeRequestNotesOptions{
 		ListOptions: gitlab.ListOptions{PerPage: 100},

--- a/e2e/gitlab.go
+++ b/e2e/gitlab.go
@@ -109,9 +109,9 @@ func (g GitlabClient) CreatePullRequest(ctx context.Context, title, branchName s
 	return mr.WebURL, mr.IID, nil
 }
 
-// GetAtlantisStatus for GitLab uses pipeline status which already aggregates all jobs.
-// The statusPrefix and expectedCount params are accepted for interface compatibility
-// but GitLab pipelines inherently represent the aggregate result.
+// GetAtlantisStatus for GitLab uses pipeline status which aggregates all jobs.
+// GitLab pipelines cannot distinguish per-project plan counts, so
+// expectedCount is ignored. Count-sensitive cases must use VCSGitHub.
 func (g GitlabClient) GetAtlantisStatus(ctx context.Context, branchName string, statusPrefix string, expectedCount int) (string, error) {
 	pipelineInfos, _, err := g.client.MergeRequests.ListMergeRequestPipelines(g.projectId, g.branchToMR[branchName])
 	if err != nil {
@@ -120,14 +120,31 @@ func (g GitlabClient) GetAtlantisStatus(ctx context.Context, branchName string, 
 	if len(pipelineInfos) == 0 {
 		return "", nil
 	}
-	// Use the most recent pipeline.
-	pipelineInfo := pipelineInfos[len(pipelineInfos)-1]
+	// GitLab returns pipelines newest-first (descending ID order).
+	// Use the first entry to get the most recent pipeline.
+	pipelineInfo := pipelineInfos[0]
 	pipeline, _, err := g.client.Pipelines.GetPipeline(g.projectId, pipelineInfo.ID)
 	if err != nil {
 		return "", err
 	}
 
 	return pipeline.Status, nil
+}
+
+// GetPRComments returns all MR note bodies for the merge request.
+// Atlantis posts plan/apply output as MR notes on GitLab.
+func (g GitlabClient) GetPRComments(ctx context.Context, pullNumber int) ([]string, error) {
+	notes, _, err := g.client.Notes.ListMergeRequestNotes(g.projectId, pullNumber, &gitlab.ListMergeRequestNotesOptions{
+		ListOptions: gitlab.ListOptions{PerPage: 100},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing MR notes: %w", err)
+	}
+	var bodies []string
+	for _, n := range notes {
+		bodies = append(bodies, n.Body)
+	}
+	return bodies, nil
 }
 
 func (g GitlabClient) ClosePullRequest(ctx context.Context, pullRequestNumber int) error {

--- a/e2e/main.go
+++ b/e2e/main.go
@@ -7,27 +7,16 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"os"
-
-	"fmt"
 
 	multierror "github.com/hashicorp/go-multierror"
 )
 
 var defaultAtlantisURL = "http://localhost:4141"
-var projectTypes = []Project{
-	{"standalone", "atlantis apply -d standalone"},
-	{"standalone-with-workspace", "atlantis apply -d standalone-with-workspace -w staging"},
-}
-
-type Project struct {
-	Name         string
-	ApplyCommand string
-}
 
 func getVCSClient() (VCSClient, error) {
-
 	if os.Getenv("ATLANTIS_GH_USER") != "" || os.Getenv("ATLANTIS_GH_APP_ID") != "" {
 		log.Print("Running tests for github")
 		return NewGithubClient(), nil
@@ -40,13 +29,15 @@ func getVCSClient() (VCSClient, error) {
 	return nil, errors.New("could not determine which vcs client")
 }
 
-func main() {
+func isGitHub() bool {
+	return os.Getenv("ATLANTIS_GH_USER") != "" || os.Getenv("ATLANTIS_GH_APP_ID") != ""
+}
 
+func main() {
 	atlantisURL := os.Getenv("ATLANTIS_URL")
 	if atlantisURL == "" {
 		atlantisURL = defaultAtlantisURL
 	}
-	// add /events to the url
 	atlantisURL = fmt.Sprintf("%s/events", atlantisURL)
 
 	cloneDirRoot := os.Getenv("CLONE_DIR")
@@ -54,65 +45,104 @@ func main() {
 		cloneDirRoot = "/tmp/atlantis-tests"
 	}
 
-	// clean workspace
 	log.Printf("cleaning workspace %s", cloneDirRoot)
-	err := cleanDir(cloneDirRoot)
-	if err != nil {
-		log.Fatalf("failed to clean dir %q before cloning, attempting to continue: %v", cloneDirRoot, err)
+	if err := os.RemoveAll(cloneDirRoot); err != nil {
+		log.Fatalf("failed to clean dir %q: %v", cloneDirRoot, err)
 	}
 
 	vcsClient, err := getVCSClient()
 	if err != nil {
 		log.Fatalf("failed to get vcs client: %v", err)
 	}
+
 	ctx := context.Background()
-	// we create atlantis hook once for the repo, since the atlantis server can handle multiple requests
 	log.Printf("creating atlantis webhook with %s url", atlantisURL)
 	hookID, err := vcsClient.CreateAtlantisWebhook(ctx, atlantisURL)
 	if err != nil {
 		log.Fatalf("error creating atlantis webhook: %v", err)
 	}
 
-	// create e2e test
-	e2e := E2ETester{
-		vcsClient:    vcsClient,
-		hookID:       hookID,
-		cloneDirRoot: cloneDirRoot,
-	}
+	cases := activeCases()
+	log.Printf("running %d test cases", len(cases))
 
-	// start e2e tests
-	results, err := startTests(ctx, e2e)
-	log.Printf("Test Results\n---------------------------\n")
-	for _, result := range results {
-		fmt.Printf("Project Type: %s \n", result.projectType)
-		fmt.Printf("Pull Request Link: %s \n", result.pullRequestURL)
-		fmt.Printf("Atlantis Run Status: %s \n", result.testResult)
-		fmt.Println("---------------------------")
+	results, err := runCases(ctx, vcsClient, hookID, cloneDirRoot, cases)
+
+	// Print results summary.
+	log.Printf("\nTest Results\n---------------------------")
+	for _, r := range results {
+		status := r.testResult
+		if r.err != nil {
+			status = fmt.Sprintf("FAIL: %v", r.err)
+		}
+		fmt.Printf("  %-35s %s\n", r.testCase, status)
+		if r.pullRequestURL != "" {
+			fmt.Printf("  %-35s PR: %s\n", "", r.pullRequestURL)
+		}
 	}
+	fmt.Println("---------------------------")
+
 	if err != nil {
-		log.Fatalf(fmt.Sprintf("%s", err))
+		log.Fatalf("%v", err)
 	}
-
 }
 
-func cleanDir(path string) error {
-	return os.RemoveAll(path)
+func activeCases() []TestCase {
+	optIn := os.Getenv("E2E_OPT_IN") == "1"
+	gh := isGitHub()
+
+	var active []TestCase
+	for _, tc := range testCases {
+		switch tc.Status {
+		case CaseDisabled:
+			log.Printf("skipping disabled case %q: %s", tc.Name, tc.SkipReason)
+			continue
+		case CaseOptIn:
+			if !optIn {
+				log.Printf("skipping opt-in case %q (set E2E_OPT_IN=1): %s", tc.Name, tc.SkipReason)
+				continue
+			}
+		}
+
+		switch tc.VCS {
+		case VCSGitHub:
+			if !gh {
+				continue
+			}
+		case VCSGitLab:
+			if gh {
+				continue
+			}
+		}
+
+		active = append(active, tc)
+	}
+	return active
 }
 
-func startTests(ctx context.Context, e2e E2ETester) ([]*E2EResult, error) {
-	var testResults []*E2EResult
+func runCases(ctx context.Context, vcsClient VCSClient, hookID int64, cloneDirRoot string, cases []TestCase) ([]*E2EResult, error) {
+	var results []*E2EResult
 	var testErrors *multierror.Error
-	// delete webhook when we are done running tests
-	defer e2e.vcsClient.DeleteAtlantisHook(ctx, e2e.hookID) // nolint: errcheck
 
-	for _, projectType := range projectTypes {
-		log.Printf("starting e2e test for project type %q", projectType.Name)
-		e2e.projectType = projectType
-		// start e2e test
+	defer vcsClient.DeleteAtlantisHook(ctx, hookID) //nolint: errcheck
+
+	for _, tc := range cases {
+		log.Printf("━━━ starting: %s ━━━", tc.Name)
+		e2e := &E2ETester{
+			vcsClient:    vcsClient,
+			hookID:       hookID,
+			cloneDirRoot: cloneDirRoot,
+			testCase:     tc,
+		}
 		result, err := e2e.Start(ctx)
-		testResults = append(testResults, result)
+		if err != nil {
+			result.err = err
+			log.Printf("━━━ FAILED: %s — %v ━━━", tc.Name, err)
+		} else {
+			log.Printf("━━━ passed: %s ━━━", tc.Name)
+		}
+		results = append(results, result)
 		testErrors = multierror.Append(testErrors, err)
 	}
 
-	return testResults, testErrors.ErrorOrNil()
+	return results, testErrors.ErrorOrNil()
 }

--- a/e2e/main.go
+++ b/e2e/main.go
@@ -123,7 +123,7 @@ func runCases(ctx context.Context, vcsClient VCSClient, hookID int64, cloneDirRo
 	var results []*E2EResult
 	var testErrors *multierror.Error
 
-	defer vcsClient.DeleteAtlantisHook(ctx, hookID) //nolint: errcheck
+	defer vcsClient.DeleteAtlantisHook(ctx, hookID) // nolint: errcheck
 
 	for _, tc := range cases {
 		log.Printf("━━━ starting: %s ━━━", tc.Name)

--- a/e2e/testcase.go
+++ b/e2e/testcase.go
@@ -1,0 +1,191 @@
+// Copyright 2017 HootSuite Media Inc.
+// SPDX-License-Identifier: Apache-2.0
+// Modified hereafter by contributors to runatlantis/atlantis.
+
+package main
+
+// VCSProvider controls which VCS backends a test case runs on.
+type VCSProvider int
+
+const (
+	VCSBoth   VCSProvider = iota // Run on both GitHub and GitLab
+	VCSGitHub                    // GitHub only
+	VCSGitLab                    // GitLab only
+)
+
+// CaseStatus controls whether a test case is run by default.
+type CaseStatus int
+
+const (
+	CaseActive   CaseStatus = iota // Run in default E2E
+	CaseOptIn                      // Run only with E2E_OPT_IN=1
+	CaseDisabled                   // Never run, documented for future
+)
+
+// TestCase defines a single E2E fixture exercise.
+type TestCase struct {
+	// Name identifies the test case in logs and results.
+	Name string
+
+	// Dir is the fixture directory relative to the repo root (e.g. "standalone").
+	Dir string
+
+	// Workspace to use. Empty means default workspace.
+	Workspace string
+
+	// MutateFile is the file path relative to Dir to create/modify.
+	// Defaults to "{Name}.tf" if empty.
+	MutateFile string
+
+	// MutateContent is written to MutateFile. Defaults to a null_resource.
+	MutateContent string
+
+	// StatusPrefix is the commit status context prefix to poll.
+	// Defaults to "atlantis/plan". For multi-project cases expecting
+	// per-project statuses, use "atlantis/plan" to match all plan statuses.
+	StatusPrefix string
+
+	// ExpectedStatusCount is how many matching statuses to expect.
+	// 0 or 1 means "at least one matching status must succeed."
+	// >1 means "exactly N matching statuses must all succeed."
+	ExpectedStatusCount int
+
+	// ExpectFailure means we expect the plan to fail (status = failure/error).
+	ExpectFailure bool
+
+	// ApplyCommand to post after plan succeeds. Empty = skip apply.
+	ApplyCommand string
+
+	// VCS controls which providers run this case.
+	VCS VCSProvider
+
+	// Status controls whether this case is active by default.
+	Status CaseStatus
+
+	// SkipReason documents why a case is opt-in or disabled.
+	SkipReason string
+}
+
+// defaultMutateContent is a minimal Terraform resource for triggering a plan.
+const defaultMutateContent = `resource "null_resource" "e2e" {
+  triggers = {
+    run = timestamp()
+  }
+}
+`
+
+// testCases is the fixture test matrix.
+// Cases with Status=CaseActive run in every E2E invocation.
+var testCases = []TestCase{
+	// ─── Original smoke-test fixtures (must not regress) ───
+	{
+		Name:         "standalone",
+		Dir:          "standalone",
+		ApplyCommand: "atlantis apply -d standalone",
+		VCS:          VCSBoth,
+		Status:       CaseActive,
+	},
+	{
+		Name:         "standalone-with-workspace",
+		Dir:          "standalone-with-workspace",
+		Workspace:    "staging",
+		ApplyCommand: "atlantis apply -d standalone-with-workspace -w staging",
+		VCS:          VCSBoth,
+		Status:       CaseActive,
+	},
+
+	// ─── Multi-project: single project change ───
+	{
+		Name:       "multi-project-single",
+		Dir:        "multi-projects/project1",
+		MutateFile: "main.tf",
+		VCS:        VCSBoth,
+		Status:     CaseActive,
+	},
+
+	// ─── Multi-project: shared-module fan-out ───
+	{
+		Name:                "multi-project-fanout",
+		Dir:                 "multi-projects/shared-module",
+		MutateFile:          "main.tf",
+		StatusPrefix:        "atlantis/plan",
+		ExpectedStatusCount: 2,
+		VCS:                 VCSBoth,
+		Status:              CaseActive,
+	},
+
+	// ─── Detection: .tf.json format ───
+	{
+		Name:          "detection-terraform-json",
+		Dir:           "detection/terraform-json",
+		MutateFile:    "extra.tf",
+		MutateContent: "resource \"null_resource\" \"json_test\" {}\n",
+		VCS:           VCSBoth,
+		Status:        CaseActive,
+	},
+
+	// ─── Autodiscovery: included project ───
+	{
+		Name:       "autodiscovery-included",
+		Dir:        "autodiscovery/included-a",
+		MutateFile: "main.tf",
+		VCS:        VCSBoth,
+		Status:     CaseActive,
+	},
+
+	// ─── Custom workflow: PROJECT_NAME env ───
+	{
+		Name:       "custom-workflow-project-name",
+		Dir:        "custom-workflows/project-name-env",
+		MutateFile: "main.tf",
+		VCS:        VCSBoth,
+		Status:     CaseActive,
+	},
+
+	// ─── Output: long-line rendering ───
+	{
+		Name:       "output-long-line",
+		Dir:        "output/long-line",
+		MutateFile: "main.tf",
+		VCS:        VCSBoth,
+		Status:     CaseActive,
+	},
+
+	// ─── Disabled/opt-in fixtures with reasons ───
+	{
+		Name:       "output-failure",
+		Dir:        "output/failure",
+		MutateFile: "main.tf",
+		Status:     CaseDisabled,
+		SkipReason: "Intentional failure fixture; autoplan disabled in atlantis.yaml. Needs manual trigger support.",
+	},
+	{
+		Name:       "detection-opentofu",
+		Dir:        "detection/opentofu-basic",
+		MutateFile: "main.tf",
+		Status:     CaseDisabled,
+		SkipReason: "Requires tofu binary in E2E environment. Not guaranteed in CI.",
+	},
+	{
+		Name:       "drift-local-file",
+		Dir:        "drift/local-file",
+		MutateFile: "main.tf",
+		Status:     CaseDisabled,
+		SkipReason: "Requires --enable-drift-detection server flag. Alpha feature.",
+	},
+	{
+		Name:       "multi-project-workspace",
+		Dir:        "multi-projects/project-with-workspace",
+		Workspace:  "dev",
+		MutateFile: "main.tf",
+		Status:     CaseOptIn,
+		SkipReason: "Workspace fixture works but adds CI time. Enable with E2E_OPT_IN=1.",
+	},
+	{
+		Name:       "autodiscovery-explicit",
+		Dir:        "autodiscovery/explicit",
+		MutateFile: "main.tf",
+		Status:     CaseOptIn,
+		SkipReason: "Validates explicit-over-autodiscovery precedence. Enable with E2E_OPT_IN=1.",
+	},
+}

--- a/e2e/testcase.go
+++ b/e2e/testcase.go
@@ -109,14 +109,16 @@ var testCases = []TestCase{
 		VCS:                        VCSGitHub,
 		Status:                     CaseActive,
 	},
-	// GitLab smoke: same fixtures but only asserts aggregate pipeline success.
-	// Cannot assert per-project status contexts on GitLab.
+	// GitLab smoke: asserts aggregate pipeline success plus plan comment marker.
+	// Cannot assert per-project status contexts on GitLab, but verifying the
+	// Atlantis MR note contains the project header prevents 0/0 false positives.
 	{
-		Name:       "standalone-gitlab",
-		Dir:        "standalone",
-		MutateFile: "e2e_trigger.tf",
-		VCS:        VCSGitLab,
-		Status:     CaseActive,
+		Name:                     "standalone-gitlab",
+		Dir:                      "standalone",
+		MutateFile:               "e2e_trigger.tf",
+		ExpectedCommentSubstring: "dir: `standalone` workspace: `default`",
+		VCS:                      VCSGitLab,
+		Status:                   CaseActive,
 	},
 
 	// ─── Multi-project: single project change ───

--- a/e2e/testcase.go
+++ b/e2e/testcase.go
@@ -31,6 +31,7 @@ type TestCase struct {
 	Dir string
 
 	// Workspace to use. Empty means default workspace.
+	// Currently used for documentation/filtering; workspace-aware execution is follow-up.
 	Workspace string
 
 	// MutateFile is the file path relative to Dir to create/modify.
@@ -45,15 +46,22 @@ type TestCase struct {
 	// per-project statuses, use "atlantis/plan" to match all plan statuses.
 	StatusPrefix string
 
-	// ExpectedStatusCount is how many matching statuses to expect.
-	// 0 or 1 means "at least one matching status must succeed."
-	// >1 means "exactly N matching statuses must all succeed."
+	// ExpectedStatusCount enforces exact status count on GitHub.
+	// 0 means "at least one matching status must succeed."
+	// >0 means "exactly N matching statuses must appear; fewer = pending, more = failure."
+	// Ignored on GitLab (aggregate pipeline). Count-sensitive cases must use VCSGitHub.
 	ExpectedStatusCount int
 
 	// ExpectFailure means we expect the plan to fail (status = failure/error).
 	ExpectFailure bool
 
+	// ExpectedCommentSubstring, if non-empty, requires this string to appear
+	// in at least one Atlantis PR/MR comment after plan succeeds.
+	// Used to verify custom workflow output, markers, etc.
+	ExpectedCommentSubstring string
+
 	// ApplyCommand to post after plan succeeds. Empty = skip apply.
+	// Currently reserved; apply execution is not yet implemented in the harness.
 	ApplyCommand string
 
 	// VCS controls which providers run this case.
@@ -95,58 +103,81 @@ var testCases = []TestCase{
 	},
 
 	// ─── Multi-project: single project change ───
+	// GitHub-only: requires exact status count assertion (GitLab uses aggregate pipeline).
 	{
-		Name:       "multi-project-single",
-		Dir:        "multi-projects/project1",
-		MutateFile: "main.tf",
-		VCS:        VCSBoth,
-		Status:     CaseActive,
+		Name:                "multi-project-single",
+		Dir:                 "multi-projects/project1",
+		MutateFile:          "e2e_trigger.tf",
+		ExpectedStatusCount: 1,
+		VCS:                 VCSGitHub,
+		Status:              CaseActive,
 	},
 
 	// ─── Multi-project: shared-module fan-out ───
+	// GitHub-only: asserts exactly 2 plan statuses (project1 + project2).
+	// Fails if an unintended third plan appears (e.g. shared-module autodiscovered).
 	{
 		Name:                "multi-project-fanout",
 		Dir:                 "multi-projects/shared-module",
-		MutateFile:          "main.tf",
+		MutateFile:          "e2e_trigger.tf",
 		StatusPrefix:        "atlantis/plan",
 		ExpectedStatusCount: 2,
-		VCS:                 VCSBoth,
+		VCS:                 VCSGitHub,
 		Status:              CaseActive,
 	},
 
 	// ─── Detection: .tf.json format ───
+	// Mutates a .tf.json file to keep the fixture JSON-only.
+	// Proves Atlantis detects/plans .tf.json projects.
 	{
-		Name:          "detection-terraform-json",
-		Dir:           "detection/terraform-json",
-		MutateFile:    "extra.tf",
-		MutateContent: "resource \"null_resource\" \"json_test\" {}\n",
-		VCS:           VCSBoth,
-		Status:        CaseActive,
+		Name:       "detection-terraform-json",
+		Dir:        "detection/terraform-json",
+		MutateFile: "extra.tf.json",
+		MutateContent: `{
+  "resource": {
+    "null_resource": {
+      "json_e2e": {
+        "triggers": {
+          "run": "e2e"
+        }
+      }
+    }
+  }
+}
+`,
+		VCS:    VCSBoth,
+		Status: CaseActive,
 	},
 
 	// ─── Autodiscovery: included project ───
 	{
 		Name:       "autodiscovery-included",
 		Dir:        "autodiscovery/included-a",
-		MutateFile: "main.tf",
+		MutateFile: "e2e_trigger.tf",
 		VCS:        VCSBoth,
 		Status:     CaseActive,
 	},
 
 	// ─── Custom workflow: PROJECT_NAME env ───
+	// The assert-project-name.sh script prints "PASS: PROJECT_NAME=custom-workflow-env"
+	// on success. If Atlantis skips the workflow, this marker won't appear.
 	{
-		Name:       "custom-workflow-project-name",
-		Dir:        "custom-workflows/project-name-env",
-		MutateFile: "main.tf",
-		VCS:        VCSBoth,
-		Status:     CaseActive,
+		Name:                     "custom-workflow-project-name",
+		Dir:                      "custom-workflows/project-name-env",
+		MutateFile:               "e2e_trigger.tf",
+		ExpectedCommentSubstring: "PASS: PROJECT_NAME=custom-workflow-env",
+		VCS:                      VCSBoth,
+		Status:                   CaseActive,
 	},
 
 	// ─── Output: long-line rendering ───
+	// Writes a separate trigger file to avoid overwriting the >64KiB long-line
+	// expression in the fixture's main.tf. The plan still includes the long-line
+	// output because Atlantis plans all resources in the directory.
 	{
 		Name:       "output-long-line",
 		Dir:        "output/long-line",
-		MutateFile: "main.tf",
+		MutateFile: "e2e_trigger.tf",
 		VCS:        VCSBoth,
 		Status:     CaseActive,
 	},

--- a/e2e/testcase.go
+++ b/e2e/testcase.go
@@ -1,6 +1,4 @@
-// Copyright 2017 HootSuite Media Inc.
 // SPDX-License-Identifier: Apache-2.0
-// Modified hereafter by contributors to runatlantis/atlantis.
 
 package main
 

--- a/e2e/testcase.go
+++ b/e2e/testcase.go
@@ -25,11 +25,10 @@ type TestCase struct {
 	// Name identifies the test case in logs and results.
 	Name string
 
-	// Dir is the fixture directory relative to the repo root (e.g. "standalone").
+	// Dir is the fixture directory relative to the repo root.
 	Dir string
 
-	// Workspace to use. Empty means default workspace.
-	// Currently used for documentation/filtering; workspace-aware execution is follow-up.
+	// Workspace for documentation. Workspace-aware execution is follow-up.
 	Workspace string
 
 	// MutateFile is the file path relative to Dir to create/modify.
@@ -39,27 +38,26 @@ type TestCase struct {
 	// MutateContent is written to MutateFile. Defaults to a null_resource.
 	MutateContent string
 
-	// StatusPrefix is the commit status context prefix to poll.
-	// Defaults to "atlantis/plan". For multi-project cases expecting
-	// per-project statuses, use "atlantis/plan" to match all plan statuses.
-	StatusPrefix string
+	// ExpectedStatusContexts lists the exact per-project commit status contexts
+	// that must appear on GitHub (e.g. "atlantis/plan: project1").
+	// Empty means no project-level assertion (only aggregate success).
+	// Cases using this field should be VCSGitHub since GitLab does not expose
+	// per-project commit statuses.
+	ExpectedStatusContexts []string
 
-	// ExpectedStatusCount enforces exact status count on GitHub.
-	// 0 means "at least one matching status must succeed."
-	// >0 means "exactly N matching statuses must appear; fewer = pending, more = failure."
-	// Ignored on GitLab (aggregate pipeline). Count-sensitive cases must use VCSGitHub.
-	ExpectedStatusCount int
+	// ForbidExtraProjectStatuses, when true, fails if any "atlantis/plan: *"
+	// status appears that is not in ExpectedStatusContexts.
+	ForbidExtraProjectStatuses bool
 
 	// ExpectFailure means we expect the plan to fail (status = failure/error).
 	ExpectFailure bool
 
 	// ExpectedCommentSubstring, if non-empty, requires this string to appear
 	// in at least one Atlantis PR/MR comment after plan succeeds.
-	// Used to verify custom workflow output, markers, etc.
 	ExpectedCommentSubstring string
 
 	// ApplyCommand to post after plan succeeds. Empty = skip apply.
-	// Currently reserved; apply execution is not yet implemented in the harness.
+	// Reserved; apply execution is not yet implemented in the harness.
 	ApplyCommand string
 
 	// VCS controls which providers run this case.
@@ -80,57 +78,81 @@ const defaultMutateContent = `resource "null_resource" "e2e" {
 }
 `
 
+// projectStatusPrefix is the prefix for per-project Atlantis statuses.
+// The aggregate status is "atlantis/plan" (no colon/space).
+const projectStatusPrefix = "atlantis/plan: "
+
 // testCases is the fixture test matrix.
 // Cases with Status=CaseActive run in every E2E invocation.
 var testCases = []TestCase{
 	// ─── Original smoke-test fixtures (must not regress) ───
+	// These use per-project context assertion on GitHub to confirm the
+	// named project was actually planned (not just aggregate success).
 	{
-		Name:         "standalone",
-		Dir:          "standalone",
-		ApplyCommand: "atlantis apply -d standalone",
-		VCS:          VCSBoth,
-		Status:       CaseActive,
+		Name:                       "standalone",
+		Dir:                        "standalone",
+		MutateFile:                 "e2e_trigger.tf",
+		ExpectedStatusContexts:     []string{"atlantis/plan: standalone"},
+		ForbidExtraProjectStatuses: true,
+		ApplyCommand:               "atlantis apply -d standalone",
+		VCS:                        VCSGitHub,
+		Status:                     CaseActive,
 	},
 	{
-		Name:         "standalone-with-workspace",
-		Dir:          "standalone-with-workspace",
-		Workspace:    "staging",
-		ApplyCommand: "atlantis apply -d standalone-with-workspace -w staging",
-		VCS:          VCSBoth,
-		Status:       CaseActive,
+		Name:                       "standalone-with-workspace",
+		Dir:                        "standalone-with-workspace",
+		Workspace:                  "staging",
+		MutateFile:                 "e2e_trigger.tf",
+		ExpectedStatusContexts:     []string{"atlantis/plan: standalone-with-workspace"},
+		ForbidExtraProjectStatuses: true,
+		ApplyCommand:               "atlantis apply -d standalone-with-workspace -w staging",
+		VCS:                        VCSGitHub,
+		Status:                     CaseActive,
+	},
+	// GitLab smoke: same fixtures but only asserts aggregate pipeline success.
+	// Cannot assert per-project status contexts on GitLab.
+	{
+		Name:       "standalone-gitlab",
+		Dir:        "standalone",
+		MutateFile: "e2e_trigger.tf",
+		VCS:        VCSGitLab,
+		Status:     CaseActive,
 	},
 
 	// ─── Multi-project: single project change ───
-	// GitHub-only: requires exact status count assertion (GitLab uses aggregate pipeline).
+	// GitHub-only. Asserts exactly project1 planned; forbids extra project statuses.
 	{
-		Name:                "multi-project-single",
-		Dir:                 "multi-projects/project1",
-		MutateFile:          "e2e_trigger.tf",
-		ExpectedStatusCount: 1,
-		VCS:                 VCSGitHub,
-		Status:              CaseActive,
+		Name:                       "multi-project-single",
+		Dir:                        "multi-projects/project1",
+		MutateFile:                 "e2e_trigger.tf",
+		ExpectedStatusContexts:     []string{"atlantis/plan: project1"},
+		ForbidExtraProjectStatuses: true,
+		VCS:                        VCSGitHub,
+		Status:                     CaseActive,
 	},
 
 	// ─── Multi-project: shared-module fan-out ───
-	// GitHub-only: asserts exactly 2 plan statuses (project1 + project2).
-	// Fails if an unintended third plan appears (e.g. shared-module autodiscovered).
+	// GitHub-only. Asserts exactly project1 + project2 via when_modified.
+	// Fails if shared-module is autodiscovered as a third project.
 	{
-		Name:                "multi-project-fanout",
-		Dir:                 "multi-projects/shared-module",
-		MutateFile:          "e2e_trigger.tf",
-		StatusPrefix:        "atlantis/plan",
-		ExpectedStatusCount: 2,
-		VCS:                 VCSGitHub,
-		Status:              CaseActive,
+		Name:                       "multi-project-fanout",
+		Dir:                        "multi-projects/shared-module",
+		MutateFile:                 "e2e_trigger.tf",
+		ExpectedStatusContexts:     []string{"atlantis/plan: project1", "atlantis/plan: project2"},
+		ForbidExtraProjectStatuses: true,
+		VCS:                        VCSGitHub,
+		Status:                     CaseActive,
 	},
 
-	// ─── Detection: .tf.json format ───
-	// Mutates a .tf.json file to keep the fixture JSON-only.
-	// Proves Atlantis detects/plans .tf.json projects.
+	// ─── Configured .tf.json project planning ───
+	// Proves Atlantis can plan a configured project containing only .tf.json files.
+	// Note: this tests configured JSON project planning, not autodiscovery/detection
+	// of unconfigured .tf.json directories (the project is explicit in atlantis.yaml).
 	{
-		Name:       "detection-terraform-json",
-		Dir:        "detection/terraform-json",
-		MutateFile: "extra.tf.json",
+		Name:                   "configured-terraform-json",
+		Dir:                    "detection/terraform-json",
+		MutateFile:             "extra.tf.json",
+		ExpectedStatusContexts: []string{"atlantis/plan: detection-json"},
 		MutateContent: `{
   "resource": {
     "null_resource": {
@@ -143,62 +165,68 @@ var testCases = []TestCase{
   }
 }
 `,
-		VCS:    VCSBoth,
+		VCS:    VCSGitHub,
 		Status: CaseActive,
 	},
 
 	// ─── Autodiscovery: included project ───
+	// GitHub-only. Proves autodiscovery selected included-a.
+	// ProjectID for unnamed autodiscovered projects is "dir/workspace".
 	{
-		Name:       "autodiscovery-included",
-		Dir:        "autodiscovery/included-a",
-		MutateFile: "e2e_trigger.tf",
-		VCS:        VCSBoth,
-		Status:     CaseActive,
+		Name:                   "autodiscovery-included",
+		Dir:                    "autodiscovery/included-a",
+		MutateFile:             "e2e_trigger.tf",
+		ExpectedStatusContexts: []string{"atlantis/plan: autodiscovery/included-a/default"},
+		VCS:                    VCSGitHub,
+		Status:                 CaseActive,
 	},
 
 	// ─── Custom workflow: PROJECT_NAME env ───
-	// The assert-project-name.sh script prints "PASS: PROJECT_NAME=custom-workflow-env"
-	// on success. If Atlantis skips the workflow, this marker won't appear.
+	// Asserts both: project status context proves the project ran, and
+	// comment marker proves the custom workflow script executed.
 	{
 		Name:                     "custom-workflow-project-name",
 		Dir:                      "custom-workflows/project-name-env",
 		MutateFile:               "e2e_trigger.tf",
+		ExpectedStatusContexts:   []string{"atlantis/plan: custom-workflow-env"},
 		ExpectedCommentSubstring: "PASS: PROJECT_NAME=custom-workflow-env",
-		VCS:                      VCSBoth,
+		VCS:                      VCSGitHub,
 		Status:                   CaseActive,
 	},
 
 	// ─── Output: long-line rendering ───
-	// Writes a separate trigger file to avoid overwriting the >64KiB long-line
-	// expression in the fixture's main.tf. The plan still includes the long-line
-	// output because Atlantis plans all resources in the directory.
+	// Writes a separate trigger file to preserve the >64KiB long-line expression.
+	// Asserts project status context proves the project was planned.
+	// TODO: Add ExpectedCommentSubstring for a post-long-line marker once
+	// atlantis-tests fixture includes one (requires fixture-side follow-up).
 	{
-		Name:       "output-long-line",
-		Dir:        "output/long-line",
-		MutateFile: "e2e_trigger.tf",
-		VCS:        VCSBoth,
-		Status:     CaseActive,
+		Name:                   "output-long-line",
+		Dir:                    "output/long-line",
+		MutateFile:             "e2e_trigger.tf",
+		ExpectedStatusContexts: []string{"atlantis/plan: output-long-line"},
+		VCS:                    VCSGitHub,
+		Status:                 CaseActive,
 	},
 
 	// ─── Disabled/opt-in fixtures with reasons ───
 	{
 		Name:       "output-failure",
 		Dir:        "output/failure",
-		MutateFile: "main.tf",
+		MutateFile: "e2e_trigger.tf",
 		Status:     CaseDisabled,
 		SkipReason: "Intentional failure fixture; autoplan disabled in atlantis.yaml. Needs manual trigger support.",
 	},
 	{
 		Name:       "detection-opentofu",
 		Dir:        "detection/opentofu-basic",
-		MutateFile: "main.tf",
+		MutateFile: "e2e_trigger.tf",
 		Status:     CaseDisabled,
 		SkipReason: "Requires tofu binary in E2E environment. Not guaranteed in CI.",
 	},
 	{
 		Name:       "drift-local-file",
 		Dir:        "drift/local-file",
-		MutateFile: "main.tf",
+		MutateFile: "e2e_trigger.tf",
 		Status:     CaseDisabled,
 		SkipReason: "Requires --enable-drift-detection server flag. Alpha feature.",
 	},
@@ -206,14 +234,14 @@ var testCases = []TestCase{
 		Name:       "multi-project-workspace",
 		Dir:        "multi-projects/project-with-workspace",
 		Workspace:  "dev",
-		MutateFile: "main.tf",
+		MutateFile: "e2e_trigger.tf",
 		Status:     CaseOptIn,
 		SkipReason: "Workspace fixture works but adds CI time. Enable with E2E_OPT_IN=1.",
 	},
 	{
 		Name:       "autodiscovery-explicit",
 		Dir:        "autodiscovery/explicit",
-		MutateFile: "main.tf",
+		MutateFile: "e2e_trigger.tf",
 		Status:     CaseOptIn,
 		SkipReason: "Validates explicit-over-autodiscovery precedence. Enable with E2E_OPT_IN=1.",
 	},

--- a/e2e/vcs.go
+++ b/e2e/vcs.go
@@ -11,9 +11,13 @@ type VCSClient interface {
 	CreateAtlantisWebhook(ctx context.Context, hookURL string) (int64, error)
 	DeleteAtlantisHook(ctx context.Context, hookID int64) error
 	CreatePullRequest(ctx context.Context, title, branchName string) (string, int, error)
-	GetAtlantisStatus(ctx context.Context, branchName string) (string, error)
+	// GetAtlantisStatus returns the aggregate state of all commit statuses
+	// matching the given prefix. Returns "success" only when all matched
+	// statuses succeed. expectedCount=0 means "at least one."
+	GetAtlantisStatus(ctx context.Context, branchName string, statusPrefix string, expectedCount int) (string, error)
 	ClosePullRequest(ctx context.Context, pullRequestNumber int) error
 	DeleteBranch(ctx context.Context, branchName string) error
 	IsAtlantisInProgress(state string) bool
 	DidAtlantisSucceed(state string) bool
+	DidAtlantisFail(state string) bool
 }

--- a/e2e/vcs.go
+++ b/e2e/vcs.go
@@ -11,11 +11,13 @@ type VCSClient interface {
 	CreateAtlantisWebhook(ctx context.Context, hookURL string) (int64, error)
 	DeleteAtlantisHook(ctx context.Context, hookID int64) error
 	CreatePullRequest(ctx context.Context, title, branchName string) (string, int, error)
-	// GetAtlantisStatus returns the aggregate state of all commit statuses
-	// matching the given prefix. Returns "success" only when all matched
-	// statuses succeed. If expectedCount > 0, fails when the actual count
-	// differs (too few = pending, too many = "unexpected_count").
-	GetAtlantisStatus(ctx context.Context, branchName string, statusPrefix string, expectedCount int) (string, error)
+	// GetAtlantisStatus polls for plan completion. Returns aggregate terminal
+	// state across all matching statuses. Used for the polling loop only.
+	GetAtlantisStatus(ctx context.Context, branchName string) (string, error)
+	// GetProjectStatuses returns all per-project Atlantis status contexts and
+	// their states. Contexts have the form "atlantis/plan: <project>".
+	// Used for post-completion assertions. Returns nil on GitLab (unsupported).
+	GetProjectStatuses(ctx context.Context, branchName string) (map[string]string, error)
 	// GetPRComments returns all comment bodies on the PR/MR.
 	GetPRComments(ctx context.Context, pullNumber int) ([]string, error)
 	ClosePullRequest(ctx context.Context, pullRequestNumber int) error

--- a/e2e/vcs.go
+++ b/e2e/vcs.go
@@ -13,8 +13,11 @@ type VCSClient interface {
 	CreatePullRequest(ctx context.Context, title, branchName string) (string, int, error)
 	// GetAtlantisStatus returns the aggregate state of all commit statuses
 	// matching the given prefix. Returns "success" only when all matched
-	// statuses succeed. expectedCount=0 means "at least one."
+	// statuses succeed. If expectedCount > 0, fails when the actual count
+	// differs (too few = pending, too many = "unexpected_count").
 	GetAtlantisStatus(ctx context.Context, branchName string, statusPrefix string, expectedCount int) (string, error)
+	// GetPRComments returns all comment bodies on the PR/MR.
+	GetPRComments(ctx context.Context, pullNumber int) ([]string, error)
 	ClosePullRequest(ctx context.Context, pullRequestNumber int) error
 	DeleteBranch(ctx context.Context, branchName string) error
 	IsAtlantisInProgress(state string) bool


### PR DESCRIPTION
## Summary

Companion PR to [runatlantis/atlantis-tests#21001](https://github.com/runatlantis/atlantis-tests/pull/21001).

Refactors the E2E harness from a hard-coded 2-project list into a structured test-case table with per-project commit status context assertions.

## Assertion Model

All project-specific cases use **exact status context validation** (not aggregate counts):
- Each case specifies `ExpectedStatusContexts` — the exact `atlantis/plan: <ProjectID>` strings that must appear
- `ForbidExtraProjectStatuses` fails the case if unexpected project plan statuses are emitted
- The aggregate `atlantis/plan` status is used only for polling terminal state, never for identity
- Cases using per-project assertions are **GitHub-only** (GitLab lacks per-project commit statuses)

## Active Fixtures (GitHub)

| Case | Fixture Dir | Asserts |
|------|-------------|---------|
| `standalone` | `standalone` | Context: `atlantis/plan: standalone`, forbids extras |
| `standalone-with-workspace` | `standalone-with-workspace` | Context: `atlantis/plan: standalone-with-workspace`, forbids extras |
| `multi-project-single` | `multi-projects/project1` | Context: exactly `project1`, forbids project2/shared-module |
| `multi-project-fanout` | `multi-projects/shared-module` | Contexts: exactly `project1` + `project2`, forbids extras |
| `configured-terraform-json` | `detection/terraform-json` | Context: `atlantis/plan: detection-json` (JSON-only mutation) |
| `autodiscovery-included` | `autodiscovery/included-a` | Context: `atlantis/plan: autodiscovery/included-a/default` |
| `custom-workflow-project-name` | `custom-workflows/project-name-env` | Context + comment marker: `PASS: PROJECT_NAME=custom-workflow-env` |
| `output-long-line` | `output/long-line` | Context: `atlantis/plan: output-long-line` (separate trigger file preserves >64KiB fixture) |

## Active Fixtures (GitLab)

| Case | Fixture Dir | Asserts |
|------|-------------|---------|
| `standalone-gitlab` | `standalone` | Aggregate pipeline success + standalone plan MR note marker (`dir: \`standalone\` workspace: \`default\``) |

GitLab does not expose the per-project commit-status contexts used by the GitHub assertions. The active GitLab case validates aggregate pipeline success plus a standalone plan MR note marker; multi-project and count-sensitive fixture coverage remains GitHub-only.

## Key Design Decisions

- **Renamed**: `detection-terraform-json` → `configured-terraform-json`. The fixture is explicitly configured in `atlantis.yaml`, so it tests configured JSON project planning, not autodetection.
- **Mutation safety**: All new fixtures write `e2e_trigger.tf` (never overwrite `main.tf` fixture content).
- **Custom workflow fail-closed**: If Atlantis skips the custom workflow, the `PASS:` marker never appears in comments → case fails.
- **GitLab pipeline selection**: Uses `max(ID)` for deterministic newest-pipeline selection.
- **Polling errors surfaced**: VCS API errors logged and included in timeout messages.

## Fixtures Intentionally Not Activated

| Case | Reason |
|------|--------|
| `output-failure` | Autoplan disabled in repo; needs manual trigger support |
| `detection-opentofu` | Requires `tofu` binary in E2E environment |
| `drift-local-file` | Requires `--enable-drift-detection` server flag (alpha) |
| `multi-project-workspace` | Opt-in (`E2E_OPT_IN=1`); works but adds CI time |
| `autodiscovery-explicit` | Opt-in; validates explicit-over-autodiscovery precedence |

**Not added (external dependencies):** Slack, Redis, TF Cloud, automerge, sticky policies, Terragrunt, localization.

## Follow-Up Needed (atlantis-tests fixture side)

- `output-long-line`: needs a post-long-line comment marker in the fixture for content assertion (currently only asserts project status context)
- True `.tf.json` detection test (unconfigured directory) requires a separate fixture

## Validation

- `go build ./...` ✓
- `gofmt` ✓
- `go vet` ✓
- Live E2E not run (requires ngrok + credentials)

## No Changes To

- Atlantis runtime behavior
- Production code
- `scripts/e2e.sh` server configuration

