### PR TITLE
ci: upload Go coverage to GitHub Code Quality

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -9,7 +9,12 @@ on:
       - '**/go.mod'
       - '**/go.sum'
       - 'Makefile'
+      - 'scripts/**'
       - '.github/workflows/code-coverage.yml'
+      - 'server/events/templates/**'
+      - 'server/i18n/**'
+      - '**/testdata/**'
+      - 'testdata/**'
   pull_request:
     branches:
       - main
@@ -23,10 +28,15 @@ on:
       - '**/go.mod'
       - '**/go.sum'
       - 'Makefile'
+      - 'scripts/**'
       - '.github/workflows/code-coverage.yml'
+      - 'server/events/templates/**'
+      - 'server/i18n/**'
+      - '**/testdata/**'
+      - 'testdata/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions: {}
@@ -38,13 +48,9 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
     container: ghcr.io/runatlantis/testing-env:latest@sha256:dc683c36e7fb8f26fcc8628fdcf328f42d3b1903e130aebb8484223fbdedfd98
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -92,7 +98,13 @@ jobs:
       contents: read
       code-quality: write
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Download coverage artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '**/*.go'
+      - '**/go.mod'
+      - '**/go.sum'
+      - 'Makefile'
+      - '.github/workflows/code-coverage.yml'
   pull_request:
     branches:
       - main
@@ -12,20 +18,27 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+    paths:
+      - '**/*.go'
+      - '**/go.mod'
+      - '**/go.sum'
+      - 'Makefile'
+      - '.github/workflows/code-coverage.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  code-quality: write
+permissions: {}
 
 jobs:
   go-coverage:
     name: Go Coverage
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
+    container: ghcr.io/runatlantis/testing-env:latest@sha256:dc683c36e7fb8f26fcc8628fdcf328f42d3b1903e130aebb8484223fbdedfd98
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -36,6 +49,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
@@ -62,8 +76,30 @@ jobs:
           print(f"validated {path}")
           PY
 
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: go-coverage-cobertura
+          path: .cover/coverage.xml
+          if-no-files-found: error
+          retention-days: 1
+
+  upload-coverage:
+    name: Upload Coverage
+    needs: go-coverage
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      code-quality: write
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download coverage artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: go-coverage-cobertura
+          path: .cover
+
       - name: Upload coverage report
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/upload-code-coverage@82c7aee3fb2ad768e00b00a0a8d749c5815085b6 # v1
         with:
           file: .cover/coverage.xml

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,71 @@
+name: Code Coverage
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  code-quality: write
+
+jobs:
+  go-coverage:
+    name: Go Coverage
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run Go tests with coverage
+        run: make test-coverage
+
+      - name: Convert Go coverage to Cobertura XML
+        run: |
+          go install github.com/boumenot/gocover-cobertura@v1.5.0
+          gocover-cobertura < .cover/cover.out > .cover/coverage.xml
+          test -s .cover/coverage.xml
+
+      - name: Validate Cobertura XML
+        run: |
+          python3 - <<'PY'
+          import xml.etree.ElementTree as ET
+          path = ".cover/coverage.xml"
+          root = ET.parse(path).getroot()
+          if root.tag != "coverage":
+              raise SystemExit(f"unexpected root tag: {root.tag}")
+          print(f"validated {path}")
+          PY
+
+      - name: Upload coverage report
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/upload-code-coverage@82c7aee3fb2ad768e00b00a0a8d749c5815085b6 # v1
+        with:
+          file: .cover/coverage.xml
+          language: Go
+          label: code-coverage/go

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   go-coverage:
     name: Go Coverage
-    if: github.event.pull_request.draft == false
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     steps:
       - name: Harden Runner


### PR DESCRIPTION
## Summary

Adds a dedicated Code Coverage workflow that uploads Go coverage to GitHub Code Quality.

## Design

Two-job split for token isolation:
1. **Go Coverage** — runs `make test-coverage` in the `testing-env` container (same as CI tests), converts to Cobertura XML, uploads artifact. Has only `contents: read`.
2. **Upload Coverage** — downloads artifact and uploads to Code Quality. Has `code-quality: write`. Skipped for fork PRs.

## Scope

- Root Go module only (`.github/workflows/code-coverage.yml`).
- No e2e coverage, no JS/TS coverage, no coverage thresholds.
- No required check changes.
- Path-filtered: skips docs/website-only PRs.

## Safety

- All Actions pinned by SHA.
- `persist-credentials: false` on checkout in test job.
- `code-quality: write` only in upload job (no code checkout).
- Upload skipped for fork PRs.
- Uses same `testing-env` container as existing CI (provides Terraform).
- `gocover-cobertura` pinned to `v1.5.0`.

## Validation

- [x] `make test-coverage` — passes locally
- [x] Cobertura XML generation and parse validation
- [x] `actionlint` — only reports expected unknown `code-quality` scope (newer GitHub feature)
- [x] PR diff is single file only
