### PR TITLE
fix: validate current head and base plan state

### DIFF
--- a/server/controllers/api_controller.go
+++ b/server/controllers/api_controller.go
@@ -527,8 +527,12 @@ func (a *APIController) apiSetup(ctx *command.Context, cmdName command.Name) (er
 		return sanitizeAPIError(ctx, err)
 	}
 
-	if err := resolveAPIHeadCommit(ctx, repoDir); err != nil {
+	headBeforeResolve := ctx.Pull.HeadCommit
+	if err := resolveAPIHeadCommit(ctx, repoDir, checkoutMergeEnabled(a.WorkingDir)); err != nil {
 		return sanitizeAPIError(ctx, err)
+	}
+	if ctx.Pull.Num > 0 && ctx.Pull.HeadCommit != headBeforeResolve {
+		a.populatePullRequestStatus(ctx)
 	}
 	return sanitizeAPIError(ctx, verifyNonPRBaseBranchReachability(ctx, repoDir))
 }
@@ -537,10 +541,10 @@ func resolveNonPRHeadCommit(ctx *command.Context, repoDir string) error {
 	if ctx.Pull.Num >= 0 || repoDir == "" {
 		return nil
 	}
-	return resolveAPIHeadCommit(ctx, repoDir)
+	return resolveAPIHeadCommit(ctx, repoDir, false)
 }
 
-func resolveAPIHeadCommit(ctx *command.Context, repoDir string) error {
+func resolveAPIHeadCommit(ctx *command.Context, repoDir string, checkoutMerge bool) error {
 	if repoDir == "" {
 		return nil
 	}
@@ -551,7 +555,7 @@ func resolveAPIHeadCommit(ctx *command.Context, repoDir string) error {
 		return fmt.Errorf("checking API checkout git metadata: %w", err)
 	}
 
-	if ctx.Pull.Num > 0 {
+	if ctx.Pull.Num > 0 && checkoutMerge {
 		if headCommit, err := checkedOutAPICommit(repoDir, "HEAD^2"); err == nil && headCommit != "" {
 			ctx.Pull.HeadCommit = headCommit
 			return nil
@@ -563,6 +567,13 @@ func resolveAPIHeadCommit(ctx *command.Context, repoDir string) error {
 	}
 	ctx.Pull.HeadCommit = headCommit
 	return nil
+}
+
+func checkoutMergeEnabled(workingDir events.WorkingDir) bool {
+	checkoutMerge, ok := workingDir.(interface {
+		CheckoutMergeEnabled() bool
+	})
+	return ok && checkoutMerge.CheckoutMergeEnabled()
 }
 
 func checkedOutAPICommit(repoDir string, ref string) (string, error) {

--- a/server/controllers/api_controller.go
+++ b/server/controllers/api_controller.go
@@ -527,7 +527,7 @@ func (a *APIController) apiSetup(ctx *command.Context, cmdName command.Name) (er
 		return sanitizeAPIError(ctx, err)
 	}
 
-	if err := resolveNonPRHeadCommit(ctx, repoDir); err != nil {
+	if err := resolveAPIHeadCommit(ctx, repoDir); err != nil {
 		return sanitizeAPIError(ctx, err)
 	}
 	return sanitizeAPIError(ctx, verifyNonPRBaseBranchReachability(ctx, repoDir))
@@ -537,6 +537,13 @@ func resolveNonPRHeadCommit(ctx *command.Context, repoDir string) error {
 	if ctx.Pull.Num >= 0 || repoDir == "" {
 		return nil
 	}
+	return resolveAPIHeadCommit(ctx, repoDir)
+}
+
+func resolveAPIHeadCommit(ctx *command.Context, repoDir string) error {
+	if repoDir == "" {
+		return nil
+	}
 	if _, err := os.Stat(filepath.Join(repoDir, ".git")); err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -544,18 +551,32 @@ func resolveNonPRHeadCommit(ctx *command.Context, repoDir string) error {
 		return fmt.Errorf("checking API checkout git metadata: %w", err)
 	}
 
-	cmd := exec.Command("git", "rev-parse", "HEAD") // nolint: gosec
-	cmd.Dir = repoDir
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("resolving checked out API ref: %s: %w", strings.TrimSpace(string(output)), err)
+	if ctx.Pull.Num > 0 {
+		if headCommit, err := checkedOutAPICommit(repoDir, "HEAD^2"); err == nil && headCommit != "" {
+			ctx.Pull.HeadCommit = headCommit
+			return nil
+		}
 	}
-	headCommit := strings.TrimSpace(string(output))
-	if headCommit == "" {
-		return fmt.Errorf("resolving checked out API ref: empty commit")
+	headCommit, err := checkedOutAPICommit(repoDir, "HEAD")
+	if err != nil {
+		return err
 	}
 	ctx.Pull.HeadCommit = headCommit
 	return nil
+}
+
+func checkedOutAPICommit(repoDir string, ref string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", ref) // nolint: gosec
+	cmd.Dir = repoDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("resolving checked out API ref %q: %s: %w", ref, strings.TrimSpace(string(output)), err)
+	}
+	headCommit := strings.TrimSpace(string(output))
+	if headCommit == "" {
+		return "", fmt.Errorf("resolving checked out API ref %q: empty commit", ref)
+	}
+	return headCommit, nil
 }
 
 func verifyNonPRBaseBranchReachability(ctx *command.Context, repoDir string) error {
@@ -856,11 +877,24 @@ func upsertProjectPolicyStatus(pullStatus *models.PullStatus, result command.Pro
 		if status.Workspace == project.Workspace &&
 			status.RepoRelDir == project.RepoRelDir &&
 			status.ProjectName == project.ProjectName {
+			project.Status = planStatusAfterPolicyCheck(project.Status, result)
 			project.PolicyStatus = mergePolicyStatuses(project.PolicyStatus, status.PolicyStatus)
 			return
 		}
 	}
+	status.Status = result.PlanStatus()
 	pullStatus.Projects = append(pullStatus.Projects, status)
+}
+
+func planStatusAfterPolicyCheck(existing models.ProjectPlanStatus, result command.ProjectResult) models.ProjectPlanStatus {
+	policyStatus := result.PlanStatus()
+	if policyStatus == models.ErroredPolicyCheckStatus {
+		return policyStatus
+	}
+	if existing == models.PlannedPlanStatus || existing == models.ErroredPolicyCheckStatus {
+		return policyStatus
+	}
+	return existing
 }
 
 func upsertProjectStatus(pullStatus *models.PullStatus, status models.ProjectStatus) {

--- a/server/controllers/api_controller.go
+++ b/server/controllers/api_controller.go
@@ -67,6 +67,9 @@ type APIController struct {
 	// apply requirements like 'mergeable' and 'approved' evaluate against real
 	// VCS state instead of always failing.
 	PullReqStatusFetcher vcs.PullReqStatusFetcher
+	// LivePullHeadFetcher is optional for tests. In production it is used for
+	// PR-backed API requests to seed live PR identity data such as base branch.
+	LivePullHeadFetcher events.LivePullHeadFetcher
 	// DriftWebhookSender sends webhook notifications when drift is detected.
 	// Nil when no drift webhooks are configured.
 	DriftWebhookSender *webhooks.DriftWebhookSender
@@ -528,13 +531,36 @@ func (a *APIController) apiSetup(ctx *command.Context, cmdName command.Name) (er
 	}
 
 	headBeforeResolve := ctx.Pull.HeadCommit
+	baseBeforeResolve := ctx.Pull.BaseBranch
 	if err := resolveAPIHeadCommit(ctx, repoDir, checkoutMergeEnabled(a.WorkingDir)); err != nil {
 		return sanitizeAPIError(ctx, err)
 	}
-	if ctx.Pull.Num > 0 && ctx.Pull.HeadCommit != headBeforeResolve {
+	if err := a.seedAPIPrBaseBranch(ctx); err != nil {
+		return sanitizeAPIError(ctx, err)
+	}
+	if ctx.Pull.Num > 0 && (ctx.Pull.HeadCommit != headBeforeResolve || ctx.Pull.BaseBranch != baseBeforeResolve) {
 		a.populatePullRequestStatus(ctx)
 	}
 	return sanitizeAPIError(ctx, verifyNonPRBaseBranchReachability(ctx, repoDir))
+}
+
+func (a *APIController) seedAPIPrBaseBranch(ctx *command.Context) error {
+	if ctx.Pull.Num <= 0 || strings.TrimSpace(ctx.Pull.BaseBranch) != "" || a.LivePullHeadFetcher == nil {
+		return nil
+	}
+	livePull, err := a.LivePullHeadFetcher.GetLivePullIdentity(command.ProjectContext{
+		Log:        ctx.Log,
+		Pull:       ctx.Pull,
+		PullStatus: ctx.PullStatus,
+		API:        ctx.API,
+	})
+	if err != nil {
+		return fmt.Errorf("fetching live pull request: %w", err)
+	}
+	if strings.TrimSpace(livePull.BaseBranch) != "" {
+		ctx.Pull.BaseBranch = livePull.BaseBranch
+	}
+	return nil
 }
 
 func resolveNonPRHeadCommit(ctx *command.Context, repoDir string) error {
@@ -994,9 +1020,13 @@ func (a *APIController) apiParseAndValidate(r *http.Request) (*APIRequest, *comm
 		pullNum = nextNonPRPullNum()
 	}
 
+	baseBranch := apiRequestBaseBranch(request.Ref, request.BaseBranch)
+	if !syntheticNonPR && strings.TrimSpace(request.BaseBranch) == "" {
+		baseBranch = ""
+	}
 	pull := models.PullRequest{
 		Num:                      pullNum,
-		BaseBranch:               apiRequestBaseBranch(request.Ref, request.BaseBranch),
+		BaseBranch:               baseBranch,
 		HeadBranch:               request.Ref,
 		HeadCommit:               request.Ref,
 		BaseRepo:                 baseRepo,

--- a/server/controllers/api_controller.go
+++ b/server/controllers/api_controller.go
@@ -347,6 +347,10 @@ func (a *APIController) Apply(w http.ResponseWriter, r *http.Request) {
 		a.apiReportLegacyError(w, apiErrorStatusCode(err), err)
 		return
 	}
+	if err := a.validateNonPRAPIRefUnchanged(ctx); err != nil {
+		a.apiReportLegacyError(w, http.StatusInternalServerError, err)
+		return
+	}
 
 	statusCode := http.StatusOK
 	if result.HasErrors() {
@@ -524,18 +528,19 @@ func (a *APIController) apiSetup(ctx *command.Context, cmdName command.Name) (er
 	ctx.Log.Debug("got workspace lock")
 	defer unlockFn()
 
+	headBeforeResolve := ctx.Pull.HeadCommit
+	baseBeforeResolve := ctx.Pull.BaseBranch
+	if err := a.seedAPIPrBaseBranch(ctx); err != nil {
+		return sanitizeAPIError(ctx, err)
+	}
+
 	// ensure workingDir is present
-	repoDir, err := a.WorkingDir.Clone(ctx.Log, headRepo, pull, events.DefaultWorkspace)
+	repoDir, err := a.WorkingDir.Clone(ctx.Log, headRepo, ctx.Pull, events.DefaultWorkspace)
 	if err != nil {
 		return sanitizeAPIError(ctx, err)
 	}
 
-	headBeforeResolve := ctx.Pull.HeadCommit
-	baseBeforeResolve := ctx.Pull.BaseBranch
 	if err := resolveAPIHeadCommit(ctx, repoDir, checkoutMergeEnabled(a.WorkingDir)); err != nil {
-		return sanitizeAPIError(ctx, err)
-	}
-	if err := a.seedAPIPrBaseBranch(ctx); err != nil {
 		return sanitizeAPIError(ctx, err)
 	}
 	if ctx.Pull.Num > 0 && (ctx.Pull.HeadCommit != headBeforeResolve || ctx.Pull.BaseBranch != baseBeforeResolve) {
@@ -858,6 +863,21 @@ func (a *APIController) apiApply(request *APIRequest, ctx *command.Context) (*co
 		a.PostWorkflowHooksCommandRunner.RunPostHooks(ctx, cc[i]) // nolint: errcheck
 	}
 	return &command.Result{ProjectResults: projectResults}, nil
+}
+
+func (a *APIController) validateNonPRAPIRefUnchanged(ctx *command.Context) error {
+	if ctx == nil || !ctx.API || ctx.Pull.Num > 0 {
+		return nil
+	}
+	repoDir, err := a.WorkingDir.GetWorkingDir(ctx.Pull.BaseRepo, ctx.Pull, events.DefaultWorkspace)
+	if err != nil {
+		return sanitizeAPIError(ctx, err)
+	}
+	return sanitizeAPIError(ctx, events.ValidateNonPRAPIRefUnchanged(command.ProjectContext{
+		Log:  ctx.Log,
+		Pull: ctx.Pull,
+		API:  ctx.API,
+	}, repoDir))
 }
 
 func updatePullStatusFromProjectResult(ctx *command.Context, result command.ProjectResult) {
@@ -1338,6 +1358,10 @@ func (e *apiRemediationExecutor) ExecuteApplyProjects(repository, ref, vcsType s
 	if err != nil {
 		return remediationResults, err
 	}
+	if err := e.controller.validateNonPRAPIRefUnchanged(ctx); err != nil {
+		markRunningRemediationResultsFailed(remediationResults, err.Error())
+		return remediationResults, err
+	}
 	remediationResults = mergeApplyRemediationResults(remediationResults, applyResult)
 	if applyResult.HasErrors() {
 		markRunningRemediationResultsFailed(remediationResults, "apply skipped because an earlier execution group failed")
@@ -1429,6 +1453,10 @@ func (e *apiRemediationExecutor) ExecuteApply(repository, ref, vcsType, projectN
 	result, err := e.controller.apiApply(request, ctx)
 	if err != nil {
 		return "", err
+	}
+	if err := e.controller.validateNonPRAPIRefUnchanged(ctx); err != nil {
+		output := applyRemediationOutput(result)
+		return output.String(), err
 	}
 
 	output := applyRemediationOutput(result)

--- a/server/controllers/api_controller.go
+++ b/server/controllers/api_controller.go
@@ -347,10 +347,6 @@ func (a *APIController) Apply(w http.ResponseWriter, r *http.Request) {
 		a.apiReportLegacyError(w, apiErrorStatusCode(err), err)
 		return
 	}
-	if err := a.validateNonPRAPIRefUnchanged(ctx); err != nil {
-		a.apiReportLegacyError(w, http.StatusInternalServerError, err)
-		return
-	}
 
 	statusCode := http.StatusOK
 	if result.HasErrors() {
@@ -708,6 +704,9 @@ func (a *APIController) apiPlan(request *APIRequest, ctx *command.Context) (*com
 	}
 
 	if len(cmds) == 0 {
+		if err := a.validateNonPRAPIRefUnchanged(ctx); err != nil {
+			return nil, err
+		}
 		ctx.Log.Info("determined there was no project to run plan in")
 		// When silence is enabled and no projects are found, don't set any VCS status
 		if !a.SilenceVCSStatusNoProjects && !ctx.SuppressVCSStatus {
@@ -802,6 +801,9 @@ func (a *APIController) apiApply(request *APIRequest, ctx *command.Context) (*co
 	}
 
 	if len(cmds) == 0 {
+		if err := a.validateNonPRAPIRefUnchanged(ctx); err != nil {
+			return nil, err
+		}
 		ctx.Log.Info("determined there was no project to run apply in")
 		// When silence is enabled and no projects are found, don't set any VCS status
 		if !a.SilenceVCSStatusNoProjects && !ctx.SuppressVCSStatus {
@@ -862,7 +864,13 @@ func (a *APIController) apiApply(request *APIRequest, ctx *command.Context) (*co
 
 		a.PostWorkflowHooksCommandRunner.RunPostHooks(ctx, cc[i]) // nolint: errcheck
 	}
-	return &command.Result{ProjectResults: projectResults}, nil
+	result := &command.Result{ProjectResults: projectResults}
+	if err := a.validateNonPRAPIRefUnchanged(ctx); err != nil {
+		a.publishDeferredApplyStatuses(cmds, result, models.FailedCommitStatus)
+		return result, err
+	}
+	a.publishDeferredApplyStatuses(cmds, result, models.SuccessCommitStatus)
+	return result, nil
 }
 
 func (a *APIController) validateNonPRAPIRefUnchanged(ctx *command.Context) error {
@@ -878,6 +886,17 @@ func (a *APIController) validateNonPRAPIRefUnchanged(ctx *command.Context) error
 		Pull: ctx.Pull,
 		API:  ctx.API,
 	}, repoDir))
+}
+
+func (a *APIController) publishDeferredApplyStatuses(projectCmds []command.ProjectContext, result *command.Result, status models.CommitStatus) {
+	if result == nil {
+		return
+	}
+	publisher, ok := a.ProjectApplyCommandRunner.(events.DeferredApplyStatusPublisher)
+	if !ok {
+		return
+	}
+	publisher.PublishDeferredApplyStatuses(projectCmds, *result, status)
 }
 
 func updatePullStatusFromProjectResult(ctx *command.Context, result command.ProjectResult) {
@@ -1356,9 +1375,6 @@ func (e *apiRemediationExecutor) ExecuteApplyProjects(repository, ref, vcsType s
 
 	applyResult, err := e.controller.apiApply(request, ctx)
 	if err != nil {
-		return remediationResults, err
-	}
-	if err := e.controller.validateNonPRAPIRefUnchanged(ctx); err != nil {
 		markRunningRemediationResultsFailed(remediationResults, err.Error())
 		return remediationResults, err
 	}
@@ -1452,11 +1468,11 @@ func (e *apiRemediationExecutor) ExecuteApply(repository, ref, vcsType, projectN
 	// Execute apply
 	result, err := e.controller.apiApply(request, ctx)
 	if err != nil {
+		if result != nil {
+			output := applyRemediationOutput(result)
+			return output.String(), err
+		}
 		return "", err
-	}
-	if err := e.controller.validateNonPRAPIRefUnchanged(ctx); err != nil {
-		output := applyRemediationOutput(result)
-		return output.String(), err
 	}
 
 	output := applyRemediationOutput(result)

--- a/server/controllers/api_controller_internal_test.go
+++ b/server/controllers/api_controller_internal_test.go
@@ -99,11 +99,31 @@ func TestResolveAPIHeadCommitUpdatesPRBranchRef(t *testing.T) {
 		},
 	}
 
-	Ok(t, resolveAPIHeadCommit(ctx, repoDir))
+	Ok(t, resolveAPIHeadCommit(ctx, repoDir, false))
 	Equals(t, headCommit, ctx.Pull.HeadCommit)
 }
 
-func TestResolveAPIHeadCommitUsesPRHeadParentForMergeCheckout(t *testing.T) {
+func TestAPIResolvePRHead_BranchCheckoutUsesHEADWhenHEADIsMergeCommit(t *testing.T) {
+	repoDir := initReachabilityRepo(t)
+	runControllerGit(t, repoDir, "checkout", "-b", "feature", "old")
+	runControllerGit(t, repoDir, "commit", "--allow-empty", "-m", "feature")
+	runControllerGit(t, repoDir, "checkout", "main")
+	runControllerGit(t, repoDir, "merge", "--no-ff", "feature", "-m", "merge feature")
+	mergeHead := strings.TrimSpace(runControllerGit(t, repoDir, "rev-parse", "HEAD"))
+	secondParent := strings.TrimSpace(runControllerGit(t, repoDir, "rev-parse", "HEAD^2"))
+	ctx := &command.Context{
+		Pull: models.PullRequest{
+			Num:        123,
+			HeadCommit: "main",
+		},
+	}
+
+	Ok(t, resolveAPIHeadCommit(ctx, repoDir, false))
+	Equals(t, mergeHead, ctx.Pull.HeadCommit)
+	Assert(t, ctx.Pull.HeadCommit != secondParent, "expected branch checkout to use HEAD, not HEAD^2")
+}
+
+func TestAPIResolvePRHead_MergeCheckoutUsesHEADSecondParent(t *testing.T) {
 	repoDir := initReachabilityRepo(t)
 	runControllerGit(t, repoDir, "checkout", "-b", "feature", "old")
 	runControllerGit(t, repoDir, "commit", "--allow-empty", "-m", "feature")
@@ -118,7 +138,7 @@ func TestResolveAPIHeadCommitUsesPRHeadParentForMergeCheckout(t *testing.T) {
 		},
 	}
 
-	Ok(t, resolveAPIHeadCommit(ctx, repoDir))
+	Ok(t, resolveAPIHeadCommit(ctx, repoDir, true))
 	Equals(t, featureHead, ctx.Pull.HeadCommit)
 	Assert(t, ctx.Pull.HeadCommit != mergeHead, "expected PR head, not merge commit")
 }

--- a/server/controllers/api_controller_internal_test.go
+++ b/server/controllers/api_controller_internal_test.go
@@ -89,6 +89,40 @@ func TestResolveNonPRHeadCommitUpdatesSyntheticNegativePull(t *testing.T) {
 	Equals(t, headCommit, ctx.Pull.HeadCommit)
 }
 
+func TestResolveAPIHeadCommitUpdatesPRBranchRef(t *testing.T) {
+	repoDir := initReachabilityRepo(t)
+	headCommit := strings.TrimSpace(runControllerGit(t, repoDir, "rev-parse", "HEAD"))
+	ctx := &command.Context{
+		Pull: models.PullRequest{
+			Num:        123,
+			HeadCommit: "main",
+		},
+	}
+
+	Ok(t, resolveAPIHeadCommit(ctx, repoDir))
+	Equals(t, headCommit, ctx.Pull.HeadCommit)
+}
+
+func TestResolveAPIHeadCommitUsesPRHeadParentForMergeCheckout(t *testing.T) {
+	repoDir := initReachabilityRepo(t)
+	runControllerGit(t, repoDir, "checkout", "-b", "feature", "old")
+	runControllerGit(t, repoDir, "commit", "--allow-empty", "-m", "feature")
+	featureHead := strings.TrimSpace(runControllerGit(t, repoDir, "rev-parse", "HEAD"))
+	runControllerGit(t, repoDir, "checkout", "main")
+	runControllerGit(t, repoDir, "merge", "--no-ff", "feature", "-m", "merge feature")
+	mergeHead := strings.TrimSpace(runControllerGit(t, repoDir, "rev-parse", "HEAD"))
+	ctx := &command.Context{
+		Pull: models.PullRequest{
+			Num:        123,
+			HeadCommit: "main",
+		},
+	}
+
+	Ok(t, resolveAPIHeadCommit(ctx, repoDir))
+	Equals(t, featureHead, ctx.Pull.HeadCommit)
+	Assert(t, ctx.Pull.HeadCommit != mergeHead, "expected PR head, not merge commit")
+}
+
 func initReachabilityRepo(t *testing.T) string {
 	t.Helper()
 	repoDir := newReachabilityGitTempDir(t, "reachability-origin-*")

--- a/server/controllers/api_controller_test.go
+++ b/server/controllers/api_controller_test.go
@@ -1373,6 +1373,7 @@ func TestAPIController_ApplySeedsPolicyStatusFromAPIPlan(t *testing.T) {
 	Equals(t, 1, len(capturedPullStatus.Projects))
 	Equals(t, 1, len(capturedPullStatus.Projects[0].PolicyStatus))
 	projectCommandRunner.VerifyWasCalled(Once()).PolicyCheck(Any[command.ProjectContext]())
+	projectCommandRunner.VerifyWasCalled(Once()).Apply(Any[command.ProjectContext]())
 }
 
 func TestAPIController_ListLocksEmpty(t *testing.T) {

--- a/server/controllers/api_controller_test.go
+++ b/server/controllers/api_controller_test.go
@@ -51,6 +51,15 @@ func (r *recordingDriftSender) Send(_ logging.SimpleLogging, result webhooks.Dri
 	return nil
 }
 
+type fakeControllerLivePullHeadFetcher struct {
+	pull models.PullRequest
+	err  error
+}
+
+func (f fakeControllerLivePullHeadFetcher) GetLivePullIdentity(command.ProjectContext) (models.PullRequest, error) {
+	return f.pull, f.err
+}
+
 func TestAPIController_Plan(t *testing.T) {
 	ac, projectCommandBuilder, projectCommandRunner := setup(t)
 
@@ -1113,6 +1122,105 @@ func TestAPISetup_RefreshesPullRequestStatusAfterResolvingPRHead(t *testing.T) {
 		"expected plan commands to use resolved-head approved status")
 	Assert(t, planCtx.PullRequestStatus.MergeableStatus.IsMergeable,
 		"expected plan commands to use resolved-head mergeable status")
+}
+
+func TestAPISetup_PRWithoutBaseBranchSeedsLivePRBase(t *testing.T) {
+	ac, projectCommandBuilder, _ := setup(t)
+	repoDir, headCommit := initAPIControllerGitRepo(t)
+	workingDir := ac.WorkingDir.(*MockWorkingDir)
+	When(workingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Eq(events.DefaultWorkspace))).
+		ThenReturn(repoDir, nil)
+	ac.LivePullHeadFetcher = fakeControllerLivePullHeadFetcher{
+		pull: models.PullRequest{HeadCommit: headCommit, BaseBranch: "main"},
+	}
+	var capturedCtx *command.Context
+	When(projectCommandBuilder.BuildPlanCommands(Any[*command.Context](), Any[*events.CommentCommand]())).
+		Then(func(args []Param) ReturnValues {
+			capturedCtx = args[0].(*command.Context)
+			return ReturnValues{[]command.ProjectContext{{CommandName: command.Plan}}, nil}
+		})
+
+	body, _ := json.Marshal(controllers.APIRequest{
+		Repository: "Repo",
+		Ref:        "feature",
+		Type:       "Gitlab",
+		PR:         42,
+		Projects:   []string{"default"},
+	})
+	req, _ := http.NewRequest("POST", "", bytes.NewBuffer(body))
+	req.Header.Set(atlantisTokenHeader, atlantisToken)
+	w := httptest.NewRecorder()
+	ac.Plan(w, req)
+
+	ResponseContains(t, w, http.StatusOK, "")
+	Assert(t, capturedCtx != nil, "expected plan command builder to be called")
+	Equals(t, headCommit, capturedCtx.Pull.HeadCommit)
+	Equals(t, "feature", capturedCtx.Pull.HeadBranch)
+	Equals(t, "main", capturedCtx.Pull.BaseBranch)
+}
+
+func TestAPIApply_PRRefDoesNotUseHeadRefAsBaseBranch(t *testing.T) {
+	ac, projectCommandBuilder, _ := setup(t)
+	repoDir, headCommit := initAPIControllerGitRepo(t)
+	workingDir := ac.WorkingDir.(*MockWorkingDir)
+	When(workingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Eq(events.DefaultWorkspace))).
+		ThenReturn(repoDir, nil)
+	ac.LivePullHeadFetcher = fakeControllerLivePullHeadFetcher{
+		pull: models.PullRequest{HeadCommit: headCommit, BaseBranch: "main"},
+	}
+	var applyCtx *command.Context
+	When(projectCommandBuilder.BuildApplyCommands(Any[*command.Context](), Any[*events.CommentCommand]())).
+		Then(func(args []Param) ReturnValues {
+			applyCtx = args[0].(*command.Context)
+			return ReturnValues{[]command.ProjectContext{{CommandName: command.Apply}}, nil}
+		})
+
+	body, _ := json.Marshal(controllers.APIRequest{
+		Repository: "Repo",
+		Ref:        "feature",
+		Type:       "Gitlab",
+		PR:         42,
+		Projects:   []string{"default"},
+	})
+	req, _ := http.NewRequest("POST", "", bytes.NewBuffer(body))
+	req.Header.Set(atlantisTokenHeader, atlantisToken)
+	w := httptest.NewRecorder()
+	ac.Apply(w, req)
+
+	ResponseContains(t, w, http.StatusOK, "")
+	Assert(t, applyCtx != nil, "expected apply command builder to be called")
+	Equals(t, "feature", applyCtx.Pull.HeadBranch)
+	Equals(t, "main", applyCtx.Pull.BaseBranch)
+	Assert(t, applyCtx.PullStatus != nil, "expected API apply to seed in-memory PullStatus")
+	Equals(t, "main", applyCtx.PullStatus.Pull.BaseBranch)
+}
+
+func TestAPIApply_PRWithoutBaseBranchCurrentLiveBaseSucceeds(t *testing.T) {
+	ac, projectCommandBuilder, projectCommandRunner := setup(t)
+	repoDir, headCommit := initAPIControllerGitRepo(t)
+	workingDir := ac.WorkingDir.(*MockWorkingDir)
+	When(workingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Eq(events.DefaultWorkspace))).
+		ThenReturn(repoDir, nil)
+	ac.LivePullHeadFetcher = fakeControllerLivePullHeadFetcher{
+		pull: models.PullRequest{HeadCommit: headCommit, BaseBranch: "main"},
+	}
+	When(projectCommandBuilder.BuildApplyCommands(Any[*command.Context](), Any[*events.CommentCommand]())).
+		ThenReturn([]command.ProjectContext{{CommandName: command.Apply}}, nil)
+
+	body, _ := json.Marshal(controllers.APIRequest{
+		Repository: "Repo",
+		Ref:        "feature",
+		Type:       "Gitlab",
+		PR:         42,
+		Projects:   []string{"default"},
+	})
+	req, _ := http.NewRequest("POST", "", bytes.NewBuffer(body))
+	req.Header.Set(atlantisTokenHeader, atlantisToken)
+	w := httptest.NewRecorder()
+	ac.Apply(w, req)
+
+	ResponseContains(t, w, http.StatusOK, "")
+	projectCommandRunner.VerifyWasCalledOnce().Apply(Any[command.ProjectContext]())
 }
 
 func TestAPIApply_UsesResolvedHeadPullRequestStatusForPlanRequirements(t *testing.T) {

--- a/server/controllers/api_controller_test.go
+++ b/server/controllers/api_controller_test.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -1159,6 +1160,67 @@ func TestAPISetup_PRWithoutBaseBranchSeedsLivePRBase(t *testing.T) {
 	Equals(t, "main", capturedCtx.Pull.BaseBranch)
 }
 
+func TestAPISetup_PRWithoutBaseBranchSeedsLiveBaseBeforeClone(t *testing.T) {
+	ac, _, _ := setup(t)
+	repoDir, headCommit := initAPIControllerGitRepo(t)
+	workingDir := ac.WorkingDir.(*MockWorkingDir)
+	var clonePull models.PullRequest
+	When(workingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Eq(events.DefaultWorkspace))).
+		Then(func(args []Param) ReturnValues {
+			clonePull = args[2].(models.PullRequest)
+			return ReturnValues{repoDir, nil}
+		})
+	ac.LivePullHeadFetcher = fakeControllerLivePullHeadFetcher{
+		pull: models.PullRequest{HeadCommit: headCommit, BaseBranch: "main"},
+	}
+
+	body, _ := json.Marshal(controllers.APIRequest{
+		Repository: "Repo",
+		Ref:        "feature",
+		Type:       "Gitlab",
+		PR:         42,
+		Projects:   []string{"default"},
+	})
+	req, _ := http.NewRequest("POST", "", bytes.NewBuffer(body))
+	req.Header.Set(atlantisTokenHeader, atlantisToken)
+	w := httptest.NewRecorder()
+	ac.Plan(w, req)
+
+	ResponseContains(t, w, http.StatusOK, "")
+	Equals(t, "main", clonePull.BaseBranch)
+	Equals(t, "feature", clonePull.HeadBranch)
+}
+
+func TestAPISetup_MergeCheckoutCloneReceivesLivePRBase(t *testing.T) {
+	ac, _, _ := setup(t)
+	repoDir, headCommit := initAPIControllerGitRepo(t)
+	workingDir := ac.WorkingDir.(*MockWorkingDir)
+	var clonePull models.PullRequest
+	When(workingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Eq(events.DefaultWorkspace))).
+		Then(func(args []Param) ReturnValues {
+			clonePull = args[2].(models.PullRequest)
+			return ReturnValues{repoDir, nil}
+		})
+	ac.LivePullHeadFetcher = fakeControllerLivePullHeadFetcher{
+		pull: models.PullRequest{HeadCommit: headCommit, BaseBranch: "main"},
+	}
+
+	body, _ := json.Marshal(controllers.APIRequest{
+		Repository: "Repo",
+		Ref:        "feature",
+		Type:       "Gitlab",
+		PR:         42,
+		Projects:   []string{"default"},
+	})
+	req, _ := http.NewRequest("POST", "", bytes.NewBuffer(body))
+	req.Header.Set(atlantisTokenHeader, atlantisToken)
+	w := httptest.NewRecorder()
+	ac.Apply(w, req)
+
+	ResponseContains(t, w, http.StatusOK, "")
+	Equals(t, "main", clonePull.BaseBranch)
+}
+
 func TestAPIApply_PRRefDoesNotUseHeadRefAsBaseBranch(t *testing.T) {
 	ac, projectCommandBuilder, _ := setup(t)
 	repoDir, headCommit := initAPIControllerGitRepo(t)
@@ -1212,6 +1274,95 @@ func TestAPIApply_PRWithoutBaseBranchCurrentLiveBaseSucceeds(t *testing.T) {
 		Ref:        "feature",
 		Type:       "Gitlab",
 		PR:         42,
+		Projects:   []string{"default"},
+	})
+	req, _ := http.NewRequest("POST", "", bytes.NewBuffer(body))
+	req.Header.Set(atlantisTokenHeader, atlantisToken)
+	w := httptest.NewRecorder()
+	ac.Apply(w, req)
+
+	ResponseContains(t, w, http.StatusOK, "")
+	projectCommandRunner.VerifyWasCalledOnce().Apply(Any[command.ProjectContext]())
+}
+
+func TestAPIApply_NonPRMutableRefChangedDuringApplyDoesNotPublishSuccess(t *testing.T) {
+	ac, _, projectCommandRunner := setup(t)
+	repoDir, _ := initAPIControllerGitRepoWithOrigin(t)
+	workingDir := ac.WorkingDir.(*MockWorkingDir)
+	When(workingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Eq(events.DefaultWorkspace))).
+		ThenReturn(repoDir, nil)
+	When(workingDir.GetWorkingDir(Any[models.Repo](), Any[models.PullRequest](), Eq(events.DefaultWorkspace))).
+		ThenReturn(repoDir, nil)
+	When(projectCommandRunner.Apply(Any[command.ProjectContext]())).
+		Then(func([]Param) ReturnValues {
+			advanceAPIControllerGitMain(t, repoDir)
+			return ReturnValues{command.ProjectCommandOutput{ApplySuccess: "success"}}
+		})
+	commitStatusUpdater := ac.CommitStatusUpdater.(*MockCommitStatusUpdater)
+
+	body, _ := json.Marshal(controllers.APIRequest{
+		Repository: "Repo",
+		Ref:        "main",
+		BaseBranch: "main",
+		Type:       "Gitlab",
+		Projects:   []string{"default"},
+	})
+	req, _ := http.NewRequest("POST", "", bytes.NewBuffer(body))
+	req.Header.Set(atlantisTokenHeader, atlantisToken)
+	w := httptest.NewRecorder()
+	ac.Apply(w, req)
+
+	Equals(t, http.StatusInternalServerError, w.Code)
+	ResponseContains(t, w, http.StatusInternalServerError, "changed")
+	commitStatusUpdater.VerifyWasCalled(Never()).UpdateCombinedCount(
+		Any[logging.SimpleLogging](),
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Eq(models.SuccessCommitStatus),
+		Eq(command.Apply),
+		Any[models.ProjectCounts](),
+	)
+}
+
+func TestAPIApply_NonPRMutableRefUnchangedAllowsApply(t *testing.T) {
+	ac, _, projectCommandRunner := setup(t)
+	repoDir, _ := initAPIControllerGitRepoWithOrigin(t)
+	workingDir := ac.WorkingDir.(*MockWorkingDir)
+	When(workingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Eq(events.DefaultWorkspace))).
+		ThenReturn(repoDir, nil)
+	When(workingDir.GetWorkingDir(Any[models.Repo](), Any[models.PullRequest](), Eq(events.DefaultWorkspace))).
+		ThenReturn(repoDir, nil)
+
+	body, _ := json.Marshal(controllers.APIRequest{
+		Repository: "Repo",
+		Ref:        "main",
+		BaseBranch: "main",
+		Type:       "Gitlab",
+		Projects:   []string{"default"},
+	})
+	req, _ := http.NewRequest("POST", "", bytes.NewBuffer(body))
+	req.Header.Set(atlantisTokenHeader, atlantisToken)
+	w := httptest.NewRecorder()
+	ac.Apply(w, req)
+
+	ResponseContains(t, w, http.StatusOK, "")
+	projectCommandRunner.VerifyWasCalledOnce().Apply(Any[command.ProjectContext]())
+}
+
+func TestAPIApply_NonPRImmutableSHAAllowsApply(t *testing.T) {
+	ac, _, projectCommandRunner := setup(t)
+	repoDir, commit := initAPIControllerGitRepoWithOrigin(t)
+	workingDir := ac.WorkingDir.(*MockWorkingDir)
+	When(workingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Eq(events.DefaultWorkspace))).
+		ThenReturn(repoDir, nil)
+	When(workingDir.GetWorkingDir(Any[models.Repo](), Any[models.PullRequest](), Eq(events.DefaultWorkspace))).
+		ThenReturn(repoDir, nil)
+
+	body, _ := json.Marshal(controllers.APIRequest{
+		Repository: "Repo",
+		Ref:        commit,
+		BaseBranch: "main",
+		Type:       "Gitlab",
 		Projects:   []string{"default"},
 	})
 	req, _ := http.NewRequest("POST", "", bytes.NewBuffer(body))
@@ -1659,6 +1810,28 @@ func initAPIControllerGitRepo(t *testing.T) (string, string) {
 	runAPIControllerGit(t, repoDir, "config", "--local", "commit.gpgsign", "false")
 	runAPIControllerGit(t, repoDir, "commit", "--allow-empty", "-m", "initial commit")
 	return repoDir, strings.TrimSpace(runAPIControllerGit(t, repoDir, "rev-parse", "HEAD"))
+}
+
+func initAPIControllerGitRepoWithOrigin(t *testing.T) (string, string) {
+	t.Helper()
+	repoDir, commit := initAPIControllerGitRepo(t)
+	originDir := filepath.Join(t.TempDir(), "origin.git")
+	runAPIControllerGit(t, repoDir, "init", "--bare", originDir)
+	runAPIControllerGit(t, originDir, "config", "gc.auto", "0")
+	runAPIControllerGit(t, originDir, "config", "maintenance.auto", "false")
+	runAPIControllerGit(t, repoDir, "remote", "add", "origin", "file://"+originDir)
+	runAPIControllerGit(t, repoDir, "push", "-q", "-u", "origin", "main")
+	return repoDir, commit
+}
+
+func advanceAPIControllerGitMain(t *testing.T, repoDir string) string {
+	t.Helper()
+	mainTF := []byte("resource \"null_resource\" \"changed\" {}\n")
+	Ok(t, os.WriteFile(filepath.Join(repoDir, "main.tf"), mainTF, 0600))
+	runAPIControllerGit(t, repoDir, "add", "main.tf")
+	runAPIControllerGit(t, repoDir, "commit", "-q", "-m", "advance main")
+	runAPIControllerGit(t, repoDir, "push", "-q", "origin", "HEAD:main")
+	return strings.TrimSpace(runAPIControllerGit(t, repoDir, "rev-parse", "HEAD"))
 }
 
 func runAPIControllerGit(t *testing.T, dir string, args ...string) string {

--- a/server/controllers/api_controller_test.go
+++ b/server/controllers/api_controller_test.go
@@ -1324,6 +1324,117 @@ func TestAPIApply_NonPRMutableRefChangedDuringApplyDoesNotPublishSuccess(t *test
 	)
 }
 
+func TestAPIApply_NonPRReleaseStableBranchChangedNoProjectsDoesNotPublishZeroZeroSuccess(t *testing.T) {
+	for _, ref := range []string{"release", "stable"} {
+		t.Run(ref, func(t *testing.T) {
+			ac, projectCommandBuilder, projectCommandRunner := setup(t)
+			repoDir, _ := initAPIControllerGitRepoWithOrigin(t)
+			createAPIControllerGitBranch(t, repoDir, ref)
+			workingDir := ac.WorkingDir.(*MockWorkingDir)
+			When(workingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Eq(events.DefaultWorkspace))).
+				ThenReturn(repoDir, nil)
+			When(workingDir.GetWorkingDir(Any[models.Repo](), Any[models.PullRequest](), Eq(events.DefaultWorkspace))).
+				ThenReturn(repoDir, nil)
+			When(projectCommandBuilder.BuildPlanCommands(Any[*command.Context](), Any[*events.CommentCommand]())).
+				Then(func([]Param) ReturnValues {
+					advanceAPIControllerGitBranch(t, repoDir, ref)
+					return ReturnValues{[]command.ProjectContext{}, nil}
+				})
+			commitStatusUpdater := ac.CommitStatusUpdater.(*MockCommitStatusUpdater)
+
+			body, _ := json.Marshal(controllers.APIRequest{
+				Repository: "Repo",
+				Ref:        ref,
+				Type:       "Gitlab",
+				Projects:   []string{"default"},
+			})
+			req, _ := http.NewRequest("POST", "", bytes.NewBuffer(body))
+			req.Header.Set(atlantisTokenHeader, atlantisToken)
+			w := httptest.NewRecorder()
+			ac.Apply(w, req)
+
+			Equals(t, http.StatusInternalServerError, w.Code)
+			ResponseContains(t, w, http.StatusInternalServerError, "changed")
+			projectCommandRunner.VerifyWasCalled(Never()).Apply(Any[command.ProjectContext]())
+			commitStatusUpdater.VerifyWasCalled(Never()).UpdateCombinedCount(
+				Any[logging.SimpleLogging](),
+				Any[models.Repo](),
+				Any[models.PullRequest](),
+				Eq(models.SuccessCommitStatus),
+				Eq(command.Apply),
+				Any[models.ProjectCounts](),
+			)
+		})
+	}
+}
+
+func TestAPIApply_NonPRAmbiguousBranchUnchangedNoProjectsSucceeds(t *testing.T) {
+	ac, projectCommandBuilder, projectCommandRunner := setup(t)
+	repoDir, _ := initAPIControllerGitRepoWithOrigin(t)
+	createAPIControllerGitBranch(t, repoDir, "release")
+	workingDir := ac.WorkingDir.(*MockWorkingDir)
+	When(workingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Eq(events.DefaultWorkspace))).
+		ThenReturn(repoDir, nil)
+	When(workingDir.GetWorkingDir(Any[models.Repo](), Any[models.PullRequest](), Eq(events.DefaultWorkspace))).
+		ThenReturn(repoDir, nil)
+	When(projectCommandBuilder.BuildPlanCommands(Any[*command.Context](), Any[*events.CommentCommand]())).
+		ThenReturn([]command.ProjectContext{}, nil)
+	When(projectCommandBuilder.BuildApplyCommands(Any[*command.Context](), Any[*events.CommentCommand]())).
+		ThenReturn([]command.ProjectContext{}, nil)
+	commitStatusUpdater := ac.CommitStatusUpdater.(*MockCommitStatusUpdater)
+
+	body, _ := json.Marshal(controllers.APIRequest{
+		Repository: "Repo",
+		Ref:        "release",
+		Type:       "Gitlab",
+		Projects:   []string{"default"},
+	})
+	req, _ := http.NewRequest("POST", "", bytes.NewBuffer(body))
+	req.Header.Set(atlantisTokenHeader, atlantisToken)
+	w := httptest.NewRecorder()
+	ac.Apply(w, req)
+
+	ResponseContains(t, w, http.StatusOK, "")
+	projectCommandRunner.VerifyWasCalled(Never()).Apply(Any[command.ProjectContext]())
+	commitStatusUpdater.VerifyWasCalled(Times(2)).UpdateCombinedCount(
+		Any[logging.SimpleLogging](),
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Eq(models.SuccessCommitStatus),
+		Eq(command.Apply),
+		Eq(models.ProjectCounts{}),
+	)
+}
+
+func TestAPIApply_NonPRImmutableSHANoProjectsSucceeds(t *testing.T) {
+	ac, projectCommandBuilder, projectCommandRunner := setup(t)
+	repoDir, commit := initAPIControllerGitRepoWithOrigin(t)
+	workingDir := ac.WorkingDir.(*MockWorkingDir)
+	When(workingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Eq(events.DefaultWorkspace))).
+		ThenReturn(repoDir, nil)
+	When(workingDir.GetWorkingDir(Any[models.Repo](), Any[models.PullRequest](), Eq(events.DefaultWorkspace))).
+		ThenReturn(repoDir, nil)
+	When(projectCommandBuilder.BuildPlanCommands(Any[*command.Context](), Any[*events.CommentCommand]())).
+		ThenReturn([]command.ProjectContext{}, nil)
+	When(projectCommandBuilder.BuildApplyCommands(Any[*command.Context](), Any[*events.CommentCommand]())).
+		ThenReturn([]command.ProjectContext{}, nil)
+
+	body, _ := json.Marshal(controllers.APIRequest{
+		Repository: "Repo",
+		Ref:        commit,
+		BaseBranch: "main",
+		Type:       "Gitlab",
+		Projects:   []string{"default"},
+	})
+	req, _ := http.NewRequest("POST", "", bytes.NewBuffer(body))
+	req.Header.Set(atlantisTokenHeader, atlantisToken)
+	w := httptest.NewRecorder()
+	ac.Apply(w, req)
+
+	ResponseContains(t, w, http.StatusOK, "")
+	projectCommandRunner.VerifyWasCalled(Never()).Apply(Any[command.ProjectContext]())
+}
+
 func TestAPIApply_NonPRMutableRefUnchangedAllowsApply(t *testing.T) {
 	ac, _, projectCommandRunner := setup(t)
 	repoDir, _ := initAPIControllerGitRepoWithOrigin(t)
@@ -1824,8 +1935,27 @@ func initAPIControllerGitRepoWithOrigin(t *testing.T) (string, string) {
 	return repoDir, commit
 }
 
+func createAPIControllerGitBranch(t *testing.T, repoDir, branch string) string {
+	t.Helper()
+	runAPIControllerGit(t, repoDir, "checkout", "-q", "-b", branch)
+	runAPIControllerGit(t, repoDir, "push", "-q", "-u", "origin", branch)
+	return strings.TrimSpace(runAPIControllerGit(t, repoDir, "rev-parse", "HEAD"))
+}
+
+func advanceAPIControllerGitBranch(t *testing.T, repoDir, branch string) string {
+	t.Helper()
+	runAPIControllerGit(t, repoDir, "checkout", "-q", branch)
+	changedTF := []byte("resource \"null_resource\" \"" + strings.ReplaceAll(branch, "-", "_") + "_changed\" {}\n")
+	Ok(t, os.WriteFile(filepath.Join(repoDir, "main.tf"), changedTF, 0600))
+	runAPIControllerGit(t, repoDir, "add", "main.tf")
+	runAPIControllerGit(t, repoDir, "commit", "-q", "-m", "advance "+branch)
+	runAPIControllerGit(t, repoDir, "push", "-q", "origin", "HEAD:"+branch)
+	return strings.TrimSpace(runAPIControllerGit(t, repoDir, "rev-parse", "HEAD"))
+}
+
 func advanceAPIControllerGitMain(t *testing.T, repoDir string) string {
 	t.Helper()
+	runAPIControllerGit(t, repoDir, "checkout", "-q", "main")
 	mainTF := []byte("resource \"null_resource\" \"changed\" {}\n")
 	Ok(t, os.WriteFile(filepath.Join(repoDir, "main.tf"), mainTF, 0600))
 	runAPIControllerGit(t, repoDir, "add", "main.tf")

--- a/server/controllers/api_controller_test.go
+++ b/server/controllers/api_controller_test.go
@@ -1065,6 +1065,99 @@ func TestAPIController_PlanContinuesWhenPullReqStatusFetchFails(t *testing.T) {
 	projectCommandRunner.VerifyWasCalled(Times(1)).Plan(Any[command.ProjectContext]())
 }
 
+func TestAPISetup_RefreshesPullRequestStatusAfterResolvingPRHead(t *testing.T) {
+	ac, projectCommandBuilder, _ := setup(t)
+	repoDir, headCommit := initAPIControllerGitRepo(t)
+	workingDir := ac.WorkingDir.(*MockWorkingDir)
+	When(workingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Eq(events.DefaultWorkspace))).
+		ThenReturn(repoDir, nil)
+	fetcher := NewMockPullReqStatusFetcher()
+	mockCall := When(fetcher.FetchPullStatus(Any[logging.SimpleLogging](), Any[models.PullRequest]()))
+	mockCall = mockCall.Then(func(args []Param) ReturnValues {
+		pull := args[1].(models.PullRequest)
+		Equals(t, "main", pull.HeadCommit)
+		return ReturnValues{models.PullReqStatus{
+			ApprovalStatus:  models.ApprovalStatus{IsApproved: false},
+			MergeableStatus: models.MergeableStatus{IsMergeable: false},
+		}, nil}
+	})
+	mockCall.Then(func(args []Param) ReturnValues {
+		pull := args[1].(models.PullRequest)
+		Equals(t, headCommit, pull.HeadCommit)
+		return ReturnValues{models.PullReqStatus{
+			ApprovalStatus:  models.ApprovalStatus{IsApproved: true},
+			MergeableStatus: models.MergeableStatus{IsMergeable: true},
+		}, nil}
+	})
+	ac.PullReqStatusFetcher = fetcher
+
+	body, _ := json.Marshal(controllers.APIRequest{
+		Repository: "Repo",
+		Ref:        "main",
+		Type:       "Gitlab",
+		PR:         42,
+		Projects:   []string{"default"},
+	})
+	req, _ := http.NewRequest("POST", "", bytes.NewBuffer(body))
+	req.Header.Set(atlantisTokenHeader, atlantisToken)
+	w := httptest.NewRecorder()
+	ac.Plan(w, req)
+	ResponseContains(t, w, http.StatusOK, "")
+
+	fetcher.VerifyWasCalled(Times(2)).FetchPullStatus(Any[logging.SimpleLogging](), Any[models.PullRequest]())
+	planCtx, _ := projectCommandBuilder.VerifyWasCalled(Times(1)).
+		BuildPlanCommands(Any[*command.Context](), Any[*events.CommentCommand]()).
+		GetCapturedArguments()
+	Equals(t, headCommit, planCtx.Pull.HeadCommit)
+	Assert(t, planCtx.PullRequestStatus.ApprovalStatus.IsApproved,
+		"expected plan commands to use resolved-head approved status")
+	Assert(t, planCtx.PullRequestStatus.MergeableStatus.IsMergeable,
+		"expected plan commands to use resolved-head mergeable status")
+}
+
+func TestAPIApply_UsesResolvedHeadPullRequestStatusForPlanRequirements(t *testing.T) {
+	ac, projectCommandBuilder, _ := setup(t)
+	repoDir, headCommit := initAPIControllerGitRepo(t)
+	workingDir := ac.WorkingDir.(*MockWorkingDir)
+	When(workingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Eq(events.DefaultWorkspace))).
+		ThenReturn(repoDir, nil)
+	fetcher := NewMockPullReqStatusFetcher()
+	mockCall := When(fetcher.FetchPullStatus(Any[logging.SimpleLogging](), Any[models.PullRequest]()))
+	mockCall = mockCall.ThenReturn(models.PullReqStatus{}, nil)
+	mockCall = mockCall.ThenReturn(models.PullReqStatus{
+		ApprovalStatus:  models.ApprovalStatus{IsApproved: true},
+		MergeableStatus: models.MergeableStatus{IsMergeable: true},
+	}, nil)
+	mockCall.ThenReturn(models.PullReqStatus{
+		ApprovalStatus:  models.ApprovalStatus{IsApproved: true},
+		MergeableStatus: models.MergeableStatus{IsMergeable: true},
+	}, nil)
+	ac.PullReqStatusFetcher = fetcher
+
+	body, _ := json.Marshal(controllers.APIRequest{
+		Repository: "Repo",
+		Ref:        "main",
+		Type:       "Gitlab",
+		PR:         42,
+		Projects:   []string{"default"},
+	})
+	req, _ := http.NewRequest("POST", "", bytes.NewBuffer(body))
+	req.Header.Set(atlantisTokenHeader, atlantisToken)
+	w := httptest.NewRecorder()
+	ac.Apply(w, req)
+	ResponseContains(t, w, http.StatusOK, "")
+
+	fetcher.VerifyWasCalled(Times(3)).FetchPullStatus(Any[logging.SimpleLogging](), Any[models.PullRequest]())
+	planCtx, _ := projectCommandBuilder.VerifyWasCalled(Times(1)).
+		BuildPlanCommands(Any[*command.Context](), Any[*events.CommentCommand]()).
+		GetCapturedArguments()
+	Equals(t, headCommit, planCtx.Pull.HeadCommit)
+	Assert(t, planCtx.PullRequestStatus.ApprovalStatus.IsApproved,
+		"expected pre-apply plan to use resolved-head approved status")
+	Assert(t, planCtx.PullRequestStatus.MergeableStatus.IsMergeable,
+		"expected pre-apply plan to use resolved-head mergeable status")
+}
+
 func TestAPIController_ApplyRefreshesPullReqStatusAfterPlan(t *testing.T) {
 	ac, projectCommandBuilder, _ := setup(t)
 	fetcher := NewMockPullReqStatusFetcher()

--- a/server/controllers/api_remediation_executor_internal_test.go
+++ b/server/controllers/api_remediation_executor_internal_test.go
@@ -927,6 +927,109 @@ func TestAPIRemediationExecutor_ExecuteApplyProjectsRejectsStaleCachedDrift(t *t
 	projectCommandRunner.VerifyWasCalled(Never()).Apply(Any[command.ProjectContext]())
 }
 
+func TestDriftApply_NonPRMutableRefChangedDuringApplyFailsClosed(t *testing.T) {
+	RegisterMockTestingT(t)
+	gmockCtrl := gomock.NewController(t)
+	logger := logging.NewNoopLogger(t)
+	baseRepo := models.Repo{
+		FullName: "owner/repo",
+		VCSHost: models.VCSHost{
+			Hostname: "github.com",
+			Type:     models.Github,
+		},
+	}
+
+	locker := NewMockLocker(gmockCtrl)
+	locker.EXPECT().UnlockByPull(baseRepo.FullName, gomock.Any()).Return(nil, nil).AnyTimes()
+	applyLockChecker := NewMockApplyLocker(gmockCtrl)
+	applyLockChecker.EXPECT().CheckApplyLock().Return(locking.ApplyCommandLock{}, nil)
+
+	workingDirLocker := NewMockWorkingDirLocker()
+	When(workingDirLocker.TryLock(Any[string](), Any[int](), Any[string](), Any[string](), Any[string](), Any[command.Name]())).
+		ThenReturn(func() {}, nil)
+	workingDir := NewMockWorkingDir()
+	repoDir, mainCommit, _, _ := initReachabilityGitRepo(t)
+	runRemediationGit(t, repoDir, "checkout", "-q", "main")
+	When(workingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Any[string]())).
+		ThenReturn(repoDir, nil)
+	When(workingDir.GetWorkingDir(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).
+		ThenReturn(repoDir, nil)
+	When(workingDir.Delete(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest]())).
+		ThenReturn(nil)
+
+	projectCommandBuilder := NewMockProjectCommandBuilder()
+	When(projectCommandBuilder.BuildPlanCommands(Any[*command.Context](), Any[*events.CommentCommand]())).
+		ThenReturn([]command.ProjectContext{{
+			CommandName: command.Plan,
+			ProjectName: "app",
+			RepoRelDir:  "app",
+			Workspace:   events.DefaultWorkspace,
+		}}, nil)
+	When(projectCommandBuilder.BuildApplyCommands(Any[*command.Context](), Any[*events.CommentCommand]())).
+		ThenReturn([]command.ProjectContext{{
+			CommandName: command.Apply,
+			ProjectName: "app",
+			RepoRelDir:  "app",
+			Workspace:   events.DefaultWorkspace,
+		}}, nil)
+
+	projectCommandRunner := NewMockProjectCommandRunner()
+	When(projectCommandRunner.Plan(Any[command.ProjectContext]())).ThenReturn(command.ProjectCommandOutput{
+		PlanSuccess: &models.PlanSuccess{TerraformOutput: "Plan: 1 to add, 0 to change, 0 to destroy."},
+	})
+	When(projectCommandRunner.Apply(Any[command.ProjectContext]())).Then(func([]Param) ReturnValues {
+		Ok(t, os.WriteFile(filepath.Join(repoDir, "main.tf"), []byte("resource \"null_resource\" \"changed\" {}\n"), 0600))
+		runRemediationGit(t, repoDir, "add", "main.tf")
+		runRemediationGit(t, repoDir, "commit", "-q", "-m", "advance main during apply")
+		runRemediationGit(t, repoDir, "push", "-q", "origin", "HEAD:main")
+		return ReturnValues{command.ProjectCommandOutput{ApplySuccess: "applied"}}
+	})
+
+	preWorkflowHooksCommandRunner := NewMockPreWorkflowHooksCommandRunner()
+	When(preWorkflowHooksCommandRunner.RunPreHooks(Any[*command.Context](), Any[*events.CommentCommand]())).ThenReturn(nil)
+	postWorkflowHooksCommandRunner := NewMockPostWorkflowHooksCommandRunner()
+	When(postWorkflowHooksCommandRunner.RunPostHooks(Any[*command.Context](), Any[*events.CommentCommand]())).ThenReturn(nil)
+	commitStatusUpdater := NewMockCommitStatusUpdater()
+	When(commitStatusUpdater.UpdateCombined(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Any[models.CommitStatus](), Any[command.Name]())).
+		ThenReturn(nil)
+
+	executor := &apiRemediationExecutor{
+		controller: &APIController{
+			Locker:                          locker,
+			ApplyLockChecker:                applyLockChecker,
+			Logger:                          logger,
+			Scope:                           metricstest.NewLoggingScope(t, logger, "null"),
+			ProjectCommandBuilder:           projectCommandBuilder,
+			ProjectPlanCommandRunner:        projectCommandRunner,
+			ProjectPolicyCheckCommandRunner: projectCommandRunner,
+			ProjectApplyCommandRunner:       projectCommandRunner,
+			PreWorkflowHooksCommandRunner:   preWorkflowHooksCommandRunner,
+			PostWorkflowHooksCommandRunner:  postWorkflowHooksCommandRunner,
+			WorkingDir:                      workingDir,
+			WorkingDirLocker:                workingDirLocker,
+			CommitStatusUpdater:             commitStatusUpdater,
+		},
+		baseRepo: baseRepo,
+		logger:   logger,
+	}
+
+	results, err := executor.ExecuteApplyProjects("owner/repo", "main", "Github", []models.ProjectDrift{{
+		ProjectName:    "app",
+		Path:           "app",
+		Workspace:      events.DefaultWorkspace,
+		Ref:            "main",
+		DetectionID:    "detect-1",
+		ResolvedCommit: mainCommit,
+		Drift:          models.DriftSummary{HasDrift: true},
+	}})
+
+	Assert(t, err != nil, "expected mutable ref movement to fail remediation apply")
+	Assert(t, strings.Contains(err.Error(), "changed"), "expected changed-ref error, got %v", err)
+	Equals(t, 1, len(results))
+	Equals(t, models.RemediationStatusFailed, results[0].Status)
+	projectCommandRunner.VerifyWasCalledOnce().Apply(Any[command.ProjectContext]())
+}
+
 func TestAPIRemediationExecutor_ExecuteApplyProjectsPolicyFailureSkipsApply(t *testing.T) {
 	RegisterMockTestingT(t)
 	gmockCtrl := gomock.NewController(t)

--- a/server/controllers/api_remediation_executor_internal_test.go
+++ b/server/controllers/api_remediation_executor_internal_test.go
@@ -1030,6 +1030,84 @@ func TestDriftApply_NonPRMutableRefChangedDuringApplyFailsClosed(t *testing.T) {
 	projectCommandRunner.VerifyWasCalledOnce().Apply(Any[command.ProjectContext]())
 }
 
+func TestDriftApply_NonPRReleaseBranchChangedNoProjectsFailsClosed(t *testing.T) {
+	RegisterMockTestingT(t)
+	gmockCtrl := gomock.NewController(t)
+	logger := logging.NewNoopLogger(t)
+	baseRepo := models.Repo{
+		FullName: "owner/repo",
+		VCSHost: models.VCSHost{
+			Hostname: "github.com",
+			Type:     models.Github,
+		},
+	}
+
+	locker := NewMockLocker(gmockCtrl)
+	locker.EXPECT().UnlockByPull(baseRepo.FullName, gomock.Any()).Return(nil, nil).AnyTimes()
+	applyLockChecker := NewMockApplyLocker(gmockCtrl)
+	applyLockChecker.EXPECT().CheckApplyLock().Return(locking.ApplyCommandLock{}, nil)
+	workingDirLocker := NewMockWorkingDirLocker()
+	When(workingDirLocker.TryLock(Any[string](), Any[int](), Any[string](), Any[string](), Any[string](), Any[command.Name]())).
+		ThenReturn(func() {}, nil)
+	workingDir := NewMockWorkingDir()
+	repoDir, _, _, _ := initReachabilityGitRepo(t)
+	releaseCommit := createRemediationGitBranch(t, repoDir, "release")
+	When(workingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Any[string]())).
+		ThenReturn(repoDir, nil)
+	When(workingDir.GetWorkingDir(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).
+		ThenReturn(repoDir, nil)
+	When(workingDir.Delete(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest]())).
+		ThenReturn(nil)
+
+	projectCommandBuilder := NewMockProjectCommandBuilder()
+	When(projectCommandBuilder.BuildPlanCommands(Any[*command.Context](), Any[*events.CommentCommand]())).
+		Then(func([]Param) ReturnValues {
+			advanceRemediationGitBranch(t, repoDir, "release")
+			return ReturnValues{[]command.ProjectContext{}, nil}
+		})
+	projectCommandRunner := NewMockProjectCommandRunner()
+	preWorkflowHooksCommandRunner := NewMockPreWorkflowHooksCommandRunner()
+	When(preWorkflowHooksCommandRunner.RunPreHooks(Any[*command.Context](), Any[*events.CommentCommand]())).ThenReturn(nil)
+	postWorkflowHooksCommandRunner := NewMockPostWorkflowHooksCommandRunner()
+	When(postWorkflowHooksCommandRunner.RunPostHooks(Any[*command.Context](), Any[*events.CommentCommand]())).ThenReturn(nil)
+	commitStatusUpdater := NewMockCommitStatusUpdater()
+	When(commitStatusUpdater.UpdateCombined(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Any[models.CommitStatus](), Any[command.Name]())).
+		ThenReturn(nil)
+
+	executor := &apiRemediationExecutor{
+		controller: &APIController{
+			Locker:                         locker,
+			ApplyLockChecker:               applyLockChecker,
+			Logger:                         logger,
+			Scope:                          metricstest.NewLoggingScope(t, logger, "null"),
+			ProjectCommandBuilder:          projectCommandBuilder,
+			ProjectPlanCommandRunner:       projectCommandRunner,
+			ProjectApplyCommandRunner:      projectCommandRunner,
+			PreWorkflowHooksCommandRunner:  preWorkflowHooksCommandRunner,
+			PostWorkflowHooksCommandRunner: postWorkflowHooksCommandRunner,
+			WorkingDir:                     workingDir,
+			WorkingDirLocker:               workingDirLocker,
+			CommitStatusUpdater:            commitStatusUpdater,
+		},
+		baseRepo: baseRepo,
+		logger:   logger,
+	}
+
+	results, err := executor.ExecuteApplyProjects("owner/repo", "release", "Github", []models.ProjectDrift{{
+		ProjectName:    "app",
+		Path:           "app",
+		Workspace:      events.DefaultWorkspace,
+		Ref:            "release",
+		ResolvedCommit: releaseCommit,
+		Drift:          models.DriftSummary{HasDrift: true},
+	}})
+
+	Assert(t, err != nil, "expected moved release ref to fail remediation apply")
+	Assert(t, strings.Contains(err.Error(), "changed"), "expected changed-ref error, got %v", err)
+	Equals(t, 0, len(results))
+	projectCommandRunner.VerifyWasCalled(Never()).Apply(Any[command.ProjectContext]())
+}
+
 func TestAPIRemediationExecutor_ExecuteApplyProjectsPolicyFailureSkipsApply(t *testing.T) {
 	RegisterMockTestingT(t)
 	gmockCtrl := gomock.NewController(t)
@@ -1332,6 +1410,24 @@ func initReachabilityGitRepo(t *testing.T) (string, string, string, string) {
 	unrelatedCommit := strings.TrimSpace(runRemediationGit(t, repoDir, "rev-parse", "HEAD"))
 
 	return repoDir, mainCommit, tagCommit, unrelatedCommit
+}
+
+func createRemediationGitBranch(t *testing.T, repoDir, branch string) string {
+	t.Helper()
+	runRemediationGit(t, repoDir, "checkout", "-q", "main")
+	runRemediationGit(t, repoDir, "checkout", "-q", "-b", branch)
+	runRemediationGit(t, repoDir, "push", "-q", "-u", "origin", branch)
+	return strings.TrimSpace(runRemediationGit(t, repoDir, "rev-parse", "HEAD"))
+}
+
+func advanceRemediationGitBranch(t *testing.T, repoDir, branch string) string {
+	t.Helper()
+	runRemediationGit(t, repoDir, "checkout", "-q", branch)
+	Ok(t, os.WriteFile(filepath.Join(repoDir, "main.tf"), []byte("resource \"null_resource\" \"release_changed\" {}\n"), 0600))
+	runRemediationGit(t, repoDir, "add", "main.tf")
+	runRemediationGit(t, repoDir, "commit", "-q", "-m", "advance "+branch)
+	runRemediationGit(t, repoDir, "push", "-q", "origin", "HEAD:"+branch)
+	return strings.TrimSpace(runRemediationGit(t, repoDir, "rev-parse", "HEAD"))
 }
 
 func remediationGitTempDir(t *testing.T) string {

--- a/server/controllers/api_remediation_executor_internal_test.go
+++ b/server/controllers/api_remediation_executor_internal_test.go
@@ -144,6 +144,65 @@ func TestSeedPullStatusFromPlanResultPreservesPlanStatusWhenPolicyCheckFollows(t
 	Equals(t, true, ctx.PullStatus.Projects[0].PolicyStatus[0].Passed)
 }
 
+func TestSeedPullStatusFromPlanResult_RecordsErroredPolicyCheckStatus(t *testing.T) {
+	ctx := &command.Context{}
+	seedPullStatusFromPlanResult(ctx, &command.Result{ProjectResults: []command.ProjectResult{
+		{
+			Command:     command.Plan,
+			ProjectName: "network",
+			RepoRelDir:  "network",
+			Workspace:   events.DefaultWorkspace,
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PlanSuccess: &models.PlanSuccess{TerraformOutput: "Plan: 1 to add, 0 to change, 0 to destroy."},
+			},
+		},
+		{
+			Command:     command.PolicyCheck,
+			ProjectName: "network",
+			RepoRelDir:  "network",
+			Workspace:   events.DefaultWorkspace,
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				Error: errors.New("policy check failed"),
+			},
+		},
+	}})
+
+	Assert(t, ctx.PullStatus != nil, "expected pull status to be initialized")
+	Equals(t, 1, len(ctx.PullStatus.Projects))
+	Equals(t, models.ErroredPolicyCheckStatus, ctx.PullStatus.Projects[0].Status)
+}
+
+func TestSeedPullStatusFromPlanResult_RecordsPassedPolicyCheckStatusForChangedPlan(t *testing.T) {
+	ctx := &command.Context{}
+	seedPullStatusFromPlanResult(ctx, &command.Result{ProjectResults: []command.ProjectResult{
+		{
+			Command:     command.Plan,
+			ProjectName: "network",
+			RepoRelDir:  "network",
+			Workspace:   events.DefaultWorkspace,
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PlanSuccess: &models.PlanSuccess{TerraformOutput: "Plan: 1 to add, 0 to change, 0 to destroy."},
+			},
+		},
+		{
+			Command:     command.PolicyCheck,
+			ProjectName: "network",
+			RepoRelDir:  "network",
+			Workspace:   events.DefaultWorkspace,
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PolicyCheckResults: &models.PolicyCheckResults{
+					PolicySetResults: []models.PolicySetResult{{PolicySetName: "default", Passed: true}},
+				},
+			},
+		},
+	}})
+
+	Assert(t, ctx.PullStatus != nil, "expected pull status to be initialized")
+	Equals(t, 1, len(ctx.PullStatus.Projects))
+	Equals(t, models.PassedPolicyCheckStatus, ctx.PullStatus.Projects[0].Status)
+	Equals(t, 1, len(ctx.PullStatus.Projects[0].PolicyStatus))
+}
+
 func TestVerifyNonPRBaseBranchReachabilityRedactsCredentialedFetchErrors(t *testing.T) {
 	logger := logging.NewNoopLogger(t)
 	repoDir := t.TempDir()

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1635,6 +1635,7 @@ func setupE2E(t *testing.T, repoDir string, opt setupOption) (events_controllers
 		parallelPoolSize,
 		silenceNoProjects,
 		false,
+		locker,
 		e2ePullReqStatusFetcher,
 		disableAutomergeLabel,
 	)

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1663,6 +1663,7 @@ func setupE2E(t *testing.T, repoDir string, opt setupOption) (events_controllers
 
 	importCommandRunner := events.NewImportCommandRunner(
 		pullUpdater,
+		dbUpdater,
 		e2ePullReqStatusFetcher,
 		projectCommandBuilder,
 		projectCommandRunner,
@@ -1671,6 +1672,7 @@ func setupE2E(t *testing.T, repoDir string, opt setupOption) (events_controllers
 
 	stateCommandRunner := events.NewStateCommandRunner(
 		pullUpdater,
+		dbUpdater,
 		projectCommandBuilder,
 		projectCommandRunner,
 	)

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1553,6 +1553,9 @@ func setupE2E(t *testing.T, repoDir string, opt setupOption) (events_controllers
 			WorkingDir: workingDir,
 		},
 		CancellationTracker: cancellationTracker,
+		ApplyPlanValidator: &events.DefaultApplyPlanValidator{
+			PullStatusFetcher: database,
+		},
 	}
 
 	dbUpdater := &events.DBUpdater{
@@ -1599,6 +1602,7 @@ func setupE2E(t *testing.T, repoDir string, opt setupOption) (events_controllers
 		e2eVCSClient,
 		&events.DefaultPendingPlanFinder{},
 		workingDir,
+		locker,
 		e2eStatusUpdater,
 		projectCommandBuilder,
 		projectCommandRunner,

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1637,6 +1637,7 @@ func setupE2E(t *testing.T, repoDir string, opt setupOption) (events_controllers
 		false,
 		locker,
 		e2ePullReqStatusFetcher,
+		nil,
 		disableAutomergeLabel,
 	)
 

--- a/server/core/boltdb/boltdb.go
+++ b/server/core/boltdb/boltdb.go
@@ -424,7 +424,7 @@ func (b *BoltDB) UpdatePullWithResults(pull models.PullRequest, newResults []com
 
 		// If there is no pull OR if the pull we have is out of date, we
 		// just write a new pull.
-		if currStatus == nil || currStatus.Pull.HeadCommit != pull.HeadCommit {
+		if currStatus == nil || pullStatusOutdatedForPull(currStatus.Pull, pull) {
 			var statuses []models.ProjectStatus
 			for _, r := range newResults {
 				statuses = append(statuses, b.projectResultToProject(r))
@@ -503,6 +503,13 @@ func (b *BoltDB) UpdatePullWithResults(pull models.PullRequest, newResults []com
 		return models.PullStatus{}, fmt.Errorf("DB transaction failed: %w", err)
 	}
 	return newStatus, nil
+}
+
+func pullStatusOutdatedForPull(statusPull models.PullRequest, pull models.PullRequest) bool {
+	if statusPull.HeadCommit != pull.HeadCommit {
+		return true
+	}
+	return statusPull.BaseBranch != "" && pull.BaseBranch != "" && statusPull.BaseBranch != pull.BaseBranch
 }
 
 // GetPullStatus returns the status for pull.

--- a/server/core/boltdb/boltdb.go
+++ b/server/core/boltdb/boltdb.go
@@ -457,7 +457,6 @@ func (b *BoltDB) UpdatePullWithResults(pull models.PullRequest, newResults []com
 			// in this command and so we don't want to delete our data about
 			// other projects that aren't affected by this command.
 			newStatus = *currStatus
-			backfillPullMetadata(&newStatus.Pull, pull)
 			for _, res := range newResults {
 				// First, check if we should update any existing projects.
 				updatedExisting := false
@@ -510,13 +509,10 @@ func pullStatusOutdatedForPull(statusPull models.PullRequest, pull models.PullRe
 	if statusPull.HeadCommit != pull.HeadCommit {
 		return true
 	}
-	return statusPull.BaseBranch != "" && pull.BaseBranch != "" && statusPull.BaseBranch != pull.BaseBranch
-}
-
-func backfillPullMetadata(statusPull *models.PullRequest, pull models.PullRequest) {
-	if statusPull.BaseBranch == "" && pull.BaseBranch != "" {
-		statusPull.BaseBranch = pull.BaseBranch
+	if pull.BaseBranch == "" {
+		return false
 	}
+	return statusPull.BaseBranch == "" || statusPull.BaseBranch != pull.BaseBranch
 }
 
 // GetPullStatus returns the status for pull.

--- a/server/core/boltdb/boltdb.go
+++ b/server/core/boltdb/boltdb.go
@@ -457,6 +457,7 @@ func (b *BoltDB) UpdatePullWithResults(pull models.PullRequest, newResults []com
 			// in this command and so we don't want to delete our data about
 			// other projects that aren't affected by this command.
 			newStatus = *currStatus
+			backfillPullMetadata(&newStatus.Pull, pull)
 			for _, res := range newResults {
 				// First, check if we should update any existing projects.
 				updatedExisting := false
@@ -510,6 +511,12 @@ func pullStatusOutdatedForPull(statusPull models.PullRequest, pull models.PullRe
 		return true
 	}
 	return statusPull.BaseBranch != "" && pull.BaseBranch != "" && statusPull.BaseBranch != pull.BaseBranch
+}
+
+func backfillPullMetadata(statusPull *models.PullRequest, pull models.PullRequest) {
+	if statusPull.BaseBranch == "" && pull.BaseBranch != "" {
+		statusPull.BaseBranch = pull.BaseBranch
+	}
 }
 
 // GetPullStatus returns the status for pull.

--- a/server/core/boltdb/boltdb_test.go
+++ b/server/core/boltdb/boltdb_test.go
@@ -913,7 +913,7 @@ func TestPullStatus_UpdateSameCommitNewBaseBranch(t *testing.T) {
 	b.Close()
 }
 
-func TestBoltDB_UpdateSameCommitBackfillsMissingBaseBranch(t *testing.T) {
+func TestBoltDB_SameCommitBackfillBaseDoesNotPromoteLegacyOldBaseProjects(t *testing.T) {
 	b := newTestDB2(t)
 
 	pull := models.PullRequest{
@@ -964,12 +964,19 @@ func TestBoltDB_UpdateSameCommitBackfillsMissingBaseBranch(t *testing.T) {
 
 	Ok(t, err)
 	Equals(t, "main", status.Pull.BaseBranch)
-	Equals(t, 2, len(status.Projects))
+	Equals(t, []models.ProjectStatus{
+		{
+			Workspace:   "staging",
+			RepoRelDir:  ".",
+			ProjectName: "",
+			Status:      models.PlannedPlanStatus,
+		},
+	}, status.Projects)
 
 	maybeStatus, err := b.GetPullStatus(pull)
 	Ok(t, err)
 	Equals(t, "main", maybeStatus.Pull.BaseBranch)
-	Equals(t, 2, len(maybeStatus.Projects))
+	Equals(t, status.Projects, maybeStatus.Projects)
 	b.Close()
 }
 

--- a/server/core/boltdb/boltdb_test.go
+++ b/server/core/boltdb/boltdb_test.go
@@ -846,6 +846,73 @@ func TestPullStatus_UpdateNewCommit(t *testing.T) {
 	b.Close()
 }
 
+func TestPullStatus_UpdateSameCommitNewBaseBranch(t *testing.T) {
+	b := newTestDB2(t)
+
+	pull := models.PullRequest{
+		Num:        1,
+		HeadCommit: "sha",
+		URL:        "url",
+		HeadBranch: "head",
+		BaseBranch: "base",
+		Author:     "lkysow",
+		State:      models.OpenPullState,
+		BaseRepo: models.Repo{
+			FullName:          "runatlantis/atlantis",
+			Owner:             "runatlantis",
+			Name:              "atlantis",
+			CloneURL:          "clone-url",
+			SanitizedCloneURL: "clone-url",
+			VCSHost: models.VCSHost{
+				Hostname: "github.com",
+				Type:     models.Github,
+			},
+		},
+	}
+	_, err := b.UpdatePullWithResults(
+		pull,
+		[]command.ProjectResult{
+			{
+				Command:    command.Plan,
+				RepoRelDir: "old-base",
+				Workspace:  "default",
+				ProjectCommandOutput: command.ProjectCommandOutput{
+					PlanSuccess: &models.PlanSuccess{},
+				},
+			},
+		})
+	Ok(t, err)
+
+	pull.BaseBranch = "release"
+	status, err := b.UpdatePullWithResults(pull,
+		[]command.ProjectResult{
+			{
+				Command:    command.Plan,
+				RepoRelDir: ".",
+				Workspace:  "staging",
+				ProjectCommandOutput: command.ProjectCommandOutput{
+					PlanSuccess: &models.PlanSuccess{},
+				},
+			},
+		})
+
+	Ok(t, err)
+	Equals(t, 1, len(status.Projects))
+
+	maybeStatus, err := b.GetPullStatus(pull)
+	Ok(t, err)
+	Equals(t, pull, maybeStatus.Pull)
+	Equals(t, []models.ProjectStatus{
+		{
+			Workspace:   "staging",
+			RepoRelDir:  ".",
+			ProjectName: "",
+			Status:      models.PlannedPlanStatus,
+		},
+	}, maybeStatus.Projects)
+	b.Close()
+}
+
 // Test that if we update an existing pull status via Apply and our new status is for a
 // the same commit, that we merge the statuses.
 func TestPullStatus_UpdateMerge_Apply(t *testing.T) {

--- a/server/core/boltdb/boltdb_test.go
+++ b/server/core/boltdb/boltdb_test.go
@@ -913,6 +913,66 @@ func TestPullStatus_UpdateSameCommitNewBaseBranch(t *testing.T) {
 	b.Close()
 }
 
+func TestBoltDB_UpdateSameCommitBackfillsMissingBaseBranch(t *testing.T) {
+	b := newTestDB2(t)
+
+	pull := models.PullRequest{
+		Num:        1,
+		HeadCommit: "sha",
+		URL:        "url",
+		HeadBranch: "head",
+		Author:     "lkysow",
+		State:      models.OpenPullState,
+		BaseRepo: models.Repo{
+			FullName:          "runatlantis/atlantis",
+			Owner:             "runatlantis",
+			Name:              "atlantis",
+			CloneURL:          "clone-url",
+			SanitizedCloneURL: "clone-url",
+			VCSHost: models.VCSHost{
+				Hostname: "github.com",
+				Type:     models.Github,
+			},
+		},
+	}
+	_, err := b.UpdatePullWithResults(
+		pull,
+		[]command.ProjectResult{
+			{
+				Command:    command.Plan,
+				RepoRelDir: "old-base",
+				Workspace:  "default",
+				ProjectCommandOutput: command.ProjectCommandOutput{
+					PlanSuccess: &models.PlanSuccess{},
+				},
+			},
+		})
+	Ok(t, err)
+
+	pull.BaseBranch = "main"
+	status, err := b.UpdatePullWithResults(pull,
+		[]command.ProjectResult{
+			{
+				Command:    command.Plan,
+				RepoRelDir: ".",
+				Workspace:  "staging",
+				ProjectCommandOutput: command.ProjectCommandOutput{
+					PlanSuccess: &models.PlanSuccess{},
+				},
+			},
+		})
+
+	Ok(t, err)
+	Equals(t, "main", status.Pull.BaseBranch)
+	Equals(t, 2, len(status.Projects))
+
+	maybeStatus, err := b.GetPullStatus(pull)
+	Ok(t, err)
+	Equals(t, "main", maybeStatus.Pull.BaseBranch)
+	Equals(t, 2, len(maybeStatus.Projects))
+	b.Close()
+}
+
 // Test that if we update an existing pull status via Apply and our new status is for a
 // the same commit, that we merge the statuses.
 func TestPullStatus_UpdateMerge_Apply(t *testing.T) {

--- a/server/core/redis/redis.go
+++ b/server/core/redis/redis.go
@@ -511,6 +511,7 @@ func (r *RedisDB) UpdatePullWithResults(pull models.PullRequest, newResults []co
 		// in this command and so we don't want to delete our data about
 		// other projects that aren't affected by this command.
 		newStatus = *currStatus
+		backfillPullMetadata(&newStatus.Pull, pull)
 		for _, res := range newResults {
 			// First, check if we should update any existing projects.
 			updatedExisting := false
@@ -563,6 +564,12 @@ func pullStatusOutdatedForPull(statusPull models.PullRequest, pull models.PullRe
 		return true
 	}
 	return statusPull.BaseBranch != "" && pull.BaseBranch != "" && statusPull.BaseBranch != pull.BaseBranch
+}
+
+func backfillPullMetadata(statusPull *models.PullRequest, pull models.PullRequest) {
+	if statusPull.BaseBranch == "" && pull.BaseBranch != "" {
+		statusPull.BaseBranch = pull.BaseBranch
+	}
 }
 
 func (r *RedisDB) getPull(key string) (*models.PullStatus, error) {

--- a/server/core/redis/redis.go
+++ b/server/core/redis/redis.go
@@ -511,7 +511,6 @@ func (r *RedisDB) UpdatePullWithResults(pull models.PullRequest, newResults []co
 		// in this command and so we don't want to delete our data about
 		// other projects that aren't affected by this command.
 		newStatus = *currStatus
-		backfillPullMetadata(&newStatus.Pull, pull)
 		for _, res := range newResults {
 			// First, check if we should update any existing projects.
 			updatedExisting := false
@@ -563,13 +562,10 @@ func pullStatusOutdatedForPull(statusPull models.PullRequest, pull models.PullRe
 	if statusPull.HeadCommit != pull.HeadCommit {
 		return true
 	}
-	return statusPull.BaseBranch != "" && pull.BaseBranch != "" && statusPull.BaseBranch != pull.BaseBranch
-}
-
-func backfillPullMetadata(statusPull *models.PullRequest, pull models.PullRequest) {
-	if statusPull.BaseBranch == "" && pull.BaseBranch != "" {
-		statusPull.BaseBranch = pull.BaseBranch
+	if pull.BaseBranch == "" {
+		return false
 	}
+	return statusPull.BaseBranch == "" || statusPull.BaseBranch != pull.BaseBranch
 }
 
 func (r *RedisDB) getPull(key string) (*models.PullStatus, error) {

--- a/server/core/redis/redis.go
+++ b/server/core/redis/redis.go
@@ -478,7 +478,7 @@ func (r *RedisDB) UpdatePullWithResults(pull models.PullRequest, newResults []co
 
 	// If there is no pull OR if the pull we have is out of date, we
 	// just write a new pull.
-	if currStatus == nil || currStatus.Pull.HeadCommit != pull.HeadCommit {
+	if currStatus == nil || pullStatusOutdatedForPull(currStatus.Pull, pull) {
 		var statuses []models.ProjectStatus
 		for _, res := range newResults {
 			statuses = append(statuses, r.projectResultToProject(res))
@@ -556,6 +556,13 @@ func (r *RedisDB) UpdatePullWithResults(pull models.PullRequest, newResults []co
 		return models.PullStatus{}, fmt.Errorf("db transaction failed: %w", err)
 	}
 	return newStatus, nil
+}
+
+func pullStatusOutdatedForPull(statusPull models.PullRequest, pull models.PullRequest) bool {
+	if statusPull.HeadCommit != pull.HeadCommit {
+		return true
+	}
+	return statusPull.BaseBranch != "" && pull.BaseBranch != "" && statusPull.BaseBranch != pull.BaseBranch
 }
 
 func (r *RedisDB) getPull(key string) (*models.PullStatus, error) {

--- a/server/core/redis/redis_test.go
+++ b/server/core/redis/redis_test.go
@@ -966,6 +966,66 @@ func TestPullStatus_UpdateSameCommitNewBaseBranch(t *testing.T) {
 	}, maybeStatus.Projects)
 }
 
+func TestRedis_UpdateSameCommitBackfillsMissingBaseBranch(t *testing.T) {
+	s := miniredis.RunT(t)
+	rdb := newTestRedis(s)
+
+	pull := models.PullRequest{
+		Num:        1,
+		HeadCommit: "sha",
+		URL:        "url",
+		HeadBranch: "head",
+		Author:     "lkysow",
+		State:      models.OpenPullState,
+		BaseRepo: models.Repo{
+			FullName:          "runatlantis/atlantis",
+			Owner:             "runatlantis",
+			Name:              "atlantis",
+			CloneURL:          "clone-url",
+			SanitizedCloneURL: "clone-url",
+			VCSHost: models.VCSHost{
+				Hostname: "github.com",
+				Type:     models.Github,
+			},
+		},
+	}
+	_, err := rdb.UpdatePullWithResults(
+		pull,
+		[]command.ProjectResult{
+			{
+				Command:    command.Plan,
+				RepoRelDir: "old-base",
+				Workspace:  "default",
+				ProjectCommandOutput: command.ProjectCommandOutput{
+					PlanSuccess: &models.PlanSuccess{},
+				},
+			},
+		})
+	Ok(t, err)
+
+	pull.BaseBranch = "main"
+	status, err := rdb.UpdatePullWithResults(pull,
+		[]command.ProjectResult{
+			{
+				Command:    command.Plan,
+				RepoRelDir: ".",
+				Workspace:  "staging",
+				ProjectCommandOutput: command.ProjectCommandOutput{
+					PlanSuccess: &models.PlanSuccess{},
+				},
+			},
+		})
+
+	Ok(t, err)
+	Equals(t, "main", status.Pull.BaseBranch)
+	Equals(t, 2, len(status.Projects))
+
+	maybeStatus, err := rdb.GetPullStatus(pull)
+	Ok(t, err)
+	Equals(t, "main", maybeStatus.Pull.BaseBranch)
+	Equals(t, 2, len(maybeStatus.Projects))
+}
+
 // Test that if we update an existing pull status via Apply and our new status is for a
 // the same commit, that we merge the statuses.
 func TestPullStatus_UpdateMerge_Apply(t *testing.T) {

--- a/server/core/redis/redis_test.go
+++ b/server/core/redis/redis_test.go
@@ -966,7 +966,7 @@ func TestPullStatus_UpdateSameCommitNewBaseBranch(t *testing.T) {
 	}, maybeStatus.Projects)
 }
 
-func TestRedis_UpdateSameCommitBackfillsMissingBaseBranch(t *testing.T) {
+func TestRedis_SameCommitBackfillBaseDoesNotPromoteLegacyOldBaseProjects(t *testing.T) {
 	s := miniredis.RunT(t)
 	rdb := newTestRedis(s)
 
@@ -1018,12 +1018,19 @@ func TestRedis_UpdateSameCommitBackfillsMissingBaseBranch(t *testing.T) {
 
 	Ok(t, err)
 	Equals(t, "main", status.Pull.BaseBranch)
-	Equals(t, 2, len(status.Projects))
+	Equals(t, []models.ProjectStatus{
+		{
+			Workspace:   "staging",
+			RepoRelDir:  ".",
+			ProjectName: "",
+			Status:      models.PlannedPlanStatus,
+		},
+	}, status.Projects)
 
 	maybeStatus, err := rdb.GetPullStatus(pull)
 	Ok(t, err)
 	Equals(t, "main", maybeStatus.Pull.BaseBranch)
-	Equals(t, 2, len(maybeStatus.Projects))
+	Equals(t, status.Projects, maybeStatus.Projects)
 }
 
 // Test that if we update an existing pull status via Apply and our new status is for a

--- a/server/core/redis/redis_test.go
+++ b/server/core/redis/redis_test.go
@@ -899,6 +899,73 @@ func TestPullStatus_UpdateNewCommit(t *testing.T) {
 	}, maybeStatus.Projects)
 }
 
+func TestPullStatus_UpdateSameCommitNewBaseBranch(t *testing.T) {
+	s := miniredis.RunT(t)
+	rdb := newTestRedis(s)
+
+	pull := models.PullRequest{
+		Num:        1,
+		HeadCommit: "sha",
+		URL:        "url",
+		HeadBranch: "head",
+		BaseBranch: "base",
+		Author:     "lkysow",
+		State:      models.OpenPullState,
+		BaseRepo: models.Repo{
+			FullName:          "runatlantis/atlantis",
+			Owner:             "runatlantis",
+			Name:              "atlantis",
+			CloneURL:          "clone-url",
+			SanitizedCloneURL: "clone-url",
+			VCSHost: models.VCSHost{
+				Hostname: "github.com",
+				Type:     models.Github,
+			},
+		},
+	}
+	_, err := rdb.UpdatePullWithResults(
+		pull,
+		[]command.ProjectResult{
+			{
+				Command:    command.Plan,
+				RepoRelDir: "old-base",
+				Workspace:  "default",
+				ProjectCommandOutput: command.ProjectCommandOutput{
+					PlanSuccess: &models.PlanSuccess{},
+				},
+			},
+		})
+	Ok(t, err)
+
+	pull.BaseBranch = "release"
+	status, err := rdb.UpdatePullWithResults(pull,
+		[]command.ProjectResult{
+			{
+				Command:    command.Plan,
+				RepoRelDir: ".",
+				Workspace:  "staging",
+				ProjectCommandOutput: command.ProjectCommandOutput{
+					PlanSuccess: &models.PlanSuccess{},
+				},
+			},
+		})
+
+	Ok(t, err)
+	Equals(t, 1, len(status.Projects))
+
+	maybeStatus, err := rdb.GetPullStatus(pull)
+	Ok(t, err)
+	Equals(t, pull, maybeStatus.Pull)
+	Equals(t, []models.ProjectStatus{
+		{
+			Workspace:   "staging",
+			RepoRelDir:  ".",
+			ProjectName: "",
+			Status:      models.PlannedPlanStatus,
+		},
+	}, maybeStatus.Projects)
+}
+
 // Test that if we update an existing pull status via Apply and our new status is for a
 // the same commit, that we merge the statuses.
 func TestPullStatus_UpdateMerge_Apply(t *testing.T) {

--- a/server/core/runtime/apply_step_runner.go
+++ b/server/core/runtime/apply_step_runner.go
@@ -197,7 +197,7 @@ func (a *ApplyStepRunner) runRemoteApply(
 	if err != nil {
 		updateStatusF(models.FailedCommitStatus, runURL)
 	} else {
-		updateStatusF(models.SuccessCommitStatus, runURL)
+		ctx.Log.Debug("remote apply succeeded; deferring success status until final apply freshness validation")
 	}
 	return output, err
 }

--- a/server/core/runtime/apply_step_runner.go
+++ b/server/core/runtime/apply_step_runner.go
@@ -159,6 +159,9 @@ func (a *ApplyStepRunner) runRemoteApply(
 			nextLineIsRunURL = true
 		} else if nextLineIsRunURL {
 			runURL = strings.TrimSpace(line.Line)
+			if ctx.RemoteApplyRunURL != nil {
+				*ctx.RemoteApplyRunURL = runURL
+			}
 			ctx.Log.Debug("remote run url found, updating commit status")
 			updateStatusF(models.PendingCommitStatus, runURL)
 			nextLineIsRunURL = false

--- a/server/core/runtime/apply_step_runner_test.go
+++ b/server/core/runtime/apply_step_runner_test.go
@@ -320,7 +320,7 @@ Apply complete! Resources: 0 added, 0 changed, 1 destroyed.
 	// Check that the status was updated with the run url.
 	runURL := "https://app.terraform.io/app/lkysow-enterprises/atlantis-tfe-test-dir2/runs/run-PiDsRYKGcerTttV2"
 	updater.VerifyWasCalledOnce().UpdateProject(ctx, command.Apply, models.PendingCommitStatus, runURL, nil)
-	updater.VerifyWasCalledOnce().UpdateProject(ctx, command.Apply, models.SuccessCommitStatus, runURL, nil)
+	updater.VerifyWasCalled(Never()).UpdateProject(ctx, command.Apply, models.SuccessCommitStatus, runURL, nil)
 }
 
 // Test that if the plan is different, we error out.

--- a/server/core/runtime/apply_step_runner_test.go
+++ b/server/core/runtime/apply_step_runner_test.go
@@ -293,12 +293,14 @@ Plan: 0 to add, 0 to change, 1 to destroy.`
 		CommitStatusUpdater: updater,
 	}
 	tfVersion, _ := version.NewVersion("0.11.0")
+	var remoteApplyRunURL string
 	ctx := command.ProjectContext{
 		Log:                logging.NewNoopLogger(t),
 		Workspace:          "workspace",
 		RepoRelDir:         ".",
 		EscapedCommentArgs: []string{"comment", "args"},
 		TerraformVersion:   tfVersion,
+		RemoteApplyRunURL:  &remoteApplyRunURL,
 	}
 	output, err := o.Run(ctx, []string{"extra", "args"}, tmpDir, map[string]string(nil))
 	<-tfExec.DoneCh
@@ -319,6 +321,7 @@ Apply complete! Resources: 0 added, 0 changed, 1 destroyed.
 
 	// Check that the status was updated with the run url.
 	runURL := "https://app.terraform.io/app/lkysow-enterprises/atlantis-tfe-test-dir2/runs/run-PiDsRYKGcerTttV2"
+	Equals(t, runURL, remoteApplyRunURL)
 	updater.VerifyWasCalledOnce().UpdateProject(ctx, command.Apply, models.PendingCommitStatus, runURL, nil)
 	updater.VerifyWasCalled(Never()).UpdateProject(ctx, command.Apply, models.SuccessCommitStatus, runURL, nil)
 }

--- a/server/events/api_ref_validator.go
+++ b/server/events/api_ref_validator.go
@@ -1,0 +1,109 @@
+// Copyright 2026 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package events
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/events/models"
+)
+
+// ValidateNonPRAPIRefUnchanged fails closed if a synthetic non-PR API apply was
+// planned against a mutable branch ref that has advanced since setup.
+func ValidateNonPRAPIRefUnchanged(ctx command.ProjectContext, repoDir string) error {
+	if !ctx.API || ctx.Pull.Num > 0 || repoDir == "" {
+		return nil
+	}
+	if _, err := os.Stat(filepath.Join(repoDir, ".git")); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("checking API checkout git metadata: %w", err)
+	}
+	headRef := strings.TrimSpace(ctx.Pull.HeadBranch)
+	if headRef == "" || isImmutableAPICommitRef(headRef) {
+		return nil
+	}
+	if !strings.HasPrefix(headRef, "refs/tags/") && models.RequiresBaseBranchForRef(headRef) {
+		return nil
+	}
+	resolved, err := resolveMutableAPIRef(repoDir, headRef)
+	if err != nil {
+		return err
+	}
+	if ctx.Pull.HeadCommit != "" && resolved != ctx.Pull.HeadCommit {
+		return fmt.Errorf("API ref %q changed from %s to %s while apply was running; rerun plan/apply for the current ref", headRef, shortAPICommit(ctx.Pull.HeadCommit), shortAPICommit(resolved))
+	}
+	return nil
+}
+
+func resolveMutableAPIRef(repoDir, ref string) (string, error) {
+	ref = strings.TrimSpace(ref)
+	if strings.HasPrefix(ref, "refs/tags/") {
+		if models.IsUnsafeAPIRef(ref) {
+			return "", fmt.Errorf("invalid API ref %q", ref)
+		}
+		remoteRef := ref
+		fetchRef := fmt.Sprintf("+%s:%s", ref, remoteRef)
+		cmd := exec.Command("git", "fetch", "origin", "--", fetchRef) //nolint:gosec // fetchRef is built from a refs/tags ref checked for unsafe forms.
+		cmd.Dir = repoDir
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("resolving API ref %q: %s: %w", ref, strings.TrimSpace(string(output)), err)
+		}
+		return checkedOutCommit(repoDir, remoteRef)
+	}
+
+	branchRef, ok := models.CheckedBaseBranchRef(ref)
+	if !ok {
+		return "", fmt.Errorf("invalid API ref %q", ref)
+	}
+	remoteRef := "refs/remotes/origin/" + branchRef
+	fetchRef := fmt.Sprintf("+refs/heads/%s:%s", branchRef, remoteRef)
+	cmd := exec.Command("git", "fetch", "origin", "--", fetchRef) //nolint:gosec // fetchRef is built from a validated branch ref.
+	cmd.Dir = repoDir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("resolving API ref %q: %s: %w", ref, strings.TrimSpace(string(output)), err)
+	}
+	return checkedOutCommit(repoDir, remoteRef)
+}
+
+func checkedOutCommit(repoDir string, ref string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", ref) //nolint:gosec // ref is either a local git ref built by Atlantis or a constant.
+	cmd.Dir = repoDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("resolving git ref %q: %s: %w", ref, strings.TrimSpace(string(output)), err)
+	}
+	commit := strings.TrimSpace(string(output))
+	if commit == "" {
+		return "", fmt.Errorf("resolving git ref %q: empty commit", ref)
+	}
+	return commit, nil
+}
+
+func isImmutableAPICommitRef(ref string) bool {
+	ref = strings.TrimSpace(ref)
+	if len(ref) < 7 || len(ref) > 40 {
+		return false
+	}
+	for _, r := range ref {
+		if (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func shortAPICommit(commit string) string {
+	if len(commit) > 12 {
+		return commit[:12]
+	}
+	return commit
+}

--- a/server/events/api_ref_validator.go
+++ b/server/events/api_ref_validator.go
@@ -29,9 +29,6 @@ func ValidateNonPRAPIRefUnchanged(ctx command.ProjectContext, repoDir string) er
 	if headRef == "" || isImmutableAPICommitRef(headRef) {
 		return nil
 	}
-	if !strings.HasPrefix(headRef, "refs/tags/") && models.RequiresBaseBranchForRef(headRef) {
-		return nil
-	}
 	resolved, err := resolveMutableAPIRef(repoDir, headRef)
 	if err != nil {
 		return err

--- a/server/events/api_ref_validator.go
+++ b/server/events/api_ref_validator.go
@@ -57,18 +57,18 @@ func hasGitMetadata(repoDir string) (bool, error) {
 
 func resolveMutableAPIRef(repoDir, ref string) (string, error) {
 	ref = strings.TrimSpace(ref)
-	if strings.HasPrefix(ref, "refs/tags/") {
-		if models.IsUnsafeAPIRef(ref) {
+	if tagName, ok := strings.CutPrefix(ref, "refs/tags/"); ok {
+		if _, ok := models.CheckedBaseBranchRef(tagName); !ok {
 			return "", fmt.Errorf("invalid API ref %q", ref)
 		}
-		remoteRef := ref
-		fetchRef := fmt.Sprintf("+%s:%s", ref, remoteRef)
+		remoteRef := "refs/tags/" + tagName
+		fetchRef := fmt.Sprintf("+%s:%s", remoteRef, remoteRef)
 		cmd := exec.Command("git", "fetch", "origin", "--", fetchRef) //nolint:gosec // fetchRef is built from a refs/tags ref checked for unsafe forms.
 		cmd.Dir = repoDir
 		if output, err := cmd.CombinedOutput(); err != nil {
 			return "", fmt.Errorf("resolving API ref %q: %s: %w", ref, strings.TrimSpace(string(output)), err)
 		}
-		return checkedOutCommit(repoDir, remoteRef)
+		return checkedOutCommit(repoDir, remoteRef+"^{commit}")
 	}
 
 	branchRef, ok := models.CheckedBaseBranchRef(ref)

--- a/server/events/api_ref_validator.go
+++ b/server/events/api_ref_validator.go
@@ -5,9 +5,7 @@ package events
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/runatlantis/atlantis/server/events/command"
@@ -20,11 +18,12 @@ func ValidateNonPRAPIRefUnchanged(ctx command.ProjectContext, repoDir string) er
 	if !ctx.API || ctx.Pull.Num > 0 || repoDir == "" {
 		return nil
 	}
-	if _, err := os.Stat(filepath.Join(repoDir, ".git")); err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("checking API checkout git metadata: %w", err)
+	gitMetadata, err := hasGitMetadata(repoDir)
+	if err != nil {
+		return err
+	}
+	if !gitMetadata {
+		return nil
 	}
 	headRef := strings.TrimSpace(ctx.Pull.HeadBranch)
 	if headRef == "" || isImmutableAPICommitRef(headRef) {
@@ -41,6 +40,19 @@ func ValidateNonPRAPIRefUnchanged(ctx command.ProjectContext, repoDir string) er
 		return fmt.Errorf("API ref %q changed from %s to %s while apply was running; rerun plan/apply for the current ref", headRef, shortAPICommit(ctx.Pull.HeadCommit), shortAPICommit(resolved))
 	}
 	return nil
+}
+
+func hasGitMetadata(repoDir string) (bool, error) {
+	cmd := exec.Command("git", "rev-parse", "--git-dir")
+	cmd.Dir = repoDir
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return strings.TrimSpace(string(output)) != "", nil
+	}
+	if strings.Contains(string(output), "not a git repository") {
+		return false, nil
+	}
+	return false, fmt.Errorf("checking API checkout git metadata: %s: %w", strings.TrimSpace(string(output)), err)
 }
 
 func resolveMutableAPIRef(repoDir, ref string) (string, error) {

--- a/server/events/api_ref_validator_test.go
+++ b/server/events/api_ref_validator_test.go
@@ -75,6 +75,22 @@ func TestValidateNonPRAPIRefUnchangedAllowsBareTagLikeRef(t *testing.T) {
 	}
 }
 
+func TestValidateNonPRAPIRefUnchangedAllowsNonGitDir(t *testing.T) {
+	ctx := command.ProjectContext{
+		Log: logging.NewNoopLogger(t),
+		API: true,
+		Pull: models.PullRequest{
+			Num:        -1,
+			HeadBranch: "main",
+			HeadCommit: strings.Repeat("a", 40),
+		},
+	}
+
+	if err := ValidateNonPRAPIRefUnchanged(ctx, t.TempDir()); err != nil {
+		t.Fatalf("expected non-git API dir to pass, got %v", err)
+	}
+}
+
 func initAPIRefValidatorGitRepo(t *testing.T) (string, string) {
 	t.Helper()
 	root := t.TempDir()

--- a/server/events/api_ref_validator_test.go
+++ b/server/events/api_ref_validator_test.go
@@ -58,7 +58,7 @@ func TestValidateNonPRAPIRefUnchangedAllowsImmutableSHA(t *testing.T) {
 
 func TestValidateNonPRAPIRefUnchangedAllowsBareTagLikeRef(t *testing.T) {
 	repoDir, initialCommit := initAPIRefValidatorGitRepo(t)
-	runAPIRefValidatorGit(t, repoDir, "tag", "v1.0.0", initialCommit)
+	createAPIRefValidatorGitBranch(t, repoDir, "v1.0.0", initialCommit)
 	advanceAPIRefValidatorGitMain(t, repoDir)
 	ctx := command.ProjectContext{
 		Log: logging.NewNoopLogger(t),
@@ -72,6 +72,78 @@ func TestValidateNonPRAPIRefUnchangedAllowsBareTagLikeRef(t *testing.T) {
 
 	if err := ValidateNonPRAPIRefUnchanged(ctx, repoDir); err != nil {
 		t.Fatalf("expected bare tag-like API ref to pass, got %v", err)
+	}
+}
+
+func TestValidateNonPRAPIRefUnchanged_BranchNamedReleaseIsRevalidated(t *testing.T) {
+	repoDir, initialCommit := initAPIRefValidatorGitRepo(t)
+	createAPIRefValidatorGitBranch(t, repoDir, "release", initialCommit)
+	advanceAPIRefValidatorGitBranch(t, repoDir, "release")
+	ctx := command.ProjectContext{
+		Log: logging.NewNoopLogger(t),
+		API: true,
+		Pull: models.PullRequest{
+			Num:        -1,
+			HeadBranch: "release",
+			HeadCommit: initialCommit,
+		},
+	}
+
+	err := ValidateNonPRAPIRefUnchanged(ctx, repoDir)
+
+	if err == nil {
+		t.Fatal("expected moved release branch to fail")
+	}
+	if !strings.Contains(err.Error(), "changed") {
+		t.Fatalf("expected changed-ref error, got %v", err)
+	}
+}
+
+func TestValidateNonPRAPIRefUnchanged_BranchNamedStableIsRevalidated(t *testing.T) {
+	repoDir, initialCommit := initAPIRefValidatorGitRepo(t)
+	createAPIRefValidatorGitBranch(t, repoDir, "stable", initialCommit)
+	advanceAPIRefValidatorGitBranch(t, repoDir, "stable")
+	ctx := command.ProjectContext{
+		Log: logging.NewNoopLogger(t),
+		API: true,
+		Pull: models.PullRequest{
+			Num:        -1,
+			HeadBranch: "stable",
+			HeadCommit: initialCommit,
+		},
+	}
+
+	err := ValidateNonPRAPIRefUnchanged(ctx, repoDir)
+
+	if err == nil {
+		t.Fatal("expected moved stable branch to fail")
+	}
+	if !strings.Contains(err.Error(), "changed") {
+		t.Fatalf("expected changed-ref error, got %v", err)
+	}
+}
+
+func TestValidateNonPRAPIRefUnchanged_TagLikeBranchNameIsRevalidated(t *testing.T) {
+	repoDir, initialCommit := initAPIRefValidatorGitRepo(t)
+	createAPIRefValidatorGitBranch(t, repoDir, "v1.2.3", initialCommit)
+	advanceAPIRefValidatorGitBranch(t, repoDir, "v1.2.3")
+	ctx := command.ProjectContext{
+		Log: logging.NewNoopLogger(t),
+		API: true,
+		Pull: models.PullRequest{
+			Num:        -1,
+			HeadBranch: "v1.2.3",
+			HeadCommit: initialCommit,
+		},
+	}
+
+	err := ValidateNonPRAPIRefUnchanged(ctx, repoDir)
+
+	if err == nil {
+		t.Fatal("expected moved tag-like branch to fail")
+	}
+	if !strings.Contains(err.Error(), "changed") {
+		t.Fatalf("expected changed-ref error, got %v", err)
 	}
 }
 
@@ -207,12 +279,32 @@ func initAPIRefValidatorGitRepo(t *testing.T) (string, string) {
 
 func advanceAPIRefValidatorGitMain(t *testing.T, repoDir string) string {
 	t.Helper()
+	runAPIRefValidatorGit(t, repoDir, "checkout", "-q", "main")
 	if err := os.WriteFile(filepath.Join(repoDir, "main.tf"), []byte("resource \"null_resource\" \"changed\" {}\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	runAPIRefValidatorGit(t, repoDir, "add", "main.tf")
 	runAPIRefValidatorGit(t, repoDir, "commit", "-q", "-m", "advance main")
 	runAPIRefValidatorGit(t, repoDir, "push", "-q", "origin", "HEAD:main")
+	return strings.TrimSpace(runAPIRefValidatorGit(t, repoDir, "rev-parse", "HEAD"))
+}
+
+func createAPIRefValidatorGitBranch(t *testing.T, repoDir string, branch string, commit string) {
+	t.Helper()
+	runAPIRefValidatorGit(t, repoDir, "checkout", "-q", "-B", branch, commit)
+	runAPIRefValidatorGit(t, repoDir, "push", "-q", "-u", "origin", "HEAD:"+branch)
+	runAPIRefValidatorGit(t, repoDir, "checkout", "-q", "main")
+}
+
+func advanceAPIRefValidatorGitBranch(t *testing.T, repoDir string, branch string) string {
+	t.Helper()
+	runAPIRefValidatorGit(t, repoDir, "checkout", "-q", branch)
+	if err := os.WriteFile(filepath.Join(repoDir, "main.tf"), []byte("resource \"null_resource\" \""+branch+"\" {}\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	runAPIRefValidatorGit(t, repoDir, "add", "main.tf")
+	runAPIRefValidatorGit(t, repoDir, "commit", "-q", "-m", "advance "+branch)
+	runAPIRefValidatorGit(t, repoDir, "push", "-q", "origin", "HEAD:"+branch)
 	return strings.TrimSpace(runAPIRefValidatorGit(t, repoDir, "rev-parse", "HEAD"))
 }
 

--- a/server/events/api_ref_validator_test.go
+++ b/server/events/api_ref_validator_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
@@ -252,7 +253,21 @@ func TestValidateNonPRAPIRefUnchangedAllowsNonGitDir(t *testing.T) {
 
 func initAPIRefValidatorGitRepo(t *testing.T) (string, string) {
 	t.Helper()
-	root := t.TempDir()
+	root, err := os.MkdirTemp("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		for range 10 {
+			if err := os.RemoveAll(root); err == nil || os.IsNotExist(err) {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		if err := os.RemoveAll(root); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("removing git fixture: %v", err)
+		}
+	})
 	originDir := filepath.Join(root, "origin.git")
 	repoDir := filepath.Join(root, "work")
 	runAPIRefValidatorGit(t, "", "init", "--bare", originDir)

--- a/server/events/api_ref_validator_test.go
+++ b/server/events/api_ref_validator_test.go
@@ -75,6 +75,93 @@ func TestValidateNonPRAPIRefUnchangedAllowsBareTagLikeRef(t *testing.T) {
 	}
 }
 
+func TestValidateNonPRAPIRefUnchanged_AnnotatedTagPeelsToCommit(t *testing.T) {
+	repoDir, initialCommit := initAPIRefValidatorGitRepo(t)
+	runAPIRefValidatorGit(t, repoDir, "tag", "-a", "v1.0.0", "-m", "release", initialCommit)
+	runAPIRefValidatorGit(t, repoDir, "push", "-q", "origin", "refs/tags/v1.0.0")
+	ctx := command.ProjectContext{
+		Log: logging.NewNoopLogger(t),
+		API: true,
+		Pull: models.PullRequest{
+			Num:        -1,
+			HeadBranch: "refs/tags/v1.0.0",
+			HeadCommit: initialCommit,
+		},
+	}
+
+	if err := ValidateNonPRAPIRefUnchanged(ctx, repoDir); err != nil {
+		t.Fatalf("expected annotated tag to peel to commit, got %v", err)
+	}
+}
+
+func TestValidateNonPRAPIRefUnchanged_LightweightTagStillMatches(t *testing.T) {
+	repoDir, initialCommit := initAPIRefValidatorGitRepo(t)
+	runAPIRefValidatorGit(t, repoDir, "tag", "lightweight", initialCommit)
+	runAPIRefValidatorGit(t, repoDir, "push", "-q", "origin", "refs/tags/lightweight")
+	ctx := command.ProjectContext{
+		Log: logging.NewNoopLogger(t),
+		API: true,
+		Pull: models.PullRequest{
+			Num:        -1,
+			HeadBranch: "refs/tags/lightweight",
+			HeadCommit: initialCommit,
+		},
+	}
+
+	if err := ValidateNonPRAPIRefUnchanged(ctx, repoDir); err != nil {
+		t.Fatalf("expected lightweight tag to match, got %v", err)
+	}
+}
+
+func TestValidateNonPRAPIRefUnchanged_AnnotatedTagChangedCommitFails(t *testing.T) {
+	repoDir, initialCommit := initAPIRefValidatorGitRepo(t)
+	runAPIRefValidatorGit(t, repoDir, "tag", "-a", "v1.0.0", "-m", "release", initialCommit)
+	runAPIRefValidatorGit(t, repoDir, "push", "-q", "origin", "refs/tags/v1.0.0")
+	advanceAPIRefValidatorGitMain(t, repoDir)
+	runAPIRefValidatorGit(t, repoDir, "tag", "-f", "-a", "v1.0.0", "-m", "release 2")
+	runAPIRefValidatorGit(t, repoDir, "push", "-q", "-f", "origin", "refs/tags/v1.0.0")
+	ctx := command.ProjectContext{
+		Log: logging.NewNoopLogger(t),
+		API: true,
+		Pull: models.PullRequest{
+			Num:        -1,
+			HeadBranch: "refs/tags/v1.0.0",
+			HeadCommit: initialCommit,
+		},
+	}
+
+	err := ValidateNonPRAPIRefUnchanged(ctx, repoDir)
+
+	if err == nil {
+		t.Fatal("expected moved annotated tag to fail")
+	}
+	if !strings.Contains(err.Error(), "changed") {
+		t.Fatalf("expected changed-ref error, got %v", err)
+	}
+}
+
+func TestValidateNonPRAPIRefUnchanged_UnsafeTagRefRejected(t *testing.T) {
+	repoDir, initialCommit := initAPIRefValidatorGitRepo(t)
+	ctx := command.ProjectContext{
+		Log: logging.NewNoopLogger(t),
+		API: true,
+		Pull: models.PullRequest{
+			Num:        -1,
+			HeadBranch: "refs/tags/../bad",
+			HeadCommit: initialCommit,
+		},
+	}
+
+	err := ValidateNonPRAPIRefUnchanged(ctx, repoDir)
+
+	if err == nil {
+		t.Fatal("expected unsafe tag ref to fail")
+	}
+	if !strings.Contains(err.Error(), "invalid API ref") {
+		t.Fatalf("expected invalid API ref error, got %v", err)
+	}
+}
+
 func TestValidateNonPRAPIRefUnchangedAllowsNonGitDir(t *testing.T) {
 	ctx := command.ProjectContext{
 		Log: logging.NewNoopLogger(t),
@@ -97,10 +184,16 @@ func initAPIRefValidatorGitRepo(t *testing.T) (string, string) {
 	originDir := filepath.Join(root, "origin.git")
 	repoDir := filepath.Join(root, "work")
 	runAPIRefValidatorGit(t, "", "init", "--bare", originDir)
+	runAPIRefValidatorGit(t, originDir, "config", "gc.auto", "0")
+	runAPIRefValidatorGit(t, originDir, "config", "maintenance.auto", "false")
+	runAPIRefValidatorGit(t, originDir, "config", "receive.autogc", "false")
 	runAPIRefValidatorGit(t, "", "init", "--initial-branch=main", repoDir)
+	runAPIRefValidatorGit(t, repoDir, "config", "gc.auto", "0")
+	runAPIRefValidatorGit(t, repoDir, "config", "maintenance.auto", "false")
 	runAPIRefValidatorGit(t, repoDir, "config", "user.email", "atlantisbot@runatlantis.io")
 	runAPIRefValidatorGit(t, repoDir, "config", "user.name", "atlantisbot")
 	runAPIRefValidatorGit(t, repoDir, "config", "commit.gpgsign", "false")
+	runAPIRefValidatorGit(t, repoDir, "config", "tag.gpgsign", "false")
 	if err := os.WriteFile(filepath.Join(repoDir, "main.tf"), []byte("resource \"null_resource\" \"main\" {}\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
@@ -125,8 +218,15 @@ func advanceAPIRefValidatorGitMain(t *testing.T, repoDir string) string {
 
 func runAPIRefValidatorGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
+	args = append([]string{
+		"-c", "protocol.file.allow=always",
+		"-c", "gc.auto=0",
+		"-c", "maintenance.auto=false",
+		"-c", "receive.autogc=false",
+	}, args...)
 	cmd := exec.Command("git", args...) //nolint:gosec
 	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null", "GIT_TERMINAL_PROMPT=0")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("running git %s: %s: %v", strings.Join(args, " "), output, err)

--- a/server/events/api_ref_validator_test.go
+++ b/server/events/api_ref_validator_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package events
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/logging"
+)
+
+func TestValidateNonPRAPIRefUnchangedFailsWhenMutableBranchMoves(t *testing.T) {
+	repoDir, initialCommit := initAPIRefValidatorGitRepo(t)
+	advanceAPIRefValidatorGitMain(t, repoDir)
+	ctx := command.ProjectContext{
+		Log: logging.NewNoopLogger(t),
+		API: true,
+		Pull: models.PullRequest{
+			Num:        -1,
+			HeadBranch: "main",
+			HeadCommit: initialCommit,
+		},
+	}
+
+	err := ValidateNonPRAPIRefUnchanged(ctx, repoDir)
+
+	if err == nil {
+		t.Fatal("expected mutable API ref change to fail")
+	}
+	if !strings.Contains(err.Error(), "changed") {
+		t.Fatalf("expected changed-ref error, got %v", err)
+	}
+}
+
+func TestValidateNonPRAPIRefUnchangedAllowsImmutableSHA(t *testing.T) {
+	repoDir, initialCommit := initAPIRefValidatorGitRepo(t)
+	advanceAPIRefValidatorGitMain(t, repoDir)
+	ctx := command.ProjectContext{
+		Log: logging.NewNoopLogger(t),
+		API: true,
+		Pull: models.PullRequest{
+			Num:        -1,
+			HeadBranch: initialCommit,
+			HeadCommit: initialCommit,
+		},
+	}
+
+	if err := ValidateNonPRAPIRefUnchanged(ctx, repoDir); err != nil {
+		t.Fatalf("expected immutable API SHA to pass, got %v", err)
+	}
+}
+
+func TestValidateNonPRAPIRefUnchangedAllowsBareTagLikeRef(t *testing.T) {
+	repoDir, initialCommit := initAPIRefValidatorGitRepo(t)
+	runAPIRefValidatorGit(t, repoDir, "tag", "v1.0.0", initialCommit)
+	advanceAPIRefValidatorGitMain(t, repoDir)
+	ctx := command.ProjectContext{
+		Log: logging.NewNoopLogger(t),
+		API: true,
+		Pull: models.PullRequest{
+			Num:        -1,
+			HeadBranch: "v1.0.0",
+			HeadCommit: initialCommit,
+		},
+	}
+
+	if err := ValidateNonPRAPIRefUnchanged(ctx, repoDir); err != nil {
+		t.Fatalf("expected bare tag-like API ref to pass, got %v", err)
+	}
+}
+
+func initAPIRefValidatorGitRepo(t *testing.T) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	originDir := filepath.Join(root, "origin.git")
+	repoDir := filepath.Join(root, "work")
+	runAPIRefValidatorGit(t, "", "init", "--bare", originDir)
+	runAPIRefValidatorGit(t, "", "init", "--initial-branch=main", repoDir)
+	runAPIRefValidatorGit(t, repoDir, "config", "user.email", "atlantisbot@runatlantis.io")
+	runAPIRefValidatorGit(t, repoDir, "config", "user.name", "atlantisbot")
+	runAPIRefValidatorGit(t, repoDir, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(repoDir, "main.tf"), []byte("resource \"null_resource\" \"main\" {}\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	runAPIRefValidatorGit(t, repoDir, "add", "main.tf")
+	runAPIRefValidatorGit(t, repoDir, "commit", "-q", "-m", "initial")
+	initialCommit := strings.TrimSpace(runAPIRefValidatorGit(t, repoDir, "rev-parse", "HEAD"))
+	runAPIRefValidatorGit(t, repoDir, "remote", "add", "origin", "file://"+originDir)
+	runAPIRefValidatorGit(t, repoDir, "push", "-q", "-u", "origin", "main")
+	return repoDir, initialCommit
+}
+
+func advanceAPIRefValidatorGitMain(t *testing.T, repoDir string) string {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(repoDir, "main.tf"), []byte("resource \"null_resource\" \"changed\" {}\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	runAPIRefValidatorGit(t, repoDir, "add", "main.tf")
+	runAPIRefValidatorGit(t, repoDir, "commit", "-q", "-m", "advance main")
+	runAPIRefValidatorGit(t, repoDir, "push", "-q", "origin", "HEAD:main")
+	return strings.TrimSpace(runAPIRefValidatorGit(t, repoDir, "rev-parse", "HEAD"))
+}
+
+func runAPIRefValidatorGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...) //nolint:gosec
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running git %s: %s: %v", strings.Join(args, " "), output, err)
+	}
+	return string(output)
+}

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -269,21 +269,20 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 		return
 	}
 
+	currentPull := applyPullWithLiveIdentity(pull, livePull)
+	if err := applyResultStatusUpdateError(result, pullStatus, pull, currentPull); err != nil {
+		ctx.Log.Warn("not publishing apply success status because %s", err)
+		ctx.CommandHasErrors = true
+		if statusErr := a.commitStatusUpdater.UpdateCombined(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, cmd.CommandName()); statusErr != nil {
+			ctx.Log.Warn("unable to update commit status: %s", statusErr)
+		}
+		return
+	}
+
 	a.updateCommitStatus(ctx, pullStatus)
 
-	if result.HasErrors() || applyResultHasStaleCommandHead(result.ProjectResults) {
+	if result.HasErrors() {
 		return
-	}
-	if err := pullStatusFreshnessError(pull, pullStatus.Pull, "recorded apply status"); err != nil {
-		ctx.Log.Warn("not automerging because %s", err)
-		return
-	}
-	currentPull := pull
-	if livePull.HeadCommit != "" {
-		currentPull.HeadCommit = livePull.HeadCommit
-		if livePull.BaseBranch != "" {
-			currentPull.BaseBranch = livePull.BaseBranch
-		}
 	}
 	if err := pullStatusFreshnessError(currentPull, pullStatus.Pull, "recorded apply status"); err != nil {
 		ctx.Log.Warn("not automerging because %s", err)
@@ -321,6 +320,40 @@ func livePullIdentityChangedDuringApply(before models.PullRequest, after models.
 			before.BaseBranch,
 			after.BaseBranch,
 		)
+	}
+	return nil
+}
+
+func applyPullWithLiveIdentity(pull models.PullRequest, livePull models.PullRequest) models.PullRequest {
+	currentPull := pull
+	if livePull.HeadCommit != "" {
+		currentPull.HeadCommit = livePull.HeadCommit
+	}
+	if livePull.BaseBranch != "" {
+		currentPull.BaseBranch = livePull.BaseBranch
+	}
+	return currentPull
+}
+
+func applyResultStatusUpdateError(result command.Result, pullStatus models.PullStatus, commandPull models.PullRequest, currentPull models.PullRequest) error {
+	if staleApplyResultForCurrentPull(commandPull, result.ProjectResults) && !pullStatusFreshForPull(commandPull, pullStatus.Pull) {
+		return fmt.Errorf(
+			"%w: apply result was for head %s base %q but recorded apply status is for head %s base %q",
+			errStaleCommandHead,
+			shortSHA(commandPull.HeadCommit),
+			commandPull.BaseBranch,
+			shortSHA(pullStatus.Pull.HeadCommit),
+			pullStatus.Pull.BaseBranch,
+		)
+	}
+	if applyResultHasStaleCommandHead(result.ProjectResults) {
+		return fmt.Errorf("%w: apply result is stale", errStaleCommandHead)
+	}
+	if err := pullStatusFreshnessError(currentPull, pullStatus.Pull, "recorded apply status"); err != nil {
+		return err
+	}
+	if result.HasErrors() && pullStatus.StatusCount(models.ErroredApplyStatus) == 0 {
+		return errors.New("apply result has errors but no errored apply status was recorded")
 	}
 	return nil
 }

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -244,6 +244,7 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 		ctx.Log.Warn("apply result is stale because %s", err)
 		ctx.CommandHasErrors = true
 		result.Error = err
+		a.publishDeferredApplyStatuses(projectCmds, result, models.FailedCommitStatus)
 		if statusErr := a.commitStatusUpdater.UpdateCombined(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, cmd.CommandName()); statusErr != nil {
 			ctx.Log.Warn("unable to update commit status: %s", statusErr)
 		}
@@ -268,12 +269,14 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 	if err := applyResultStatusUpdateError(result, pullStatus, pull, currentPull, preApplyPullStatus); err != nil {
 		ctx.Log.Warn("not publishing apply success status because %s", err)
 		ctx.CommandHasErrors = true
+		a.publishDeferredApplyStatuses(projectCmds, result, models.FailedCommitStatus)
 		if statusErr := a.commitStatusUpdater.UpdateCombined(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, cmd.CommandName()); statusErr != nil {
 			ctx.Log.Warn("unable to update commit status: %s", statusErr)
 		}
 		return
 	}
 
+	a.publishDeferredApplyStatuses(projectCmds, result, models.SuccessCommitStatus)
 	a.updateCommitStatus(ctx, pullStatus)
 
 	if result.HasErrors() {
@@ -297,6 +300,14 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 		}
 		a.autoMerger.automerge(ctx, pullStatus, a.autoMerger.deleteSourceBranchOnMergeEnabled(projectCmds), cmd.AutoMergeMethod)
 	}
+}
+
+func (a *ApplyCommandRunner) publishDeferredApplyStatuses(projectCmds []command.ProjectContext, result command.Result, status models.CommitStatus) {
+	publisher, ok := a.prjCmdRunner.(DeferredApplyStatusPublisher)
+	if !ok {
+		return
+	}
+	publisher.PublishDeferredApplyStatuses(projectCmds, result, status)
 }
 
 func livePullIdentityChangedDuringApply(before models.PullRequest, after models.PullRequest) error {

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -234,6 +234,28 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 	}
 
 	result := runProjectCmdsWithCancellationTracker(ctx, projectCmds, a.cancellationTracker, a.parallelPoolSize, a.isParallelEnabled(projectCmds), a.prjCmdRunner.Apply)
+	finalLivePull, err := a.refreshLivePullIdentity(ctx)
+	if err != nil {
+		ctx.Log.Err("fetching live pull request after apply: %s", err)
+		ctx.CommandHasErrors = true
+		result.Error = fmt.Errorf("fetching live pull request after apply: %w", err)
+		if statusErr := a.commitStatusUpdater.UpdateCombined(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, cmd.CommandName()); statusErr != nil {
+			ctx.Log.Warn("unable to update commit status: %s", statusErr)
+		}
+		a.pullUpdater.updatePull(ctx, cmd, result)
+		return
+	}
+	if err := livePullIdentityChangedDuringApply(livePull, finalLivePull); err != nil {
+		ctx.Log.Warn("apply result is stale because %s", err)
+		ctx.CommandHasErrors = true
+		result.Error = err
+		if statusErr := a.commitStatusUpdater.UpdateCombined(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, cmd.CommandName()); statusErr != nil {
+			ctx.Log.Warn("unable to update commit status: %s", statusErr)
+		}
+		a.pullUpdater.updatePull(ctx, cmd, result)
+		return
+	}
+	livePull = finalLivePull
 	ctx.CommandHasErrors = result.HasErrors()
 
 	a.pullUpdater.updatePull(
@@ -281,6 +303,26 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 		}
 		a.autoMerger.automerge(ctx, pullStatus, a.autoMerger.deleteSourceBranchOnMergeEnabled(projectCmds), cmd.AutoMergeMethod)
 	}
+}
+
+func livePullIdentityChangedDuringApply(before models.PullRequest, after models.PullRequest) error {
+	if before.HeadCommit != "" && after.HeadCommit != "" && before.HeadCommit != after.HeadCommit {
+		return fmt.Errorf(
+			"%w: pull request head changed from %s to %s while apply was running; run `atlantis plan` before apply",
+			errStaleCommandHead,
+			shortSHA(before.HeadCommit),
+			shortSHA(after.HeadCommit),
+		)
+	}
+	if before.BaseBranch != "" && after.BaseBranch != "" && before.BaseBranch != after.BaseBranch {
+		return fmt.Errorf(
+			"%w: pull request base branch changed from %q to %q while apply was running; run `atlantis plan` before apply",
+			errStaleCommandHead,
+			before.BaseBranch,
+			after.BaseBranch,
+		)
+	}
+	return nil
 }
 
 func applyResultHasStaleCommandHead(results []command.ProjectResult) bool {

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -233,6 +233,7 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 		a.updatePendingCommitStatus(ctx)
 	}
 
+	preApplyPullStatus := ctx.PullStatus
 	result := runProjectCmdsWithCancellationTracker(ctx, projectCmds, a.cancellationTracker, a.parallelPoolSize, a.isParallelEnabled(projectCmds), a.prjCmdRunner.Apply)
 	finalLivePull, err := a.refreshLivePullIdentity(ctx)
 	if err != nil {
@@ -270,7 +271,7 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 	}
 
 	currentPull := applyPullWithLiveIdentity(pull, livePull)
-	if err := applyResultStatusUpdateError(result, pullStatus, pull, currentPull); err != nil {
+	if err := applyResultStatusUpdateError(result, pullStatus, pull, currentPull, preApplyPullStatus); err != nil {
 		ctx.Log.Warn("not publishing apply success status because %s", err)
 		ctx.CommandHasErrors = true
 		if statusErr := a.commitStatusUpdater.UpdateCombined(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, cmd.CommandName()); statusErr != nil {
@@ -335,7 +336,15 @@ func applyPullWithLiveIdentity(pull models.PullRequest, livePull models.PullRequ
 	return currentPull
 }
 
-func applyResultStatusUpdateError(result command.Result, pullStatus models.PullStatus, commandPull models.PullRequest, currentPull models.PullRequest) error {
+func applyResultStatusUpdateError(result command.Result, pullStatus models.PullStatus, commandPull models.PullRequest, currentPull models.PullRequest, preApplyPullStatus *models.PullStatus) error {
+	if len(result.ProjectResults) == 0 {
+		if preApplyPullStatus == nil {
+			return errors.New("apply produced no project results and no recorded plan status was available")
+		}
+		if err := pullStatusApplyEligibilityError(currentPull, preApplyPullStatus.Pull, "recorded plan status"); err != nil {
+			return err
+		}
+	}
 	if staleApplyResultForCurrentPull(commandPull, result.ProjectResults) && !pullStatusFreshForPull(commandPull, pullStatus.Pull) {
 		return fmt.Errorf(
 			"%w: apply result was for head %s base %q but recorded apply status is for head %s base %q",
@@ -349,7 +358,7 @@ func applyResultStatusUpdateError(result command.Result, pullStatus models.PullS
 	if applyResultHasStaleCommandHead(result.ProjectResults) {
 		return fmt.Errorf("%w: apply result is stale", errStaleCommandHead)
 	}
-	if err := pullStatusFreshnessError(currentPull, pullStatus.Pull, "recorded apply status"); err != nil {
+	if err := pullStatusApplyEligibilityError(currentPull, pullStatus.Pull, "recorded apply status"); err != nil {
 		return err
 	}
 	if result.HasErrors() && pullStatus.StatusCount(models.ErroredApplyStatus) == 0 {

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -94,6 +94,9 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 	if a.ShouldSkipPreWorkflowHooks(ctx, cmd) {
 		return
 	}
+	if a.skipIgnoredTargetedDirBeforeApplyLocks(ctx, cmd) {
+		return
+	}
 
 	locked, err := a.IsLocked()
 	if err != nil {
@@ -149,18 +152,21 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 		a.pullUpdater.updatePull(ctx, cmd, command.Result{Error: fmt.Errorf("fetching current plan status: %w", err)})
 		return
 	}
-	liveHead, err := a.refreshLivePullHead(ctx)
+	livePull, err := a.refreshLivePullIdentity(ctx)
 	if err != nil {
-		ctx.Log.Err("fetching live pull request head: %s", err)
+		ctx.Log.Err("fetching live pull request: %s", err)
 		ctx.CommandHasErrors = true
 		if statusErr := a.commitStatusUpdater.UpdateCombined(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, cmd.CommandName()); statusErr != nil {
 			ctx.Log.Warn("unable to update commit status: %s", statusErr)
 		}
-		a.pullUpdater.updatePull(ctx, cmd, command.Result{Error: fmt.Errorf("fetching live pull request head: %w", err)})
+		a.pullUpdater.updatePull(ctx, cmd, command.Result{Error: fmt.Errorf("fetching live pull request: %w", err)})
 		return
 	}
-	if liveHead != "" && !cmd.IsForSpecificProject() {
-		ctx.Pull.HeadCommit = liveHead
+	if livePull.HeadCommit != "" && !cmd.IsForSpecificProject() {
+		ctx.Pull.HeadCommit = livePull.HeadCommit
+		if livePull.BaseBranch != "" {
+			ctx.Pull.BaseBranch = livePull.BaseBranch
+		}
 		pull = ctx.Pull
 	}
 
@@ -251,8 +257,11 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 		return
 	}
 	currentPull := pull
-	if liveHead != "" {
-		currentPull.HeadCommit = liveHead
+	if livePull.HeadCommit != "" {
+		currentPull.HeadCommit = livePull.HeadCommit
+		if livePull.BaseBranch != "" {
+			currentPull.BaseBranch = livePull.BaseBranch
+		}
 	}
 	if err := pullStatusFreshnessError(currentPull, pullStatus.Pull, "recorded apply status"); err != nil {
 		ctx.Log.Warn("not automerging because %s", err)
@@ -295,23 +304,23 @@ func (a *ApplyCommandRunner) refreshPullStatus(ctx *command.Context, pull models
 	return nil
 }
 
-func (a *ApplyCommandRunner) refreshLivePullHead(ctx *command.Context) (string, error) {
+func (a *ApplyCommandRunner) refreshLivePullIdentity(ctx *command.Context) (models.PullRequest, error) {
 	if a.livePullHeadFetcher == nil {
-		return "", nil
+		return models.PullRequest{}, nil
 	}
-	liveHead, err := a.livePullHeadFetcher.GetLiveHeadCommit(command.ProjectContext{
+	livePull, err := a.livePullHeadFetcher.GetLivePullIdentity(command.ProjectContext{
 		Log:        ctx.Log,
 		Pull:       ctx.Pull,
 		PullStatus: ctx.PullStatus,
 		API:        ctx.API,
 	})
 	if err != nil {
-		return "", err
+		return models.PullRequest{}, err
 	}
-	if liveHead == "" {
-		return "", fmt.Errorf("live pull request head is empty")
+	if livePull.HeadCommit == "" {
+		return models.PullRequest{}, fmt.Errorf("live pull request head is empty")
 	}
-	return liveHead, nil
+	return livePull, nil
 }
 
 func (a *ApplyCommandRunner) updatePendingCommitStatus(ctx *command.Context) {
@@ -326,6 +335,14 @@ func (a *ApplyCommandRunner) updatePendingCommitStatus(ctx *command.Context) {
 
 func (a *ApplyCommandRunner) ShouldSkipPreWorkflowHooks(ctx *command.Context, cmd *CommentCommand) bool {
 	return MarkCommandSkippedIfIgnoredTarget(ctx, command.Apply, cmd, a.prjCmdBuilder)
+}
+
+func (a *ApplyCommandRunner) skipIgnoredTargetedDirBeforeApplyLocks(ctx *command.Context, cmd *CommentCommand) bool {
+	if cmd.ProjectName != "" || cmd.RepoRelDir == "" {
+		return false
+	}
+	_, err := a.prjCmdBuilder.BuildApplyCommands(ctx, cmd)
+	return MarkCommandSkippedIfIgnoredTargetedDir(ctx, cmd.CommandName(), err)
 }
 
 func (a *ApplyCommandRunner) IsLocked() (bool, error) {

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -199,21 +199,15 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 	if len(projectCmds) == 0 && a.SilenceNoProjects {
 		ctx.Log.Info("determined there was no project to run plan in")
 		if !a.silenceVCSStatusNoProjects {
+			currentPull := applyPullWithLiveIdentity(pull, livePull)
+			pullStatus, err := a.currentNoProjectApplyPullStatus(ctx, pull, currentPull)
+			if err != nil {
+				ctx.Log.Warn("not publishing no-project apply success status because %s", err)
+				ctx.CommandHasErrors = true
+				return
+			}
 			if cmd.IsForSpecificProject() {
 				// With a specific apply, just reset the status so it's not stuck in pending state
-				pullStatus, err := a.Database.GetPullStatus(pull)
-				if err != nil {
-					ctx.Log.Warn("unable to fetch pull status: %s", err)
-					return
-				}
-				if pullStatus == nil {
-					// default to 0/0
-					ctx.Log.Debug("setting VCS status to 0/0 success as no previous state was found")
-					if err := a.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.Apply, models.ProjectCounts{}); err != nil {
-						ctx.Log.Warn("unable to update commit status: %s", err)
-					}
-					return
-				}
 				ctx.Log.Debug("resetting VCS status")
 				a.updateCommitStatus(ctx, *pullStatus)
 			} else {
@@ -374,6 +368,24 @@ func applyResultHasStaleCommandHead(results []command.ProjectResult) bool {
 		}
 	}
 	return false
+}
+
+func (a *ApplyCommandRunner) currentNoProjectApplyPullStatus(ctx *command.Context, pull models.PullRequest, currentPull models.PullRequest) (*models.PullStatus, error) {
+	pullStatus := ctx.PullStatus
+	if pullStatus == nil && a.Database != nil {
+		var err error
+		pullStatus, err = a.Database.GetPullStatus(pull)
+		if err != nil {
+			return nil, fmt.Errorf("fetching recorded plan status: %w", err)
+		}
+	}
+	if pullStatus == nil {
+		return nil, errors.New("no recorded plan status found")
+	}
+	if err := pullStatusApplyEligibilityError(currentPull, pullStatus.Pull, "recorded plan status"); err != nil {
+		return nil, err
+	}
+	return pullStatus, nil
 }
 
 func (a *ApplyCommandRunner) refreshPullStatus(ctx *command.Context, pull models.PullRequest) error {

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -4,6 +4,7 @@
 package events
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 
@@ -89,6 +90,10 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 
 	var projectCmds []command.ProjectContext
 	var projectCmdsErr error
+
+	if a.ShouldSkipPreWorkflowHooks(ctx, cmd) {
+		return
+	}
 
 	locked, err := a.IsLocked()
 	if err != nil {
@@ -238,6 +243,22 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 
 	a.updateCommitStatus(ctx, pullStatus)
 
+	if result.HasErrors() || applyResultHasStaleCommandHead(result.ProjectResults) {
+		return
+	}
+	if err := pullStatusFreshnessError(pull, pullStatus.Pull, "recorded apply status"); err != nil {
+		ctx.Log.Warn("not automerging because %s", err)
+		return
+	}
+	currentPull := pull
+	if liveHead != "" {
+		currentPull.HeadCommit = liveHead
+	}
+	if err := pullStatusFreshnessError(currentPull, pullStatus.Pull, "recorded apply status"); err != nil {
+		ctx.Log.Warn("not automerging because %s", err)
+		return
+	}
+
 	if a.autoMerger.automergeEnabled(projectCmds) && !cmd.AutoMergeDisabled {
 		if len(a.disableAutomergeLabel) > 0 {
 			labels, err := a.vcsClient.GetPullLabels(ctx.Log, baseRepo, pull)
@@ -251,6 +272,15 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 		}
 		a.autoMerger.automerge(ctx, pullStatus, a.autoMerger.deleteSourceBranchOnMergeEnabled(projectCmds), cmd.AutoMergeMethod)
 	}
+}
+
+func applyResultHasStaleCommandHead(results []command.ProjectResult) bool {
+	for _, result := range results {
+		if errors.Is(result.Error, errStaleCommandHead) {
+			return true
+		}
+	}
+	return false
 }
 
 func (a *ApplyCommandRunner) refreshPullStatus(ctx *command.Context, pull models.PullRequest) error {

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -28,6 +28,7 @@ func NewApplyCommandRunner(
 	parallelPoolSize int,
 	SilenceNoProjects bool,
 	silenceVCSStatusNoProjects bool,
+	workingDirLocker WorkingDirLocker,
 	pullReqStatusFetcher vcs.PullReqStatusFetcher,
 	disableAutomergeLabel string,
 ) *ApplyCommandRunner {
@@ -46,6 +47,7 @@ func NewApplyCommandRunner(
 		parallelPoolSize:           parallelPoolSize,
 		SilenceNoProjects:          SilenceNoProjects,
 		silenceVCSStatusNoProjects: silenceVCSStatusNoProjects,
+		workingDirLocker:           workingDirLocker,
 		pullReqStatusFetcher:       pullReqStatusFetcher,
 		disableAutomergeLabel:      disableAutomergeLabel,
 	}
@@ -64,6 +66,7 @@ type ApplyCommandRunner struct {
 	pullUpdater           *PullUpdater
 	dbUpdater             *DBUpdater
 	parallelPoolSize      int
+	workingDirLocker      WorkingDirLocker
 	pullReqStatusFetcher  vcs.PullReqStatusFetcher
 	disableAutomergeLabel string
 	// SilenceNoProjects is whether Atlantis should respond to PRs if no projects
@@ -128,6 +131,20 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 		}
 
 		return
+	}
+
+	var unlockPullApply func()
+	if !cmd.IsForSpecificProject() && a.workingDirLocker != nil {
+		unlockPullApply, err = a.workingDirLocker.TryLockPull(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, command.Apply)
+		if err != nil {
+			ctx.CommandHasErrors = true
+			if statusErr := a.commitStatusUpdater.UpdateCombined(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, cmd.CommandName()); statusErr != nil {
+				ctx.Log.Warn("unable to update commit status: %s", statusErr)
+			}
+			a.pullUpdater.updatePull(ctx, cmd, command.Result{Error: err})
+			return
+		}
+		defer unlockPullApply()
 	}
 
 	if !projectCmdsBuilt {

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -31,6 +31,7 @@ func NewApplyCommandRunner(
 	silenceVCSStatusNoProjects bool,
 	workingDirLocker WorkingDirLocker,
 	pullReqStatusFetcher vcs.PullReqStatusFetcher,
+	livePullHeadFetcher LivePullHeadFetcher,
 	disableAutomergeLabel string,
 ) *ApplyCommandRunner {
 	return &ApplyCommandRunner{
@@ -50,6 +51,7 @@ func NewApplyCommandRunner(
 		silenceVCSStatusNoProjects: silenceVCSStatusNoProjects,
 		workingDirLocker:           workingDirLocker,
 		pullReqStatusFetcher:       pullReqStatusFetcher,
+		livePullHeadFetcher:        livePullHeadFetcher,
 		disableAutomergeLabel:      disableAutomergeLabel,
 	}
 }
@@ -69,6 +71,7 @@ type ApplyCommandRunner struct {
 	parallelPoolSize      int
 	workingDirLocker      WorkingDirLocker
 	pullReqStatusFetcher  vcs.PullReqStatusFetcher
+	livePullHeadFetcher   LivePullHeadFetcher
 	disableAutomergeLabel string
 	// SilenceNoProjects is whether Atlantis should respond to PRs if no projects
 	// are found
@@ -141,6 +144,16 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 		a.pullUpdater.updatePull(ctx, cmd, command.Result{Error: fmt.Errorf("fetching current plan status: %w", err)})
 		return
 	}
+	if err := a.refreshLivePullHead(ctx); err != nil {
+		ctx.Log.Err("fetching live pull request head: %s", err)
+		ctx.CommandHasErrors = true
+		if statusErr := a.commitStatusUpdater.UpdateCombined(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, cmd.CommandName()); statusErr != nil {
+			ctx.Log.Warn("unable to update commit status: %s", statusErr)
+		}
+		a.pullUpdater.updatePull(ctx, cmd, command.Result{Error: fmt.Errorf("fetching live pull request head: %w", err)})
+		return
+	}
+	pull = ctx.Pull
 
 	// Get the mergeable status before we set any build statuses of our own.
 	// We do this here because when we set a "Pending" status, if users have
@@ -245,6 +258,26 @@ func (a *ApplyCommandRunner) refreshPullStatus(ctx *command.Context, pull models
 		return err
 	}
 	ctx.PullStatus = pullStatus
+	return nil
+}
+
+func (a *ApplyCommandRunner) refreshLivePullHead(ctx *command.Context) error {
+	if a.livePullHeadFetcher == nil {
+		return nil
+	}
+	liveHead, err := a.livePullHeadFetcher.GetLiveHeadCommit(command.ProjectContext{
+		Log:        ctx.Log,
+		Pull:       ctx.Pull,
+		PullStatus: ctx.PullStatus,
+		API:        ctx.API,
+	})
+	if err != nil {
+		return err
+	}
+	if liveHead == "" {
+		return fmt.Errorf("live pull request head is empty")
+	}
+	ctx.Pull.HeadCommit = liveHead
 	return nil
 }
 

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -4,6 +4,7 @@
 package events
 
 import (
+	"fmt"
 	"slices"
 
 	"github.com/runatlantis/atlantis/server/core/db"
@@ -84,23 +85,7 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 	pull := ctx.Pull
 
 	var projectCmds []command.ProjectContext
-	var projectCmdsBuilt bool
 	var projectCmdsErr error
-	if cmd.IsForSpecificProject() {
-		ctx.PullRequestStatus, err = a.pullReqStatusFetcher.FetchPullStatus(ctx.Log, pull)
-		if err != nil {
-			// On error we continue the request with mergeable assumed false.
-			// We want to continue because not all apply's will need this status,
-			// only if they rely on the mergeability requirement.
-			// All PullRequestStatus fields are set to false by default when error.
-			ctx.Log.Warn("unable to get pull request status: %s. Continuing with mergeable and approved assumed false", err)
-		}
-		projectCmds, projectCmdsErr = a.prjCmdBuilder.BuildApplyCommands(ctx, cmd)
-		projectCmdsBuilt = true
-		if MarkCommandSkippedIfIgnoredTargetedDir(ctx, cmd.CommandName(), projectCmdsErr) {
-			return
-		}
-	}
 
 	locked, err := a.IsLocked()
 	if err != nil {
@@ -134,7 +119,7 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 	}
 
 	var unlockPullApply func()
-	if !cmd.IsForSpecificProject() && a.workingDirLocker != nil {
+	if a.workingDirLocker != nil {
 		unlockPullApply, err = a.workingDirLocker.TryLockPull(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, command.Apply)
 		if err != nil {
 			ctx.CommandHasErrors = true
@@ -147,24 +132,32 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 		defer unlockPullApply()
 	}
 
-	if !projectCmdsBuilt {
-		// Get the mergeable status before we set any build statuses of our own.
-		// We do this here because when we set a "Pending" status, if users have
-		// required the Atlantis status checks to pass, then we've now changed
-		// the mergeability status of the pull request.
-		// This sets the approved, mergeable, and sqlocked status in the context.
-		ctx.PullRequestStatus, err = a.pullReqStatusFetcher.FetchPullStatus(ctx.Log, pull)
-		if err != nil {
-			// On error we continue the request with mergeable assumed false.
-			// We want to continue because not all apply's will need this status,
-			// only if they rely on the mergeability requirement.
-			// All PullRequestStatus fields are set to false by default when error.
-			ctx.Log.Warn("unable to get pull request status: %s. Continuing with mergeable and approved assumed false", err)
+	if err := a.refreshPullStatus(ctx, pull); err != nil {
+		ctx.Log.Err("fetching current plan status: %s", err)
+		ctx.CommandHasErrors = true
+		if statusErr := a.commitStatusUpdater.UpdateCombined(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, cmd.CommandName()); statusErr != nil {
+			ctx.Log.Warn("unable to update commit status: %s", statusErr)
 		}
-		projectCmds, projectCmdsErr = a.prjCmdBuilder.BuildApplyCommands(ctx, cmd)
-		if MarkCommandSkippedIfIgnoredTargetedDir(ctx, cmd.CommandName(), projectCmdsErr) {
-			return
-		}
+		a.pullUpdater.updatePull(ctx, cmd, command.Result{Error: fmt.Errorf("fetching current plan status: %w", err)})
+		return
+	}
+
+	// Get the mergeable status before we set any build statuses of our own.
+	// We do this here because when we set a "Pending" status, if users have
+	// required the Atlantis status checks to pass, then we've now changed
+	// the mergeability status of the pull request.
+	// This sets the approved, mergeable, and sqlocked status in the context.
+	ctx.PullRequestStatus, err = a.pullReqStatusFetcher.FetchPullStatus(ctx.Log, pull)
+	if err != nil {
+		// On error we continue the request with mergeable assumed false.
+		// We want to continue because not all apply's will need this status,
+		// only if they rely on the mergeability requirement.
+		// All PullRequestStatus fields are set to false by default when error.
+		ctx.Log.Warn("unable to get pull request status: %s. Continuing with mergeable and approved assumed false", err)
+	}
+	projectCmds, projectCmdsErr = a.prjCmdBuilder.BuildApplyCommands(ctx, cmd)
+	if MarkCommandSkippedIfIgnoredTargetedDir(ctx, cmd.CommandName(), projectCmdsErr) {
+		return
 	}
 	if projectCmdsErr != nil {
 		if statusErr := a.commitStatusUpdater.UpdateCombined(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, cmd.CommandName()); statusErr != nil {
@@ -241,6 +234,18 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 		}
 		a.autoMerger.automerge(ctx, pullStatus, a.autoMerger.deleteSourceBranchOnMergeEnabled(projectCmds), cmd.AutoMergeMethod)
 	}
+}
+
+func (a *ApplyCommandRunner) refreshPullStatus(ctx *command.Context, pull models.PullRequest) error {
+	if a.Database == nil {
+		return nil
+	}
+	pullStatus, err := a.Database.GetPullStatus(pull)
+	if err != nil {
+		return err
+	}
+	ctx.PullStatus = pullStatus
+	return nil
 }
 
 func (a *ApplyCommandRunner) updatePendingCommitStatus(ctx *command.Context) {

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -144,7 +144,8 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 		a.pullUpdater.updatePull(ctx, cmd, command.Result{Error: fmt.Errorf("fetching current plan status: %w", err)})
 		return
 	}
-	if err := a.refreshLivePullHead(ctx); err != nil {
+	liveHead, err := a.refreshLivePullHead(ctx)
+	if err != nil {
 		ctx.Log.Err("fetching live pull request head: %s", err)
 		ctx.CommandHasErrors = true
 		if statusErr := a.commitStatusUpdater.UpdateCombined(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, cmd.CommandName()); statusErr != nil {
@@ -153,7 +154,10 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 		a.pullUpdater.updatePull(ctx, cmd, command.Result{Error: fmt.Errorf("fetching live pull request head: %w", err)})
 		return
 	}
-	pull = ctx.Pull
+	if liveHead != "" && !cmd.IsForSpecificProject() {
+		ctx.Pull.HeadCommit = liveHead
+		pull = ctx.Pull
+	}
 
 	// Get the mergeable status before we set any build statuses of our own.
 	// We do this here because when we set a "Pending" status, if users have
@@ -261,9 +265,9 @@ func (a *ApplyCommandRunner) refreshPullStatus(ctx *command.Context, pull models
 	return nil
 }
 
-func (a *ApplyCommandRunner) refreshLivePullHead(ctx *command.Context) error {
+func (a *ApplyCommandRunner) refreshLivePullHead(ctx *command.Context) (string, error) {
 	if a.livePullHeadFetcher == nil {
-		return nil
+		return "", nil
 	}
 	liveHead, err := a.livePullHeadFetcher.GetLiveHeadCommit(command.ProjectContext{
 		Log:        ctx.Log,
@@ -272,13 +276,12 @@ func (a *ApplyCommandRunner) refreshLivePullHead(ctx *command.Context) error {
 		API:        ctx.API,
 	})
 	if err != nil {
-		return err
+		return "", err
 	}
 	if liveHead == "" {
-		return fmt.Errorf("live pull request head is empty")
+		return "", fmt.Errorf("live pull request head is empty")
 	}
-	ctx.Pull.HeadCommit = liveHead
-	return nil
+	return liveHead, nil
 }
 
 func (a *ApplyCommandRunner) updatePendingCommitStatus(ctx *command.Context) {

--- a/server/events/apply_command_runner_internal_test.go
+++ b/server/events/apply_command_runner_internal_test.go
@@ -152,6 +152,78 @@ func TestApplyCommandRunner_StaleCommandResultWithEmptyPullStatusDoesNotPublishZ
 	}
 }
 
+func TestApplyCommandRunner_NoPlanLegacyEmptyIdentityDoesNotPublishZeroZeroSuccess(t *testing.T) {
+	database, err := boltdb.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	legacyPull := models.PullRequest{
+		BaseRepo: testdata.GithubRepo,
+		State:    models.OpenPullState,
+		Num:      testdata.Pull.Num,
+	}
+	if _, err := database.UpdatePullWithResults(legacyPull, nil); err != nil {
+		t.Fatal(err)
+	}
+	vcsClient := &vcs.NotConfiguredVCSClient{Host: models.Github}
+	commitUpdater := &recordingApplyStatusUpdater{}
+	pullUpdater := &PullUpdater{
+		VCSClient:        vcsClient,
+		MarkdownRenderer: NewMarkdownRenderer(false, false, false, false, false, false, "", "atlantis", false, false),
+	}
+	runner := NewApplyCommandRunner(
+		vcsClient,
+		false,
+		unlockedApplyLockChecker{},
+		commitUpdater,
+		staticApplyCommandBuilder{},
+		staticProjectApplyRunner{},
+		NewCancellationTracker(),
+		&AutoMerger{VCSClient: vcsClient},
+		pullUpdater,
+		&DBUpdater{Database: database},
+		database,
+		1,
+		false,
+		false,
+		nil,
+		noopPullReqStatusFetcher{},
+		nil,
+		"",
+	)
+	pull := models.PullRequest{
+		BaseRepo:   testdata.GithubRepo,
+		State:      models.OpenPullState,
+		Num:        testdata.Pull.Num,
+		HeadCommit: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		BaseBranch: "release",
+	}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     pull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+
+	runner.Run(ctx, &CommentCommand{Name: command.Apply})
+
+	if !ctx.CommandHasErrors {
+		t.Fatal("expected legacy empty identity apply to mark the command as errored")
+	}
+	if containsCommitStatus(commitUpdater.combinedCount, models.SuccessCommitStatus) {
+		t.Fatal("expected no successful 0/0 apply count status for legacy empty identity")
+	}
+	if containsCommitStatus(commitUpdater.combined, models.SuccessCommitStatus) {
+		t.Fatal("expected no successful apply status for legacy empty identity")
+	}
+	if !containsCommitStatus(commitUpdater.combined, models.FailedCommitStatus) {
+		t.Fatal("expected failed apply status for legacy empty identity")
+	}
+}
+
 func containsCommitStatus(statuses []models.CommitStatus, expected models.CommitStatus) bool {
 	return slices.Contains(statuses, expected)
 }

--- a/server/events/apply_command_runner_internal_test.go
+++ b/server/events/apply_command_runner_internal_test.go
@@ -73,6 +73,179 @@ func (r staticProjectApplyRunner) Apply(command.ProjectContext) command.ProjectC
 	return r.output
 }
 
+type recordingDeferredApplyRunner struct {
+	output   command.ProjectCommandOutput
+	statuses []models.CommitStatus
+}
+
+func (r *recordingDeferredApplyRunner) Apply(command.ProjectContext) command.ProjectCommandOutput {
+	return r.output
+}
+
+func (r *recordingDeferredApplyRunner) PublishDeferredApplyStatuses(_ []command.ProjectContext, _ command.Result, status models.CommitStatus) {
+	r.statuses = append(r.statuses, status)
+}
+
+type sequenceApplyIdentityFetcher struct {
+	identities []models.PullRequest
+	calls      int
+}
+
+func (f *sequenceApplyIdentityFetcher) GetLivePullIdentity(command.ProjectContext) (models.PullRequest, error) {
+	if len(f.identities) == 0 {
+		return models.PullRequest{}, nil
+	}
+	idx := f.calls
+	if idx >= len(f.identities) {
+		idx = len(f.identities) - 1
+	}
+	f.calls++
+	return f.identities[idx], nil
+}
+
+func TestApplyCommandRunner_DeferredApplySuccessPublishesAfterFinalFreshness(t *testing.T) {
+	database, err := boltdb.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	pull := models.PullRequest{
+		BaseRepo:   testdata.GithubRepo,
+		State:      models.OpenPullState,
+		Num:        testdata.Pull.Num,
+		HeadCommit: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		BaseBranch: "main",
+	}
+	_, err = database.UpdatePullWithResults(pull, []command.ProjectResult{internalPlannedProjectResult("dirA", DefaultWorkspace, "projA")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deferredRunner := &recordingDeferredApplyRunner{output: command.ProjectCommandOutput{
+		ApplySuccess:    "applied",
+		ApplySuccessURL: "https://app.terraform.io/app/org/workspace/runs/run-123",
+	}}
+	runner := newInternalApplyCommandRunner(t, database, staticApplyCommandBuilder{commands: []command.ProjectContext{{
+		CommandName:       command.Apply,
+		RepoRelDir:        "dirA",
+		Workspace:         DefaultWorkspace,
+		ProjectName:       "projA",
+		ProjectPlanStatus: models.PlannedPlanStatus,
+		Pull:              pull,
+	}}}, deferredRunner, &sequenceApplyIdentityFetcher{identities: []models.PullRequest{pull, pull}})
+	ctx := newInternalApplyContext(t, pull)
+
+	runner.Run(ctx, &CommentCommand{Name: command.Apply, ProjectName: "projA"})
+
+	if ctx.CommandHasErrors {
+		t.Fatal("expected current apply to succeed")
+	}
+	if !containsCommitStatus(deferredRunner.statuses, models.SuccessCommitStatus) {
+		t.Fatalf("expected deferred project apply success after final freshness, got %v", deferredRunner.statuses)
+	}
+	if containsCommitStatus(deferredRunner.statuses, models.FailedCommitStatus) {
+		t.Fatalf("did not expect deferred failed project status for current apply, got %v", deferredRunner.statuses)
+	}
+}
+
+func TestApplyCommandRunner_DeferredApplySuccessFailsWhenFinalFreshnessFails(t *testing.T) {
+	database, err := boltdb.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	initialPull := models.PullRequest{
+		BaseRepo:   testdata.GithubRepo,
+		State:      models.OpenPullState,
+		Num:        testdata.Pull.Num,
+		HeadCommit: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		BaseBranch: "main",
+	}
+	finalPull := initialPull
+	finalPull.BaseBranch = "release"
+	_, err = database.UpdatePullWithResults(initialPull, []command.ProjectResult{internalPlannedProjectResult("dirA", DefaultWorkspace, "projA")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deferredRunner := &recordingDeferredApplyRunner{output: command.ProjectCommandOutput{
+		ApplySuccess:    "applied",
+		ApplySuccessURL: "https://app.terraform.io/app/org/workspace/runs/run-123",
+	}}
+	runner := newInternalApplyCommandRunner(t, database, staticApplyCommandBuilder{commands: []command.ProjectContext{{
+		CommandName:       command.Apply,
+		RepoRelDir:        "dirA",
+		Workspace:         DefaultWorkspace,
+		ProjectName:       "projA",
+		ProjectPlanStatus: models.PlannedPlanStatus,
+		Pull:              initialPull,
+	}}}, deferredRunner, &sequenceApplyIdentityFetcher{identities: []models.PullRequest{initialPull, finalPull}})
+	ctx := newInternalApplyContext(t, initialPull)
+
+	runner.Run(ctx, &CommentCommand{Name: command.Apply, ProjectName: "projA"})
+
+	if !ctx.CommandHasErrors {
+		t.Fatal("expected final freshness failure to mark the command as errored")
+	}
+	if containsCommitStatus(deferredRunner.statuses, models.SuccessCommitStatus) {
+		t.Fatalf("expected no deferred project apply success for stale final identity, got %v", deferredRunner.statuses)
+	}
+	if !containsCommitStatus(deferredRunner.statuses, models.FailedCommitStatus) {
+		t.Fatalf("expected deferred project apply failure for stale final identity, got %v", deferredRunner.statuses)
+	}
+}
+
+func newInternalApplyCommandRunner(t *testing.T, database *boltdb.BoltDB, builder ProjectApplyCommandBuilder, projectRunner ProjectApplyCommandRunner, liveFetcher LivePullHeadFetcher) *ApplyCommandRunner {
+	t.Helper()
+	vcsClient := &vcs.NotConfiguredVCSClient{Host: models.Github}
+	pullUpdater := &PullUpdater{
+		VCSClient:        vcsClient,
+		MarkdownRenderer: NewMarkdownRenderer(false, false, false, false, false, false, "", "atlantis", false, false),
+	}
+	return NewApplyCommandRunner(
+		vcsClient,
+		false,
+		unlockedApplyLockChecker{},
+		&recordingApplyStatusUpdater{},
+		builder,
+		projectRunner,
+		NewCancellationTracker(),
+		&AutoMerger{VCSClient: vcsClient},
+		pullUpdater,
+		&DBUpdater{Database: database},
+		database,
+		1,
+		false,
+		false,
+		nil,
+		noopPullReqStatusFetcher{},
+		liveFetcher,
+		"",
+	)
+}
+
+func newInternalApplyContext(t *testing.T, pull models.PullRequest) *command.Context {
+	t.Helper()
+	return &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     pull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+}
+
+func internalPlannedProjectResult(repoRelDir, workspace, projectName string) command.ProjectResult {
+	return command.ProjectResult{
+		Command:     command.Plan,
+		RepoRelDir:  repoRelDir,
+		Workspace:   workspace,
+		ProjectName: projectName,
+		ProjectCommandOutput: command.ProjectCommandOutput{
+			PlanSuccess: &models.PlanSuccess{TerraformOutput: "Plan: 1 to add, 0 to change, 0 to destroy."},
+		},
+	}
+}
+
 func TestApplyCommandRunner_StaleCommandResultWithEmptyPullStatusDoesNotPublishZeroZeroSuccess(t *testing.T) {
 	database, err := boltdb.New(t.TempDir())
 	if err != nil {

--- a/server/events/apply_command_runner_internal_test.go
+++ b/server/events/apply_command_runner_internal_test.go
@@ -224,6 +224,75 @@ func TestApplyCommandRunner_NoPlanLegacyEmptyIdentityDoesNotPublishZeroZeroSucce
 	}
 }
 
+func TestApplyCommandRunner_SilencedNoProjectLegacyEmptyIdentityDoesNotPublishZeroZeroSuccess(t *testing.T) {
+	database, err := boltdb.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	legacyPull := models.PullRequest{
+		BaseRepo: testdata.GithubRepo,
+		State:    models.OpenPullState,
+		Num:      testdata.Pull.Num,
+	}
+	if _, err := database.UpdatePullWithResults(legacyPull, nil); err != nil {
+		t.Fatal(err)
+	}
+	vcsClient := &vcs.NotConfiguredVCSClient{Host: models.Github}
+	commitUpdater := &recordingApplyStatusUpdater{}
+	pullUpdater := &PullUpdater{
+		VCSClient:        vcsClient,
+		MarkdownRenderer: NewMarkdownRenderer(false, false, false, false, false, false, "", "atlantis", false, false),
+	}
+	runner := NewApplyCommandRunner(
+		vcsClient,
+		false,
+		unlockedApplyLockChecker{},
+		commitUpdater,
+		staticApplyCommandBuilder{},
+		staticProjectApplyRunner{},
+		NewCancellationTracker(),
+		&AutoMerger{VCSClient: vcsClient},
+		pullUpdater,
+		&DBUpdater{Database: database},
+		database,
+		1,
+		true,
+		false,
+		nil,
+		noopPullReqStatusFetcher{},
+		nil,
+		"",
+	)
+	pull := models.PullRequest{
+		BaseRepo:   testdata.GithubRepo,
+		State:      models.OpenPullState,
+		Num:        testdata.Pull.Num,
+		HeadCommit: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		BaseBranch: "release",
+	}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     pull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+
+	runner.Run(ctx, &CommentCommand{Name: command.Apply, RepoRelDir: "missing"})
+
+	if !ctx.CommandHasErrors {
+		t.Fatal("expected legacy empty identity apply to mark the command as errored")
+	}
+	if containsCommitStatus(commitUpdater.combinedCount, models.SuccessCommitStatus) {
+		t.Fatal("expected no successful 0/0 apply count status for silenced legacy empty identity")
+	}
+	if containsCommitStatus(commitUpdater.combined, models.SuccessCommitStatus) {
+		t.Fatal("expected no successful apply status for silenced legacy empty identity")
+	}
+}
+
 func containsCommitStatus(statuses []models.CommitStatus, expected models.CommitStatus) bool {
 	return slices.Contains(statuses, expected)
 }

--- a/server/events/apply_command_runner_internal_test.go
+++ b/server/events/apply_command_runner_internal_test.go
@@ -1,0 +1,157 @@
+// Copyright 2026 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package events
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/core/boltdb"
+	"github.com/runatlantis/atlantis/server/core/locking"
+	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/events/models/testdata"
+	"github.com/runatlantis/atlantis/server/events/vcs"
+	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/runatlantis/atlantis/server/metrics/metricstest"
+)
+
+type unlockedApplyLockChecker struct{}
+
+func (unlockedApplyLockChecker) CheckApplyLock() (locking.ApplyCommandLock, error) {
+	return locking.ApplyCommandLock{}, nil
+}
+
+type noopPullReqStatusFetcher struct{}
+
+func (noopPullReqStatusFetcher) FetchPullStatus(logging.SimpleLogging, models.PullRequest) (models.PullReqStatus, error) {
+	return models.PullReqStatus{}, nil
+}
+
+type recordingApplyStatusUpdater struct {
+	combined      []models.CommitStatus
+	combinedCount []models.CommitStatus
+}
+
+func (u *recordingApplyStatusUpdater) UpdateCombined(_ logging.SimpleLogging, _ models.Repo, _ models.PullRequest, status models.CommitStatus, _ command.Name) error {
+	u.combined = append(u.combined, status)
+	return nil
+}
+
+func (u *recordingApplyStatusUpdater) UpdateCombinedCount(_ logging.SimpleLogging, _ models.Repo, _ models.PullRequest, status models.CommitStatus, _ command.Name, _ models.ProjectCounts) error {
+	u.combinedCount = append(u.combinedCount, status)
+	return nil
+}
+
+func (*recordingApplyStatusUpdater) UpdatePreWorkflowHook(logging.SimpleLogging, models.PullRequest, models.CommitStatus, string, string, string) error {
+	return nil
+}
+
+func (*recordingApplyStatusUpdater) UpdatePostWorkflowHook(logging.SimpleLogging, models.PullRequest, models.CommitStatus, string, string, string) error {
+	return nil
+}
+
+type staticApplyCommandBuilder struct {
+	commands []command.ProjectContext
+}
+
+func (b staticApplyCommandBuilder) BuildApplyCommands(*command.Context, *CommentCommand) ([]command.ProjectContext, error) {
+	return b.commands, nil
+}
+
+func (staticApplyCommandBuilder) ShouldIgnoreTargetedDir(*command.Context, *CommentCommand) bool {
+	return false
+}
+
+type staticProjectApplyRunner struct {
+	output command.ProjectCommandOutput
+}
+
+func (r staticProjectApplyRunner) Apply(command.ProjectContext) command.ProjectCommandOutput {
+	return r.output
+}
+
+func TestApplyCommandRunner_StaleCommandResultWithEmptyPullStatusDoesNotPublishZeroZeroSuccess(t *testing.T) {
+	database, err := boltdb.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	vcsClient := &vcs.NotConfiguredVCSClient{Host: models.Github}
+	commitUpdater := &recordingApplyStatusUpdater{}
+	pullUpdater := &PullUpdater{
+		VCSClient:        vcsClient,
+		MarkdownRenderer: NewMarkdownRenderer(false, false, false, false, false, false, "", "atlantis", false, false),
+	}
+	runner := NewApplyCommandRunner(
+		vcsClient,
+		false,
+		unlockedApplyLockChecker{},
+		commitUpdater,
+		staticApplyCommandBuilder{commands: []command.ProjectContext{{
+			CommandName: command.Apply,
+			RepoRelDir:  "dirA",
+			Workspace:   DefaultWorkspace,
+			ProjectName: "projA",
+			Pull: models.PullRequest{
+				BaseRepo:   testdata.GithubRepo,
+				State:      models.OpenPullState,
+				Num:        testdata.Pull.Num,
+				HeadCommit: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+				BaseBranch: "main",
+			},
+		}}},
+		staticProjectApplyRunner{output: command.ProjectCommandOutput{
+			Error: fmt.Errorf("%w: pull request base branch changed", errStaleCommandHead),
+		}},
+		NewCancellationTracker(),
+		&AutoMerger{VCSClient: vcsClient},
+		pullUpdater,
+		&DBUpdater{Database: database},
+		database,
+		1,
+		false,
+		false,
+		nil,
+		noopPullReqStatusFetcher{},
+		nil,
+		"",
+	)
+	pull := models.PullRequest{
+		BaseRepo:   testdata.GithubRepo,
+		State:      models.OpenPullState,
+		Num:        testdata.Pull.Num,
+		HeadCommit: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		BaseBranch: "main",
+	}
+	cmd := &CommentCommand{Name: command.Apply, ProjectName: "projA"}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     pull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+
+	runner.Run(ctx, cmd)
+
+	if !ctx.CommandHasErrors {
+		t.Fatal("expected stale apply to mark the command as errored")
+	}
+	if containsCommitStatus(commitUpdater.combinedCount, models.SuccessCommitStatus) {
+		t.Fatal("expected no successful apply count status for stale command result")
+	}
+	if containsCommitStatus(commitUpdater.combined, models.SuccessCommitStatus) {
+		t.Fatal("expected no successful apply status for stale command result")
+	}
+	if !containsCommitStatus(commitUpdater.combined, models.FailedCommitStatus) {
+		t.Fatal("expected failed apply status for stale command result")
+	}
+}
+
+func containsCommitStatus(statuses []models.CommitStatus, expected models.CommitStatus) bool {
+	return slices.Contains(statuses, expected)
+}

--- a/server/events/apply_command_runner_test.go
+++ b/server/events/apply_command_runner_test.go
@@ -367,6 +367,74 @@ func TestApplyCommandRunner_RefreshesPullStatusAfterApplyLock(t *testing.T) {
 	Assert(t, !ctx.CommandHasErrors, "expected refreshed PullStatus apply to succeed")
 }
 
+func TestApplyCommandRunner_GenericApplyUsesLiveHeadForBuilderValidation(t *testing.T) {
+	database := newTestBoltDB(t)
+	oldHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	liveHead := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	setup(t, func(tc *TestConfig) {
+		tc.database = database
+		tc.livePullHeadFetcher = fakeLivePullHeadFetcher{head: liveHead}
+	})
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: liveHead}
+	_, err := database.UpdatePullWithResults(modelPull, []command.ProjectResult{plannedProjectResult("dirA", events.DefaultWorkspace, "projA")})
+	Ok(t, err)
+	cmd := &events.CommentCommand{Name: command.Apply}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: oldHead},
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).Then(func([]Param) ReturnValues {
+		Equals(t, liveHead, ctx.Pull.HeadCommit)
+		Equals(t, liveHead, ctx.PullStatus.Pull.HeadCommit)
+		return ReturnValues{[]command.ProjectContext{}, nil}
+	})
+
+	applyCommandRunner.Run(ctx, cmd)
+
+	Assert(t, !ctx.CommandHasErrors, "expected live-head refreshed apply build to succeed")
+}
+
+func TestApplyCommandRunner_GenericApplyDoesNotRejectCurrentPlanAfterPullStatusRefresh(t *testing.T) {
+	database := newTestBoltDB(t)
+	oldHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	liveHead := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	setup(t, func(tc *TestConfig) {
+		tc.database = database
+		tc.livePullHeadFetcher = fakeLivePullHeadFetcher{head: liveHead}
+	})
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: liveHead}
+	_, err := database.UpdatePullWithResults(modelPull, []command.ProjectResult{plannedProjectResult("dirA", events.DefaultWorkspace, "projA")})
+	Ok(t, err)
+	cmd := &events.CommentCommand{Name: command.Apply}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: oldHead},
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).Then(func([]Param) ReturnValues {
+		err := events.ValidatePlansForApply(ctx, []events.PendingPlan{{
+			RepoRelDir:  "dirA",
+			Workspace:   events.DefaultWorkspace,
+			ProjectName: "projA",
+		}})
+		if err != nil {
+			return ReturnValues{nil, err}
+		}
+		return ReturnValues{[]command.ProjectContext{}, nil}
+	})
+
+	applyCommandRunner.Run(ctx, cmd)
+
+	Assert(t, !ctx.CommandHasErrors, "expected current live-head plan to pass builder validation after refresh")
+}
+
 func TestApplyCommandRunner_GenericApplyHoldsApplyLockDuringPullStatusRefresh(t *testing.T) {
 	realDB := newTestBoltDB(t)
 	locker := events.NewDefaultWorkingDirLocker()

--- a/server/events/apply_command_runner_test.go
+++ b/server/events/apply_command_runner_test.go
@@ -541,6 +541,98 @@ func TestApplyCommandRunner_TargetedApplyParsedBeforePushDoesNotApplyNewHeadPlan
 	Ok(t, err)
 }
 
+func TestApplyCommandRunner_TargetedStaleApplyRequirementFailurePreservesLivePullStatus(t *testing.T) {
+	database := newTestBoltDB(t)
+	oldHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	liveHead := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	setup(t, func(tc *TestConfig) {
+		tc.database = database
+		tc.livePullHeadFetcher = fakeLivePullHeadFetcher{head: liveHead}
+	})
+	currentPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: liveHead}
+	_, err := database.UpdatePullWithResults(currentPull, []command.ProjectResult{plannedProjectResult("dirA", events.DefaultWorkspace, "projA")})
+	Ok(t, err)
+	cmd := &events.CommentCommand{Name: command.Apply, ProjectName: "projA"}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: oldHead},
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	projectCtx := command.ProjectContext{
+		CommandName: command.Apply,
+		RepoRelDir:  "dirA",
+		Workspace:   events.DefaultWorkspace,
+		ProjectName: "projA",
+		Pull:        ctx.Pull,
+		PullStatus:  ctx.PullStatus,
+	}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).Then(func([]Param) ReturnValues {
+		projectCtx.Pull = ctx.Pull
+		projectCtx.PullStatus = ctx.PullStatus
+		return ReturnValues{[]command.ProjectContext{projectCtx}, nil}
+	})
+	When(projectCommandRunner.Apply(Any[command.ProjectContext]())).ThenReturn(command.ProjectCommandOutput{
+		Error: errors.New("mergeable requirement failed"),
+	})
+
+	applyCommandRunner.Run(ctx, cmd)
+
+	Assert(t, ctx.CommandHasErrors, "expected stale targeted apply to fail")
+	pullStatus, err := database.GetPullStatus(currentPull)
+	Ok(t, err)
+	Equals(t, liveHead, pullStatus.Pull.HeadCommit)
+	Equals(t, models.PlannedPlanStatus, pullStatus.Projects[0].Status)
+}
+
+func TestApplyCommandRunner_TargetedStaleApplyDependencyFailurePreservesLivePullStatus(t *testing.T) {
+	database := newTestBoltDB(t)
+	oldHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	liveHead := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	setup(t, func(tc *TestConfig) {
+		tc.database = database
+		tc.livePullHeadFetcher = fakeLivePullHeadFetcher{head: liveHead}
+	})
+	currentPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: liveHead}
+	_, err := database.UpdatePullWithResults(currentPull, []command.ProjectResult{plannedProjectResult("dirA", events.DefaultWorkspace, "projA")})
+	Ok(t, err)
+	cmd := &events.CommentCommand{Name: command.Apply, ProjectName: "projA"}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: oldHead},
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	projectCtx := command.ProjectContext{
+		CommandName: command.Apply,
+		RepoRelDir:  "dirA",
+		Workspace:   events.DefaultWorkspace,
+		ProjectName: "projA",
+		Pull:        ctx.Pull,
+		PullStatus:  ctx.PullStatus,
+	}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).Then(func([]Param) ReturnValues {
+		projectCtx.Pull = ctx.Pull
+		projectCtx.PullStatus = ctx.PullStatus
+		return ReturnValues{[]command.ProjectContext{projectCtx}, nil}
+	})
+	When(projectCommandRunner.Apply(Any[command.ProjectContext]())).ThenReturn(command.ProjectCommandOutput{
+		Error: errors.New("dependency validation failed"),
+	})
+
+	applyCommandRunner.Run(ctx, cmd)
+
+	Assert(t, ctx.CommandHasErrors, "expected stale targeted apply to fail")
+	pullStatus, err := database.GetPullStatus(currentPull)
+	Ok(t, err)
+	Equals(t, liveHead, pullStatus.Pull.HeadCommit)
+	Equals(t, models.PlannedPlanStatus, pullStatus.Projects[0].Status)
+}
+
 func TestApplyCommandRunner_GenericApplyHoldsApplyLockDuringPullStatusRefresh(t *testing.T) {
 	realDB := newTestBoltDB(t)
 	locker := events.NewDefaultWorkingDirLocker()

--- a/server/events/apply_command_runner_test.go
+++ b/server/events/apply_command_runner_test.go
@@ -221,6 +221,9 @@ func TestApplyCommandRunner_IsSilenced(t *testing.T) {
 				}
 				return ReturnValues{[]command.ProjectContext{}, nil}
 			})
+			if c.Matched {
+				When(projectCommandRunner.Apply(Any[command.ProjectContext]())).ThenReturn(command.ProjectCommandOutput{ApplySuccess: "applied"})
+			}
 
 			applyCommandRunner.Run(ctx, cmd)
 
@@ -632,6 +635,9 @@ func TestApplyCommandRunner_TargetedApplyPreservesCommandStartHeadAfterLiveRefre
 	applyCommandRunner.Run(ctx, cmd)
 
 	Assert(t, !ctx.CommandHasErrors, "expected targeted build to preserve command-start head without failing build")
+	pullStatus, err := database.GetPullStatus(currentPull)
+	Ok(t, err)
+	Equals(t, liveHead, pullStatus.Pull.HeadCommit)
 }
 
 func TestApplyCommandRunner_TargetedApplyParsedBeforePushDoesNotApplyNewHeadPlan(t *testing.T) {

--- a/server/events/apply_command_runner_test.go
+++ b/server/events/apply_command_runner_test.go
@@ -303,6 +303,30 @@ func TestApplyCommandRunner_IgnoredTargetedDirSkipsWhenApplyLockBackendFails(t *
 	})
 }
 
+func TestApplyCommandRunner_LocalConfigIgnoredTargetSkipsBeforeApplyLock(t *testing.T) {
+	assertBuildIgnoredTargetedDirSkipsBeforeApplyLock(t, nil, nil)
+}
+
+func TestApplyCommandRunner_MergeCheckoutIgnoredTargetSkipsBeforeApplyLock(t *testing.T) {
+	assertBuildIgnoredTargetedDirSkipsBeforeApplyLock(t, nil, nil)
+}
+
+func TestApplyCommandRunner_LocalConfigIgnoredTargetSkipsWhenPlanInFlight(t *testing.T) {
+	locker := events.NewDefaultWorkingDirLocker()
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	unlockPlan, err := locker.TryLockPull(modelPull.BaseRepo.FullName, modelPull.Num, command.Plan)
+	Ok(t, err)
+	defer unlockPlan()
+
+	assertBuildIgnoredTargetedDirSkipsBeforeApplyLock(t, locker, &modelPull)
+}
+
+func TestApplyCommandRunner_LocalConfigIgnoredTargetSkipsWhenApplyLockBackendFails(t *testing.T) {
+	assertBuildIgnoredTargetedDirSkipsBeforeApplyLock(t, nil, nil, func(tc *TestConfig) {
+		tc.applyLockCheckerErr = errors.New("lock backend unavailable")
+	})
+}
+
 func assertIgnoredTargetedDirSkipsBeforeApplyLock(t *testing.T, locker events.WorkingDirLocker, pull *models.PullRequest, options ...func(*TestConfig)) {
 	t.Helper()
 	configOptions := append([]func(*TestConfig){func(tc *TestConfig) {
@@ -331,6 +355,41 @@ func assertIgnoredTargetedDirSkipsBeforeApplyLock(t *testing.T, locker events.Wo
 	Assert(t, ctx.CommandSkipped, "expected ignored targeted dir to skip")
 	Assert(t, !ctx.CommandHasErrors, "expected ignored targeted dir not to fail")
 	projectCommandBuilder.VerifyWasCalled(Never()).BuildApplyCommands(Any[*command.Context](), Any[*events.CommentCommand]())
+	projectCommandRunner.VerifyWasCalled(Never()).Apply(Any[command.ProjectContext]())
+	vcsClient.VerifyWasCalled(Never()).CreateComment(
+		Any[logging.SimpleLogging](), Any[models.Repo](), Any[int](), Any[string](), Any[string]())
+	commitUpdater.VerifyWasCalled(Never()).UpdateCombined(
+		Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Any[models.CommitStatus](), Any[command.Name]())
+}
+
+func assertBuildIgnoredTargetedDirSkipsBeforeApplyLock(t *testing.T, locker events.WorkingDirLocker, pull *models.PullRequest, options ...func(*TestConfig)) {
+	t.Helper()
+	configOptions := append([]func(*TestConfig){func(tc *TestConfig) {
+		if locker != nil {
+			tc.workingDirLocker = locker
+		}
+	}}, options...)
+	vcsClient := setup(t, configOptions...)
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	if pull != nil {
+		modelPull = *pull
+	}
+	cmd := &events.CommentCommand{Name: command.Apply, RepoRelDir: "ignored"}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     modelPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).ThenReturn(nil, events.ErrIgnoredTargetedDir)
+
+	applyCommandRunner.Run(ctx, cmd)
+
+	Assert(t, ctx.CommandSkipped, "expected ignored targeted dir to skip")
+	Assert(t, !ctx.CommandHasErrors, "expected ignored targeted dir not to fail")
+	projectCommandBuilder.VerifyWasCalledOnce().BuildApplyCommands(ctx, cmd)
 	projectCommandRunner.VerifyWasCalled(Never()).Apply(Any[command.ProjectContext]())
 	vcsClient.VerifyWasCalled(Never()).CreateComment(
 		Any[logging.SimpleLogging](), Any[models.Repo](), Any[int](), Any[string](), Any[string]())
@@ -380,7 +439,9 @@ func testApplyCommandRunnerTargetedApplyBlocksWhenPlanInFlight(t *testing.T, cmd
 	applyCommandRunner.Run(ctx, cmd)
 
 	Assert(t, ctx.CommandHasErrors, "expected targeted apply to fail while plan is in flight")
-	projectCommandBuilder.VerifyWasCalled(Never()).BuildApplyCommands(Any[*command.Context](), Any[*events.CommentCommand]())
+	if cmd.RepoRelDir == "" || cmd.ProjectName != "" {
+		projectCommandBuilder.VerifyWasCalled(Never()).BuildApplyCommands(Any[*command.Context](), Any[*events.CommentCommand]())
+	}
 	projectCommandRunner.VerifyWasCalled(Never()).Apply(Any[command.ProjectContext]())
 	commitUpdater.VerifyWasCalledOnce().UpdateCombined(
 		Any[logging.SimpleLogging](),
@@ -430,11 +491,12 @@ func TestApplyCommandRunner_GenericApplyUsesLiveHeadForBuilderValidation(t *test
 	database := newTestBoltDB(t)
 	oldHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	liveHead := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	liveBase := "release"
 	setup(t, func(tc *TestConfig) {
 		tc.database = database
-		tc.livePullHeadFetcher = fakeLivePullHeadFetcher{head: liveHead}
+		tc.livePullHeadFetcher = fakeLivePullHeadFetcher{head: liveHead, base: liveBase}
 	})
-	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: liveHead}
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: liveHead, BaseBranch: liveBase}
 	_, err := database.UpdatePullWithResults(modelPull, []command.ProjectResult{plannedProjectResult("dirA", events.DefaultWorkspace, "projA")})
 	Ok(t, err)
 	cmd := &events.CommentCommand{Name: command.Apply}
@@ -448,7 +510,9 @@ func TestApplyCommandRunner_GenericApplyUsesLiveHeadForBuilderValidation(t *test
 	}
 	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).Then(func([]Param) ReturnValues {
 		Equals(t, liveHead, ctx.Pull.HeadCommit)
+		Equals(t, liveBase, ctx.Pull.BaseBranch)
 		Equals(t, liveHead, ctx.PullStatus.Pull.HeadCommit)
+		Equals(t, liveBase, ctx.PullStatus.Pull.BaseBranch)
 		return ReturnValues{[]command.ProjectContext{}, nil}
 	})
 
@@ -492,6 +556,50 @@ func TestApplyCommandRunner_GenericApplyDoesNotRejectCurrentPlanAfterPullStatusR
 	applyCommandRunner.Run(ctx, cmd)
 
 	Assert(t, !ctx.CommandHasErrors, "expected current live-head plan to pass builder validation after refresh")
+}
+
+func TestApplyCommandRunner_GenericApplyRejectsRetargetedPRSameHead(t *testing.T) {
+	database := newTestBoltDB(t)
+	head := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	setup(t, func(tc *TestConfig) {
+		tc.database = database
+		tc.livePullHeadFetcher = fakeLivePullHeadFetcher{head: head, base: "release"}
+	})
+	storedPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: head, BaseBranch: "main"}
+	_, err := database.UpdatePullWithResults(storedPull, []command.ProjectResult{plannedProjectResult("dirA", events.DefaultWorkspace, "projA")})
+	Ok(t, err)
+	cmd := &events.CommentCommand{Name: command.Apply}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     storedPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).Then(func([]Param) ReturnValues {
+		Equals(t, "release", ctx.Pull.BaseBranch)
+		err := events.ValidatePlansForApply(ctx, []events.PendingPlan{{
+			RepoRelDir:  "dirA",
+			Workspace:   events.DefaultWorkspace,
+			ProjectName: "projA",
+		}})
+		if err != nil {
+			return ReturnValues{nil, err}
+		}
+		return ReturnValues{[]command.ProjectContext{}, nil}
+	})
+
+	applyCommandRunner.Run(ctx, cmd)
+
+	projectCommandRunner.VerifyWasCalled(Never()).Apply(Any[command.ProjectContext]())
+	commitUpdater.VerifyWasCalledOnce().UpdateCombined(
+		Any[logging.SimpleLogging](),
+		Eq(testdata.GithubRepo),
+		Eq(ctx.Pull),
+		Eq(models.FailedCommitStatus),
+		Eq(command.Apply),
+	)
 }
 
 func TestApplyCommandRunner_TargetedApplyPreservesCommandStartHeadAfterLiveRefresh(t *testing.T) {
@@ -595,6 +703,58 @@ func TestApplyCommandRunner_TargetedApplyParsedBeforePushDoesNotApplyNewHeadPlan
 		ProjectName: projectCtx.ProjectName,
 	}})
 	Ok(t, err)
+}
+
+func TestApplyCommandRunner_TargetedApplyRejectsRetargetedPRSameHead(t *testing.T) {
+	database := newTestBoltDB(t)
+	repoDir := t.TempDir()
+	head := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	setup(t, func(tc *TestConfig) {
+		tc.database = database
+		tc.livePullHeadFetcher = fakeLivePullHeadFetcher{head: head, base: "release"}
+	})
+	storedPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: head, BaseBranch: "main"}
+	_, err := database.UpdatePullWithResults(storedPull, []command.ProjectResult{plannedProjectResult("dirA", events.DefaultWorkspace, "projA")})
+	Ok(t, err)
+	planPath := filepath.Join(repoDir, "dirA", runtime.GetPlanFilename(events.DefaultWorkspace, "projA"))
+	Ok(t, os.MkdirAll(filepath.Dir(planPath), 0700))
+	Ok(t, os.WriteFile(planPath, []byte("old-base plan"), 0600))
+	validator := &events.DefaultApplyPlanValidator{
+		PullStatusFetcher:   database,
+		LivePullHeadFetcher: fakeLivePullHeadFetcher{head: head, base: "release"},
+	}
+	cmd := &events.CommentCommand{Name: command.Apply, ProjectName: "projA"}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     storedPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	projectCtx := command.ProjectContext{
+		CommandName: command.Apply,
+		RepoRelDir:  "dirA",
+		Workspace:   events.DefaultWorkspace,
+		ProjectName: "projA",
+	}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).Then(func([]Param) ReturnValues {
+		projectCtx.Pull = ctx.Pull
+		projectCtx.PullStatus = ctx.PullStatus
+		return ReturnValues{[]command.ProjectContext{projectCtx}, nil}
+	})
+	When(projectCommandRunner.Apply(Any[command.ProjectContext]())).Then(func(args []Param) ReturnValues {
+		projCtx := args[0].(command.ProjectContext)
+		err := validator.ValidateProjectPlan(projCtx, filepath.Join(repoDir, projCtx.RepoRelDir))
+		return ReturnValues{command.ProjectCommandOutput{Error: err}}
+	})
+
+	applyCommandRunner.Run(ctx, cmd)
+
+	Assert(t, ctx.CommandHasErrors, "expected same-head retargeted targeted apply to fail")
+	contents, readErr := os.ReadFile(planPath)
+	Ok(t, readErr)
+	Equals(t, "old-base plan", string(contents))
 }
 
 func TestApplyCommandRunner_TargetedStaleApplyRequirementFailurePreservesLivePullStatus(t *testing.T) {
@@ -713,16 +873,72 @@ func TestApplyCommandRunner_AutomergeRequiresReturnedPullStatusMatchesLiveHead(t
 	})
 }
 
+func TestApplyCommandRunner_AutomergeSucceedsWhenReturnedPullStatusMatchesLiveHeadAndBase(t *testing.T) {
+	database := newTestBoltDB(t)
+	head := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	vcsClient := setup(t, func(tc *TestConfig) {
+		tc.database = database
+		tc.livePullHeadFetcher = fakeLivePullHeadFetcher{head: head, base: "main"}
+	})
+	autoMerger.GlobalAutomerge = true
+	defer func() { autoMerger.GlobalAutomerge = false }()
+	pull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: head, BaseBranch: "main"}
+	cmd := &events.CommentCommand{Name: command.Apply, ProjectName: "projA"}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     pull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	projectCtx := command.ProjectContext{
+		CommandName:       command.Apply,
+		RepoRelDir:        "dirA",
+		Workspace:         events.DefaultWorkspace,
+		ProjectName:       "projA",
+		AutomergeEnabled:  true,
+		ProjectPlanStatus: models.PlannedPlanStatus,
+		Pull:              pull,
+	}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).ThenReturn([]command.ProjectContext{projectCtx}, nil)
+	When(projectCommandRunner.Apply(projectCtx)).ThenReturn(command.ProjectCommandOutput{ApplySuccess: "applied"})
+
+	applyCommandRunner.Run(ctx, cmd)
+
+	vcsClient.VerifyWasCalledOnce().MergePull(Any[logging.SimpleLogging](), Any[models.PullRequest](), Any[models.PullRequestOptions]())
+}
+
+func TestApplyCommandRunner_DoesNotAutomergeWhenReturnedPullStatusBaseIsStale(t *testing.T) {
+	assertApplyCommandRunnerDoesNotAutomergeAfterPreservedStaleApplyWithBase(t, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "release", command.ProjectCommandOutput{
+		ApplySuccess: "applied old-base command",
+	})
+}
+
+func TestApplyCommandRunner_DoesNotAutomergeWhenLiveBaseChangedAfterApplyCommandStart(t *testing.T) {
+	assertApplyCommandRunnerDoesNotAutomergeAfterPreservedStaleApplyWithBase(t, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "release", command.ProjectCommandOutput{
+		ApplySuccess: "applied old-base command",
+	})
+}
+
 func assertApplyCommandRunnerDoesNotAutomergeAfterPreservedStaleApply(t *testing.T, liveHead string, applyOutput command.ProjectCommandOutput) {
+	assertApplyCommandRunnerDoesNotAutomergeAfterPreservedStaleApplyWithBase(t, liveHead, "", applyOutput)
+}
+
+func assertApplyCommandRunnerDoesNotAutomergeAfterPreservedStaleApplyWithBase(t *testing.T, liveHead string, liveBase string, applyOutput command.ProjectCommandOutput) {
 	t.Helper()
 	database := newTestBoltDB(t)
 	oldHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	recordedHead := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	commandHead := oldHead
+	if liveBase != "" {
+		commandHead = recordedHead
+	}
 	vcsClient := setup(t, func(tc *TestConfig) {
 		tc.database = database
-		tc.livePullHeadFetcher = fakeLivePullHeadFetcher{head: liveHead}
+		tc.livePullHeadFetcher = fakeLivePullHeadFetcher{head: liveHead, base: liveBase}
 	})
-	currentPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: recordedHead}
+	currentPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: recordedHead, BaseBranch: "main"}
 	_, err := database.UpdatePullWithResults(currentPull, []command.ProjectResult{{
 		Command:     command.Apply,
 		RepoRelDir:  "dirA",
@@ -741,7 +957,7 @@ func assertApplyCommandRunnerDoesNotAutomergeAfterPreservedStaleApply(t *testing
 		User:     testdata.User,
 		Log:      logging.NewNoopLogger(t),
 		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
-		Pull:     models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: oldHead},
+		Pull:     models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: commandHead, BaseBranch: "main"},
 		HeadRepo: testdata.GithubRepo,
 		Trigger:  command.CommentTrigger,
 	}

--- a/server/events/apply_command_runner_test.go
+++ b/server/events/apply_command_runner_test.go
@@ -5,6 +5,8 @@ package events_test
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -13,6 +15,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/boltdb"
 	"github.com/runatlantis/atlantis/server/core/db"
 	"github.com/runatlantis/atlantis/server/core/locking"
+	"github.com/runatlantis/atlantis/server/core/runtime"
 	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
@@ -433,6 +436,109 @@ func TestApplyCommandRunner_GenericApplyDoesNotRejectCurrentPlanAfterPullStatusR
 	applyCommandRunner.Run(ctx, cmd)
 
 	Assert(t, !ctx.CommandHasErrors, "expected current live-head plan to pass builder validation after refresh")
+}
+
+func TestApplyCommandRunner_TargetedApplyPreservesCommandStartHeadAfterLiveRefresh(t *testing.T) {
+	database := newTestBoltDB(t)
+	oldHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	liveHead := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	setup(t, func(tc *TestConfig) {
+		tc.database = database
+		tc.livePullHeadFetcher = fakeLivePullHeadFetcher{head: liveHead}
+	})
+	currentPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: liveHead}
+	_, err := database.UpdatePullWithResults(currentPull, []command.ProjectResult{plannedProjectResult("dirA", events.DefaultWorkspace, "projA")})
+	Ok(t, err)
+	cmd := &events.CommentCommand{Name: command.Apply, ProjectName: "projA"}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: oldHead},
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).Then(func([]Param) ReturnValues {
+		Equals(t, oldHead, ctx.Pull.HeadCommit)
+		Equals(t, liveHead, ctx.PullStatus.Pull.HeadCommit)
+		return ReturnValues{[]command.ProjectContext{}, nil}
+	})
+
+	applyCommandRunner.Run(ctx, cmd)
+
+	Assert(t, !ctx.CommandHasErrors, "expected targeted build to preserve command-start head without failing build")
+}
+
+func TestApplyCommandRunner_TargetedApplyParsedBeforePushDoesNotApplyNewHeadPlan(t *testing.T) {
+	database := newTestBoltDB(t)
+	repoDir := t.TempDir()
+	oldHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	liveHead := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	setup(t, func(tc *TestConfig) {
+		tc.database = database
+		tc.livePullHeadFetcher = fakeLivePullHeadFetcher{head: liveHead}
+	})
+	currentPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: liveHead}
+	_, err := database.UpdatePullWithResults(currentPull, []command.ProjectResult{plannedProjectResult("dirA", events.DefaultWorkspace, "projA")})
+	Ok(t, err)
+	planPath := filepath.Join(repoDir, "dirA", runtime.GetPlanFilename(events.DefaultWorkspace, "projA"))
+	Ok(t, os.MkdirAll(filepath.Dir(planPath), 0700))
+	Ok(t, os.WriteFile(planPath, []byte("current plan"), 0600))
+	validator := &events.DefaultApplyPlanValidator{
+		PullStatusFetcher:   database,
+		LivePullHeadFetcher: fakeLivePullHeadFetcher{head: liveHead},
+	}
+	cmd := &events.CommentCommand{Name: command.Apply, ProjectName: "projA"}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: oldHead},
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	projectCtx := command.ProjectContext{
+		CommandName:      command.Apply,
+		RepoRelDir:       "dirA",
+		Workspace:        events.DefaultWorkspace,
+		ProjectName:      "projA",
+		Pull:             ctx.Pull,
+		PullStatus:       ctx.PullStatus,
+		ExpectedPlanHash: "",
+	}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).Then(func([]Param) ReturnValues {
+		projectCtx.Pull = ctx.Pull
+		projectCtx.PullStatus = ctx.PullStatus
+		return ReturnValues{[]command.ProjectContext{projectCtx}, nil}
+	})
+	When(projectCommandRunner.Apply(Any[command.ProjectContext]())).Then(func(args []Param) ReturnValues {
+		projCtx := args[0].(command.ProjectContext)
+		Equals(t, oldHead, projCtx.Pull.HeadCommit)
+		err := validator.ValidateProjectPlan(projCtx, filepath.Join(repoDir, projCtx.RepoRelDir))
+		return ReturnValues{command.ProjectCommandOutput{Error: err}}
+	})
+
+	applyCommandRunner.Run(ctx, cmd)
+
+	Assert(t, ctx.CommandHasErrors, "expected stale targeted apply to fail")
+	contents, readErr := os.ReadFile(planPath)
+	Ok(t, readErr)
+	Equals(t, "current plan", string(contents))
+	pullStatus, err := database.GetPullStatus(currentPull)
+	Ok(t, err)
+	Equals(t, liveHead, pullStatus.Pull.HeadCommit)
+	Equals(t, models.PlannedPlanStatus, pullStatus.Projects[0].Status)
+	err = events.ValidatePlansForApply(&command.Context{
+		Log:        logging.NewNoopLogger(t),
+		Pull:       currentPull,
+		PullStatus: pullStatus,
+	}, []events.PendingPlan{{
+		RepoDir:     repoDir,
+		RepoRelDir:  projectCtx.RepoRelDir,
+		Workspace:   projectCtx.Workspace,
+		ProjectName: projectCtx.ProjectName,
+	}})
+	Ok(t, err)
 }
 
 func TestApplyCommandRunner_GenericApplyHoldsApplyLockDuringPullStatusRefresh(t *testing.T) {

--- a/server/events/apply_command_runner_test.go
+++ b/server/events/apply_command_runner_test.go
@@ -1024,6 +1024,47 @@ func TestApplyCommandRunner_AutomergeStillSucceedsWhenLiveIdentityUnchangedAfter
 	vcsClient.VerifyWasCalledOnce().MergePull(Any[logging.SimpleLogging](), Any[models.PullRequest](), Any[models.PullRequestOptions]())
 }
 
+func TestApplyCommandRunner_UnchangedIdentityApplyPublishesSuccessCommitStatus(t *testing.T) {
+	database := newTestBoltDB(t)
+	head := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	livePull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: head, BaseBranch: "main"}
+	fetcher := &sequenceLivePullIdentityFetcher{identities: []models.PullRequest{livePull, livePull}}
+	setup(t, func(tc *TestConfig) {
+		tc.database = database
+		tc.livePullHeadFetcher = fetcher
+	})
+	cmd := &events.CommentCommand{Name: command.Apply, ProjectName: "projA"}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     livePull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	projectCtx := command.ProjectContext{
+		CommandName:       command.Apply,
+		RepoRelDir:        "dirA",
+		Workspace:         events.DefaultWorkspace,
+		ProjectName:       "projA",
+		ProjectPlanStatus: models.PlannedPlanStatus,
+		Pull:              livePull,
+	}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).ThenReturn([]command.ProjectContext{projectCtx}, nil)
+	When(projectCommandRunner.Apply(projectCtx)).ThenReturn(command.ProjectCommandOutput{ApplySuccess: "applied"})
+
+	applyCommandRunner.Run(ctx, cmd)
+
+	commitUpdater.VerifyWasCalledOnce().UpdateCombinedCount(
+		Any[logging.SimpleLogging](),
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Eq(models.SuccessCommitStatus),
+		Eq(command.Apply),
+		Any[models.ProjectCounts](),
+	)
+}
+
 func TestApplyCommandRunner_DoesNotAutomergeWhenBaseChangesDuringApply(t *testing.T) {
 	database, vcsClient, ctx, initialPull := runApplyCommandRunnerWithBaseChangeDuringApply(t)
 
@@ -1032,6 +1073,33 @@ func TestApplyCommandRunner_DoesNotAutomergeWhenBaseChangesDuringApply(t *testin
 	pullStatus, err := database.GetPullStatus(initialPull)
 	Ok(t, err)
 	Equals(t, models.PlannedPlanStatus, pullStatus.Projects[0].Status)
+}
+
+func TestApplyCommandRunner_BaseRetargetDuringApplyDoesNotPublishSuccessCommitStatus(t *testing.T) {
+	_, _, ctx, _ := runApplyCommandRunnerWithBaseChangeDuringApply(t)
+
+	Assert(t, ctx.CommandHasErrors, "expected base retarget during apply to fail")
+	commitUpdater.VerifyWasCalled(Never()).UpdateCombined(
+		Any[logging.SimpleLogging](),
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Eq(models.SuccessCommitStatus),
+		Eq(command.Apply),
+	)
+}
+
+func TestApplyCommandRunner_BaseRetargetDuringApplyDoesNotPublishSuccessCommitStatusCount(t *testing.T) {
+	_, _, ctx, _ := runApplyCommandRunnerWithBaseChangeDuringApply(t)
+
+	Assert(t, ctx.CommandHasErrors, "expected base retarget during apply to fail")
+	commitUpdater.VerifyWasCalled(Never()).UpdateCombinedCount(
+		Any[logging.SimpleLogging](),
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Eq(models.SuccessCommitStatus),
+		Eq(command.Apply),
+		Any[models.ProjectCounts](),
+	)
 }
 
 func TestApplyCommandRunner_DoesNotWriteAppliedStatusWhenBaseChangesDuringApply(t *testing.T) {

--- a/server/events/apply_command_runner_test.go
+++ b/server/events/apply_command_runner_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/events/models/testdata"
+	vcsmocks "github.com/runatlantis/atlantis/server/events/vcs/mocks"
 	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/metrics/metricstest"
 	. "github.com/runatlantis/atlantis/testing"
@@ -757,6 +758,44 @@ func TestApplyCommandRunner_TargetedApplyRejectsRetargetedPRSameHead(t *testing.
 	Equals(t, "old-base plan", string(contents))
 }
 
+func TestApplyCommandRunner_TargetedBaseRetargetPreservesCurrentPullStatus(t *testing.T) {
+	database := newTestBoltDB(t)
+	head := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	setup(t, func(tc *TestConfig) {
+		tc.database = database
+		tc.livePullHeadFetcher = fakeLivePullHeadFetcher{head: head, base: "release"}
+	})
+	currentPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: head, BaseBranch: "release"}
+	_, err := database.UpdatePullWithResults(currentPull, []command.ProjectResult{plannedProjectResult("dirA", events.DefaultWorkspace, "projA")})
+	Ok(t, err)
+	cmd := &events.CommentCommand{Name: command.Apply, ProjectName: "projA"}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: head, BaseBranch: "main"},
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	projectCtx := command.ProjectContext{
+		CommandName: command.Apply,
+		RepoRelDir:  "dirA",
+		Workspace:   events.DefaultWorkspace,
+		ProjectName: "projA",
+		Pull:        ctx.Pull,
+	}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).ThenReturn([]command.ProjectContext{projectCtx}, nil)
+	When(projectCommandRunner.Apply(projectCtx)).ThenReturn(command.ProjectCommandOutput{Error: errors.New("apply requirement failed")})
+
+	applyCommandRunner.Run(ctx, cmd)
+
+	Assert(t, ctx.CommandHasErrors, "expected retargeted command failure")
+	pullStatus, err := database.GetPullStatus(currentPull)
+	Ok(t, err)
+	Equals(t, currentPull.BaseBranch, pullStatus.Pull.BaseBranch)
+	Equals(t, models.PlannedPlanStatus, pullStatus.Projects[0].Status)
+}
+
 func TestApplyCommandRunner_TargetedStaleApplyRequirementFailurePreservesLivePullStatus(t *testing.T) {
 	database := newTestBoltDB(t)
 	oldHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -909,6 +948,109 @@ func TestApplyCommandRunner_AutomergeSucceedsWhenReturnedPullStatusMatchesLiveHe
 	vcsClient.VerifyWasCalledOnce().MergePull(Any[logging.SimpleLogging](), Any[models.PullRequest](), Any[models.PullRequestOptions]())
 }
 
+func TestApplyCommandRunner_RefetchesLiveIdentityBeforeAutomerge(t *testing.T) {
+	database := newTestBoltDB(t)
+	head := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	livePull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: head, BaseBranch: "main"}
+	fetcher := &sequenceLivePullIdentityFetcher{identities: []models.PullRequest{livePull, livePull}}
+	vcsClient := setup(t, func(tc *TestConfig) {
+		tc.database = database
+		tc.livePullHeadFetcher = fetcher
+	})
+	autoMerger.GlobalAutomerge = true
+	defer func() { autoMerger.GlobalAutomerge = false }()
+	cmd := &events.CommentCommand{Name: command.Apply, ProjectName: "projA"}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     livePull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	projectCtx := command.ProjectContext{
+		CommandName:       command.Apply,
+		RepoRelDir:        "dirA",
+		Workspace:         events.DefaultWorkspace,
+		ProjectName:       "projA",
+		AutomergeEnabled:  true,
+		ProjectPlanStatus: models.PlannedPlanStatus,
+		Pull:              livePull,
+	}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).ThenReturn([]command.ProjectContext{projectCtx}, nil)
+	When(projectCommandRunner.Apply(projectCtx)).ThenReturn(command.ProjectCommandOutput{ApplySuccess: "applied"})
+
+	applyCommandRunner.Run(ctx, cmd)
+
+	Equals(t, 2, fetcher.calls)
+	vcsClient.VerifyWasCalledOnce().MergePull(Any[logging.SimpleLogging](), Any[models.PullRequest](), Any[models.PullRequestOptions]())
+}
+
+func TestApplyCommandRunner_AutomergeStillSucceedsWhenLiveIdentityUnchangedAfterApply(t *testing.T) {
+	database := newTestBoltDB(t)
+	head := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	livePull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: head, BaseBranch: "main"}
+	fetcher := &sequenceLivePullIdentityFetcher{identities: []models.PullRequest{livePull, livePull}}
+	vcsClient := setup(t, func(tc *TestConfig) {
+		tc.database = database
+		tc.livePullHeadFetcher = fetcher
+	})
+	autoMerger.GlobalAutomerge = true
+	defer func() { autoMerger.GlobalAutomerge = false }()
+	cmd := &events.CommentCommand{Name: command.Apply, ProjectName: "projA"}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     livePull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	projectCtx := command.ProjectContext{
+		CommandName:       command.Apply,
+		RepoRelDir:        "dirA",
+		Workspace:         events.DefaultWorkspace,
+		ProjectName:       "projA",
+		AutomergeEnabled:  true,
+		ProjectPlanStatus: models.PlannedPlanStatus,
+		Pull:              livePull,
+	}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).ThenReturn([]command.ProjectContext{projectCtx}, nil)
+	When(projectCommandRunner.Apply(projectCtx)).ThenReturn(command.ProjectCommandOutput{ApplySuccess: "applied"})
+
+	applyCommandRunner.Run(ctx, cmd)
+
+	Assert(t, !ctx.CommandHasErrors, "expected unchanged live identity apply to succeed")
+	vcsClient.VerifyWasCalledOnce().MergePull(Any[logging.SimpleLogging](), Any[models.PullRequest](), Any[models.PullRequestOptions]())
+}
+
+func TestApplyCommandRunner_DoesNotAutomergeWhenBaseChangesDuringApply(t *testing.T) {
+	database, vcsClient, ctx, initialPull := runApplyCommandRunnerWithBaseChangeDuringApply(t)
+
+	Assert(t, ctx.CommandHasErrors, "expected base retarget during apply to fail")
+	vcsClient.VerifyWasCalled(Never()).MergePull(Any[logging.SimpleLogging](), Any[models.PullRequest](), Any[models.PullRequestOptions]())
+	pullStatus, err := database.GetPullStatus(initialPull)
+	Ok(t, err)
+	Equals(t, models.PlannedPlanStatus, pullStatus.Projects[0].Status)
+}
+
+func TestApplyCommandRunner_DoesNotWriteAppliedStatusWhenBaseChangesDuringApply(t *testing.T) {
+	database, _, ctx, initialPull := runApplyCommandRunnerWithBaseChangeDuringApply(t)
+
+	Assert(t, ctx.CommandHasErrors, "expected base retarget during apply to fail")
+	pullStatus, err := database.GetPullStatus(initialPull)
+	Ok(t, err)
+	Equals(t, initialPull.BaseBranch, pullStatus.Pull.BaseBranch)
+	Equals(t, models.PlannedPlanStatus, pullStatus.Projects[0].Status)
+}
+
+func TestApplyCommandRunner_FinalFreshnessGateUsesPostApplyLiveIdentity(t *testing.T) {
+	_, vcsClient, ctx, _ := runApplyCommandRunnerWithBaseChangeDuringApply(t)
+
+	Assert(t, ctx.CommandHasErrors, "expected post-apply live identity change to fail")
+	vcsClient.VerifyWasCalled(Never()).MergePull(Any[logging.SimpleLogging](), Any[models.PullRequest](), Any[models.PullRequestOptions]())
+}
+
 func TestApplyCommandRunner_DoesNotAutomergeWhenReturnedPullStatusBaseIsStale(t *testing.T) {
 	assertApplyCommandRunnerDoesNotAutomergeAfterPreservedStaleApplyWithBase(t, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "release", command.ProjectCommandOutput{
 		ApplySuccess: "applied old-base command",
@@ -976,6 +1118,65 @@ func assertApplyCommandRunnerDoesNotAutomergeAfterPreservedStaleApplyWithBase(t 
 	applyCommandRunner.Run(ctx, cmd)
 
 	vcsClient.VerifyWasCalled(Never()).MergePull(Any[logging.SimpleLogging](), Any[models.PullRequest](), Any[models.PullRequestOptions]())
+}
+
+func runApplyCommandRunnerWithBaseChangeDuringApply(t *testing.T) (db.Database, *vcsmocks.MockClient, *command.Context, models.PullRequest) {
+	t.Helper()
+	database := newTestBoltDB(t)
+	head := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	initialPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: head, BaseBranch: "main"}
+	finalPull := initialPull
+	finalPull.BaseBranch = "release"
+	fetcher := &sequenceLivePullIdentityFetcher{identities: []models.PullRequest{initialPull, finalPull}}
+	vcsClient := setup(t, func(tc *TestConfig) {
+		tc.database = database
+		tc.livePullHeadFetcher = fetcher
+	})
+	_, err := database.UpdatePullWithResults(initialPull, []command.ProjectResult{plannedProjectResult("dirA", events.DefaultWorkspace, "projA")})
+	Ok(t, err)
+	autoMerger.GlobalAutomerge = true
+	t.Cleanup(func() { autoMerger.GlobalAutomerge = false })
+	cmd := &events.CommentCommand{Name: command.Apply, ProjectName: "projA"}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     initialPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	projectCtx := command.ProjectContext{
+		CommandName:       command.Apply,
+		RepoRelDir:        "dirA",
+		Workspace:         events.DefaultWorkspace,
+		ProjectName:       "projA",
+		AutomergeEnabled:  true,
+		ProjectPlanStatus: models.PlannedPlanStatus,
+		Pull:              initialPull,
+	}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).ThenReturn([]command.ProjectContext{projectCtx}, nil)
+	When(projectCommandRunner.Apply(projectCtx)).ThenReturn(command.ProjectCommandOutput{ApplySuccess: "applied"})
+
+	applyCommandRunner.Run(ctx, cmd)
+
+	return database, vcsClient, ctx, initialPull
+}
+
+type sequenceLivePullIdentityFetcher struct {
+	identities []models.PullRequest
+	calls      int
+}
+
+func (f *sequenceLivePullIdentityFetcher) GetLivePullIdentity(command.ProjectContext) (models.PullRequest, error) {
+	if len(f.identities) == 0 {
+		return models.PullRequest{}, nil
+	}
+	idx := f.calls
+	if idx >= len(f.identities) {
+		idx = len(f.identities) - 1
+	}
+	f.calls++
+	return f.identities[idx], nil
 }
 
 func TestApplyCommandRunner_GenericApplyHoldsApplyLockDuringPullStatusRefresh(t *testing.T) {

--- a/server/events/apply_command_runner_test.go
+++ b/server/events/apply_command_runner_test.go
@@ -268,11 +268,12 @@ func TestApplyCommandRunner_IgnoredTargetedDirNoOp(t *testing.T) {
 		Trigger:  command.CommentTrigger,
 	}
 
-	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).ThenReturn([]command.ProjectContext{}, events.ErrIgnoredTargetedDir)
+	When(projectCommandBuilder.ShouldIgnoreTargetedDir(ctx, cmd)).ThenReturn(true)
 
 	applyCommandRunner.Run(ctx, cmd)
 	Assert(t, ctx.CommandSkipped, "expected ignored targeted dir to mark the command skipped")
 
+	projectCommandBuilder.VerifyWasCalled(Never()).BuildApplyCommands(Any[*command.Context](), Any[*events.CommentCommand]())
 	vcsClient.VerifyWasCalled(Never()).CreateComment(
 		Any[logging.SimpleLogging](), Any[models.Repo](), Any[int](), Any[string](), Any[string]())
 	commitUpdater.VerifyWasCalled(Never()).UpdateCombined(
@@ -280,6 +281,61 @@ func TestApplyCommandRunner_IgnoredTargetedDirNoOp(t *testing.T) {
 	commitUpdater.VerifyWasCalled(Never()).UpdateCombinedCount(
 		Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Any[models.CommitStatus](), Any[command.Name](), Any[models.ProjectCounts]())
 	projectCommandRunner.VerifyWasCalled(Never()).Apply(Any[command.ProjectContext]())
+}
+
+func TestApplyCommandRunner_IgnoredTargetedDirSkipsBeforeApplyLock(t *testing.T) {
+	assertIgnoredTargetedDirSkipsBeforeApplyLock(t, nil, nil)
+}
+
+func TestApplyCommandRunner_IgnoredTargetedDirSkipsWhenPlanInFlight(t *testing.T) {
+	locker := events.NewDefaultWorkingDirLocker()
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	unlockPlan, err := locker.TryLockPull(modelPull.BaseRepo.FullName, modelPull.Num, command.Plan)
+	Ok(t, err)
+	defer unlockPlan()
+
+	assertIgnoredTargetedDirSkipsBeforeApplyLock(t, locker, &modelPull)
+}
+
+func TestApplyCommandRunner_IgnoredTargetedDirSkipsWhenApplyLockBackendFails(t *testing.T) {
+	assertIgnoredTargetedDirSkipsBeforeApplyLock(t, nil, nil, func(tc *TestConfig) {
+		tc.applyLockCheckerErr = errors.New("lock backend unavailable")
+	})
+}
+
+func assertIgnoredTargetedDirSkipsBeforeApplyLock(t *testing.T, locker events.WorkingDirLocker, pull *models.PullRequest, options ...func(*TestConfig)) {
+	t.Helper()
+	configOptions := append([]func(*TestConfig){func(tc *TestConfig) {
+		if locker != nil {
+			tc.workingDirLocker = locker
+		}
+	}}, options...)
+	vcsClient := setup(t, configOptions...)
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	if pull != nil {
+		modelPull = *pull
+	}
+	cmd := &events.CommentCommand{Name: command.Apply, RepoRelDir: "ignored"}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     modelPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	When(projectCommandBuilder.ShouldIgnoreTargetedDir(ctx, cmd)).ThenReturn(true)
+
+	applyCommandRunner.Run(ctx, cmd)
+
+	Assert(t, ctx.CommandSkipped, "expected ignored targeted dir to skip")
+	Assert(t, !ctx.CommandHasErrors, "expected ignored targeted dir not to fail")
+	projectCommandBuilder.VerifyWasCalled(Never()).BuildApplyCommands(Any[*command.Context](), Any[*events.CommentCommand]())
+	projectCommandRunner.VerifyWasCalled(Never()).Apply(Any[command.ProjectContext]())
+	vcsClient.VerifyWasCalled(Never()).CreateComment(
+		Any[logging.SimpleLogging](), Any[models.Repo](), Any[int](), Any[string](), Any[string]())
+	commitUpdater.VerifyWasCalled(Never()).UpdateCombined(
+		Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Any[models.CommitStatus](), Any[command.Name]())
 }
 
 func TestApplyCommandRunner_TargetedApplyBlocksWhenPlanInFlight(t *testing.T) {
@@ -631,6 +687,79 @@ func TestApplyCommandRunner_TargetedStaleApplyDependencyFailurePreservesLivePull
 	Ok(t, err)
 	Equals(t, liveHead, pullStatus.Pull.HeadCommit)
 	Equals(t, models.PlannedPlanStatus, pullStatus.Projects[0].Status)
+}
+
+func TestApplyCommandRunner_DoesNotAutomergeAfterStaleApplyError(t *testing.T) {
+	assertApplyCommandRunnerDoesNotAutomergeAfterPreservedStaleApply(t, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", command.ProjectCommandOutput{
+		Error: errors.New("mergeable requirement failed"),
+	})
+}
+
+func TestApplyCommandRunner_DoesNotAutomergeWhenDBUpdaterSkippedStaleApplyResult(t *testing.T) {
+	assertApplyCommandRunnerDoesNotAutomergeAfterPreservedStaleApply(t, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", command.ProjectCommandOutput{
+		ApplySuccess: "stale apply result",
+	})
+}
+
+func TestApplyCommandRunner_AutomergeRequiresResultWithoutErrors(t *testing.T) {
+	assertApplyCommandRunnerDoesNotAutomergeAfterPreservedStaleApply(t, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", command.ProjectCommandOutput{
+		Error: errors.New("apply failed"),
+	})
+}
+
+func TestApplyCommandRunner_AutomergeRequiresReturnedPullStatusMatchesLiveHead(t *testing.T) {
+	assertApplyCommandRunnerDoesNotAutomergeAfterPreservedStaleApply(t, "cccccccccccccccccccccccccccccccccccccccc", command.ProjectCommandOutput{
+		ApplySuccess: "applied old command",
+	})
+}
+
+func assertApplyCommandRunnerDoesNotAutomergeAfterPreservedStaleApply(t *testing.T, liveHead string, applyOutput command.ProjectCommandOutput) {
+	t.Helper()
+	database := newTestBoltDB(t)
+	oldHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	recordedHead := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	vcsClient := setup(t, func(tc *TestConfig) {
+		tc.database = database
+		tc.livePullHeadFetcher = fakeLivePullHeadFetcher{head: liveHead}
+	})
+	currentPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: recordedHead}
+	_, err := database.UpdatePullWithResults(currentPull, []command.ProjectResult{{
+		Command:     command.Apply,
+		RepoRelDir:  "dirA",
+		Workspace:   events.DefaultWorkspace,
+		ProjectName: "projA",
+		ProjectCommandOutput: command.ProjectCommandOutput{
+			ApplySuccess: "already applied",
+		},
+	}})
+	Ok(t, err)
+	autoMerger.GlobalAutomerge = true
+	defer func() { autoMerger.GlobalAutomerge = false }()
+
+	cmd := &events.CommentCommand{Name: command.Apply, ProjectName: "projA"}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: oldHead},
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	projectCtx := command.ProjectContext{
+		CommandName:       command.Apply,
+		RepoRelDir:        "dirA",
+		Workspace:         events.DefaultWorkspace,
+		ProjectName:       "projA",
+		AutomergeEnabled:  true,
+		ProjectPlanStatus: models.PlannedPlanStatus,
+		Pull:              ctx.Pull,
+	}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).ThenReturn([]command.ProjectContext{projectCtx}, nil)
+	When(projectCommandRunner.Apply(projectCtx)).ThenReturn(applyOutput)
+
+	applyCommandRunner.Run(ctx, cmd)
+
+	vcsClient.VerifyWasCalled(Never()).MergePull(Any[logging.SimpleLogging](), Any[models.PullRequest](), Any[models.PullRequestOptions]())
 }
 
 func TestApplyCommandRunner_GenericApplyHoldsApplyLockDuringPullStatusRefresh(t *testing.T) {

--- a/server/events/apply_command_runner_test.go
+++ b/server/events/apply_command_runner_test.go
@@ -367,6 +367,135 @@ func TestApplyCommandRunner_RefreshesPullStatusAfterApplyLock(t *testing.T) {
 	Assert(t, !ctx.CommandHasErrors, "expected refreshed PullStatus apply to succeed")
 }
 
+func TestApplyCommandRunner_GenericApplyHoldsApplyLockDuringPullStatusRefresh(t *testing.T) {
+	realDB := newTestBoltDB(t)
+	locker := events.NewDefaultWorkingDirLocker()
+	refreshObserved := false
+	database := assertApplyLockDB{
+		Database:     realDB,
+		t:            t,
+		locker:       locker,
+		repoFullName: testdata.GithubRepo.FullName,
+		pullNum:      testdata.Pull.Num,
+		called:       &refreshObserved,
+	}
+	setup(t, func(tc *TestConfig) {
+		tc.database = database
+		tc.workingDirLocker = locker
+	})
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	cmd := &events.CommentCommand{Name: command.Apply}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     modelPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).ThenReturn([]command.ProjectContext{}, nil)
+
+	applyCommandRunner.Run(ctx, cmd)
+
+	Assert(t, refreshObserved, "expected pull status refresh to be observed")
+}
+
+func TestApplyCommandRunner_GenericApplyHoldsApplyLockDuringCommandBuild(t *testing.T) {
+	locker := events.NewDefaultWorkingDirLocker()
+	setup(t, func(tc *TestConfig) {
+		tc.workingDirLocker = locker
+	})
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	cmd := &events.CommentCommand{Name: command.Apply}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     modelPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).Then(func([]Param) ReturnValues {
+		Assert(t, locker.HasCommandLock(testdata.GithubRepo.FullName, testdata.Pull.Num, command.Apply), "expected apply lock during command build")
+		return ReturnValues{[]command.ProjectContext{}, nil}
+	})
+
+	applyCommandRunner.Run(ctx, cmd)
+}
+
+func TestApplyCommandRunner_GenericApplyHoldsApplyLockDuringExecution(t *testing.T) {
+	locker := events.NewDefaultWorkingDirLocker()
+	setup(t, func(tc *TestConfig) {
+		tc.workingDirLocker = locker
+	})
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	cmd := &events.CommentCommand{Name: command.Apply}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     modelPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	projectCtx := command.ProjectContext{CommandName: command.Apply, RepoRelDir: "dirA", Workspace: events.DefaultWorkspace, ProjectName: "projA"}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).ThenReturn([]command.ProjectContext{projectCtx}, nil)
+	When(projectCommandRunner.Apply(projectCtx)).Then(func([]Param) ReturnValues {
+		Assert(t, locker.HasCommandLock(testdata.GithubRepo.FullName, testdata.Pull.Num, command.Apply), "expected apply lock during project execution")
+		return ReturnValues{command.ProjectCommandOutput{ApplySuccess: "applied"}}
+	})
+
+	applyCommandRunner.Run(ctx, cmd)
+}
+
+func TestApplyCommandRunner_TargetedApplyHoldsApplyLockDuringCommandBuild(t *testing.T) {
+	locker := events.NewDefaultWorkingDirLocker()
+	setup(t, func(tc *TestConfig) {
+		tc.workingDirLocker = locker
+	})
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	cmd := &events.CommentCommand{Name: command.Apply, ProjectName: "projA"}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     modelPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).Then(func([]Param) ReturnValues {
+		Assert(t, locker.HasCommandLock(testdata.GithubRepo.FullName, testdata.Pull.Num, command.Apply), "expected targeted apply lock during command build")
+		return ReturnValues{[]command.ProjectContext{}, nil}
+	})
+
+	applyCommandRunner.Run(ctx, cmd)
+}
+
+func TestApplyCommandRunner_TargetedApplyHoldsApplyLockDuringExecution(t *testing.T) {
+	locker := events.NewDefaultWorkingDirLocker()
+	setup(t, func(tc *TestConfig) {
+		tc.workingDirLocker = locker
+	})
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	cmd := &events.CommentCommand{Name: command.Apply, ProjectName: "projA"}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     modelPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	projectCtx := command.ProjectContext{CommandName: command.Apply, RepoRelDir: "dirA", Workspace: events.DefaultWorkspace, ProjectName: "projA"}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).ThenReturn([]command.ProjectContext{projectCtx}, nil)
+	When(projectCommandRunner.Apply(projectCtx)).Then(func([]Param) ReturnValues {
+		Assert(t, locker.HasCommandLock(testdata.GithubRepo.FullName, testdata.Pull.Num, command.Apply), "expected targeted apply lock during project execution")
+		return ReturnValues{command.ProjectCommandOutput{ApplySuccess: "applied"}}
+	})
+
+	applyCommandRunner.Run(ctx, cmd)
+}
+
 func TestBuildApplyCommands_UsesFreshPullStatusAfterPlanFinishes(t *testing.T) {
 	database := newTestBoltDB(t)
 	setup(t, func(tc *TestConfig) {
@@ -806,4 +935,19 @@ type failingGetPullStatusDB struct {
 
 func (f failingGetPullStatusDB) GetPullStatus(models.PullRequest) (*models.PullStatus, error) {
 	return nil, f.err
+}
+
+type assertApplyLockDB struct {
+	db.Database
+	t            *testing.T
+	locker       events.WorkingDirLocker
+	repoFullName string
+	pullNum      int
+	called       *bool
+}
+
+func (a assertApplyLockDB) GetPullStatus(pull models.PullRequest) (*models.PullStatus, error) {
+	*a.called = true
+	Assert(a.t, a.locker.HasCommandLock(a.repoFullName, a.pullNum, command.Apply), "expected apply lock during pull status refresh")
+	return a.Database.GetPullStatus(pull)
 }

--- a/server/events/apply_command_runner_test.go
+++ b/server/events/apply_command_runner_test.go
@@ -76,6 +76,8 @@ func TestApplyCommandRunner_IsLocked(t *testing.T) {
 			modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num}
 			When(githubGetter.GetPullRequest(logger, testdata.GithubRepo, testdata.Pull.Num)).ThenReturn(pull, nil)
 			When(eventParsing.ParseGithubPull(logger, pull)).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+			_, err := dbUpdater.Database.UpdatePullWithResults(modelPull, nil)
+			Ok(t, err)
 
 			ctx := &command.Context{
 				User:     testdata.User,

--- a/server/events/apply_command_runner_test.go
+++ b/server/events/apply_command_runner_test.go
@@ -188,7 +188,7 @@ func TestApplyCommandRunner_IsSilenced(t *testing.T) {
 			})
 
 			scopeNull := metricstest.NewLoggingScope(t, logger, "atlantis")
-			modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num}
+			modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123", BaseBranch: "main"}
 
 			cmd := &events.CommentCommand{Name: command.Apply}
 			if c.Targeted {
@@ -211,6 +211,9 @@ func TestApplyCommandRunner_IsSilenced(t *testing.T) {
 						Workspace:  "default",
 					},
 				})
+				Ok(t, err)
+			} else if c.ExpVCSStatusSet && !c.Matched {
+				_, err = db.UpdatePullWithResults(modelPull, nil)
 				Ok(t, err)
 			}
 

--- a/server/events/apply_command_runner_test.go
+++ b/server/events/apply_command_runner_test.go
@@ -5,11 +5,13 @@ package events_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/google/go-github/v88/github"
 	. "github.com/petergtz/pegomock/v4"
 	"github.com/runatlantis/atlantis/server/core/boltdb"
+	"github.com/runatlantis/atlantis/server/core/db"
 	"github.com/runatlantis/atlantis/server/core/locking"
 	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/events/command"
@@ -249,54 +251,180 @@ func TestApplyCommandRunner_IsSilenced(t *testing.T) {
 }
 
 func TestApplyCommandRunner_IgnoredTargetedDirNoOp(t *testing.T) {
-	cases := []struct {
-		description string
-		setup       func(*TestConfig)
-	}{
-		{
-			description: "global lock backend errors",
-			setup: func(tc *TestConfig) {
-				tc.applyLockCheckerErr = errors.New("lock backend down")
-			},
-		},
-		{
-			description: "global apply lock is active",
-			setup: func(tc *TestConfig) {
-				tc.applyLockCheckerReturn = locking.ApplyCommandLock{Locked: true}
-			},
-		},
+	RegisterMockTestingT(t)
+	vcsClient := setup(t)
+	scopeNull := metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis")
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num}
+	cmd := &events.CommentCommand{Name: command.Apply, RepoRelDir: "ignored"}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    scopeNull,
+		Pull:     modelPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
 	}
 
-	for _, c := range cases {
-		t.Run(c.description, func(t *testing.T) {
-			RegisterMockTestingT(t)
-			vcsClient := setup(t, c.setup)
-			scopeNull := metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis")
-			modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num}
-			cmd := &events.CommentCommand{Name: command.Apply, RepoRelDir: "ignored"}
-			ctx := &command.Context{
-				User:     testdata.User,
-				Log:      logging.NewNoopLogger(t),
-				Scope:    scopeNull,
-				Pull:     modelPull,
-				HeadRepo: testdata.GithubRepo,
-				Trigger:  command.CommentTrigger,
-			}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).ThenReturn([]command.ProjectContext{}, events.ErrIgnoredTargetedDir)
 
-			When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).ThenReturn([]command.ProjectContext{}, events.ErrIgnoredTargetedDir)
+	applyCommandRunner.Run(ctx, cmd)
+	Assert(t, ctx.CommandSkipped, "expected ignored targeted dir to mark the command skipped")
 
-			applyCommandRunner.Run(ctx, cmd)
-			Assert(t, ctx.CommandSkipped, "expected ignored targeted dir to mark the command skipped")
+	vcsClient.VerifyWasCalled(Never()).CreateComment(
+		Any[logging.SimpleLogging](), Any[models.Repo](), Any[int](), Any[string](), Any[string]())
+	commitUpdater.VerifyWasCalled(Never()).UpdateCombined(
+		Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Any[models.CommitStatus](), Any[command.Name]())
+	commitUpdater.VerifyWasCalled(Never()).UpdateCombinedCount(
+		Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Any[models.CommitStatus](), Any[command.Name](), Any[models.ProjectCounts]())
+	projectCommandRunner.VerifyWasCalled(Never()).Apply(Any[command.ProjectContext]())
+}
 
-			vcsClient.VerifyWasCalled(Never()).CreateComment(
-				Any[logging.SimpleLogging](), Any[models.Repo](), Any[int](), Any[string](), Any[string]())
-			commitUpdater.VerifyWasCalled(Never()).UpdateCombined(
-				Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Any[models.CommitStatus](), Any[command.Name]())
-			commitUpdater.VerifyWasCalled(Never()).UpdateCombinedCount(
-				Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Any[models.CommitStatus](), Any[command.Name](), Any[models.ProjectCounts]())
-			projectCommandRunner.VerifyWasCalled(Never()).Apply(Any[command.ProjectContext]())
-		})
+func TestApplyCommandRunner_TargetedApplyBlocksWhenPlanInFlight(t *testing.T) {
+	testApplyCommandRunnerTargetedApplyBlocksWhenPlanInFlight(t, &events.CommentCommand{Name: command.Apply, ProjectName: "projA"})
+}
+
+func TestApplyCommandRunner_TargetedApplyProjectBlocksWhenPlanInFlight(t *testing.T) {
+	testApplyCommandRunnerTargetedApplyBlocksWhenPlanInFlight(t, &events.CommentCommand{Name: command.Apply, ProjectName: "projA"})
+}
+
+func TestApplyCommandRunner_TargetedApplyDirBlocksWhenPlanInFlight(t *testing.T) {
+	testApplyCommandRunnerTargetedApplyBlocksWhenPlanInFlight(t, &events.CommentCommand{Name: command.Apply, RepoRelDir: "dirA"})
+}
+
+func TestApplyCommandRunner_TargetedApplyWorkspaceBlocksWhenPlanInFlight(t *testing.T) {
+	testApplyCommandRunnerTargetedApplyBlocksWhenPlanInFlight(t, &events.CommentCommand{Name: command.Apply, Workspace: "workspaceA"})
+}
+
+func TestApplyCommandRunner_TargetedApplyDoesNotRunTerraformBeforePlanStateFinalized(t *testing.T) {
+	testApplyCommandRunnerTargetedApplyBlocksWhenPlanInFlight(t, &events.CommentCommand{Name: command.Apply, ProjectName: "projA"})
+}
+
+func testApplyCommandRunnerTargetedApplyBlocksWhenPlanInFlight(t *testing.T, cmd *events.CommentCommand) {
+	locker := events.NewDefaultWorkingDirLocker()
+	vcsClient := setup(t, func(tc *TestConfig) {
+		tc.workingDirLocker = locker
+	})
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	unlockPlan, err := locker.TryLockPull(modelPull.BaseRepo.FullName, modelPull.Num, command.Plan)
+	Ok(t, err)
+	defer unlockPlan()
+
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     modelPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
 	}
+
+	applyCommandRunner.Run(ctx, cmd)
+
+	Assert(t, ctx.CommandHasErrors, "expected targeted apply to fail while plan is in flight")
+	projectCommandBuilder.VerifyWasCalled(Never()).BuildApplyCommands(Any[*command.Context](), Any[*events.CommentCommand]())
+	projectCommandRunner.VerifyWasCalled(Never()).Apply(Any[command.ProjectContext]())
+	commitUpdater.VerifyWasCalledOnce().UpdateCombined(
+		Any[logging.SimpleLogging](),
+		Eq(testdata.GithubRepo),
+		Eq(modelPull),
+		Eq(models.FailedCommitStatus),
+		Eq(command.Apply),
+	)
+	_, _, _, comment, _ := vcsClient.VerifyWasCalledOnce().CreateComment(
+		Any[logging.SimpleLogging](), Any[models.Repo](), Any[int](), Any[string](), Any[string]()).GetCapturedArguments()
+	Assert(t, strings.Contains(comment, "currently locked by \"plan\""), "got comment: %s", comment)
+}
+
+func TestApplyCommandRunner_RefreshesPullStatusAfterApplyLock(t *testing.T) {
+	database := newTestBoltDB(t)
+	setup(t, func(tc *TestConfig) {
+		tc.database = database
+	})
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	_, err := database.UpdatePullWithResults(modelPull, []command.ProjectResult{plannedProjectResult("dirA", events.DefaultWorkspace, "projA")})
+	Ok(t, err)
+	cmd := &events.CommentCommand{Name: command.Apply}
+	ctx := &command.Context{
+		User:       testdata.User,
+		Log:        logging.NewNoopLogger(t),
+		Scope:      metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:       modelPull,
+		PullStatus: nil,
+		HeadRepo:   testdata.GithubRepo,
+		Trigger:    command.CommentTrigger,
+	}
+	projectCtx := command.ProjectContext{CommandName: command.Apply, RepoRelDir: "dirA", Workspace: events.DefaultWorkspace, ProjectName: "projA"}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).Then(func([]Param) ReturnValues {
+		Assert(t, ctx.PullStatus != nil, "expected PullStatus to be refreshed before build")
+		Equals(t, "abc123", ctx.PullStatus.Pull.HeadCommit)
+		Equals(t, 1, len(ctx.PullStatus.Projects))
+		return ReturnValues{[]command.ProjectContext{projectCtx}, nil}
+	})
+	When(projectCommandRunner.Apply(projectCtx)).ThenReturn(command.ProjectCommandOutput{ApplySuccess: "applied"})
+
+	applyCommandRunner.Run(ctx, cmd)
+
+	Assert(t, !ctx.CommandHasErrors, "expected refreshed PullStatus apply to succeed")
+}
+
+func TestBuildApplyCommands_UsesFreshPullStatusAfterPlanFinishes(t *testing.T) {
+	database := newTestBoltDB(t)
+	setup(t, func(tc *TestConfig) {
+		tc.database = database
+	})
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "new123"}
+	_, err := database.UpdatePullWithResults(modelPull, []command.ProjectResult{plannedProjectResult("dirA", events.DefaultWorkspace, "projA")})
+	Ok(t, err)
+	cmd := &events.CommentCommand{Name: command.Apply, ProjectName: "projA"}
+	ctx := &command.Context{
+		User:  testdata.User,
+		Log:   logging.NewNoopLogger(t),
+		Scope: metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:  modelPull,
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "old123"},
+		},
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	projectCtx := command.ProjectContext{CommandName: command.Apply, RepoRelDir: "dirA", Workspace: events.DefaultWorkspace, ProjectName: "projA"}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).Then(func([]Param) ReturnValues {
+		Assert(t, ctx.PullStatus != nil, "expected PullStatus to be refreshed before build")
+		Equals(t, "new123", ctx.PullStatus.Pull.HeadCommit)
+		return ReturnValues{[]command.ProjectContext{projectCtx}, nil}
+	})
+	When(projectCommandRunner.Apply(projectCtx)).ThenReturn(command.ProjectCommandOutput{ApplySuccess: "applied"})
+
+	applyCommandRunner.Run(ctx, cmd)
+
+	Assert(t, !ctx.CommandHasErrors, "expected fresh PullStatus apply to succeed")
+}
+
+func TestApplyCommandRunner_PullStatusRefreshFailureFailsClosed(t *testing.T) {
+	realDB := newTestBoltDB(t)
+	database := failingGetPullStatusDB{Database: realDB, err: errors.New("db unavailable")}
+	vcsClient := setup(t, func(tc *TestConfig) {
+		tc.database = database
+	})
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	cmd := &events.CommentCommand{Name: command.Apply}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     modelPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+
+	applyCommandRunner.Run(ctx, cmd)
+
+	Assert(t, ctx.CommandHasErrors, "expected PullStatus refresh failure to fail closed")
+	projectCommandBuilder.VerifyWasCalled(Never()).BuildApplyCommands(Any[*command.Context](), Any[*events.CommentCommand]())
+	projectCommandRunner.VerifyWasCalled(Never()).Apply(Any[command.ProjectContext]())
+	_, _, _, comment, _ := vcsClient.VerifyWasCalledOnce().CreateComment(
+		Any[logging.SimpleLogging](), Any[models.Repo](), Any[int](), Any[string](), Any[string]()).GetCapturedArguments()
+	Assert(t, strings.Contains(comment, "fetching current plan status"), "got comment: %s", comment)
 }
 
 func TestApplyCommandRunner_ExecutionOrder(t *testing.T) {
@@ -669,4 +797,13 @@ func TestApplyCommandRunner_NoChangesCount(t *testing.T) {
 		Eq[command.Name](command.Apply),
 		Eq(models.ProjectCounts{Success: 2, Total: 2, NoChanges: 1}),
 	)
+}
+
+type failingGetPullStatusDB struct {
+	db.Database
+	err error
+}
+
+func (f failingGetPullStatusDB) GetPullStatus(models.PullRequest) (*models.PullStatus, error) {
+	return nil, f.err
 }

--- a/server/events/apply_plan_validator.go
+++ b/server/events/apply_plan_validator.go
@@ -70,29 +70,19 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 	if err != nil {
 		return fmt.Errorf("fetching live pull request: %w", err)
 	}
-	if livePull.HeadCommit != "" {
-		if pullStatus.Pull.HeadCommit == "" {
-			return fmt.Errorf("recorded plan status has no head commit; run `atlantis plan` before apply")
-		}
-		if pullStatus.Pull.HeadCommit != livePull.HeadCommit {
-			return fmt.Errorf(
-				"recorded plan status is from commit %s but live pull request head is %s; run `atlantis plan` before apply",
-				shortSHA(pullStatus.Pull.HeadCommit),
-				shortSHA(livePull.HeadCommit),
-			)
-		}
+	if livePull.HeadCommit != "" || livePull.BaseBranch != "" {
 		currentPull := ctx.Pull
 		currentPull.HeadCommit = livePull.HeadCommit
 		if livePull.BaseBranch != "" {
 			currentPull.BaseBranch = livePull.BaseBranch
 		}
-		if err := pullStatusFreshnessError(currentPull, pullStatus.Pull, "recorded plan status"); err != nil {
+		if err := pullStatusApplyEligibilityError(currentPull, pullStatus.Pull, "recorded plan status"); err != nil {
 			return err
 		}
 		if err := validateCommandStartIdentity(ctx, livePull); err != nil {
 			return err
 		}
-	} else if err := pullStatusFreshnessError(ctx.Pull, pullStatus.Pull, "recorded plan status"); err != nil {
+	} else if err := pullStatusApplyEligibilityError(ctx.Pull, pullStatus.Pull, "recorded plan status"); err != nil {
 		return rejectProjectPlan(planPath, "%s", err)
 	}
 
@@ -283,9 +273,25 @@ func pullStatusFreshForPull(pull models.PullRequest, statusPull models.PullReque
 }
 
 func pullStatusFreshnessError(pull models.PullRequest, statusPull models.PullRequest, subject string) error {
+	return pullStatusFreshnessErrorWithMissingFields(pull, statusPull, subject, false)
+}
+
+func pullStatusApplyEligibilityError(pull models.PullRequest, statusPull models.PullRequest, subject string) error {
+	return pullStatusFreshnessErrorWithMissingFields(pull, statusPull, subject, true)
+}
+
+func pullStatusFreshnessErrorWithMissingFields(pull models.PullRequest, statusPull models.PullRequest, subject string, rejectMissing bool) error {
 	verb := "is"
 	if subject == "plans" {
 		verb = "are"
+	}
+	if rejectMissing && pull.HeadCommit != "" && statusPull.HeadCommit == "" {
+		return fmt.Errorf(
+			"%s %s missing a recorded head commit while current head is %s; run `atlantis plan` before apply",
+			subject,
+			verb,
+			shortSHA(pull.HeadCommit),
+		)
 	}
 	if pull.HeadCommit != "" && statusPull.HeadCommit != "" && statusPull.HeadCommit != pull.HeadCommit {
 		return fmt.Errorf(
@@ -298,6 +304,14 @@ func pullStatusFreshnessError(pull models.PullRequest, statusPull models.PullReq
 	}
 	currentBase := strings.TrimSpace(pull.BaseBranch)
 	statusBase := strings.TrimSpace(statusPull.BaseBranch)
+	if rejectMissing && currentBase != "" && statusBase == "" {
+		return fmt.Errorf(
+			"%s %s missing a recorded base branch while current base branch is %q; run `atlantis plan` before apply",
+			subject,
+			verb,
+			currentBase,
+		)
+	}
 	if currentBase != "" && statusBase != "" && statusBase != currentBase {
 		return fmt.Errorf(
 			"%s %s for base branch %q but current base branch is %q; run `atlantis plan` before apply",

--- a/server/events/apply_plan_validator.go
+++ b/server/events/apply_plan_validator.go
@@ -81,15 +81,16 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 				shortSHA(liveHead),
 			)
 		}
+		currentPull := ctx.Pull
+		currentPull.HeadCommit = liveHead
+		if err := pullStatusFreshnessError(currentPull, pullStatus.Pull, "recorded plan status"); err != nil {
+			return err
+		}
 		if err := validateCommandStartHead(ctx, liveHead); err != nil {
 			return err
 		}
-	} else if !pullStatusHeadMatchesPull(ctx.Pull, pullStatus.Pull) {
-		return rejectProjectPlan(planPath,
-			"recorded plan status is from commit %s but current head is %s; run `atlantis plan` before apply",
-			shortSHA(pullStatus.Pull.HeadCommit),
-			shortSHA(ctx.Pull.HeadCommit),
-		)
+	} else if err := pullStatusFreshnessError(ctx.Pull, pullStatus.Pull, "recorded plan status"); err != nil {
+		return rejectProjectPlan(planPath, "%s", err)
 	}
 
 	proj := findProjectInPullStatus(pullStatus, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName)
@@ -264,9 +265,34 @@ func looksLikeCommitSHA(s string) bool {
 	return true
 }
 
-func pullStatusHeadMatchesPull(pull models.PullRequest, statusPull models.PullRequest) bool {
-	if pull.HeadCommit == "" || statusPull.HeadCommit == "" {
-		return true
+func pullStatusFreshForPull(pull models.PullRequest, statusPull models.PullRequest) bool {
+	return pullStatusFreshnessError(pull, statusPull, "recorded plan status") == nil
+}
+
+func pullStatusFreshnessError(pull models.PullRequest, statusPull models.PullRequest, subject string) error {
+	verb := "is"
+	if subject == "plans" {
+		verb = "are"
 	}
-	return statusPull.HeadCommit == pull.HeadCommit
+	if pull.HeadCommit != "" && statusPull.HeadCommit != "" && statusPull.HeadCommit != pull.HeadCommit {
+		return fmt.Errorf(
+			"%s %s from commit %s but current head is %s; run `atlantis plan` before apply",
+			subject,
+			verb,
+			shortSHA(statusPull.HeadCommit),
+			shortSHA(pull.HeadCommit),
+		)
+	}
+	currentBase := strings.TrimSpace(pull.BaseBranch)
+	statusBase := strings.TrimSpace(statusPull.BaseBranch)
+	if currentBase != "" && statusBase != "" && statusBase != currentBase {
+		return fmt.Errorf(
+			"%s %s for base branch %q but current base branch is %q; run `atlantis plan` before apply",
+			subject,
+			verb,
+			statusBase,
+			currentBase,
+		)
+	}
+	return nil
 }

--- a/server/events/apply_plan_validator.go
+++ b/server/events/apply_plan_validator.go
@@ -23,6 +23,10 @@ type ApplyPlanValidator interface {
 	ValidateProjectPlan(ctx command.ProjectContext, absPath string) error
 }
 
+type ApplyCommandStartValidator interface {
+	ValidateCommandStartHead(ctx command.ProjectContext) error
+}
+
 type LivePullHeadFetcher interface {
 	GetLiveHeadCommit(ctx command.ProjectContext) (string, error)
 }
@@ -33,6 +37,17 @@ type DefaultApplyPlanValidator struct {
 }
 
 var errStaleCommandHead = errors.New("stale command head")
+
+func (v *DefaultApplyPlanValidator) ValidateCommandStartHead(ctx command.ProjectContext) error {
+	if v == nil || v.LivePullHeadFetcher == nil {
+		return nil
+	}
+	liveHead, err := v.getLiveHeadCommit(ctx)
+	if err != nil {
+		return fmt.Errorf("fetching live pull request head: %w", err)
+	}
+	return validateCommandStartHead(ctx, liveHead)
+}
 
 func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectContext, absPath string) error {
 	if v == nil || v.PullStatusFetcher == nil {
@@ -66,13 +81,8 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 				shortSHA(liveHead),
 			)
 		}
-		if ctx.Pull.HeadCommit != "" && looksLikeCommitSHA(ctx.Pull.HeadCommit) && ctx.Pull.HeadCommit != liveHead {
-			return fmt.Errorf(
-				"%w: pull request head changed from %s to %s; run `atlantis plan` before apply",
-				errStaleCommandHead,
-				shortSHA(ctx.Pull.HeadCommit),
-				shortSHA(liveHead),
-			)
+		if err := validateCommandStartHead(ctx, liveHead); err != nil {
+			return err
 		}
 	} else if !pullStatusHeadMatchesPull(ctx.Pull, pullStatus.Pull) {
 		return rejectProjectPlan(planPath,
@@ -126,6 +136,18 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 	}
 
 	return nil
+}
+
+func validateCommandStartHead(ctx command.ProjectContext, liveHead string) error {
+	if liveHead == "" || ctx.Pull.HeadCommit == "" || !looksLikeCommitSHA(ctx.Pull.HeadCommit) || ctx.Pull.HeadCommit == liveHead {
+		return nil
+	}
+	return fmt.Errorf(
+		"%w: pull request head changed from %s to %s; run `atlantis plan` before apply",
+		errStaleCommandHead,
+		shortSHA(ctx.Pull.HeadCommit),
+		shortSHA(liveHead),
+	)
 }
 
 func (v *DefaultApplyPlanValidator) pullStatusForApply(ctx command.ProjectContext) (*models.PullStatus, error) {

--- a/server/events/apply_plan_validator.go
+++ b/server/events/apply_plan_validator.go
@@ -46,7 +46,7 @@ func (v *DefaultApplyPlanValidator) ValidateCommandStartHead(ctx command.Project
 	if err != nil {
 		return fmt.Errorf("fetching live pull request: %w", err)
 	}
-	return validateCommandStartHead(ctx, livePull.HeadCommit)
+	return validateCommandStartIdentity(ctx, livePull)
 }
 
 func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectContext, absPath string) error {
@@ -89,7 +89,7 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 		if err := pullStatusFreshnessError(currentPull, pullStatus.Pull, "recorded plan status"); err != nil {
 			return err
 		}
-		if err := validateCommandStartHead(ctx, livePull.HeadCommit); err != nil {
+		if err := validateCommandStartIdentity(ctx, livePull); err != nil {
 			return err
 		}
 	} else if err := pullStatusFreshnessError(ctx.Pull, pullStatus.Pull, "recorded plan status"); err != nil {
@@ -143,14 +143,28 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 }
 
 func validateCommandStartHead(ctx command.ProjectContext, liveHead string) error {
-	if liveHead == "" || ctx.Pull.HeadCommit == "" || !looksLikeCommitSHA(ctx.Pull.HeadCommit) || ctx.Pull.HeadCommit == liveHead {
+	return validateCommandStartIdentity(ctx, models.PullRequest{HeadCommit: liveHead})
+}
+
+func validateCommandStartIdentity(ctx command.ProjectContext, livePull models.PullRequest) error {
+	if livePull.HeadCommit != "" && ctx.Pull.HeadCommit != "" && looksLikeCommitSHA(ctx.Pull.HeadCommit) && ctx.Pull.HeadCommit != livePull.HeadCommit {
+		return fmt.Errorf(
+			"%w: pull request head changed from %s to %s; run `atlantis plan` before apply",
+			errStaleCommandHead,
+			shortSHA(ctx.Pull.HeadCommit),
+			shortSHA(livePull.HeadCommit),
+		)
+	}
+	commandBase := strings.TrimSpace(ctx.Pull.BaseBranch)
+	liveBase := strings.TrimSpace(livePull.BaseBranch)
+	if commandBase == "" || liveBase == "" || commandBase == liveBase {
 		return nil
 	}
 	return fmt.Errorf(
-		"%w: pull request head changed from %s to %s; run `atlantis plan` before apply",
+		"%w: pull request base branch changed from %q to %q; run `atlantis plan` before apply",
 		errStaleCommandHead,
-		shortSHA(ctx.Pull.HeadCommit),
-		shortSHA(liveHead),
+		commandBase,
+		liveBase,
 	)
 }
 

--- a/server/events/apply_plan_validator.go
+++ b/server/events/apply_plan_validator.go
@@ -28,7 +28,7 @@ type ApplyCommandStartValidator interface {
 }
 
 type LivePullHeadFetcher interface {
-	GetLiveHeadCommit(ctx command.ProjectContext) (string, error)
+	GetLivePullIdentity(ctx command.ProjectContext) (models.PullRequest, error)
 }
 
 type DefaultApplyPlanValidator struct {
@@ -42,11 +42,11 @@ func (v *DefaultApplyPlanValidator) ValidateCommandStartHead(ctx command.Project
 	if v == nil || v.LivePullHeadFetcher == nil {
 		return nil
 	}
-	liveHead, err := v.getLiveHeadCommit(ctx)
+	livePull, err := v.getLivePullIdentity(ctx)
 	if err != nil {
-		return fmt.Errorf("fetching live pull request head: %w", err)
+		return fmt.Errorf("fetching live pull request: %w", err)
 	}
-	return validateCommandStartHead(ctx, liveHead)
+	return validateCommandStartHead(ctx, livePull.HeadCommit)
 }
 
 func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectContext, absPath string) error {
@@ -66,27 +66,30 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 		return rejectProjectPlan(planPath, "no current plan status found; run `atlantis plan` before apply")
 	}
 
-	liveHead, err := v.getLiveHeadCommit(ctx)
+	livePull, err := v.getLivePullIdentity(ctx)
 	if err != nil {
-		return fmt.Errorf("fetching live pull request head: %w", err)
+		return fmt.Errorf("fetching live pull request: %w", err)
 	}
-	if liveHead != "" {
+	if livePull.HeadCommit != "" {
 		if pullStatus.Pull.HeadCommit == "" {
 			return fmt.Errorf("recorded plan status has no head commit; run `atlantis plan` before apply")
 		}
-		if pullStatus.Pull.HeadCommit != liveHead {
+		if pullStatus.Pull.HeadCommit != livePull.HeadCommit {
 			return fmt.Errorf(
 				"recorded plan status is from commit %s but live pull request head is %s; run `atlantis plan` before apply",
 				shortSHA(pullStatus.Pull.HeadCommit),
-				shortSHA(liveHead),
+				shortSHA(livePull.HeadCommit),
 			)
 		}
 		currentPull := ctx.Pull
-		currentPull.HeadCommit = liveHead
+		currentPull.HeadCommit = livePull.HeadCommit
+		if livePull.BaseBranch != "" {
+			currentPull.BaseBranch = livePull.BaseBranch
+		}
 		if err := pullStatusFreshnessError(currentPull, pullStatus.Pull, "recorded plan status"); err != nil {
 			return err
 		}
-		if err := validateCommandStartHead(ctx, liveHead); err != nil {
+		if err := validateCommandStartHead(ctx, livePull.HeadCommit); err != nil {
 			return err
 		}
 	} else if err := pullStatusFreshnessError(ctx.Pull, pullStatus.Pull, "recorded plan status"); err != nil {
@@ -165,21 +168,21 @@ func (v *DefaultApplyPlanValidator) pullStatusForApply(ctx command.ProjectContex
 	return nil, nil
 }
 
-func (v *DefaultApplyPlanValidator) getLiveHeadCommit(ctx command.ProjectContext) (string, error) {
+func (v *DefaultApplyPlanValidator) getLivePullIdentity(ctx command.ProjectContext) (models.PullRequest, error) {
 	if v.LivePullHeadFetcher == nil {
-		return "", nil
+		return models.PullRequest{}, nil
 	}
 	if ctx.API && ctx.Pull.Num <= 0 {
-		return "", nil
+		return models.PullRequest{}, nil
 	}
-	liveHead, err := v.LivePullHeadFetcher.GetLiveHeadCommit(ctx)
+	livePull, err := v.LivePullHeadFetcher.GetLivePullIdentity(ctx)
 	if err != nil {
-		return "", err
+		return models.PullRequest{}, err
 	}
-	if liveHead == "" {
-		return "", fmt.Errorf("live pull request head is empty")
+	if livePull.HeadCommit == "" {
+		return models.PullRequest{}, fmt.Errorf("live pull request head is empty")
 	}
-	return liveHead, nil
+	return livePull, nil
 }
 
 func statusAllowedForApplyExecution(status models.ProjectPlanStatus) bool {

--- a/server/events/apply_plan_validator.go
+++ b/server/events/apply_plan_validator.go
@@ -1,0 +1,77 @@
+// Copyright 2025 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package events
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/runatlantis/atlantis/server/core/runtime"
+	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/events/models"
+)
+
+type ApplyPlanValidator interface {
+	ValidateProjectPlan(ctx command.ProjectContext, absPath string) error
+}
+
+type DefaultApplyPlanValidator struct {
+	PullStatusFetcher PullStatusFetcher
+}
+
+func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectContext, absPath string) error {
+	if v == nil || v.PullStatusFetcher == nil {
+		return nil
+	}
+
+	pullStatus, err := v.PullStatusFetcher.GetPullStatus(ctx.Pull)
+	if err != nil {
+		return fmt.Errorf("fetching current plan status: %w", err)
+	}
+	if pullStatus == nil {
+		return fmt.Errorf("no current plan status found; run `atlantis plan` before apply")
+	}
+	if !pullStatusHeadMatchesPull(ctx.Pull, pullStatus.Pull) {
+		return fmt.Errorf(
+			"recorded plan status is from commit %s but current head is %s; run `atlantis plan` before apply",
+			shortSHA(pullStatus.Pull.HeadCommit),
+			shortSHA(ctx.Pull.HeadCommit),
+		)
+	}
+
+	proj := findProjectInPullStatus(pullStatus, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName)
+	if proj == nil {
+		return fmt.Errorf(
+			"no matching plan status exists for dir %q workspace %q project %q; run `atlantis plan`",
+			ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName,
+		)
+	}
+	if !statusAllowedForDiscoveredPlan(proj.Status) {
+		return fmt.Errorf(
+			"plan for dir %q workspace %q project %q has status %q and cannot be applied; run `atlantis plan`",
+			ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName, proj.Status.String(),
+		)
+	}
+
+	planPath := filepath.Join(absPath, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	if _, err := os.Stat(planPath); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf(
+				"plan file is missing for dir %q workspace %q project %q; run `atlantis plan`",
+				ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName,
+			)
+		}
+		return fmt.Errorf("checking plan file for dir %q workspace %q project %q: %w", ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName, err)
+	}
+
+	return nil
+}
+
+func pullStatusHeadMatchesPull(pull models.PullRequest, statusPull models.PullRequest) bool {
+	if pull.HeadCommit == "" || statusPull.HeadCommit == "" {
+		return true
+	}
+	return statusPull.HeadCommit == pull.HeadCommit
+}

--- a/server/events/apply_plan_validator.go
+++ b/server/events/apply_plan_validator.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/runatlantis/atlantis/server/core/runtime"
 	"github.com/runatlantis/atlantis/server/events/command"
@@ -39,7 +40,7 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 		return err
 	}
 
-	pullStatus, err := v.PullStatusFetcher.GetPullStatus(ctx.Pull)
+	pullStatus, err := v.pullStatusForApply(ctx)
 	if err != nil {
 		return fmt.Errorf("fetching current plan status: %w", err)
 	}
@@ -53,17 +54,17 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 	}
 	if liveHead != "" {
 		if ctx.Pull.HeadCommit != "" && ctx.Pull.HeadCommit != liveHead {
-			return rejectProjectPlan(planPath,
+			return fmt.Errorf(
 				"pull request head changed from %s to %s; run `atlantis plan` before apply",
 				shortSHA(ctx.Pull.HeadCommit),
 				shortSHA(liveHead),
 			)
 		}
 		if pullStatus.Pull.HeadCommit == "" {
-			return rejectProjectPlan(planPath, "recorded plan status has no head commit; run `atlantis plan` before apply")
+			return fmt.Errorf("recorded plan status has no head commit; run `atlantis plan` before apply")
 		}
 		if pullStatus.Pull.HeadCommit != liveHead {
-			return rejectProjectPlan(planPath,
+			return fmt.Errorf(
 				"recorded plan status is from commit %s but live pull request head is %s; run `atlantis plan` before apply",
 				shortSHA(pullStatus.Pull.HeadCommit),
 				shortSHA(liveHead),
@@ -108,7 +109,7 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 	}
 
 	if ctx.ExpectedPlanHash != "" {
-		actualHash, err := hashFile(planPath)
+		actualHash, err := hashFile(absPath, planPath)
 		if err != nil {
 			return fmt.Errorf("hashing plan file for dir %q workspace %q project %q: %w", ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName, err)
 		}
@@ -123,8 +124,25 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 	return nil
 }
 
+func (v *DefaultApplyPlanValidator) pullStatusForApply(ctx command.ProjectContext) (*models.PullStatus, error) {
+	pullStatus, err := v.PullStatusFetcher.GetPullStatus(ctx.Pull)
+	if err != nil {
+		return nil, err
+	}
+	if pullStatus != nil {
+		return pullStatus, nil
+	}
+	if ctx.API && ctx.PullStatus != nil {
+		return ctx.PullStatus, nil
+	}
+	return nil, nil
+}
+
 func (v *DefaultApplyPlanValidator) getLiveHeadCommit(ctx command.ProjectContext) (string, error) {
 	if v.LivePullHeadFetcher == nil {
+		return "", nil
+	}
+	if ctx.API && ctx.Pull.Num <= 0 {
 		return "", nil
 	}
 	liveHead, err := v.LivePullHeadFetcher.GetLiveHeadCommit(ctx)
@@ -153,8 +171,8 @@ func planFilePath(ctx command.ProjectContext, absPath string) string {
 
 func safePlanFilePath(ctx command.ProjectContext, absPath string) (string, error) {
 	planPath := planFilePath(ctx, absPath)
-	if err := utils.EnsureSubPath(absPath, planPath); err != nil {
-		return "", fmt.Errorf("plan path traversal detected: %w", err)
+	if _, err := containedPlanRelPath(absPath, planPath); err != nil {
+		return "", err
 	}
 	return planPath, nil
 }
@@ -162,14 +180,18 @@ func safePlanFilePath(ctx command.ProjectContext, absPath string) (string, error
 func pendingPlanFilePath(plan PendingPlan) (string, error) {
 	absPath := filepath.Join(plan.RepoDir, plan.RepoRelDir)
 	planPath := filepath.Join(absPath, runtime.GetPlanFilename(plan.Workspace, plan.ProjectName))
-	if err := utils.EnsureSubPath(absPath, planPath); err != nil {
-		return "", fmt.Errorf("plan path traversal detected: %w", err)
+	if _, err := containedPlanRelPath(absPath, planPath); err != nil {
+		return "", err
 	}
 	return planPath, nil
 }
 
-func hashFile(path string) (string, error) {
-	file, err := os.Open(path)
+func hashFile(baseDir, path string) (string, error) {
+	relPath, err := containedPlanRelPath(baseDir, path)
+	if err != nil {
+		return "", err
+	}
+	file, err := os.OpenInRoot(filepath.Clean(baseDir), relPath)
 	if err != nil {
 		return "", err
 	}
@@ -180,6 +202,19 @@ func hashFile(path string) (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func containedPlanRelPath(baseDir, path string) (string, error) {
+	cleanBase := filepath.Clean(baseDir)
+	cleanPath := filepath.Clean(path)
+	relPath, err := filepath.Rel(cleanBase, cleanPath)
+	if err != nil {
+		return "", fmt.Errorf("checking plan path containment: %w", err)
+	}
+	if relPath == ".." || strings.HasPrefix(relPath, ".."+string(os.PathSeparator)) || filepath.IsAbs(relPath) {
+		return "", fmt.Errorf("plan path traversal detected: %w", utils.ErrPathEscapesBase)
+	}
+	return relPath, nil
 }
 
 func rejectProjectPlan(planPath string, format string, args ...any) error {

--- a/server/events/apply_plan_validator.go
+++ b/server/events/apply_plan_validator.go
@@ -142,10 +142,6 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 	return nil
 }
 
-func validateCommandStartHead(ctx command.ProjectContext, liveHead string) error {
-	return validateCommandStartIdentity(ctx, models.PullRequest{HeadCommit: liveHead})
-}
-
 func validateCommandStartIdentity(ctx command.ProjectContext, livePull models.PullRequest) error {
 	if livePull.HeadCommit != "" && ctx.Pull.HeadCommit != "" && looksLikeCommitSHA(ctx.Pull.HeadCommit) && ctx.Pull.HeadCommit != livePull.HeadCommit {
 		return fmt.Errorf(

--- a/server/events/apply_plan_validator.go
+++ b/server/events/apply_plan_validator.go
@@ -6,6 +6,7 @@ package events
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -30,6 +31,8 @@ type DefaultApplyPlanValidator struct {
 	PullStatusFetcher   PullStatusFetcher
 	LivePullHeadFetcher LivePullHeadFetcher
 }
+
+var errStaleCommandHead = errors.New("stale command head")
 
 func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectContext, absPath string) error {
 	if v == nil || v.PullStatusFetcher == nil {
@@ -65,7 +68,8 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 		}
 		if ctx.Pull.HeadCommit != "" && looksLikeCommitSHA(ctx.Pull.HeadCommit) && ctx.Pull.HeadCommit != liveHead {
 			return fmt.Errorf(
-				"pull request head changed from %s to %s; run `atlantis plan` before apply",
+				"%w: pull request head changed from %s to %s; run `atlantis plan` before apply",
+				errStaleCommandHead,
 				shortSHA(ctx.Pull.HeadCommit),
 				shortSHA(liveHead),
 			)

--- a/server/events/apply_plan_validator.go
+++ b/server/events/apply_plan_validator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/runtime"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/utils"
 )
 
 type ApplyPlanValidator interface {
@@ -25,16 +26,17 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 	if v == nil || v.PullStatusFetcher == nil {
 		return nil
 	}
+	planPath := planFilePath(ctx, absPath)
 
 	pullStatus, err := v.PullStatusFetcher.GetPullStatus(ctx.Pull)
 	if err != nil {
 		return fmt.Errorf("fetching current plan status: %w", err)
 	}
 	if pullStatus == nil {
-		return fmt.Errorf("no current plan status found; run `atlantis plan` before apply")
+		return rejectProjectPlan(planPath, "no current plan status found; run `atlantis plan` before apply")
 	}
 	if !pullStatusHeadMatchesPull(ctx.Pull, pullStatus.Pull) {
-		return fmt.Errorf(
+		return rejectProjectPlan(planPath,
 			"recorded plan status is from commit %s but current head is %s; run `atlantis plan` before apply",
 			shortSHA(pullStatus.Pull.HeadCommit),
 			shortSHA(ctx.Pull.HeadCommit),
@@ -43,19 +45,24 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 
 	proj := findProjectInPullStatus(pullStatus, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName)
 	if proj == nil {
-		return fmt.Errorf(
+		return rejectProjectPlan(planPath,
 			"no matching plan status exists for dir %q workspace %q project %q; run `atlantis plan`",
 			ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName,
 		)
 	}
-	if !statusAllowedForDiscoveredPlan(proj.Status) {
-		return fmt.Errorf(
+	if !statusAllowedForApplyExecution(proj.Status) {
+		if proj.Status == models.ErroredPolicyCheckStatus {
+			return rejectProjectPlan(planPath,
+				"policy checks have errored for dir %q workspace %q project %q and cannot be applied; run `atlantis plan`",
+				ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName,
+			)
+		}
+		return rejectProjectPlan(planPath,
 			"plan for dir %q workspace %q project %q has status %q and cannot be applied; run `atlantis plan`",
 			ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName, proj.Status.String(),
 		)
 	}
 
-	planPath := filepath.Join(absPath, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
 	if _, err := os.Stat(planPath); err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf(
@@ -67,6 +74,28 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 	}
 
 	return nil
+}
+
+func statusAllowedForApplyExecution(status models.ProjectPlanStatus) bool {
+	switch status {
+	case models.PlannedPlanStatus, models.PassedPolicyCheckStatus, models.ErroredApplyStatus,
+		models.PlannedNoChangesPlanStatus:
+		return true
+	default:
+		return false
+	}
+}
+
+func planFilePath(ctx command.ProjectContext, absPath string) string {
+	return filepath.Join(absPath, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+}
+
+func rejectProjectPlan(planPath string, format string, args ...any) error {
+	err := fmt.Errorf(format, args...)
+	if removeErr := utils.RemoveIgnoreNonExistent(planPath); removeErr != nil {
+		return fmt.Errorf("%w; deleting rejected plan file %q: %v", err, planPath, removeErr)
+	}
+	return err
 }
 
 func pullStatusHeadMatchesPull(pull models.PullRequest, statusPull models.PullRequest) bool {

--- a/server/events/apply_plan_validator.go
+++ b/server/events/apply_plan_validator.go
@@ -4,7 +4,10 @@
 package events
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -18,8 +21,13 @@ type ApplyPlanValidator interface {
 	ValidateProjectPlan(ctx command.ProjectContext, absPath string) error
 }
 
+type LivePullHeadFetcher interface {
+	GetLiveHeadCommit(ctx command.ProjectContext) (string, error)
+}
+
 type DefaultApplyPlanValidator struct {
-	PullStatusFetcher PullStatusFetcher
+	PullStatusFetcher   PullStatusFetcher
+	LivePullHeadFetcher LivePullHeadFetcher
 }
 
 func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectContext, absPath string) error {
@@ -35,7 +43,30 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 	if pullStatus == nil {
 		return rejectProjectPlan(planPath, "no current plan status found; run `atlantis plan` before apply")
 	}
-	if !pullStatusHeadMatchesPull(ctx.Pull, pullStatus.Pull) {
+
+	liveHead, err := v.getLiveHeadCommit(ctx)
+	if err != nil {
+		return fmt.Errorf("fetching live pull request head: %w", err)
+	}
+	if liveHead != "" {
+		if ctx.Pull.HeadCommit != "" && ctx.Pull.HeadCommit != liveHead {
+			return rejectProjectPlan(planPath,
+				"pull request head changed from %s to %s; run `atlantis plan` before apply",
+				shortSHA(ctx.Pull.HeadCommit),
+				shortSHA(liveHead),
+			)
+		}
+		if pullStatus.Pull.HeadCommit == "" {
+			return rejectProjectPlan(planPath, "recorded plan status has no head commit; run `atlantis plan` before apply")
+		}
+		if pullStatus.Pull.HeadCommit != liveHead {
+			return rejectProjectPlan(planPath,
+				"recorded plan status is from commit %s but live pull request head is %s; run `atlantis plan` before apply",
+				shortSHA(pullStatus.Pull.HeadCommit),
+				shortSHA(liveHead),
+			)
+		}
+	} else if !pullStatusHeadMatchesPull(ctx.Pull, pullStatus.Pull) {
 		return rejectProjectPlan(planPath,
 			"recorded plan status is from commit %s but current head is %s; run `atlantis plan` before apply",
 			shortSHA(pullStatus.Pull.HeadCommit),
@@ -73,7 +104,34 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 		return fmt.Errorf("checking plan file for dir %q workspace %q project %q: %w", ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName, err)
 	}
 
+	if ctx.ExpectedPlanHash != "" {
+		actualHash, err := hashFile(planPath)
+		if err != nil {
+			return fmt.Errorf("hashing plan file for dir %q workspace %q project %q: %w", ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName, err)
+		}
+		if actualHash != ctx.ExpectedPlanHash {
+			return rejectProjectPlan(planPath,
+				"plan file changed for dir %q workspace %q project %q; run `atlantis plan` before apply",
+				ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName,
+			)
+		}
+	}
+
 	return nil
+}
+
+func (v *DefaultApplyPlanValidator) getLiveHeadCommit(ctx command.ProjectContext) (string, error) {
+	if v.LivePullHeadFetcher == nil {
+		return "", nil
+	}
+	liveHead, err := v.LivePullHeadFetcher.GetLiveHeadCommit(ctx)
+	if err != nil {
+		return "", err
+	}
+	if liveHead == "" {
+		return "", fmt.Errorf("live pull request head is empty")
+	}
+	return liveHead, nil
 }
 
 func statusAllowedForApplyExecution(status models.ProjectPlanStatus) bool {
@@ -88,6 +146,24 @@ func statusAllowedForApplyExecution(status models.ProjectPlanStatus) bool {
 
 func planFilePath(ctx command.ProjectContext, absPath string) string {
 	return filepath.Join(absPath, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+}
+
+func pendingPlanFilePath(plan PendingPlan) string {
+	return filepath.Join(plan.RepoDir, plan.RepoRelDir, runtime.GetPlanFilename(plan.Workspace, plan.ProjectName))
+}
+
+func hashFile(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
 func rejectProjectPlan(planPath string, format string, args ...any) error {

--- a/server/events/apply_plan_validator.go
+++ b/server/events/apply_plan_validator.go
@@ -34,7 +34,10 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 	if v == nil || v.PullStatusFetcher == nil {
 		return nil
 	}
-	planPath := planFilePath(ctx, absPath)
+	planPath, err := safePlanFilePath(ctx, absPath)
+	if err != nil {
+		return err
+	}
 
 	pullStatus, err := v.PullStatusFetcher.GetPullStatus(ctx.Pull)
 	if err != nil {
@@ -110,7 +113,7 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 			return fmt.Errorf("hashing plan file for dir %q workspace %q project %q: %w", ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName, err)
 		}
 		if actualHash != ctx.ExpectedPlanHash {
-			return rejectProjectPlan(planPath,
+			return fmt.Errorf(
 				"plan file changed for dir %q workspace %q project %q; run `atlantis plan` before apply",
 				ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName,
 			)
@@ -148,8 +151,21 @@ func planFilePath(ctx command.ProjectContext, absPath string) string {
 	return filepath.Join(absPath, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
 }
 
-func pendingPlanFilePath(plan PendingPlan) string {
-	return filepath.Join(plan.RepoDir, plan.RepoRelDir, runtime.GetPlanFilename(plan.Workspace, plan.ProjectName))
+func safePlanFilePath(ctx command.ProjectContext, absPath string) (string, error) {
+	planPath := planFilePath(ctx, absPath)
+	if err := utils.EnsureSubPath(absPath, planPath); err != nil {
+		return "", fmt.Errorf("plan path traversal detected: %w", err)
+	}
+	return planPath, nil
+}
+
+func pendingPlanFilePath(plan PendingPlan) (string, error) {
+	absPath := filepath.Join(plan.RepoDir, plan.RepoRelDir)
+	planPath := filepath.Join(absPath, runtime.GetPlanFilename(plan.Workspace, plan.ProjectName))
+	if err := utils.EnsureSubPath(absPath, planPath); err != nil {
+		return "", fmt.Errorf("plan path traversal detected: %w", err)
+	}
+	return planPath, nil
 }
 
 func hashFile(path string) (string, error) {

--- a/server/events/apply_plan_validator.go
+++ b/server/events/apply_plan_validator.go
@@ -53,13 +53,6 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 		return fmt.Errorf("fetching live pull request head: %w", err)
 	}
 	if liveHead != "" {
-		if ctx.Pull.HeadCommit != "" && ctx.Pull.HeadCommit != liveHead {
-			return fmt.Errorf(
-				"pull request head changed from %s to %s; run `atlantis plan` before apply",
-				shortSHA(ctx.Pull.HeadCommit),
-				shortSHA(liveHead),
-			)
-		}
 		if pullStatus.Pull.HeadCommit == "" {
 			return fmt.Errorf("recorded plan status has no head commit; run `atlantis plan` before apply")
 		}
@@ -67,6 +60,13 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 			return fmt.Errorf(
 				"recorded plan status is from commit %s but live pull request head is %s; run `atlantis plan` before apply",
 				shortSHA(pullStatus.Pull.HeadCommit),
+				shortSHA(liveHead),
+			)
+		}
+		if ctx.Pull.HeadCommit != "" && looksLikeCommitSHA(ctx.Pull.HeadCommit) && ctx.Pull.HeadCommit != liveHead {
+			return fmt.Errorf(
+				"pull request head changed from %s to %s; run `atlantis plan` before apply",
+				shortSHA(ctx.Pull.HeadCommit),
 				shortSHA(liveHead),
 			)
 		}
@@ -125,15 +125,15 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 }
 
 func (v *DefaultApplyPlanValidator) pullStatusForApply(ctx command.ProjectContext) (*models.PullStatus, error) {
+	if ctx.API && ctx.PullStatus != nil {
+		return ctx.PullStatus, nil
+	}
 	pullStatus, err := v.PullStatusFetcher.GetPullStatus(ctx.Pull)
 	if err != nil {
 		return nil, err
 	}
 	if pullStatus != nil {
 		return pullStatus, nil
-	}
-	if ctx.API && ctx.PullStatus != nil {
-		return ctx.PullStatus, nil
 	}
 	return nil, nil
 }
@@ -223,6 +223,19 @@ func rejectProjectPlan(planPath string, format string, args ...any) error {
 		return fmt.Errorf("%w; deleting rejected plan file %q: %v", err, planPath, removeErr)
 	}
 	return err
+}
+
+func looksLikeCommitSHA(s string) bool {
+	if len(s) < 7 || len(s) > 64 {
+		return false
+	}
+	for _, r := range s {
+		if (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F') {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func pullStatusHeadMatchesPull(pull models.PullRequest, statusPull models.PullRequest) bool {

--- a/server/events/command/project_context.go
+++ b/server/events/command/project_context.go
@@ -166,6 +166,10 @@ type ProjectContext struct {
 	// remediation from sending legacy event: apply webhooks.
 	SuppressApplyWebhooks bool
 
+	// RemoteApplyRunURL receives the Terraform Cloud/Enterprise run URL found by
+	// remote apply execution so deferred final status publication can use it.
+	RemoteApplyRunURL *string
+
 	// FailOnMissingDependencies makes apply dependency validation fail when a
 	// configured dependency is not present in PullStatus.
 	FailOnMissingDependencies bool

--- a/server/events/command/project_context.go
+++ b/server/events/command/project_context.go
@@ -78,6 +78,9 @@ type ProjectContext struct {
 	PullReqStatus models.PullReqStatus
 	// CurrentProjectPlanStatus is the status of the current project prior to this command.
 	ProjectPlanStatus models.ProjectPlanStatus
+	// ExpectedPlanHash is the SHA-256 hash of the plan file selected when the
+	// apply command was built.
+	ExpectedPlanHash string
 	//PullStatus is the status of the current pull request prior to this command.
 	PullStatus *models.PullStatus
 	// ProjectPolicyStatus is the status of policy sets of the current project prior to this command.

--- a/server/events/command/project_result.go
+++ b/server/events/command/project_result.go
@@ -23,6 +23,7 @@ type ProjectCommandOutput struct {
 	PlanSuccess        *models.PlanSuccess
 	PolicyCheckResults *models.PolicyCheckResults
 	ApplySuccess       string
+	ApplySuccessURL    string `json:"-"`
 	VersionSuccess     string
 	ImportSuccess      *models.ImportSuccess
 	StateRmSuccess     *models.StateRmSuccess

--- a/server/events/command/project_result.go
+++ b/server/events/command/project_result.go
@@ -84,6 +84,13 @@ func (p ProjectResult) PlanStatus() models.ProjectPlanStatus {
 			return models.ErroredApplyStatus
 		}
 		return models.AppliedPlanStatus
+	case Import, State:
+		if p.Error != nil {
+			return models.ErroredPlanStatus
+		} else if p.Failure != "" {
+			return models.ErroredPlanStatus
+		}
+		return models.DiscardedPlanStatus
 	}
 
 	panic("PlanStatus() missing a combination")

--- a/server/events/command/project_result_test.go
+++ b/server/events/command/project_result_test.go
@@ -173,6 +173,25 @@ func TestProjectResult_PlanStatus(t *testing.T) {
 			},
 			expStatus: models.ErroredPolicyCheckStatus,
 		},
+		{
+			p: command.ProjectResult{
+				Command: command.Import,
+				ProjectCommandOutput: command.ProjectCommandOutput{
+					ImportSuccess: &models.ImportSuccess{},
+				},
+			},
+			expStatus: models.DiscardedPlanStatus,
+		},
+		{
+			p: command.ProjectResult{
+				Command:    command.State,
+				SubCommand: "rm",
+				ProjectCommandOutput: command.ProjectCommandOutput{
+					StateRmSuccess: &models.StateRmSuccess{},
+				},
+			},
+			expStatus: models.DiscardedPlanStatus,
+		},
 	}
 
 	for _, c := range cases {

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -238,6 +238,7 @@ func setup(t *testing.T, options ...func(testConfig *TestConfig)) *vcsmocks.Mock
 
 	importCommandRunner = events.NewImportCommandRunner(
 		pullUpdater,
+		dbUpdater,
 		pullReqStatusFetcher,
 		projectCommandBuilder,
 		projectCommandRunner,
@@ -246,6 +247,7 @@ func setup(t *testing.T, options ...func(testConfig *TestConfig)) *vcsmocks.Mock
 
 	stateCommandRunner = events.NewStateCommandRunner(
 		pullUpdater,
+		dbUpdater,
 		projectCommandBuilder,
 		projectCommandRunner,
 	)
@@ -451,6 +453,36 @@ func TestRunCommentCommandPlan_NoProjects_SilenceEnabled(t *testing.T) {
 		Eq[command.Name](command.Plan),
 		Eq(models.ProjectCounts{}),
 	)
+}
+
+func TestRunCommentCommandPlan_NoProjectsWritesCurrentEmptyPullStatus(t *testing.T) {
+	_ = setup(t)
+	planCommandRunner.SilenceNoProjects = true
+
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	_, err := dbUpdater.Database.UpdatePullWithResults(modelPull, []command.ProjectResult{
+		{
+			Command:    command.Plan,
+			RepoRelDir: "old-project",
+			Workspace:  events.DefaultWorkspace,
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PlanSuccess: &models.PlanSuccess{},
+			},
+		},
+	})
+	Ok(t, err)
+
+	var pull github.PullRequest
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(&pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(&pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+
+	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan})
+
+	pullStatus, err := dbUpdater.Database.GetPullStatus(modelPull)
+	Ok(t, err)
+	Assert(t, pullStatus != nil, "expected current empty PullStatus")
+	Equals(t, "abc123", pullStatus.Pull.HeadCommit)
+	Equals(t, 0, len(pullStatus.Projects))
 }
 
 func TestRunCommentCommandPlan_NoProjectsTarget_SilenceEnabled(t *testing.T) {
@@ -829,6 +861,95 @@ func TestRunCommentCommandImport_NoProjects_SilenceEnabled(t *testing.T) {
 
 	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Import})
 	vcsClient.VerifyWasCalled(Never()).CreateComment(Any[logging.SimpleLogging](), Any[models.Repo](), Any[int](), Any[string](), Any[string]())
+}
+
+func TestImportOrStateRm_DiscardedPlanStatusAllowsLaterGenericApply(t *testing.T) {
+	cases := []struct {
+		name       string
+		cmd        events.CommentCommand
+		projectCmd command.ProjectContext
+		output     command.ProjectCommandOutput
+	}{
+		{
+			name: "import",
+			cmd:  events.CommentCommand{Name: command.Import, ProjectName: "projA"},
+			projectCmd: command.ProjectContext{
+				CommandName: command.Import,
+				RepoRelDir:  "dir1",
+				Workspace:   events.DefaultWorkspace,
+				ProjectName: "projA",
+			},
+			output: command.ProjectCommandOutput{ImportSuccess: &models.ImportSuccess{}},
+		},
+		{
+			name: "state rm",
+			cmd:  events.CommentCommand{Name: command.State, SubName: "rm", ProjectName: "projA"},
+			projectCmd: command.ProjectContext{
+				CommandName: command.State,
+				SubCommand:  "rm",
+				RepoRelDir:  "dir1",
+				Workspace:   events.DefaultWorkspace,
+				ProjectName: "projA",
+			},
+			output: command.ProjectCommandOutput{StateRmSuccess: &models.StateRmSuccess{}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_ = setup(t)
+			logger := logging.NewNoopLogger(t)
+			modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+			_, err := dbUpdater.Database.UpdatePullWithResults(modelPull, []command.ProjectResult{
+				{
+					Command:     command.Plan,
+					RepoRelDir:  tc.projectCmd.RepoRelDir,
+					Workspace:   tc.projectCmd.Workspace,
+					ProjectName: tc.projectCmd.ProjectName,
+					ProjectCommandOutput: command.ProjectCommandOutput{
+						PlanSuccess: &models.PlanSuccess{},
+					},
+				},
+			})
+			Ok(t, err)
+
+			ctx := &command.Context{
+				User:     testdata.User,
+				Log:      logger,
+				Scope:    metricstest.NewLoggingScope(t, logger, "atlantis"),
+				Pull:     modelPull,
+				HeadRepo: testdata.GithubRepo,
+				Trigger:  command.CommentTrigger,
+			}
+			tc.projectCmd.BaseRepo = testdata.GithubRepo
+			tc.projectCmd.Pull = modelPull
+
+			switch tc.cmd.Name {
+			case command.Import:
+				When(pullReqStatusFetcher.FetchPullStatus(logger, modelPull)).ThenReturn(models.PullReqStatus{}, nil)
+				When(projectCommandBuilder.BuildImportCommands(ctx, &tc.cmd)).ThenReturn([]command.ProjectContext{tc.projectCmd}, nil)
+				When(projectCommandRunner.Import(tc.projectCmd)).ThenReturn(tc.output)
+				importCommandRunner.Run(ctx, &tc.cmd)
+			case command.State:
+				When(projectCommandBuilder.BuildStateRmCommands(ctx, &tc.cmd)).ThenReturn([]command.ProjectContext{tc.projectCmd}, nil)
+				When(projectCommandRunner.StateRm(tc.projectCmd)).ThenReturn(tc.output)
+				stateCommandRunner.Run(ctx, &tc.cmd)
+			}
+
+			pullStatus, err := dbUpdater.Database.GetPullStatus(modelPull)
+			Ok(t, err)
+			Assert(t, pullStatus != nil, "expected PullStatus")
+			Equals(t, 1, len(pullStatus.Projects))
+			Equals(t, models.DiscardedPlanStatus, pullStatus.Projects[0].Status)
+
+			applyCtx := &command.Context{
+				Log:        logger,
+				Pull:       modelPull,
+				PullStatus: pullStatus,
+			}
+			Ok(t, events.ValidatePlansForApply(applyCtx, nil))
+		})
+	}
 }
 
 func TestRunCommentCommand_DisableApplyAllDisabled(t *testing.T) {

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -694,7 +694,9 @@ func TestRunCommentCommandApply_NoProjects_SilenceEnabled(t *testing.T) {
 	vcsClient := setup(t)
 	applyCommandRunner.SilenceNoProjects = true
 	var pull github.PullRequest
-	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState}
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123", BaseBranch: "main"}
+	_, err := dbUpdater.Database.UpdatePullWithResults(modelPull, nil)
+	Ok(t, err)
 	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(&pull, nil)
 	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(&pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
 

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -2756,6 +2756,8 @@ func setupApplyWithAutoMerge(t *testing.T, options ...func(testConfig *TestConfi
 	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState}
 	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(pull, nil)
 	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+	_, err := dbUpdater.Database.UpdatePullWithResults(modelPull, nil)
+	Ok(t, err)
 	autoMerger.GlobalAutomerge = true
 	autoMerger.GlobalAutomergeMethod = ""
 	t.Cleanup(func() {

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -830,6 +830,142 @@ func TestPlanCommandRunner_HoldsPlanInFlightLockAcrossCleanupPlanAndDBWrite(t *t
 	Assert(t, !locker.HasCommandLock(testdata.GithubRepo.FullName, testdata.Pull.Num, command.Plan), "expected plan lock to be released")
 }
 
+func TestPlanCommandRunner_HoldsPlanLockDuringStalePlanCleanup(t *testing.T) {
+	locker := events.NewDefaultWorkingDirLocker()
+	setup(t, func(tc *TestConfig) {
+		tc.workingDirLocker = locker
+	})
+	pull := &github.PullRequest{State: github.Ptr("open")}
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	cmd := &events.CommentCommand{Name: command.Plan}
+	projectCtx := command.ProjectContext{
+		CommandName: command.Plan,
+		RepoRelDir:  ".",
+		Workspace:   events.DefaultWorkspace,
+		BaseRepo:    testdata.GithubRepo,
+		Pull:        modelPull,
+	}
+	tmp := t.TempDir()
+
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+	When(projectCommandBuilder.BuildPlanCommands(Any[*command.Context](), Eq(cmd))).ThenReturn([]command.ProjectContext{projectCtx}, nil)
+	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(tmp, nil)
+	When(pendingPlanFinder.Find(tmp)).Then(func([]Param) ReturnValues {
+		Assert(t, locker.HasCommandLock(testdata.GithubRepo.FullName, testdata.Pull.Num, command.Plan), "expected plan lock during stale plan cleanup")
+		return ReturnValues{[]events.PendingPlan{}, nil}
+	})
+	When(projectCommandRunner.Plan(projectCtx)).ThenReturn(command.ProjectCommandOutput{PlanSuccess: &models.PlanSuccess{}})
+
+	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, cmd)
+
+	pendingPlanFinder.VerifyWasCalledOnce().Find(tmp)
+}
+
+func TestPlanCommandRunner_HoldsPlanLockDuringPullStatusWrite(t *testing.T) {
+	locker := events.NewDefaultWorkingDirLocker()
+	realDB := newTestBoltDB(t)
+	writeObserved := false
+	database := assertPlanLockDB{
+		Database:     realDB,
+		t:            t,
+		locker:       locker,
+		repoFullName: testdata.GithubRepo.FullName,
+		pullNum:      testdata.Pull.Num,
+		called:       &writeObserved,
+	}
+	setup(t, func(tc *TestConfig) {
+		tc.database = database
+		tc.workingDirLocker = locker
+	})
+	pull := &github.PullRequest{State: github.Ptr("open")}
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	cmd := &events.CommentCommand{Name: command.Plan}
+	projectCtx := command.ProjectContext{
+		CommandName: command.Plan,
+		RepoRelDir:  ".",
+		Workspace:   events.DefaultWorkspace,
+		BaseRepo:    testdata.GithubRepo,
+		Pull:        modelPull,
+	}
+	tmp := t.TempDir()
+
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+	When(projectCommandBuilder.BuildPlanCommands(Any[*command.Context](), Eq(cmd))).ThenReturn([]command.ProjectContext{projectCtx}, nil)
+	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(tmp, nil)
+	When(pendingPlanFinder.Find(tmp)).ThenReturn([]events.PendingPlan{}, nil)
+	When(projectCommandRunner.Plan(projectCtx)).ThenReturn(command.ProjectCommandOutput{PlanSuccess: &models.PlanSuccess{}})
+
+	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, cmd)
+
+	Assert(t, writeObserved, "expected pull status write to be observed")
+}
+
+func TestPlanCommandRunner_AutoplanHoldsPlanLockDuringStalePlanCleanup(t *testing.T) {
+	locker := events.NewDefaultWorkingDirLocker()
+	setup(t, func(tc *TestConfig) {
+		tc.workingDirLocker = locker
+	})
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	projectCtx := command.ProjectContext{
+		CommandName: command.Plan,
+		RepoRelDir:  ".",
+		Workspace:   events.DefaultWorkspace,
+		BaseRepo:    testdata.GithubRepo,
+		Pull:        modelPull,
+	}
+	tmp := t.TempDir()
+
+	When(projectCommandBuilder.BuildAutoplanCommands(Any[*command.Context]())).ThenReturn([]command.ProjectContext{projectCtx}, nil)
+	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(tmp, nil)
+	When(pendingPlanFinder.Find(tmp)).Then(func([]Param) ReturnValues {
+		Assert(t, locker.HasCommandLock(testdata.GithubRepo.FullName, testdata.Pull.Num, command.Plan), "expected autoplan lock during stale plan cleanup")
+		return ReturnValues{[]events.PendingPlan{}, nil}
+	})
+	When(projectCommandRunner.Plan(projectCtx)).ThenReturn(command.ProjectCommandOutput{PlanSuccess: &models.PlanSuccess{}})
+
+	ch.RunAutoplanCommand(testdata.GithubRepo, testdata.GithubRepo, modelPull, testdata.User)
+
+	pendingPlanFinder.VerifyWasCalledOnce().Find(tmp)
+}
+
+func TestPlanCommandRunner_AutoplanHoldsPlanLockDuringPullStatusWrite(t *testing.T) {
+	locker := events.NewDefaultWorkingDirLocker()
+	realDB := newTestBoltDB(t)
+	writeObserved := false
+	database := assertPlanLockDB{
+		Database:     realDB,
+		t:            t,
+		locker:       locker,
+		repoFullName: testdata.GithubRepo.FullName,
+		pullNum:      testdata.Pull.Num,
+		called:       &writeObserved,
+	}
+	setup(t, func(tc *TestConfig) {
+		tc.database = database
+		tc.workingDirLocker = locker
+	})
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	projectCtx := command.ProjectContext{
+		CommandName: command.Plan,
+		RepoRelDir:  ".",
+		Workspace:   events.DefaultWorkspace,
+		BaseRepo:    testdata.GithubRepo,
+		Pull:        modelPull,
+	}
+	tmp := t.TempDir()
+
+	When(projectCommandBuilder.BuildAutoplanCommands(Any[*command.Context]())).ThenReturn([]command.ProjectContext{projectCtx}, nil)
+	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(tmp, nil)
+	When(pendingPlanFinder.Find(tmp)).ThenReturn([]events.PendingPlan{}, nil)
+	When(projectCommandRunner.Plan(projectCtx)).ThenReturn(command.ProjectCommandOutput{PlanSuccess: &models.PlanSuccess{}})
+
+	ch.RunAutoplanCommand(testdata.GithubRepo, testdata.GithubRepo, modelPull, testdata.User)
+
+	Assert(t, writeObserved, "expected autoplan pull status write to be observed")
+}
+
 func TestRunCommentCommand_IgnoredTargetedDirNoOp(t *testing.T) {
 	cases := []struct {
 		name        string
@@ -1677,6 +1813,21 @@ func plannedProjectResult(repoRelDir, workspace, projectName string) command.Pro
 			PlanSuccess: &models.PlanSuccess{},
 		},
 	}
+}
+
+type assertPlanLockDB struct {
+	db.Database
+	t            *testing.T
+	locker       events.WorkingDirLocker
+	repoFullName string
+	pullNum      int
+	called       *bool
+}
+
+func (a assertPlanLockDB) UpdatePullWithResults(pull models.PullRequest, results []command.ProjectResult) (models.PullStatus, error) {
+	*a.called = true
+	Assert(a.t, a.locker.HasCommandLock(a.repoFullName, a.pullNum, command.Plan), "expected plan lock during pull status write")
+	return a.Database.UpdatePullWithResults(pull, results)
 }
 
 func projectStatus(t *testing.T, pullStatus *models.PullStatus, workspace, repoRelDir, projectName string) models.ProjectStatus {

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -7,6 +7,8 @@ package events_test
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -15,6 +17,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/core/db"
 	"github.com/runatlantis/atlantis/server/core/locking"
+	"github.com/runatlantis/atlantis/server/core/runtime"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/metrics/metricstest"
@@ -174,6 +177,7 @@ func setup(t *testing.T, options ...func(testConfig *TestConfig)) *vcsmocks.Mock
 		vcsClient,
 		pendingPlanFinder,
 		workingDir,
+		events.NewDefaultWorkingDirLocker(),
 		commitUpdater,
 		projectCommandBuilder,
 		projectCommandRunner,
@@ -492,6 +496,10 @@ func TestRunCommentCommandPlan_NoProjectsClearsOldPlanFilesAndPullStatus(t *test
 	planCommandRunner.SilenceNoProjects = true
 
 	tmp := t.TempDir()
+	oldPlanDir := filepath.Join(tmp, "old-project")
+	Ok(t, os.MkdirAll(oldPlanDir, 0700))
+	oldPlanPath := filepath.Join(oldPlanDir, runtime.GetPlanFilename(events.DefaultWorkspace, ""))
+	Ok(t, os.WriteFile(oldPlanPath, []byte("old plan"), 0600))
 	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
 	_, err := dbUpdater.Database.UpdatePullWithResults(modelPull, []command.ProjectResult{
 		{
@@ -509,15 +517,68 @@ func TestRunCommentCommandPlan_NoProjectsClearsOldPlanFilesAndPullStatus(t *test
 	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(&pull, nil)
 	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(&pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
 	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(tmp, nil)
+	When(pendingPlanFinder.Find(tmp)).ThenReturn([]events.PendingPlan{
+		{RepoDir: tmp, RepoRelDir: "old-project", Workspace: events.DefaultWorkspace},
+	}, nil)
 
 	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan})
 
-	pendingPlanFinder.VerifyWasCalledOnce().DeletePlans(tmp)
+	pendingPlanFinder.VerifyWasCalledOnce().Find(tmp)
+	_, err = os.Stat(oldPlanPath)
+	Assert(t, os.IsNotExist(err), "expected old plan file to be removed")
 	pullStatus, err := dbUpdater.Database.GetPullStatus(modelPull)
 	Ok(t, err)
 	Assert(t, pullStatus != nil, "expected current empty PullStatus")
 	Equals(t, "abc123", pullStatus.Pull.HeadCommit)
 	Equals(t, 0, len(pullStatus.Projects))
+}
+
+func TestRunCommentCommandPlan_NoProjectsDoesNotUnlockActiveLocks(t *testing.T) {
+	vcsClient := setup(t)
+	installPlanCommandRunnerLocker(vcsClient, failUnlockByPullLocker{t: t}, true)
+
+	tmp := t.TempDir()
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	var pull github.PullRequest
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(&pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(&pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(tmp, nil)
+
+	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan})
+
+	pendingPlanFinder.VerifyWasCalledOnce().Find(tmp)
+}
+
+func TestRunCommentCommandPlan_NoProjectsEmptyPullStatusWriteFailureIsUserVisible(t *testing.T) {
+	vcsClient := setup(t)
+	planCommandRunner.SilenceNoProjects = true
+
+	tmp := t.TempDir()
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	cmd := &events.CommentCommand{Name: command.Plan}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     modelPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	closer := dbUpdater.Database.(interface{ Close() error })
+	Ok(t, closer.Close())
+
+	When(projectCommandBuilder.BuildPlanCommands(ctx, cmd)).ThenReturn([]command.ProjectContext{}, nil)
+	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(tmp, nil)
+
+	planCommandRunner.Run(ctx, cmd)
+
+	Assert(t, ctx.CommandHasErrors, "expected empty PullStatus write failure to mark command errored")
+	commitUpdater.VerifyWasCalledOnce().UpdateCombined(
+		Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull), Eq(models.FailedCommitStatus), Eq(command.Plan))
+	_, _, _, comment, _ := vcsClient.VerifyWasCalledOnce().CreateComment(
+		Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull.Num), Any[string](), Eq("plan")).GetCapturedArguments()
+	Assert(t, strings.Contains(comment, "Plan Error"), "got: %s", comment)
+	Assert(t, strings.Contains(comment, "writing empty plan status"), "got: %s", comment)
 }
 
 func TestRunCommentCommandPlan_NoProjectsTarget_SilenceEnabled(t *testing.T) {
@@ -1203,6 +1264,313 @@ func TestImportOrStateRm_DoesNotDiscardPlanStatusOnErrorOrFailure(t *testing.T) 
 	}
 }
 
+func TestImportOrStateRm_DiscardsOnlyExistingPullStatusProject(t *testing.T) {
+	cases := []struct {
+		name       string
+		cmd        events.CommentCommand
+		projectCmd command.ProjectContext
+		output     command.ProjectCommandOutput
+	}{
+		{
+			name: "import",
+			cmd:  events.CommentCommand{Name: command.Import, ProjectName: "projB"},
+			projectCmd: command.ProjectContext{
+				CommandName: command.Import,
+				RepoRelDir:  "dir1",
+				Workspace:   events.DefaultWorkspace,
+				ProjectName: "projB",
+			},
+			output: command.ProjectCommandOutput{ImportSuccess: &models.ImportSuccess{}},
+		},
+		{
+			name: "state rm",
+			cmd:  events.CommentCommand{Name: command.State, SubName: "rm", ProjectName: "projB"},
+			projectCmd: command.ProjectContext{
+				CommandName: command.State,
+				SubCommand:  "rm",
+				RepoRelDir:  "dir1",
+				Workspace:   events.DefaultWorkspace,
+				ProjectName: "projB",
+			},
+			output: command.ProjectCommandOutput{StateRmSuccess: &models.StateRmSuccess{}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_ = setup(t)
+			modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+			_, err := dbUpdater.Database.UpdatePullWithResults(modelPull, []command.ProjectResult{
+				plannedProjectResult("dir1", events.DefaultWorkspace, "projA"),
+				plannedProjectResult("dir1", events.DefaultWorkspace, "projB"),
+			})
+			Ok(t, err)
+
+			runImportOrStateRmResult(t, modelPull, tc.cmd, tc.projectCmd, tc.output)
+
+			pullStatus, err := dbUpdater.Database.GetPullStatus(modelPull)
+			Ok(t, err)
+			Equals(t, models.PlannedPlanStatus, projectStatus(t, pullStatus, events.DefaultWorkspace, "dir1", "projA").Status)
+			Equals(t, models.DiscardedPlanStatus, projectStatus(t, pullStatus, events.DefaultWorkspace, "dir1", "projB").Status)
+		})
+	}
+}
+
+func TestImportOrStateRm_DoesNotCreateDiscardedStatusWithoutPullStatus(t *testing.T) {
+	cases := []struct {
+		name       string
+		cmd        events.CommentCommand
+		projectCmd command.ProjectContext
+		output     command.ProjectCommandOutput
+	}{
+		{
+			name: "import",
+			cmd:  events.CommentCommand{Name: command.Import, ProjectName: "projA"},
+			projectCmd: command.ProjectContext{
+				CommandName: command.Import,
+				RepoRelDir:  "dir1",
+				Workspace:   events.DefaultWorkspace,
+				ProjectName: "projA",
+			},
+			output: command.ProjectCommandOutput{ImportSuccess: &models.ImportSuccess{}},
+		},
+		{
+			name: "state rm",
+			cmd:  events.CommentCommand{Name: command.State, SubName: "rm", ProjectName: "projA"},
+			projectCmd: command.ProjectContext{
+				CommandName: command.State,
+				SubCommand:  "rm",
+				RepoRelDir:  "dir1",
+				Workspace:   events.DefaultWorkspace,
+				ProjectName: "projA",
+			},
+			output: command.ProjectCommandOutput{StateRmSuccess: &models.StateRmSuccess{}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_ = setup(t)
+			modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+
+			runImportOrStateRmResult(t, modelPull, tc.cmd, tc.projectCmd, tc.output)
+
+			pullStatus, err := dbUpdater.Database.GetPullStatus(modelPull)
+			Ok(t, err)
+			Assert(t, pullStatus == nil, "expected no PullStatus to be created")
+		})
+	}
+}
+
+func TestImportOrStateRm_DoesNotCreateDiscardedStatusForMissingProject(t *testing.T) {
+	cases := []struct {
+		name       string
+		cmd        events.CommentCommand
+		projectCmd command.ProjectContext
+		output     command.ProjectCommandOutput
+	}{
+		{
+			name: "import",
+			cmd:  events.CommentCommand{Name: command.Import, ProjectName: "projB"},
+			projectCmd: command.ProjectContext{
+				CommandName: command.Import,
+				RepoRelDir:  "dir1",
+				Workspace:   events.DefaultWorkspace,
+				ProjectName: "projB",
+			},
+			output: command.ProjectCommandOutput{ImportSuccess: &models.ImportSuccess{}},
+		},
+		{
+			name: "state rm",
+			cmd:  events.CommentCommand{Name: command.State, SubName: "rm", ProjectName: "projB"},
+			projectCmd: command.ProjectContext{
+				CommandName: command.State,
+				SubCommand:  "rm",
+				RepoRelDir:  "dir1",
+				Workspace:   events.DefaultWorkspace,
+				ProjectName: "projB",
+			},
+			output: command.ProjectCommandOutput{StateRmSuccess: &models.StateRmSuccess{}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_ = setup(t)
+			modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+			_, err := dbUpdater.Database.UpdatePullWithResults(modelPull, []command.ProjectResult{
+				plannedProjectResult("dir1", events.DefaultWorkspace, "projA"),
+			})
+			Ok(t, err)
+
+			runImportOrStateRmResult(t, modelPull, tc.cmd, tc.projectCmd, tc.output)
+
+			pullStatus, err := dbUpdater.Database.GetPullStatus(modelPull)
+			Ok(t, err)
+			Equals(t, 1, len(pullStatus.Projects))
+			Equals(t, models.PlannedPlanStatus, projectStatus(t, pullStatus, events.DefaultWorkspace, "dir1", "projA").Status)
+		})
+	}
+}
+
+func TestImportOrStateRm_DoesNotDiscardStaleHeadPullStatus(t *testing.T) {
+	cases := []struct {
+		name       string
+		cmd        events.CommentCommand
+		projectCmd command.ProjectContext
+		output     command.ProjectCommandOutput
+	}{
+		{
+			name: "import",
+			cmd:  events.CommentCommand{Name: command.Import, ProjectName: "projA"},
+			projectCmd: command.ProjectContext{
+				CommandName: command.Import,
+				RepoRelDir:  "dir1",
+				Workspace:   events.DefaultWorkspace,
+				ProjectName: "projA",
+			},
+			output: command.ProjectCommandOutput{ImportSuccess: &models.ImportSuccess{}},
+		},
+		{
+			name: "state rm",
+			cmd:  events.CommentCommand{Name: command.State, SubName: "rm", ProjectName: "projA"},
+			projectCmd: command.ProjectContext{
+				CommandName: command.State,
+				SubCommand:  "rm",
+				RepoRelDir:  "dir1",
+				Workspace:   events.DefaultWorkspace,
+				ProjectName: "projA",
+			},
+			output: command.ProjectCommandOutput{StateRmSuccess: &models.StateRmSuccess{}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_ = setup(t)
+			stalePull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "old123"}
+			currentPull := stalePull
+			currentPull.HeadCommit = "new123"
+			_, err := dbUpdater.Database.UpdatePullWithResults(stalePull, []command.ProjectResult{
+				plannedProjectResult("dir1", events.DefaultWorkspace, "projA"),
+			})
+			Ok(t, err)
+
+			runImportOrStateRmResult(t, currentPull, tc.cmd, tc.projectCmd, tc.output)
+
+			pullStatus, err := dbUpdater.Database.GetPullStatus(currentPull)
+			Ok(t, err)
+			Assert(t, pullStatus != nil, "expected stale PullStatus to remain")
+			Equals(t, "old123", pullStatus.Pull.HeadCommit)
+			Equals(t, models.PlannedPlanStatus, projectStatus(t, pullStatus, events.DefaultWorkspace, "dir1", "projA").Status)
+		})
+	}
+}
+
+func runImportOrStateRmResult(t *testing.T, pull models.PullRequest, cmd events.CommentCommand, projectCmd command.ProjectContext, output command.ProjectCommandOutput) {
+	t.Helper()
+	logger := logging.NewNoopLogger(t)
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logger,
+		Scope:    metricstest.NewLoggingScope(t, logger, "atlantis"),
+		Pull:     pull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	projectCmd.BaseRepo = testdata.GithubRepo
+	projectCmd.Pull = pull
+
+	switch cmd.Name {
+	case command.Import:
+		When(pullReqStatusFetcher.FetchPullStatus(logger, pull)).ThenReturn(models.PullReqStatus{}, nil)
+		When(projectCommandBuilder.BuildImportCommands(ctx, &cmd)).ThenReturn([]command.ProjectContext{projectCmd}, nil)
+		When(projectCommandRunner.Import(projectCmd)).ThenReturn(output)
+		importCommandRunner.Run(ctx, &cmd)
+	case command.State:
+		When(projectCommandBuilder.BuildStateRmCommands(ctx, &cmd)).ThenReturn([]command.ProjectContext{projectCmd}, nil)
+		When(projectCommandRunner.StateRm(projectCmd)).ThenReturn(output)
+		stateCommandRunner.Run(ctx, &cmd)
+	default:
+		t.Fatalf("unsupported command %q", cmd.Name)
+	}
+}
+
+func plannedProjectResult(repoRelDir, workspace, projectName string) command.ProjectResult {
+	return command.ProjectResult{
+		Command:     command.Plan,
+		RepoRelDir:  repoRelDir,
+		Workspace:   workspace,
+		ProjectName: projectName,
+		ProjectCommandOutput: command.ProjectCommandOutput{
+			PlanSuccess: &models.PlanSuccess{},
+		},
+	}
+}
+
+func projectStatus(t *testing.T, pullStatus *models.PullStatus, workspace, repoRelDir, projectName string) models.ProjectStatus {
+	t.Helper()
+	for _, project := range pullStatus.Projects {
+		if project.Workspace == workspace && project.RepoRelDir == repoRelDir && project.ProjectName == projectName {
+			return project
+		}
+	}
+	t.Fatalf("missing project status for dir %q workspace %q project %q", repoRelDir, workspace, projectName)
+	return models.ProjectStatus{}
+}
+
+type failUnlockByPullLocker struct {
+	t *testing.T
+}
+
+func (l failUnlockByPullLocker) TryLock(models.Project, string, models.PullRequest, models.User) (locking.TryLockResponse, error) {
+	return locking.TryLockResponse{}, nil
+}
+
+func (l failUnlockByPullLocker) Unlock(string) (*models.ProjectLock, error) {
+	return nil, nil
+}
+
+func (l failUnlockByPullLocker) List() (map[string]models.ProjectLock, error) {
+	return nil, nil
+}
+
+func (l failUnlockByPullLocker) UnlockByPull(string, int) ([]models.ProjectLock, error) {
+	l.t.Fatalf("no-project cleanup must not call UnlockByPull")
+	return nil, nil
+}
+
+func (l failUnlockByPullLocker) GetLock(string) (*models.ProjectLock, error) {
+	return nil, nil
+}
+
+func installPlanCommandRunnerLocker(vcsClient *vcsmocks.MockClient, locker locking.Locker, silenceNoProjects bool) {
+	planCommandRunner = events.NewPlanCommandRunner(
+		false,
+		false,
+		vcsClient,
+		pendingPlanFinder,
+		workingDir,
+		events.NewDefaultWorkingDirLocker(),
+		commitUpdater,
+		projectCommandBuilder,
+		projectCommandRunner,
+		cancellationTracker,
+		dbUpdater,
+		pullUpdater,
+		policyCheckCommandRunner,
+		autoMerger,
+		1,
+		silenceNoProjects,
+		dbUpdater.Database,
+		locker,
+		false,
+		pullReqStatusFetcher,
+		false,
+	)
+	ch.CommentCommandRunnerByCmd[command.Plan] = planCommandRunner
+}
+
 func TestRunCommentCommand_DisableApplyAllDisabled(t *testing.T) {
 	t.Log("if \"atlantis apply\" is run and this is disabled atlantis should" +
 		" comment saying that this is not allowed")
@@ -1511,7 +1879,7 @@ func TestRunAutoplanCommand_DeletePlans(t *testing.T) {
 	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(tmp, nil)
 	testdata.Pull.BaseRepo = testdata.GithubRepo
 	ch.RunAutoplanCommand(testdata.GithubRepo, testdata.GithubRepo, testdata.Pull, testdata.User)
-	pendingPlanFinder.VerifyWasCalledOnce().DeletePlans(tmp)
+	pendingPlanFinder.VerifyWasCalledOnce().Find(tmp)
 }
 
 func TestRunAutoplan_NoProjectsWritesCurrentEmptyPullStatus(t *testing.T) {
@@ -1546,6 +1914,10 @@ func TestRunAutoplan_NoProjectsWritesCurrentEmptyPullStatus(t *testing.T) {
 func TestRunAutoplan_NoProjectsClearsOldPlanFilesAndPullStatus(t *testing.T) {
 	setup(t)
 	tmp := t.TempDir()
+	oldPlanDir := filepath.Join(tmp, "old-project")
+	Ok(t, os.MkdirAll(oldPlanDir, 0700))
+	oldPlanPath := filepath.Join(oldPlanDir, runtime.GetPlanFilename(events.DefaultWorkspace, ""))
+	Ok(t, os.WriteFile(oldPlanPath, []byte("old plan"), 0600))
 	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
 	_, err := dbUpdater.Database.UpdatePullWithResults(modelPull, []command.ProjectResult{
 		{
@@ -1562,15 +1934,64 @@ func TestRunAutoplan_NoProjectsClearsOldPlanFilesAndPullStatus(t *testing.T) {
 	When(projectCommandBuilder.BuildAutoplanCommands(Any[*command.Context]())).
 		ThenReturn([]command.ProjectContext{}, nil)
 	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(tmp, nil)
+	When(pendingPlanFinder.Find(tmp)).ThenReturn([]events.PendingPlan{
+		{RepoDir: tmp, RepoRelDir: "old-project", Workspace: events.DefaultWorkspace},
+	}, nil)
 
 	ch.RunAutoplanCommand(testdata.GithubRepo, testdata.GithubRepo, modelPull, testdata.User)
 
-	pendingPlanFinder.VerifyWasCalledOnce().DeletePlans(tmp)
+	pendingPlanFinder.VerifyWasCalledOnce().Find(tmp)
+	_, err = os.Stat(oldPlanPath)
+	Assert(t, os.IsNotExist(err), "expected old plan file to be removed")
 	pullStatus, err := dbUpdater.Database.GetPullStatus(modelPull)
 	Ok(t, err)
 	Assert(t, pullStatus != nil, "expected current empty PullStatus")
 	Equals(t, "abc123", pullStatus.Pull.HeadCommit)
 	Equals(t, 0, len(pullStatus.Projects))
+}
+
+func TestRunAutoplan_NoProjectsDoesNotUnlockActiveLocks(t *testing.T) {
+	vcsClient := setup(t)
+	installPlanCommandRunnerLocker(vcsClient, failUnlockByPullLocker{t: t}, false)
+
+	tmp := t.TempDir()
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	When(projectCommandBuilder.BuildAutoplanCommands(Any[*command.Context]())).
+		ThenReturn([]command.ProjectContext{}, nil)
+	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(tmp, nil)
+
+	ch.RunAutoplanCommand(testdata.GithubRepo, testdata.GithubRepo, modelPull, testdata.User)
+
+	pendingPlanFinder.VerifyWasCalledOnce().Find(tmp)
+}
+
+func TestRunAutoplan_NoProjectsEmptyPullStatusWriteFailureIsUserVisible(t *testing.T) {
+	vcsClient := setup(t)
+	tmp := t.TempDir()
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     modelPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.AutoTrigger,
+	}
+	closer := dbUpdater.Database.(interface{ Close() error })
+	Ok(t, closer.Close())
+
+	When(projectCommandBuilder.BuildAutoplanCommands(ctx)).ThenReturn([]command.ProjectContext{}, nil)
+	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(tmp, nil)
+
+	planCommandRunner.Run(ctx, &events.CommentCommand{Name: command.Plan})
+
+	Assert(t, ctx.CommandHasErrors, "expected empty PullStatus write failure to mark autoplan errored")
+	commitUpdater.VerifyWasCalledOnce().UpdateCombined(
+		Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull), Eq(models.FailedCommitStatus), Eq(command.Plan))
+	_, _, _, comment, _ := vcsClient.VerifyWasCalledOnce().CreateComment(
+		Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull.Num), Any[string](), Eq("plan")).GetCapturedArguments()
+	Assert(t, strings.Contains(comment, "Plan Error"), "got: %s", comment)
+	Assert(t, strings.Contains(comment, "writing empty plan status"), "got: %s", comment)
 }
 
 func TestRunAutoplanCommand_FailedPreWorkflowHook_FailOnPreWorkflowHookError_False(t *testing.T) {
@@ -1596,7 +2017,7 @@ func TestRunAutoplanCommand_FailedPreWorkflowHook_FailOnPreWorkflowHookError_Fal
 	testdata.Pull.BaseRepo = testdata.GithubRepo
 	ch.FailOnPreWorkflowHookError = false
 	ch.RunAutoplanCommand(testdata.GithubRepo, testdata.GithubRepo, testdata.Pull, testdata.User)
-	pendingPlanFinder.VerifyWasCalledOnce().DeletePlans(tmp)
+	pendingPlanFinder.VerifyWasCalledOnce().Find(tmp)
 	commitUpdater.VerifyWasCalledOnce().UpdateCombined(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](),
 		Eq(models.PendingCommitStatus), Eq(command.Plan))
 	commitUpdater.VerifyWasCalled(Never()).UpdateCombined(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](),
@@ -1624,7 +2045,7 @@ func TestRunAutoplanCommand_FailedPreWorkflowHook_FailOnPreWorkflowHookError_Tru
 	testdata.Pull.BaseRepo = testdata.GithubRepo
 	ch.FailOnPreWorkflowHookError = true
 	ch.RunAutoplanCommand(testdata.GithubRepo, testdata.GithubRepo, testdata.Pull, testdata.User)
-	pendingPlanFinder.VerifyWasCalled(Never()).DeletePlans(Any[string]())
+	pendingPlanFinder.VerifyWasCalled(Never()).Find(Any[string]())
 	// gomock will fail if lockingLocker.UnlockByPull is called unexpectedly (no EXPECT set)
 	commitUpdater.VerifyWasCalledOnce().UpdateCombined(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](),
 		Eq(models.FailedCommitStatus), Eq(command.Plan))
@@ -1656,7 +2077,7 @@ func TestRunCommentCommand_FailedPreWorkflowHook_FailOnPreWorkflowHookError_Fals
 	testdata.Pull.BaseRepo = testdata.GithubRepo
 	ch.FailOnPreWorkflowHookError = false
 	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan})
-	pendingPlanFinder.VerifyWasCalledOnce().DeletePlans(tmp)
+	pendingPlanFinder.VerifyWasCalledOnce().Find(tmp)
 }
 
 func TestRunCommentCommand_FailedPreWorkflowHook_FailOnPreWorkflowHookError_True(t *testing.T) {
@@ -1676,7 +2097,7 @@ func TestRunCommentCommand_FailedPreWorkflowHook_FailOnPreWorkflowHookError_True
 	testdata.Pull.BaseRepo = testdata.GithubRepo
 	ch.FailOnPreWorkflowHookError = true
 	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan})
-	pendingPlanFinder.VerifyWasCalled(Never()).DeletePlans(Any[string]())
+	pendingPlanFinder.VerifyWasCalled(Never()).Find(Any[string]())
 	// gomock will fail if lockingLocker.UnlockByPull is called unexpectedly (no EXPECT set)
 }
 
@@ -1715,7 +2136,7 @@ func TestRunGenericPlanCommand_DeletePlans(t *testing.T) {
 	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
 	testdata.Pull.BaseRepo = testdata.GithubRepo
 	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan})
-	pendingPlanFinder.VerifyWasCalledOnce().DeletePlans(tmp)
+	pendingPlanFinder.VerifyWasCalledOnce().Find(tmp)
 }
 
 func TestRunSpecificPlanCommandDoesnt_DeletePlans(t *testing.T) {
@@ -1735,7 +2156,7 @@ func TestRunSpecificPlanCommandDoesnt_DeletePlans(t *testing.T) {
 	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(tmp, nil)
 	testdata.Pull.BaseRepo = testdata.GithubRepo
 	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan, ProjectName: "default"})
-	pendingPlanFinder.VerifyWasCalled(Never()).DeletePlans(tmp)
+	pendingPlanFinder.VerifyWasCalled(Never()).Find(tmp)
 }
 
 // Test that if one plan fails and we are using automerge, that
@@ -1788,7 +2209,7 @@ func TestRunAutoplanCommandWithError_DeletePlans(t *testing.T) {
 	testdata.Pull.BaseRepo = testdata.GithubRepo
 	ch.RunAutoplanCommand(testdata.GithubRepo, testdata.GithubRepo, testdata.Pull, testdata.User)
 	// gets called twice: the first time before the plan starts, the second time after the plan errors
-	pendingPlanFinder.VerifyWasCalled(Times(2)).DeletePlans(tmp)
+	pendingPlanFinder.VerifyWasCalled(Times(2)).Find(tmp)
 
 	vcsClient.VerifyWasCalled(Times(0)).DiscardReviews(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest]())
 }
@@ -1817,7 +2238,7 @@ func TestRunGenericPlanCommand_DiscardApprovals(t *testing.T) {
 	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
 	testdata.Pull.BaseRepo = testdata.GithubRepo
 	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan})
-	pendingPlanFinder.VerifyWasCalledOnce().DeletePlans(tmp)
+	pendingPlanFinder.VerifyWasCalledOnce().Find(tmp)
 
 	vcsClient.VerifyWasCalledOnce().DiscardReviews(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest]())
 }

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -81,6 +81,7 @@ type TestConfig struct {
 	applyLockCheckerReturn     locking.ApplyCommandLock
 	applyLockCheckerErr        error
 	workingDirLocker           events.WorkingDirLocker
+	livePullHeadFetcher        events.LivePullHeadFetcher
 }
 
 type configuredPreWorkflowHooksCommandRunner struct {
@@ -217,6 +218,7 @@ func setup(t *testing.T, options ...func(testConfig *TestConfig)) *vcsmocks.Mock
 		testConfig.silenceVCSStatusNoProjects,
 		workingDirLocker,
 		pullReqStatusFetcher,
+		testConfig.livePullHeadFetcher,
 		testConfig.DisableAutomergeLabel,
 	)
 

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -80,6 +80,7 @@ type TestConfig struct {
 	PendingApplyStatus         bool
 	applyLockCheckerReturn     locking.ApplyCommandLock
 	applyLockCheckerErr        error
+	workingDirLocker           events.WorkingDirLocker
 }
 
 type configuredPreWorkflowHooksCommandRunner struct {
@@ -171,13 +172,17 @@ func setup(t *testing.T, options ...func(testConfig *TestConfig)) *vcsmocks.Mock
 		false,
 	)
 
+	workingDirLocker := testConfig.workingDirLocker
+	if workingDirLocker == nil {
+		workingDirLocker = events.NewDefaultWorkingDirLocker()
+	}
 	planCommandRunner = events.NewPlanCommandRunner(
 		testConfig.silenceVCSStatusNoPlans,
 		testConfig.silenceVCSStatusNoProjects,
 		vcsClient,
 		pendingPlanFinder,
 		workingDir,
-		events.NewDefaultWorkingDirLocker(),
+		workingDirLocker,
 		commitUpdater,
 		projectCommandBuilder,
 		projectCommandRunner,
@@ -210,6 +215,7 @@ func setup(t *testing.T, options ...func(testConfig *TestConfig)) *vcsmocks.Mock
 		testConfig.parallelPoolSize,
 		testConfig.SilenceNoProjects,
 		testConfig.silenceVCSStatusNoProjects,
+		workingDirLocker,
 		pullReqStatusFetcher,
 		testConfig.DisableAutomergeLabel,
 	)
@@ -761,6 +767,67 @@ func TestRunApply_NoProjectsAfterEmptyPullStatusDoesNotSucceedWhilePlanInFlight(
 	Assert(t, strings.Contains(comment, "plan is currently running"), "got: %s", comment)
 	commitUpdater.VerifyWasCalled(Never()).UpdateCombinedCount(
 		Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Eq(models.SuccessCommitStatus), Eq(command.Apply), Eq(models.ProjectCounts{}))
+}
+
+func TestRunApply_DoesNotReturnZeroProjectsWhilePlanInFlight(t *testing.T) {
+	locker := events.NewDefaultWorkingDirLocker()
+	vcsClient := setup(t, func(tc *TestConfig) {
+		tc.SilenceNoProjects = true
+		tc.workingDirLocker = locker
+	})
+	unlock, err := locker.TryLockPull(testdata.GithubRepo.FullName, testdata.Pull.Num, command.Plan)
+	Ok(t, err)
+	defer unlock()
+
+	var pull github.PullRequest
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(&pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(&pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+
+	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Apply})
+
+	projectCommandBuilder.VerifyWasCalled(Never()).BuildApplyCommands(Any[*command.Context](), Any[*events.CommentCommand]())
+	projectCommandRunner.VerifyWasCalled(Never()).Apply(Any[command.ProjectContext]())
+	commitUpdater.VerifyWasCalledOnce().UpdateCombined(
+		Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull), Eq(models.FailedCommitStatus), Eq(command.Apply))
+	_, _, _, comment, _ := vcsClient.VerifyWasCalledOnce().CreateComment(
+		Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull.Num), Any[string](), Eq("apply")).GetCapturedArguments()
+	Assert(t, strings.Contains(comment, "Apply Error"), "got: %s", comment)
+	Assert(t, strings.Contains(comment, "currently locked by"), "got: %s", comment)
+	commitUpdater.VerifyWasCalled(Never()).UpdateCombinedCount(
+		Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Eq(models.SuccessCommitStatus), Eq(command.Apply), Eq(models.ProjectCounts{}))
+}
+
+func TestPlanCommandRunner_HoldsPlanInFlightLockAcrossCleanupPlanAndDBWrite(t *testing.T) {
+	locker := events.NewDefaultWorkingDirLocker()
+	setup(t, func(tc *TestConfig) {
+		tc.workingDirLocker = locker
+	})
+	pull := &github.PullRequest{State: github.Ptr("open")}
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	cmd := &events.CommentCommand{Name: command.Plan}
+	projectCtx := command.ProjectContext{
+		CommandName: command.Plan,
+		RepoRelDir:  ".",
+		Workspace:   events.DefaultWorkspace,
+		BaseRepo:    testdata.GithubRepo,
+		Pull:        modelPull,
+	}
+
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+	When(projectCommandBuilder.BuildPlanCommands(Any[*command.Context](), Eq(cmd))).Then(func(args []Param) ReturnValues {
+		Assert(t, locker.HasCommandLock(testdata.GithubRepo.FullName, testdata.Pull.Num, command.Plan), "expected plan lock during command build")
+		return ReturnValues{[]command.ProjectContext{projectCtx}, nil}
+	})
+	When(projectCommandRunner.Plan(projectCtx)).Then(func(args []Param) ReturnValues {
+		Assert(t, locker.HasCommandLock(testdata.GithubRepo.FullName, testdata.Pull.Num, command.Plan), "expected plan lock during project plan")
+		return ReturnValues{command.ProjectCommandOutput{PlanSuccess: &models.PlanSuccess{}}}
+	})
+
+	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, cmd)
+
+	Assert(t, !locker.HasCommandLock(testdata.GithubRepo.FullName, testdata.Pull.Num, command.Plan), "expected plan lock to be released")
 }
 
 func TestRunCommentCommand_IgnoredTargetedDirNoOp(t *testing.T) {

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -491,6 +491,26 @@ func TestRunCommentCommandPlan_NoProjectsWritesCurrentEmptyPullStatus(t *testing
 	Equals(t, 0, len(pullStatus.Projects))
 }
 
+func TestRunCommentCommandPlan_NoProjectsMissingPullDirWritesEmptyPullStatus(t *testing.T) {
+	_ = setup(t)
+	planCommandRunner.SilenceNoProjects = true
+
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	var pull github.PullRequest
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(&pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(&pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn("", os.ErrNotExist)
+
+	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan})
+
+	pendingPlanFinder.VerifyWasCalled(Never()).Find(Any[string]())
+	pullStatus, err := dbUpdater.Database.GetPullStatus(modelPull)
+	Ok(t, err)
+	Assert(t, pullStatus != nil, "expected current empty PullStatus")
+	Equals(t, "abc123", pullStatus.Pull.HeadCommit)
+	Equals(t, 0, len(pullStatus.Projects))
+}
+
 func TestRunCommentCommandPlan_NoProjectsClearsOldPlanFilesAndPullStatus(t *testing.T) {
 	_ = setup(t)
 	planCommandRunner.SilenceNoProjects = true
@@ -533,9 +553,66 @@ func TestRunCommentCommandPlan_NoProjectsClearsOldPlanFilesAndPullStatus(t *test
 	Equals(t, 0, len(pullStatus.Projects))
 }
 
+func TestRunCommentCommandPlan_NoProjectsNonSilencedUsesSafeCleanup(t *testing.T) {
+	_ = setup(t)
+
+	tmp := t.TempDir()
+	oldPlanDir := filepath.Join(tmp, "old-project")
+	Ok(t, os.MkdirAll(oldPlanDir, 0700))
+	oldPlanPath := filepath.Join(oldPlanDir, runtime.GetPlanFilename(events.DefaultWorkspace, ""))
+	Ok(t, os.WriteFile(oldPlanPath, []byte("old plan"), 0600))
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	_, err := dbUpdater.Database.UpdatePullWithResults(modelPull, []command.ProjectResult{
+		{
+			Command:    command.Plan,
+			RepoRelDir: "old-project",
+			Workspace:  events.DefaultWorkspace,
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PlanSuccess: &models.PlanSuccess{},
+			},
+		},
+	})
+	Ok(t, err)
+
+	var pull github.PullRequest
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(&pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(&pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(tmp, nil)
+	When(pendingPlanFinder.Find(tmp)).ThenReturn([]events.PendingPlan{
+		{RepoDir: tmp, RepoRelDir: "old-project", Workspace: events.DefaultWorkspace},
+	}, nil)
+
+	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan})
+
+	pendingPlanFinder.VerifyWasCalledOnce().Find(tmp)
+	_, err = os.Stat(oldPlanPath)
+	Assert(t, os.IsNotExist(err), "expected old plan file to be removed")
+	pullStatus, err := dbUpdater.Database.GetPullStatus(modelPull)
+	Ok(t, err)
+	Assert(t, pullStatus != nil, "expected current empty PullStatus")
+	Equals(t, "abc123", pullStatus.Pull.HeadCommit)
+	Equals(t, 0, len(pullStatus.Projects))
+}
+
 func TestRunCommentCommandPlan_NoProjectsDoesNotUnlockActiveLocks(t *testing.T) {
 	vcsClient := setup(t)
 	installPlanCommandRunnerLocker(vcsClient, failUnlockByPullLocker{t: t}, true)
+
+	tmp := t.TempDir()
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	var pull github.PullRequest
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(&pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(&pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(tmp, nil)
+
+	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan})
+
+	pendingPlanFinder.VerifyWasCalledOnce().Find(tmp)
+}
+
+func TestRunCommentCommandPlan_NoProjectsNonSilencedDoesNotUnlockByPull(t *testing.T) {
+	vcsClient := setup(t)
+	installPlanCommandRunnerLocker(vcsClient, failUnlockByPullLocker{t: t}, false)
 
 	tmp := t.TempDir()
 	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
@@ -657,6 +734,33 @@ func TestRunApply_NoProjectsAfterEmptyPullStatusNoOpsSafely(t *testing.T) {
 		Eq[command.Name](command.Apply),
 		Eq(models.ProjectCounts{}),
 	)
+}
+
+func TestRunApply_NoProjectsAfterEmptyPullStatusDoesNotSucceedWhilePlanInFlight(t *testing.T) {
+	vcsClient := setup(t)
+	applyCommandRunner.SilenceNoProjects = true
+
+	var pull github.PullRequest
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	_, err := dbUpdater.Database.UpdatePullWithResults(modelPull, nil)
+	Ok(t, err)
+
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(&pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(&pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+	When(projectCommandBuilder.BuildApplyCommands(Any[*command.Context](), Any[*events.CommentCommand]())).
+		ThenReturn(nil, fmt.Errorf("a plan is currently running for this pull request; wait for it to finish before applying"))
+
+	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Apply})
+
+	projectCommandRunner.VerifyWasCalled(Never()).Apply(Any[command.ProjectContext]())
+	commitUpdater.VerifyWasCalledOnce().UpdateCombined(
+		Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull), Eq(models.FailedCommitStatus), Eq(command.Apply))
+	_, _, _, comment, _ := vcsClient.VerifyWasCalledOnce().CreateComment(
+		Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull.Num), Any[string](), Eq("apply")).GetCapturedArguments()
+	Assert(t, strings.Contains(comment, "Apply Error"), "got: %s", comment)
+	Assert(t, strings.Contains(comment, "plan is currently running"), "got: %s", comment)
+	commitUpdater.VerifyWasCalled(Never()).UpdateCombinedCount(
+		Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Eq(models.SuccessCommitStatus), Eq(command.Apply), Eq(models.ProjectCounts{}))
 }
 
 func TestRunCommentCommand_IgnoredTargetedDirNoOp(t *testing.T) {
@@ -1540,6 +1644,10 @@ func (l failUnlockByPullLocker) UnlockByPull(string, int) ([]models.ProjectLock,
 	return nil, nil
 }
 
+func (l failUnlockByPullLocker) UnlockIfOwnedByPull(models.Project, string, int) (*models.ProjectLock, error) {
+	return nil, nil
+}
+
 func (l failUnlockByPullLocker) GetLock(string) (*models.ProjectLock, error) {
 	return nil, nil
 }
@@ -1904,6 +2012,24 @@ func TestRunAutoplan_NoProjectsWritesCurrentEmptyPullStatus(t *testing.T) {
 
 	ch.RunAutoplanCommand(testdata.GithubRepo, testdata.GithubRepo, modelPull, testdata.User)
 
+	pullStatus, err := dbUpdater.Database.GetPullStatus(modelPull)
+	Ok(t, err)
+	Assert(t, pullStatus != nil, "expected current empty PullStatus")
+	Equals(t, "abc123", pullStatus.Pull.HeadCommit)
+	Equals(t, 0, len(pullStatus.Projects))
+}
+
+func TestRunAutoplan_NoProjectsMissingPullDirWritesEmptyPullStatus(t *testing.T) {
+	setup(t)
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+
+	When(projectCommandBuilder.BuildAutoplanCommands(Any[*command.Context]())).
+		ThenReturn([]command.ProjectContext{}, nil)
+	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn("", os.ErrNotExist)
+
+	ch.RunAutoplanCommand(testdata.GithubRepo, testdata.GithubRepo, modelPull, testdata.User)
+
+	pendingPlanFinder.VerifyWasCalled(Never()).Find(Any[string]())
 	pullStatus, err := dbUpdater.Database.GetPullStatus(modelPull)
 	Ok(t, err)
 	Assert(t, pullStatus != nil, "expected current empty PullStatus")

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -459,6 +459,7 @@ func TestRunCommentCommandPlan_NoProjectsWritesCurrentEmptyPullStatus(t *testing
 	_ = setup(t)
 	planCommandRunner.SilenceNoProjects = true
 
+	tmp := t.TempDir()
 	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
 	_, err := dbUpdater.Database.UpdatePullWithResults(modelPull, []command.ProjectResult{
 		{
@@ -475,9 +476,43 @@ func TestRunCommentCommandPlan_NoProjectsWritesCurrentEmptyPullStatus(t *testing
 	var pull github.PullRequest
 	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(&pull, nil)
 	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(&pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(tmp, nil)
 
 	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan})
 
+	pullStatus, err := dbUpdater.Database.GetPullStatus(modelPull)
+	Ok(t, err)
+	Assert(t, pullStatus != nil, "expected current empty PullStatus")
+	Equals(t, "abc123", pullStatus.Pull.HeadCommit)
+	Equals(t, 0, len(pullStatus.Projects))
+}
+
+func TestRunCommentCommandPlan_NoProjectsClearsOldPlanFilesAndPullStatus(t *testing.T) {
+	_ = setup(t)
+	planCommandRunner.SilenceNoProjects = true
+
+	tmp := t.TempDir()
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	_, err := dbUpdater.Database.UpdatePullWithResults(modelPull, []command.ProjectResult{
+		{
+			Command:    command.Plan,
+			RepoRelDir: "old-project",
+			Workspace:  events.DefaultWorkspace,
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PlanSuccess: &models.PlanSuccess{},
+			},
+		},
+	})
+	Ok(t, err)
+
+	var pull github.PullRequest
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(&pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(&pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(tmp, nil)
+
+	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan})
+
+	pendingPlanFinder.VerifyWasCalledOnce().DeletePlans(tmp)
 	pullStatus, err := dbUpdater.Database.GetPullStatus(modelPull)
 	Ok(t, err)
 	Assert(t, pullStatus != nil, "expected current empty PullStatus")
@@ -518,6 +553,39 @@ func TestRunCommentCommandApply_NoProjects_SilenceEnabled(t *testing.T) {
 	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(&pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
 
 	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Apply})
+	vcsClient.VerifyWasCalled(Never()).CreateComment(
+		Any[logging.SimpleLogging](), Any[models.Repo](), Any[int](), Any[string](), Any[string]())
+	commitUpdater.VerifyWasCalledOnce().UpdateCombinedCount(
+		Any[logging.SimpleLogging](),
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Eq[models.CommitStatus](models.SuccessCommitStatus),
+		Eq[command.Name](command.Apply),
+		Eq(models.ProjectCounts{}),
+	)
+}
+
+func TestRunApply_NoProjectsAfterEmptyPullStatusNoOpsSafely(t *testing.T) {
+	vcsClient := setup(t)
+	applyCommandRunner.SilenceNoProjects = true
+
+	var pull github.PullRequest
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	_, err := dbUpdater.Database.UpdatePullWithResults(modelPull, nil)
+	Ok(t, err)
+
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(&pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(&pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+	When(projectCommandBuilder.BuildApplyCommands(Any[*command.Context](), Any[*events.CommentCommand]())).Then(func(args []Param) ReturnValues {
+		ctx := args[0].(*command.Context)
+		Assert(t, ctx.PullStatus != nil, "expected command context to include empty PullStatus")
+		Equals(t, 0, len(ctx.PullStatus.Projects))
+		return ReturnValues{[]command.ProjectContext{}, nil}
+	})
+
+	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Apply})
+
+	projectCommandRunner.VerifyWasCalled(Never()).Apply(Any[command.ProjectContext]())
 	vcsClient.VerifyWasCalled(Never()).CreateComment(
 		Any[logging.SimpleLogging](), Any[models.Repo](), Any[int](), Any[string](), Any[string]())
 	commitUpdater.VerifyWasCalledOnce().UpdateCombinedCount(
@@ -952,6 +1020,189 @@ func TestImportOrStateRm_DiscardedPlanStatusAllowsLaterGenericApply(t *testing.T
 	}
 }
 
+func TestImportCommandRunner_DiscardedPlanDBFailureIsUserVisible(t *testing.T) {
+	vcsClient := setup(t)
+	logger := logging.NewNoopLogger(t)
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	projectCmd := command.ProjectContext{
+		CommandName: command.Import,
+		RepoRelDir:  "dir1",
+		Workspace:   events.DefaultWorkspace,
+		ProjectName: "projA",
+		BaseRepo:    testdata.GithubRepo,
+		Pull:        modelPull,
+	}
+	cmd := events.CommentCommand{Name: command.Import, ProjectName: "projA"}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logger,
+		Scope:    metricstest.NewLoggingScope(t, logger, "atlantis"),
+		Pull:     modelPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+
+	closer := dbUpdater.Database.(interface{ Close() error })
+	Ok(t, closer.Close())
+
+	When(pullReqStatusFetcher.FetchPullStatus(logger, modelPull)).ThenReturn(models.PullReqStatus{}, nil)
+	When(projectCommandBuilder.BuildImportCommands(ctx, &cmd)).ThenReturn([]command.ProjectContext{projectCmd}, nil)
+	When(projectCommandRunner.Import(projectCmd)).ThenReturn(command.ProjectCommandOutput{ImportSuccess: &models.ImportSuccess{}})
+
+	importCommandRunner.Run(ctx, &cmd)
+
+	Assert(t, ctx.CommandHasErrors, "expected discarded plan DB failure to mark command errored")
+	_, _, _, comment, _ := vcsClient.VerifyWasCalledOnce().CreateComment(
+		Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull.Num), Any[string](), Eq("import")).GetCapturedArguments()
+	Assert(t, strings.Contains(comment, "Import Error"), "got: %s", comment)
+	Assert(t, strings.Contains(comment, "writing discarded plan status"), "got: %s", comment)
+}
+
+func TestStateCommandRunner_DiscardedPlanDBFailureIsUserVisible(t *testing.T) {
+	vcsClient := setup(t)
+	logger := logging.NewNoopLogger(t)
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	projectCmd := command.ProjectContext{
+		CommandName: command.State,
+		SubCommand:  "rm",
+		RepoRelDir:  "dir1",
+		Workspace:   events.DefaultWorkspace,
+		ProjectName: "projA",
+		BaseRepo:    testdata.GithubRepo,
+		Pull:        modelPull,
+	}
+	cmd := events.CommentCommand{Name: command.State, SubName: "rm", ProjectName: "projA"}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logger,
+		Scope:    metricstest.NewLoggingScope(t, logger, "atlantis"),
+		Pull:     modelPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+
+	closer := dbUpdater.Database.(interface{ Close() error })
+	Ok(t, closer.Close())
+
+	When(projectCommandBuilder.BuildStateRmCommands(ctx, &cmd)).ThenReturn([]command.ProjectContext{projectCmd}, nil)
+	When(projectCommandRunner.StateRm(projectCmd)).ThenReturn(command.ProjectCommandOutput{StateRmSuccess: &models.StateRmSuccess{}})
+
+	stateCommandRunner.Run(ctx, &cmd)
+
+	Assert(t, ctx.CommandHasErrors, "expected discarded plan DB failure to mark command errored")
+	_, _, _, comment, _ := vcsClient.VerifyWasCalledOnce().CreateComment(
+		Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull.Num), Any[string](), Eq("state")).GetCapturedArguments()
+	Assert(t, strings.Contains(comment, "State Error"), "got: %s", comment)
+	Assert(t, strings.Contains(comment, "writing discarded plan status"), "got: %s", comment)
+}
+
+func TestImportOrStateRm_DoesNotDiscardPlanStatusOnErrorOrFailure(t *testing.T) {
+	cases := []struct {
+		name       string
+		cmd        events.CommentCommand
+		projectCmd command.ProjectContext
+		output     command.ProjectCommandOutput
+	}{
+		{
+			name: "import error",
+			cmd:  events.CommentCommand{Name: command.Import, ProjectName: "projA"},
+			projectCmd: command.ProjectContext{
+				CommandName: command.Import,
+				RepoRelDir:  "dir1",
+				Workspace:   events.DefaultWorkspace,
+				ProjectName: "projA",
+			},
+			output: command.ProjectCommandOutput{Error: errors.New("import error")},
+		},
+		{
+			name: "import failure",
+			cmd:  events.CommentCommand{Name: command.Import, ProjectName: "projA"},
+			projectCmd: command.ProjectContext{
+				CommandName: command.Import,
+				RepoRelDir:  "dir1",
+				Workspace:   events.DefaultWorkspace,
+				ProjectName: "projA",
+			},
+			output: command.ProjectCommandOutput{Failure: "import failed"},
+		},
+		{
+			name: "state rm error",
+			cmd:  events.CommentCommand{Name: command.State, SubName: "rm", ProjectName: "projA"},
+			projectCmd: command.ProjectContext{
+				CommandName: command.State,
+				SubCommand:  "rm",
+				RepoRelDir:  "dir1",
+				Workspace:   events.DefaultWorkspace,
+				ProjectName: "projA",
+			},
+			output: command.ProjectCommandOutput{Error: errors.New("state rm error")},
+		},
+		{
+			name: "state rm failure",
+			cmd:  events.CommentCommand{Name: command.State, SubName: "rm", ProjectName: "projA"},
+			projectCmd: command.ProjectContext{
+				CommandName: command.State,
+				SubCommand:  "rm",
+				RepoRelDir:  "dir1",
+				Workspace:   events.DefaultWorkspace,
+				ProjectName: "projA",
+			},
+			output: command.ProjectCommandOutput{Failure: "state rm failed"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_ = setup(t)
+			logger := logging.NewNoopLogger(t)
+			modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+			_, err := dbUpdater.Database.UpdatePullWithResults(modelPull, []command.ProjectResult{
+				{
+					Command:     command.Plan,
+					RepoRelDir:  tc.projectCmd.RepoRelDir,
+					Workspace:   tc.projectCmd.Workspace,
+					ProjectName: tc.projectCmd.ProjectName,
+					ProjectCommandOutput: command.ProjectCommandOutput{
+						PlanSuccess: &models.PlanSuccess{},
+					},
+				},
+			})
+			Ok(t, err)
+
+			ctx := &command.Context{
+				User:     testdata.User,
+				Log:      logger,
+				Scope:    metricstest.NewLoggingScope(t, logger, "atlantis"),
+				Pull:     modelPull,
+				HeadRepo: testdata.GithubRepo,
+				Trigger:  command.CommentTrigger,
+			}
+			cmd := tc.cmd
+			projectCmd := tc.projectCmd
+			projectCmd.BaseRepo = testdata.GithubRepo
+			projectCmd.Pull = modelPull
+
+			switch cmd.Name {
+			case command.Import:
+				When(pullReqStatusFetcher.FetchPullStatus(logger, modelPull)).ThenReturn(models.PullReqStatus{}, nil)
+				When(projectCommandBuilder.BuildImportCommands(ctx, &cmd)).ThenReturn([]command.ProjectContext{projectCmd}, nil)
+				When(projectCommandRunner.Import(projectCmd)).ThenReturn(tc.output)
+				importCommandRunner.Run(ctx, &cmd)
+			case command.State:
+				When(projectCommandBuilder.BuildStateRmCommands(ctx, &cmd)).ThenReturn([]command.ProjectContext{projectCmd}, nil)
+				When(projectCommandRunner.StateRm(projectCmd)).ThenReturn(tc.output)
+				stateCommandRunner.Run(ctx, &cmd)
+			}
+
+			pullStatus, err := dbUpdater.Database.GetPullStatus(modelPull)
+			Ok(t, err)
+			Assert(t, pullStatus != nil, "expected PullStatus")
+			Equals(t, 1, len(pullStatus.Projects))
+			Equals(t, models.PlannedPlanStatus, pullStatus.Projects[0].Status)
+		})
+	}
+}
+
 func TestRunCommentCommand_DisableApplyAllDisabled(t *testing.T) {
 	t.Log("if \"atlantis apply\" is run and this is disabled atlantis should" +
 		" comment saying that this is not allowed")
@@ -1261,6 +1512,65 @@ func TestRunAutoplanCommand_DeletePlans(t *testing.T) {
 	testdata.Pull.BaseRepo = testdata.GithubRepo
 	ch.RunAutoplanCommand(testdata.GithubRepo, testdata.GithubRepo, testdata.Pull, testdata.User)
 	pendingPlanFinder.VerifyWasCalledOnce().DeletePlans(tmp)
+}
+
+func TestRunAutoplan_NoProjectsWritesCurrentEmptyPullStatus(t *testing.T) {
+	setup(t)
+	tmp := t.TempDir()
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	_, err := dbUpdater.Database.UpdatePullWithResults(modelPull, []command.ProjectResult{
+		{
+			Command:    command.Plan,
+			RepoRelDir: "old-project",
+			Workspace:  events.DefaultWorkspace,
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PlanSuccess: &models.PlanSuccess{},
+			},
+		},
+	})
+	Ok(t, err)
+
+	When(projectCommandBuilder.BuildAutoplanCommands(Any[*command.Context]())).
+		ThenReturn([]command.ProjectContext{}, nil)
+	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(tmp, nil)
+
+	ch.RunAutoplanCommand(testdata.GithubRepo, testdata.GithubRepo, modelPull, testdata.User)
+
+	pullStatus, err := dbUpdater.Database.GetPullStatus(modelPull)
+	Ok(t, err)
+	Assert(t, pullStatus != nil, "expected current empty PullStatus")
+	Equals(t, "abc123", pullStatus.Pull.HeadCommit)
+	Equals(t, 0, len(pullStatus.Projects))
+}
+
+func TestRunAutoplan_NoProjectsClearsOldPlanFilesAndPullStatus(t *testing.T) {
+	setup(t)
+	tmp := t.TempDir()
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+	_, err := dbUpdater.Database.UpdatePullWithResults(modelPull, []command.ProjectResult{
+		{
+			Command:    command.Plan,
+			RepoRelDir: "old-project",
+			Workspace:  events.DefaultWorkspace,
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PlanSuccess: &models.PlanSuccess{},
+			},
+		},
+	})
+	Ok(t, err)
+
+	When(projectCommandBuilder.BuildAutoplanCommands(Any[*command.Context]())).
+		ThenReturn([]command.ProjectContext{}, nil)
+	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(tmp, nil)
+
+	ch.RunAutoplanCommand(testdata.GithubRepo, testdata.GithubRepo, modelPull, testdata.User)
+
+	pendingPlanFinder.VerifyWasCalledOnce().DeletePlans(tmp)
+	pullStatus, err := dbUpdater.Database.GetPullStatus(modelPull)
+	Ok(t, err)
+	Assert(t, pullStatus != nil, "expected current empty PullStatus")
+	Equals(t, "abc123", pullStatus.Pull.HeadCommit)
+	Equals(t, 0, len(pullStatus.Projects))
 }
 
 func TestRunAutoplanCommand_FailedPreWorkflowHook_FailOnPreWorkflowHookError_False(t *testing.T) {

--- a/server/events/db_updater.go
+++ b/server/events/db_updater.go
@@ -16,6 +16,17 @@ type DBUpdater struct {
 }
 
 func (c *DBUpdater) updateDB(ctx *command.Context, pull models.PullRequest, results []command.ProjectResult) (models.PullStatus, error) {
+	if len(results) == 0 && pull.HeadCommit != "" {
+		pullStatus, err := c.Database.GetPullStatus(pull)
+		if err != nil {
+			return models.PullStatus{}, err
+		}
+		if pullStatus != nil && !pullStatusFreshForPull(pull, pullStatus.Pull) {
+			ctx.Log.Debug("ignoring empty result from pull head %q base %q because current plan status is for head %q base %q", pull.HeadCommit, pull.BaseBranch, pullStatus.Pull.HeadCommit, pullStatus.Pull.BaseBranch)
+			return *pullStatus, nil
+		}
+	}
+
 	if staleApplyResultForCurrentPull(pull, results) {
 		pullStatus, err := c.Database.GetPullStatus(pull)
 		if err != nil {

--- a/server/events/db_updater.go
+++ b/server/events/db_updater.go
@@ -4,6 +4,8 @@
 package events
 
 import (
+	"errors"
+
 	"github.com/runatlantis/atlantis/server/core/db"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
@@ -18,12 +20,28 @@ func (c *DBUpdater) updateDB(ctx *command.Context, pull models.PullRequest, resu
 	// don't store these in the database because they would never be "apply-able"
 	// and so the pull request would always have errors.
 	var filtered []command.ProjectResult
+	skippedStaleCommandHead := false
 	for _, r := range results {
 		if _, ok := r.Error.(DirNotExistErr); ok {
 			ctx.Log.Debug("ignoring error result from project at dir %q workspace %q because it is dir not exist error", r.RepoRelDir, r.Workspace)
 			continue
 		}
+		if errors.Is(r.Error, errStaleCommandHead) {
+			ctx.Log.Debug("ignoring stale command-head result from project at dir %q workspace %q project %q", r.RepoRelDir, r.Workspace, r.ProjectName)
+			skippedStaleCommandHead = true
+			continue
+		}
 		filtered = append(filtered, r)
+	}
+	if skippedStaleCommandHead && len(filtered) == 0 {
+		pullStatus, err := c.Database.GetPullStatus(pull)
+		if err != nil {
+			return models.PullStatus{}, err
+		}
+		if pullStatus != nil {
+			return *pullStatus, nil
+		}
+		return models.PullStatus{Pull: pull}, nil
 	}
 	ctx.Log.Debug("updating DB with pull results")
 	return c.Database.UpdatePullWithResults(pull, filtered)

--- a/server/events/db_updater.go
+++ b/server/events/db_updater.go
@@ -16,6 +16,17 @@ type DBUpdater struct {
 }
 
 func (c *DBUpdater) updateDB(ctx *command.Context, pull models.PullRequest, results []command.ProjectResult) (models.PullStatus, error) {
+	if staleApplyResultForCurrentPull(pull, results) {
+		pullStatus, err := c.Database.GetPullStatus(pull)
+		if err != nil {
+			return models.PullStatus{}, err
+		}
+		if pullStatus != nil && !pullStatusFreshForPull(pull, pullStatus.Pull) {
+			ctx.Log.Debug("ignoring stale apply result from pull head %q base %q because current plan status is for head %q base %q", pull.HeadCommit, pull.BaseBranch, pullStatus.Pull.HeadCommit, pullStatus.Pull.BaseBranch)
+			return *pullStatus, nil
+		}
+	}
+
 	// Filter out results that errored due to the directory not existing. We
 	// don't store these in the database because they would never be "apply-able"
 	// and so the pull request would always have errors.
@@ -42,16 +53,6 @@ func (c *DBUpdater) updateDB(ctx *command.Context, pull models.PullRequest, resu
 			return *pullStatus, nil
 		}
 		return models.PullStatus{Pull: pull}, nil
-	}
-	if staleApplyResultForCurrentPull(pull, filtered) {
-		pullStatus, err := c.Database.GetPullStatus(pull)
-		if err != nil {
-			return models.PullStatus{}, err
-		}
-		if pullStatus != nil && pullStatus.Pull.HeadCommit != "" && pull.HeadCommit != "" && pullStatus.Pull.HeadCommit != pull.HeadCommit {
-			ctx.Log.Debug("ignoring stale apply result from pull head %q because current plan status is for head %q", pull.HeadCommit, pullStatus.Pull.HeadCommit)
-			return *pullStatus, nil
-		}
 	}
 	ctx.Log.Debug("updating DB with pull results")
 	return c.Database.UpdatePullWithResults(pull, filtered)
@@ -81,7 +82,7 @@ func (c *DBUpdater) updateDBForDiscardedPlans(ctx *command.Context, pull models.
 	if err != nil {
 		return err
 	}
-	if pullStatus == nil || !pullStatusHeadMatchesPull(pull, pullStatus.Pull) {
+	if pullStatus == nil || !pullStatusFreshForPull(pull, pullStatus.Pull) {
 		return nil
 	}
 

--- a/server/events/db_updater.go
+++ b/server/events/db_updater.go
@@ -37,6 +37,14 @@ func (c *DBUpdater) replaceDB(ctx *command.Context, pull models.PullRequest, res
 }
 
 func (c *DBUpdater) updateDBForDiscardedPlans(ctx *command.Context, pull models.PullRequest, results []command.ProjectResult) error {
+	pullStatus, err := c.Database.GetPullStatus(pull)
+	if err != nil {
+		return err
+	}
+	if pullStatus == nil || !pullStatusHeadMatchesPull(pull, pullStatus.Pull) {
+		return nil
+	}
+
 	var discarded []command.ProjectResult
 	for _, res := range results {
 		if res.Error != nil || res.Failure != "" {
@@ -45,11 +53,15 @@ func (c *DBUpdater) updateDBForDiscardedPlans(ctx *command.Context, pull models.
 		if res.ImportSuccess == nil && res.StateRmSuccess == nil {
 			continue
 		}
+		proj := findProjectInPullStatus(pullStatus, res.Workspace, res.RepoRelDir, res.ProjectName)
+		if proj == nil || !statusAllowedForDiscoveredPlan(proj.Status) {
+			continue
+		}
 		discarded = append(discarded, res)
 	}
 	if len(discarded) == 0 {
 		return nil
 	}
-	_, err := c.updateDB(ctx, pull, discarded)
+	_, err = c.updateDB(ctx, pull, discarded)
 	return err
 }

--- a/server/events/db_updater.go
+++ b/server/events/db_updater.go
@@ -28,3 +28,28 @@ func (c *DBUpdater) updateDB(ctx *command.Context, pull models.PullRequest, resu
 	ctx.Log.Debug("updating DB with pull results")
 	return c.Database.UpdatePullWithResults(pull, filtered)
 }
+
+func (c *DBUpdater) replaceDB(ctx *command.Context, pull models.PullRequest, results []command.ProjectResult) (models.PullStatus, error) {
+	if err := c.Database.DeletePullStatus(pull); err != nil {
+		return models.PullStatus{}, err
+	}
+	return c.updateDB(ctx, pull, results)
+}
+
+func (c *DBUpdater) updateDBForDiscardedPlans(ctx *command.Context, pull models.PullRequest, results []command.ProjectResult) error {
+	var discarded []command.ProjectResult
+	for _, res := range results {
+		if res.Error != nil || res.Failure != "" {
+			continue
+		}
+		if res.ImportSuccess == nil && res.StateRmSuccess == nil {
+			continue
+		}
+		discarded = append(discarded, res)
+	}
+	if len(discarded) == 0 {
+		return nil
+	}
+	_, err := c.updateDB(ctx, pull, discarded)
+	return err
+}

--- a/server/events/db_updater.go
+++ b/server/events/db_updater.go
@@ -43,8 +43,30 @@ func (c *DBUpdater) updateDB(ctx *command.Context, pull models.PullRequest, resu
 		}
 		return models.PullStatus{Pull: pull}, nil
 	}
+	if staleApplyResultForCurrentPull(pull, filtered) {
+		pullStatus, err := c.Database.GetPullStatus(pull)
+		if err != nil {
+			return models.PullStatus{}, err
+		}
+		if pullStatus != nil && pullStatus.Pull.HeadCommit != "" && pull.HeadCommit != "" && pullStatus.Pull.HeadCommit != pull.HeadCommit {
+			ctx.Log.Debug("ignoring stale apply result from pull head %q because current plan status is for head %q", pull.HeadCommit, pullStatus.Pull.HeadCommit)
+			return *pullStatus, nil
+		}
+	}
 	ctx.Log.Debug("updating DB with pull results")
 	return c.Database.UpdatePullWithResults(pull, filtered)
+}
+
+func staleApplyResultForCurrentPull(pull models.PullRequest, results []command.ProjectResult) bool {
+	if pull.HeadCommit == "" {
+		return false
+	}
+	for _, result := range results {
+		if result.Command == command.Apply {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *DBUpdater) replaceDB(ctx *command.Context, pull models.PullRequest, results []command.ProjectResult) (models.PullStatus, error) {

--- a/server/events/db_updater_internal_test.go
+++ b/server/events/db_updater_internal_test.go
@@ -5,6 +5,7 @@ package events
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/runatlantis/atlantis/server/core/boltdb"
@@ -247,6 +248,63 @@ func TestDBUpdater_SameHeadSameBaseApplyFailureWritesErroredApplyStatus(t *testi
 
 func TestDBUpdater_SameHeadDifferentBaseApplyFailureDoesNotOverwriteCurrentBaseStatus(t *testing.T) {
 	assertDBUpdaterSameHeadDifferentBaseApplyFailurePreservesCurrentBase(t)
+}
+
+func TestDBUpdater_BaseRetargetStaleCommandDoesNotWriteApplyError(t *testing.T) {
+	database, err := boltdb.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	updater := &DBUpdater{Database: database}
+	stalePull := models.PullRequest{
+		Num:        1,
+		HeadCommit: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		BaseBranch: "main",
+		BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+	}
+	currentPull := stalePull
+	currentPull.BaseBranch = "release"
+	_, err = database.UpdatePullWithResults(currentPull, []command.ProjectResult{
+		{
+			Command:     command.Plan,
+			Workspace:   DefaultWorkspace,
+			RepoRelDir:  "dirA",
+			ProjectName: "projA",
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PlanSuccess: &models.PlanSuccess{},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pullStatus, err := updater.updateDB(&command.Context{Log: logging.NewNoopLogger(t)}, stalePull, []command.ProjectResult{
+		{
+			Command:     command.Apply,
+			Workspace:   DefaultWorkspace,
+			RepoRelDir:  "dirA",
+			ProjectName: "projA",
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				Error: fmt.Errorf("%w: pull request base branch changed", errStaleCommandHead),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pullStatus.Pull.BaseBranch != currentPull.BaseBranch {
+		t.Fatalf("expected DBUpdater to preserve current base %q, got %q", currentPull.BaseBranch, pullStatus.Pull.BaseBranch)
+	}
+	project := findProjectInPullStatus(&pullStatus, DefaultWorkspace, "dirA", "projA")
+	if project == nil {
+		t.Fatal("expected current project status to remain")
+	}
+	if project.Status != models.PlannedPlanStatus {
+		t.Fatalf("expected current project status %q, got %q", models.PlannedPlanStatus, project.Status)
+	}
 }
 
 func TestDBUpdater_SameHeadApplyErrorDoesNotTriggerStaleResultGuard(t *testing.T) {

--- a/server/events/db_updater_internal_test.go
+++ b/server/events/db_updater_internal_test.go
@@ -14,6 +14,175 @@ import (
 )
 
 func TestDBUpdater_StaleApplyResultDoesNotOverwriteNewerPullStatus(t *testing.T) {
+	assertDBUpdaterStaleApplyPreservesNewerPullStatus(t, command.ProjectCommandOutput{
+		Error: errors.New("mergeable requirement failed"),
+	})
+}
+
+func TestDBUpdater_StaleApplyFailurePreservesNewerPullStatus(t *testing.T) {
+	assertDBUpdaterStaleApplyPreservesNewerPullStatus(t, command.ProjectCommandOutput{
+		Failure: "mergeable requirement failed",
+	})
+}
+
+func assertDBUpdaterStaleApplyPreservesNewerPullStatus(t *testing.T, output command.ProjectCommandOutput) {
+	t.Helper()
+	database, err := boltdb.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	updater := &DBUpdater{Database: database}
+	stalePull := models.PullRequest{
+		Num:        1,
+		HeadCommit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+	}
+	currentPull := stalePull
+	currentPull.HeadCommit = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	_, err = database.UpdatePullWithResults(currentPull, []command.ProjectResult{
+		{
+			Command:     command.Plan,
+			Workspace:   DefaultWorkspace,
+			RepoRelDir:  "dirA",
+			ProjectName: "projA",
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PlanSuccess: &models.PlanSuccess{},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pullStatus, err := updater.updateDB(&command.Context{Log: logging.NewNoopLogger(t)}, stalePull, []command.ProjectResult{
+		{
+			Command:              command.Apply,
+			Workspace:            DefaultWorkspace,
+			RepoRelDir:           "dirA",
+			ProjectName:          "projA",
+			ProjectCommandOutput: output,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pullStatus.Pull.HeadCommit != currentPull.HeadCommit {
+		t.Fatalf("expected DBUpdater to preserve current head %q, got %q", currentPull.HeadCommit, pullStatus.Pull.HeadCommit)
+	}
+	project := findProjectInPullStatus(&pullStatus, DefaultWorkspace, "dirA", "projA")
+	if project == nil {
+		t.Fatal("expected current project status to remain")
+	}
+	if project.Status != models.PlannedPlanStatus {
+		t.Fatalf("expected current project status %q, got %q", models.PlannedPlanStatus, project.Status)
+	}
+}
+
+func TestDBUpdater_SameHeadApplyFailureWritesErroredApplyStatus(t *testing.T) {
+	database, err := boltdb.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	updater := &DBUpdater{Database: database}
+	pull := models.PullRequest{
+		Num:        1,
+		HeadCommit: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+	}
+	_, err = database.UpdatePullWithResults(pull, []command.ProjectResult{
+		{
+			Command:     command.Plan,
+			Workspace:   DefaultWorkspace,
+			RepoRelDir:  "dirA",
+			ProjectName: "projA",
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PlanSuccess: &models.PlanSuccess{},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pullStatus, err := updater.updateDB(&command.Context{Log: logging.NewNoopLogger(t)}, pull, []command.ProjectResult{
+		{
+			Command:     command.Apply,
+			Workspace:   DefaultWorkspace,
+			RepoRelDir:  "dirA",
+			ProjectName: "projA",
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				Failure: "mergeable requirement failed",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	project := findProjectInPullStatus(&pullStatus, DefaultWorkspace, "dirA", "projA")
+	if project == nil {
+		t.Fatal("expected current project status to remain")
+	}
+	if project.Status != models.ErroredApplyStatus {
+		t.Fatalf("expected current project status %q, got %q", models.ErroredApplyStatus, project.Status)
+	}
+}
+
+func TestDBUpdater_SameHeadApplyErrorDoesNotTriggerStaleResultGuard(t *testing.T) {
+	database, err := boltdb.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	updater := &DBUpdater{Database: database}
+	pull := models.PullRequest{
+		Num:        1,
+		HeadCommit: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+	}
+	_, err = database.UpdatePullWithResults(pull, []command.ProjectResult{
+		{
+			Command:     command.Plan,
+			Workspace:   DefaultWorkspace,
+			RepoRelDir:  "dirA",
+			ProjectName: "projA",
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PlanSuccess: &models.PlanSuccess{},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pullStatus, err := updater.updateDB(&command.Context{Log: logging.NewNoopLogger(t)}, pull, []command.ProjectResult{
+		{
+			Command:     command.Apply,
+			Workspace:   DefaultWorkspace,
+			RepoRelDir:  "dirA",
+			ProjectName: "projA",
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				Error: errors.New("apply failed"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	project := findProjectInPullStatus(&pullStatus, DefaultWorkspace, "dirA", "projA")
+	if project == nil {
+		t.Fatal("expected current project status to remain")
+	}
+	if project.Status != models.ErroredApplyStatus {
+		t.Fatalf("expected current project status %q, got %q", models.ErroredApplyStatus, project.Status)
+	}
+}
+
+func TestDBUpdater_StaleApplyResultGuardRunsBeforeDirNotExistFiltering(t *testing.T) {
 	database, err := boltdb.New(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
@@ -49,7 +218,7 @@ func TestDBUpdater_StaleApplyResultDoesNotOverwriteNewerPullStatus(t *testing.T)
 			RepoRelDir:  "dirA",
 			ProjectName: "projA",
 			ProjectCommandOutput: command.ProjectCommandOutput{
-				Error: errors.New("mergeable requirement failed"),
+				Error: DirNotExistErr{RepoRelDir: "dirA"},
 			},
 		},
 	})

--- a/server/events/db_updater_internal_test.go
+++ b/server/events/db_updater_internal_test.go
@@ -25,6 +25,68 @@ func TestDBUpdater_StaleApplyFailurePreservesNewerPullStatus(t *testing.T) {
 	})
 }
 
+func TestDBUpdater_StaleApplyFailurePreservesNewerPullStatusWhenBaseDiffers(t *testing.T) {
+	assertDBUpdaterSameHeadDifferentBaseApplyFailurePreservesCurrentBase(t)
+}
+
+func assertDBUpdaterSameHeadDifferentBaseApplyFailurePreservesCurrentBase(t *testing.T) {
+	t.Helper()
+	database, err := boltdb.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	updater := &DBUpdater{Database: database}
+	stalePull := models.PullRequest{
+		Num:        1,
+		HeadCommit: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		BaseBranch: "main",
+		BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+	}
+	currentPull := stalePull
+	currentPull.BaseBranch = "release"
+	_, err = database.UpdatePullWithResults(currentPull, []command.ProjectResult{
+		{
+			Command:     command.Plan,
+			Workspace:   DefaultWorkspace,
+			RepoRelDir:  "dirA",
+			ProjectName: "projA",
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PlanSuccess: &models.PlanSuccess{},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pullStatus, err := updater.updateDB(&command.Context{Log: logging.NewNoopLogger(t)}, stalePull, []command.ProjectResult{
+		{
+			Command:     command.Apply,
+			Workspace:   DefaultWorkspace,
+			RepoRelDir:  "dirA",
+			ProjectName: "projA",
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				Failure: "mergeable requirement failed",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pullStatus.Pull.BaseBranch != currentPull.BaseBranch {
+		t.Fatalf("expected DBUpdater to preserve current base %q, got %q", currentPull.BaseBranch, pullStatus.Pull.BaseBranch)
+	}
+	project := findProjectInPullStatus(&pullStatus, DefaultWorkspace, "dirA", "projA")
+	if project == nil {
+		t.Fatal("expected current project status to remain")
+	}
+	if project.Status != models.PlannedPlanStatus {
+		t.Fatalf("expected current project status %q, got %q", models.PlannedPlanStatus, project.Status)
+	}
+}
+
 func assertDBUpdaterStaleApplyPreservesNewerPullStatus(t *testing.T, output command.ProjectCommandOutput) {
 	t.Helper()
 	database, err := boltdb.New(t.TempDir())
@@ -129,6 +191,62 @@ func TestDBUpdater_SameHeadApplyFailureWritesErroredApplyStatus(t *testing.T) {
 	if project.Status != models.ErroredApplyStatus {
 		t.Fatalf("expected current project status %q, got %q", models.ErroredApplyStatus, project.Status)
 	}
+}
+
+func TestDBUpdater_SameHeadSameBaseApplyFailureWritesErroredApplyStatus(t *testing.T) {
+	database, err := boltdb.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	updater := &DBUpdater{Database: database}
+	pull := models.PullRequest{
+		Num:        1,
+		HeadCommit: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		BaseBranch: "release",
+		BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+	}
+	_, err = database.UpdatePullWithResults(pull, []command.ProjectResult{
+		{
+			Command:     command.Plan,
+			Workspace:   DefaultWorkspace,
+			RepoRelDir:  "dirA",
+			ProjectName: "projA",
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PlanSuccess: &models.PlanSuccess{},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pullStatus, err := updater.updateDB(&command.Context{Log: logging.NewNoopLogger(t)}, pull, []command.ProjectResult{
+		{
+			Command:     command.Apply,
+			Workspace:   DefaultWorkspace,
+			RepoRelDir:  "dirA",
+			ProjectName: "projA",
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				Failure: "mergeable requirement failed",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	project := findProjectInPullStatus(&pullStatus, DefaultWorkspace, "dirA", "projA")
+	if project == nil {
+		t.Fatal("expected current project status to remain")
+	}
+	if project.Status != models.ErroredApplyStatus {
+		t.Fatalf("expected current project status %q, got %q", models.ErroredApplyStatus, project.Status)
+	}
+}
+
+func TestDBUpdater_SameHeadDifferentBaseApplyFailureDoesNotOverwriteCurrentBaseStatus(t *testing.T) {
+	assertDBUpdaterSameHeadDifferentBaseApplyFailurePreservesCurrentBase(t)
 }
 
 func TestDBUpdater_SameHeadApplyErrorDoesNotTriggerStaleResultGuard(t *testing.T) {

--- a/server/events/db_updater_internal_test.go
+++ b/server/events/db_updater_internal_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package events
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/core/boltdb"
+	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/logging"
+)
+
+func TestDBUpdater_StaleApplyResultDoesNotOverwriteNewerPullStatus(t *testing.T) {
+	database, err := boltdb.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	updater := &DBUpdater{Database: database}
+	stalePull := models.PullRequest{
+		Num:        1,
+		HeadCommit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+	}
+	currentPull := stalePull
+	currentPull.HeadCommit = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	_, err = database.UpdatePullWithResults(currentPull, []command.ProjectResult{
+		{
+			Command:     command.Plan,
+			Workspace:   DefaultWorkspace,
+			RepoRelDir:  "dirA",
+			ProjectName: "projA",
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PlanSuccess: &models.PlanSuccess{},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pullStatus, err := updater.updateDB(&command.Context{Log: logging.NewNoopLogger(t)}, stalePull, []command.ProjectResult{
+		{
+			Command:     command.Apply,
+			Workspace:   DefaultWorkspace,
+			RepoRelDir:  "dirA",
+			ProjectName: "projA",
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				Error: errors.New("mergeable requirement failed"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pullStatus.Pull.HeadCommit != currentPull.HeadCommit {
+		t.Fatalf("expected DBUpdater to preserve current head %q, got %q", currentPull.HeadCommit, pullStatus.Pull.HeadCommit)
+	}
+	project := findProjectInPullStatus(&pullStatus, DefaultWorkspace, "dirA", "projA")
+	if project == nil {
+		t.Fatal("expected current project status to remain")
+	}
+	if project.Status != models.PlannedPlanStatus {
+		t.Fatalf("expected current project status %q, got %q", models.PlannedPlanStatus, project.Status)
+	}
+}

--- a/server/events/import_command_runner.go
+++ b/server/events/import_command_runner.go
@@ -10,6 +10,7 @@ import (
 
 func NewImportCommandRunner(
 	pullUpdater *PullUpdater,
+	dbUpdater *DBUpdater,
 	pullReqStatusFetcher vcs.PullReqStatusFetcher,
 	prjCmdBuilder ProjectImportCommandBuilder,
 	prjCmdRunner ProjectImportCommandRunner,
@@ -17,6 +18,7 @@ func NewImportCommandRunner(
 ) *ImportCommandRunner {
 	return &ImportCommandRunner{
 		pullUpdater:          pullUpdater,
+		dbUpdater:            dbUpdater,
 		pullReqStatusFetcher: pullReqStatusFetcher,
 		prjCmdBuilder:        prjCmdBuilder,
 		prjCmdRunner:         prjCmdRunner,
@@ -26,6 +28,7 @@ func NewImportCommandRunner(
 
 type ImportCommandRunner struct {
 	pullUpdater          *PullUpdater
+	dbUpdater            *DBUpdater
 	pullReqStatusFetcher vcs.PullReqStatusFetcher
 	prjCmdBuilder        ProjectImportCommandBuilder
 	prjCmdRunner         ProjectImportCommandRunner
@@ -72,6 +75,9 @@ func (v *ImportCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 		result = runProjectCmds(projectCmds, v.prjCmdRunner.Import)
 	}
 	v.pullUpdater.updatePull(ctx, cmd, result)
+	if err := v.dbUpdater.updateDBForDiscardedPlans(ctx, ctx.Pull, result.ProjectResults); err != nil {
+		ctx.Log.Err("writing discarded plan status: %s", err)
+	}
 }
 
 func (v *ImportCommandRunner) ShouldSkipPreWorkflowHooks(ctx *command.Context, cmd *CommentCommand) bool {

--- a/server/events/import_command_runner.go
+++ b/server/events/import_command_runner.go
@@ -4,6 +4,8 @@
 package events
 
 import (
+	"fmt"
+
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/vcs"
 )
@@ -74,10 +76,11 @@ func (v *ImportCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 	} else {
 		result = runProjectCmds(projectCmds, v.prjCmdRunner.Import)
 	}
-	v.pullUpdater.updatePull(ctx, cmd, result)
 	if err := v.dbUpdater.updateDBForDiscardedPlans(ctx, ctx.Pull, result.ProjectResults); err != nil {
-		ctx.Log.Err("writing discarded plan status: %s", err)
+		result.Error = fmt.Errorf("writing discarded plan status: %w", err)
+		ctx.CommandHasErrors = true
 	}
+	v.pullUpdater.updatePull(ctx, cmd, result)
 }
 
 func (v *ImportCommandRunner) ShouldSkipPreWorkflowHooks(ctx *command.Context, cmd *CommentCommand) bool {

--- a/server/events/instrumented_project_command_runner.go
+++ b/server/events/instrumented_project_command_runner.go
@@ -5,6 +5,7 @@ package events
 
 import (
 	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/metrics"
 	tally "github.com/uber-go/tally/v4"
 )
@@ -47,6 +48,14 @@ func (p *InstrumentedProjectCommandRunner) PolicyCheck(ctx command.ProjectContex
 
 func (p *InstrumentedProjectCommandRunner) Apply(ctx command.ProjectContext) command.ProjectCommandOutput {
 	return RunAndEmitStats(ctx, p.projectCommandRunner.Apply, p.scope)
+}
+
+func (p *InstrumentedProjectCommandRunner) PublishDeferredApplyStatuses(projectCmds []command.ProjectContext, result command.Result, status models.CommitStatus) {
+	publisher, ok := p.projectCommandRunner.(DeferredApplyStatusPublisher)
+	if !ok {
+		return
+	}
+	publisher.PublishDeferredApplyStatuses(projectCmds, result, status)
 }
 
 func (p *InstrumentedProjectCommandRunner) ApprovePolicies(ctx command.ProjectContext) command.ProjectCommandOutput {

--- a/server/events/live_pull_head_fetcher.go
+++ b/server/events/live_pull_head_fetcher.go
@@ -1,0 +1,94 @@
+// Copyright 2025 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package events
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/events/vcs/gitea"
+	"github.com/runatlantis/atlantis/server/logging"
+)
+
+type PullHeadCommitGetter interface {
+	GetPullRequestHeadCommit(logger logging.SimpleLogging, repo models.Repo, pull models.PullRequest) (string, error)
+}
+
+type DefaultLivePullHeadFetcher struct {
+	EventParser               EventParsing
+	GithubPullGetter          GithubPullGetter
+	GitlabMergeRequestGetter  GitlabMergeRequestGetter
+	AzureDevopsPullGetter     AzureDevopsPullGetter
+	GiteaPullGetter           *gitea.Client
+	BitbucketCloudPullGetter  PullHeadCommitGetter
+	BitbucketServerPullGetter PullHeadCommitGetter
+}
+
+func (f *DefaultLivePullHeadFetcher) GetLiveHeadCommit(ctx command.ProjectContext) (string, error) {
+	switch ctx.Pull.BaseRepo.VCSHost.Type {
+	case models.Github:
+		if f.GithubPullGetter == nil || f.EventParser == nil {
+			return "", errors.New("atlantis is not configured to fetch live GitHub pull request heads")
+		}
+		ghPull, err := f.GithubPullGetter.GetPullRequest(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull.Num)
+		if err != nil {
+			return "", fmt.Errorf("making pull request API call to GitHub: %w", err)
+		}
+		pull, _, _, err := f.EventParser.ParseGithubPull(ctx.Log, ghPull)
+		if err != nil {
+			return "", fmt.Errorf("extracting GitHub pull request head: %w", err)
+		}
+		return pull.HeadCommit, nil
+	case models.Gitlab:
+		if f.GitlabMergeRequestGetter == nil || f.EventParser == nil {
+			return "", errors.New("atlantis is not configured to fetch live GitLab merge request heads")
+		}
+		mr, err := f.GitlabMergeRequestGetter.GetMergeRequest(ctx.Log, ctx.Pull.BaseRepo.FullName, ctx.Pull.Num)
+		if err != nil {
+			return "", fmt.Errorf("making merge request API call to GitLab: %w", err)
+		}
+		pull := f.EventParser.ParseGitlabMergeRequest(mr, ctx.Pull.BaseRepo)
+		return pull.HeadCommit, nil
+	case models.AzureDevops:
+		if f.AzureDevopsPullGetter == nil || f.EventParser == nil {
+			return "", errors.New("atlantis is not configured to fetch live Azure DevOps pull request heads")
+		}
+		adPull, err := f.AzureDevopsPullGetter.GetPullRequest(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull.Num)
+		if err != nil {
+			return "", fmt.Errorf("making pull request API call to Azure DevOps: %w", err)
+		}
+		pull, _, _, err := f.EventParser.ParseAzureDevopsPull(adPull)
+		if err != nil {
+			return "", fmt.Errorf("extracting Azure DevOps pull request head: %w", err)
+		}
+		return pull.HeadCommit, nil
+	case models.Gitea:
+		if f.GiteaPullGetter == nil || f.EventParser == nil {
+			return "", errors.New("atlantis is not configured to fetch live Gitea pull request heads")
+		}
+		giteaPull, err := f.GiteaPullGetter.GetPullRequest(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull.Num)
+		if err != nil {
+			return "", fmt.Errorf("making pull request API call to Gitea: %w", err)
+		}
+		pull, _, _, err := f.EventParser.ParseGiteaPull(giteaPull)
+		if err != nil {
+			return "", fmt.Errorf("extracting Gitea pull request head: %w", err)
+		}
+		return pull.HeadCommit, nil
+	case models.BitbucketCloud:
+		if f.BitbucketCloudPullGetter == nil {
+			return "", errors.New("atlantis is not configured to fetch live Bitbucket Cloud pull request heads")
+		}
+		return f.BitbucketCloudPullGetter.GetPullRequestHeadCommit(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull)
+	case models.BitbucketServer:
+		if f.BitbucketServerPullGetter == nil {
+			return "", errors.New("atlantis is not configured to fetch live Bitbucket Server pull request heads")
+		}
+		return f.BitbucketServerPullGetter.GetPullRequestHeadCommit(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull)
+	default:
+		return "", fmt.Errorf("unsupported vcs host type %q", ctx.Pull.BaseRepo.VCSHost.Type.String())
+	}
+}

--- a/server/events/live_pull_head_fetcher.go
+++ b/server/events/live_pull_head_fetcher.go
@@ -13,8 +13,8 @@ import (
 	"github.com/runatlantis/atlantis/server/logging"
 )
 
-type PullHeadCommitGetter interface {
-	GetPullRequestHeadCommit(logger logging.SimpleLogging, repo models.Repo, pull models.PullRequest) (string, error)
+type PullIdentityGetter interface {
+	GetPullRequestIdentity(logger logging.SimpleLogging, repo models.Repo, pull models.PullRequest) (models.PullRequest, error)
 }
 
 type DefaultLivePullHeadFetcher struct {
@@ -23,72 +23,72 @@ type DefaultLivePullHeadFetcher struct {
 	GitlabMergeRequestGetter  GitlabMergeRequestGetter
 	AzureDevopsPullGetter     AzureDevopsPullGetter
 	GiteaPullGetter           *gitea.Client
-	BitbucketCloudPullGetter  PullHeadCommitGetter
-	BitbucketServerPullGetter PullHeadCommitGetter
+	BitbucketCloudPullGetter  PullIdentityGetter
+	BitbucketServerPullGetter PullIdentityGetter
 }
 
-func (f *DefaultLivePullHeadFetcher) GetLiveHeadCommit(ctx command.ProjectContext) (string, error) {
+func (f *DefaultLivePullHeadFetcher) GetLivePullIdentity(ctx command.ProjectContext) (models.PullRequest, error) {
 	switch ctx.Pull.BaseRepo.VCSHost.Type {
 	case models.Github:
 		if f.GithubPullGetter == nil || f.EventParser == nil {
-			return "", errors.New("atlantis is not configured to fetch live GitHub pull request heads")
+			return models.PullRequest{}, errors.New("atlantis is not configured to fetch live GitHub pull requests")
 		}
 		ghPull, err := f.GithubPullGetter.GetPullRequest(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull.Num)
 		if err != nil {
-			return "", fmt.Errorf("making pull request API call to GitHub: %w", err)
+			return models.PullRequest{}, fmt.Errorf("making pull request API call to GitHub: %w", err)
 		}
 		pull, _, _, err := f.EventParser.ParseGithubPull(ctx.Log, ghPull)
 		if err != nil {
-			return "", fmt.Errorf("extracting GitHub pull request head: %w", err)
+			return models.PullRequest{}, fmt.Errorf("extracting GitHub pull request identity: %w", err)
 		}
-		return pull.HeadCommit, nil
+		return pull, nil
 	case models.Gitlab:
 		if f.GitlabMergeRequestGetter == nil || f.EventParser == nil {
-			return "", errors.New("atlantis is not configured to fetch live GitLab merge request heads")
+			return models.PullRequest{}, errors.New("atlantis is not configured to fetch live GitLab merge requests")
 		}
 		mr, err := f.GitlabMergeRequestGetter.GetMergeRequest(ctx.Log, ctx.Pull.BaseRepo.FullName, ctx.Pull.Num)
 		if err != nil {
-			return "", fmt.Errorf("making merge request API call to GitLab: %w", err)
+			return models.PullRequest{}, fmt.Errorf("making merge request API call to GitLab: %w", err)
 		}
 		pull := f.EventParser.ParseGitlabMergeRequest(mr, ctx.Pull.BaseRepo)
-		return pull.HeadCommit, nil
+		return pull, nil
 	case models.AzureDevops:
 		if f.AzureDevopsPullGetter == nil || f.EventParser == nil {
-			return "", errors.New("atlantis is not configured to fetch live Azure DevOps pull request heads")
+			return models.PullRequest{}, errors.New("atlantis is not configured to fetch live Azure DevOps pull requests")
 		}
 		adPull, err := f.AzureDevopsPullGetter.GetPullRequest(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull.Num)
 		if err != nil {
-			return "", fmt.Errorf("making pull request API call to Azure DevOps: %w", err)
+			return models.PullRequest{}, fmt.Errorf("making pull request API call to Azure DevOps: %w", err)
 		}
 		pull, _, _, err := f.EventParser.ParseAzureDevopsPull(adPull)
 		if err != nil {
-			return "", fmt.Errorf("extracting Azure DevOps pull request head: %w", err)
+			return models.PullRequest{}, fmt.Errorf("extracting Azure DevOps pull request identity: %w", err)
 		}
-		return pull.HeadCommit, nil
+		return pull, nil
 	case models.Gitea:
 		if f.GiteaPullGetter == nil || f.EventParser == nil {
-			return "", errors.New("atlantis is not configured to fetch live Gitea pull request heads")
+			return models.PullRequest{}, errors.New("atlantis is not configured to fetch live Gitea pull requests")
 		}
 		giteaPull, err := f.GiteaPullGetter.GetPullRequest(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull.Num)
 		if err != nil {
-			return "", fmt.Errorf("making pull request API call to Gitea: %w", err)
+			return models.PullRequest{}, fmt.Errorf("making pull request API call to Gitea: %w", err)
 		}
 		pull, _, _, err := f.EventParser.ParseGiteaPull(giteaPull)
 		if err != nil {
-			return "", fmt.Errorf("extracting Gitea pull request head: %w", err)
+			return models.PullRequest{}, fmt.Errorf("extracting Gitea pull request identity: %w", err)
 		}
-		return pull.HeadCommit, nil
+		return pull, nil
 	case models.BitbucketCloud:
 		if f.BitbucketCloudPullGetter == nil {
-			return "", errors.New("atlantis is not configured to fetch live Bitbucket Cloud pull request heads")
+			return models.PullRequest{}, errors.New("atlantis is not configured to fetch live Bitbucket Cloud pull requests")
 		}
-		return f.BitbucketCloudPullGetter.GetPullRequestHeadCommit(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull)
+		return f.BitbucketCloudPullGetter.GetPullRequestIdentity(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull)
 	case models.BitbucketServer:
 		if f.BitbucketServerPullGetter == nil {
-			return "", errors.New("atlantis is not configured to fetch live Bitbucket Server pull request heads")
+			return models.PullRequest{}, errors.New("atlantis is not configured to fetch live Bitbucket Server pull requests")
 		}
-		return f.BitbucketServerPullGetter.GetPullRequestHeadCommit(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull)
+		return f.BitbucketServerPullGetter.GetPullRequestIdentity(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull)
 	default:
-		return "", fmt.Errorf("unsupported vcs host type %q", ctx.Pull.BaseRepo.VCSHost.Type.String())
+		return models.PullRequest{}, fmt.Errorf("unsupported vcs host type %q", ctx.Pull.BaseRepo.VCSHost.Type.String())
 	}
 }

--- a/server/events/mocks/mock_working_dir_locker.go
+++ b/server/events/mocks/mock_working_dir_locker.go
@@ -59,6 +59,25 @@ func (mock *MockWorkingDirLocker) TryLock(repoFullName string, pullNum int, work
 	return _ret0, _ret1
 }
 
+func (mock *MockWorkingDirLocker) TryLockPull(repoFullName string, pullNum int, cmdName command.Name) (func(), error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockWorkingDirLocker().")
+	}
+	_params := []pegomock.Param{repoFullName, pullNum, cmdName}
+	_result := pegomock.GetGenericMockFrom(mock).Invoke("TryLockPull", _params, []reflect.Type{reflect.TypeOf((*func())(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var _ret0 func()
+	var _ret1 error
+	if len(_result) != 0 {
+		if _result[0] != nil {
+			_ret0 = _result[0].(func())
+		}
+		if _result[1] != nil {
+			_ret1 = _result[1].(error)
+		}
+	}
+	return _ret0, _ret1
+}
+
 func (mock *MockWorkingDirLocker) UnlockByPull(repoFullName string, pullNum int) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockWorkingDirLocker().")
@@ -198,6 +217,47 @@ func (c *MockWorkingDirLocker_TryLock_OngoingVerification) GetAllCapturedArgumen
 			_param5 = make([]command.Name, len(c.methodInvocations))
 			for u, param := range _params[5] {
 				_param5[u] = param.(command.Name)
+			}
+		}
+	}
+	return
+}
+
+func (verifier *VerifierMockWorkingDirLocker) TryLockPull(repoFullName string, pullNum int, cmdName command.Name) *MockWorkingDirLocker_TryLockPull_OngoingVerification {
+	_params := []pegomock.Param{repoFullName, pullNum, cmdName}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "TryLockPull", _params, verifier.timeout)
+	return &MockWorkingDirLocker_TryLockPull_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockWorkingDirLocker_TryLockPull_OngoingVerification struct {
+	mock              *MockWorkingDirLocker
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockWorkingDirLocker_TryLockPull_OngoingVerification) GetCapturedArguments() (string, int, command.Name) {
+	repoFullName, pullNum, cmdName := c.GetAllCapturedArguments()
+	return repoFullName[len(repoFullName)-1], pullNum[len(pullNum)-1], cmdName[len(cmdName)-1]
+}
+
+func (c *MockWorkingDirLocker_TryLockPull_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []int, _param2 []command.Name) {
+	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(_params) > 0 {
+		if len(_params) > 0 {
+			_param0 = make([]string, len(c.methodInvocations))
+			for u, param := range _params[0] {
+				_param0[u] = param.(string)
+			}
+		}
+		if len(_params) > 1 {
+			_param1 = make([]int, len(c.methodInvocations))
+			for u, param := range _params[1] {
+				_param1[u] = param.(int)
+			}
+		}
+		if len(_params) > 2 {
+			_param2 = make([]command.Name, len(c.methodInvocations))
+			for u, param := range _params[2] {
+				_param2[u] = param.(command.Name)
 			}
 		}
 	}

--- a/server/events/mocks/mock_working_dir_locker.go
+++ b/server/events/mocks/mock_working_dir_locker.go
@@ -25,6 +25,21 @@ func NewMockWorkingDirLocker(options ...pegomock.Option) *MockWorkingDirLocker {
 func (mock *MockWorkingDirLocker) SetFailHandler(fh pegomock.FailHandler) { mock.fail = fh }
 func (mock *MockWorkingDirLocker) FailHandler() pegomock.FailHandler      { return mock.fail }
 
+func (mock *MockWorkingDirLocker) HasCommandLock(repoFullName string, pullNum int, cmdName command.Name) bool {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockWorkingDirLocker().")
+	}
+	_params := []pegomock.Param{repoFullName, pullNum, cmdName}
+	_result := pegomock.GetGenericMockFrom(mock).Invoke("HasCommandLock", _params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem()})
+	var _ret0 bool
+	if len(_result) != 0 {
+		if _result[0] != nil {
+			_ret0 = _result[0].(bool)
+		}
+	}
+	return _ret0
+}
+
 func (mock *MockWorkingDirLocker) TryLock(repoFullName string, pullNum int, workspace string, path string, projectName string, cmdName command.Name) (func(), error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockWorkingDirLocker().")
@@ -87,6 +102,47 @@ type VerifierMockWorkingDirLocker struct {
 	invocationCountMatcher pegomock.InvocationCountMatcher
 	inOrderContext         *pegomock.InOrderContext
 	timeout                time.Duration
+}
+
+func (verifier *VerifierMockWorkingDirLocker) HasCommandLock(repoFullName string, pullNum int, cmdName command.Name) *MockWorkingDirLocker_HasCommandLock_OngoingVerification {
+	_params := []pegomock.Param{repoFullName, pullNum, cmdName}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "HasCommandLock", _params, verifier.timeout)
+	return &MockWorkingDirLocker_HasCommandLock_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockWorkingDirLocker_HasCommandLock_OngoingVerification struct {
+	mock              *MockWorkingDirLocker
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockWorkingDirLocker_HasCommandLock_OngoingVerification) GetCapturedArguments() (string, int, command.Name) {
+	repoFullName, pullNum, cmdName := c.GetAllCapturedArguments()
+	return repoFullName[len(repoFullName)-1], pullNum[len(pullNum)-1], cmdName[len(cmdName)-1]
+}
+
+func (c *MockWorkingDirLocker_HasCommandLock_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []int, _param2 []command.Name) {
+	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(_params) > 0 {
+		if len(_params) > 0 {
+			_param0 = make([]string, len(c.methodInvocations))
+			for u, param := range _params[0] {
+				_param0[u] = param.(string)
+			}
+		}
+		if len(_params) > 1 {
+			_param1 = make([]int, len(c.methodInvocations))
+			for u, param := range _params[1] {
+				_param1[u] = param.(int)
+			}
+		}
+		if len(_params) > 2 {
+			_param2 = make([]command.Name, len(c.methodInvocations))
+			for u, param := range _params[2] {
+				_param2[u] = param.(command.Name)
+			}
+		}
+	}
+	return
 }
 
 func (verifier *VerifierMockWorkingDirLocker) TryLock(repoFullName string, pullNum int, workspace string, path string, projectName string, cmdName command.Name) *MockWorkingDirLocker_TryLock_OngoingVerification {

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -125,7 +125,7 @@ func (p *PlanCommandRunner) runAutoplan(ctx *command.Context) {
 
 	if len(projectCmds) == 0 {
 		ctx.Log.Info("determined there was no project to run plan in")
-		p.replacePullStatusWithEmptyProjects(ctx, pull)
+		p.clearPlansLocksAndPullStatusForNoProjects(ctx, pull)
 		if !p.silenceVCSStatusNoPlans && !p.silenceVCSStatusNoProjects {
 			// If there were no projects modified, we set successful commit statuses
 			// with 0/0 projects planned/policy_checked/applied successfully because some users require
@@ -222,7 +222,7 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 	if len(projectCmds) == 0 && p.SilenceNoProjects {
 		ctx.Log.Info("determined there was no project to run plan in")
 		if !cmd.IsForSpecificProject() {
-			p.replacePullStatusWithEmptyProjects(ctx, pull)
+			p.clearPlansLocksAndPullStatusForNoProjects(ctx, pull)
 		}
 		if !p.silenceVCSStatusNoProjects {
 			if cmd.IsForSpecificProject() {
@@ -329,7 +329,11 @@ func (p *PlanCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 	}
 }
 
-func (p *PlanCommandRunner) replacePullStatusWithEmptyProjects(ctx *command.Context, pull models.PullRequest) {
+func (p *PlanCommandRunner) clearPlansLocksAndPullStatusForNoProjects(ctx *command.Context, pull models.PullRequest) {
+	p.deletePlans(ctx)
+	if _, err := p.lockingLocker.UnlockByPull(pull.BaseRepo.FullName, pull.Num); err != nil {
+		ctx.Log.Err("deleting locks: %s", err)
+	}
 	if _, err := p.dbUpdater.replaceDB(ctx, pull, nil); err != nil {
 		ctx.Log.Err("writing empty plan status: %s", err)
 	}

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -4,11 +4,16 @@
 package events
 
 import (
+	"fmt"
+	"path/filepath"
+
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/core/locking"
+	"github.com/runatlantis/atlantis/server/core/runtime"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/events/vcs"
+	"github.com/runatlantis/atlantis/server/utils"
 )
 
 // GenerateLockID creates a consistent lock ID for a project context.
@@ -25,6 +30,7 @@ func NewPlanCommandRunner(
 	vcsClient vcs.Client,
 	pendingPlanFinder PendingPlanFinder,
 	workingDir WorkingDir,
+	workingDirLocker WorkingDirLocker,
 	commitStatusUpdater CommitStatusUpdater,
 	projectCommandBuilder ProjectPlanCommandBuilder,
 	projectCommandRunner ProjectPlanCommandRunner,
@@ -48,6 +54,7 @@ func NewPlanCommandRunner(
 		vcsClient:                  vcsClient,
 		pendingPlanFinder:          pendingPlanFinder,
 		workingDir:                 workingDir,
+		workingDirLocker:           workingDirLocker,
 		commitStatusUpdater:        commitStatusUpdater,
 		prjCmdBuilder:              projectCommandBuilder,
 		prjCmdRunner:               projectCommandRunner,
@@ -80,6 +87,7 @@ type PlanCommandRunner struct {
 	commitStatusUpdater        CommitStatusUpdater
 	pendingPlanFinder          PendingPlanFinder
 	workingDir                 WorkingDir
+	workingDirLocker           WorkingDirLocker
 	prjCmdBuilder              ProjectPlanCommandBuilder
 	prjCmdRunner               ProjectPlanCommandRunner
 	cancellationTracker        CancellationTracker
@@ -125,7 +133,10 @@ func (p *PlanCommandRunner) runAutoplan(ctx *command.Context) {
 
 	if len(projectCmds) == 0 {
 		ctx.Log.Info("determined there was no project to run plan in")
-		p.clearPlansLocksAndPullStatusForNoProjects(ctx, pull)
+		if err := p.clearPlansAndPullStatusForNoProjects(ctx, pull); err != nil {
+			p.handleNoProjectPlanStateError(ctx, AutoplanCommand{}, err)
+			return
+		}
 		if !p.silenceVCSStatusNoPlans && !p.silenceVCSStatusNoProjects {
 			// If there were no projects modified, we set successful commit statuses
 			// with 0/0 projects planned/policy_checked/applied successfully because some users require
@@ -150,13 +161,21 @@ func (p *PlanCommandRunner) runAutoplan(ctx *command.Context) {
 
 	// discard previous plans that might not be relevant anymore
 	ctx.Log.Debug("deleting previous plans and locks")
-	p.deletePlansAndPlanLocks(ctx, projectCmds)
+	if err := p.deletePlansAndPlanLocks(ctx, projectCmds); err != nil {
+		if statusErr := p.commitStatusUpdater.UpdateCombined(ctx.Log, baseRepo, pull, models.FailedCommitStatus, command.Plan); statusErr != nil {
+			ctx.Log.Warn("unable to update commit status: %s", statusErr)
+		}
+		p.pullUpdater.updatePull(ctx, AutoplanCommand{}, command.Result{Error: err})
+		return
+	}
 
 	result := runProjectCmdsWithCancellationTracker(ctx, projectCmds, p.cancellationTracker, p.parallelPoolSize, p.isParallelEnabled(projectCmds), p.prjCmdRunner.Plan)
 
 	if p.autoMerger.automergeEnabled(projectCmds) && result.HasErrors() {
 		ctx.Log.Info("deleting plans because there were errors and automerge requires all plans succeed")
-		p.deletePlansAndPlanLocks(ctx, projectCmds)
+		if err := p.deletePlansAndPlanLocks(ctx, projectCmds); err != nil {
+			ctx.Log.Err("deleting pending plans: %s", err)
+		}
 		result.PlansDeleted = true
 	}
 
@@ -222,7 +241,10 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 	if len(projectCmds) == 0 && p.SilenceNoProjects {
 		ctx.Log.Info("determined there was no project to run plan in")
 		if !cmd.IsForSpecificProject() {
-			p.clearPlansLocksAndPullStatusForNoProjects(ctx, pull)
+			if err := p.clearPlansAndPullStatusForNoProjects(ctx, pull); err != nil {
+				p.handleNoProjectPlanStateError(ctx, cmd, err)
+				return
+			}
 		}
 		if !p.silenceVCSStatusNoProjects {
 			if cmd.IsForSpecificProject() {
@@ -273,7 +295,13 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 	// discard previous plans that might not be relevant anymore
 	if !cmd.IsForSpecificProject() {
 		ctx.Log.Debug("deleting previous plans and locks")
-		p.deletePlansAndPlanLocks(ctx, projectCmds)
+		if err := p.deletePlansAndPlanLocks(ctx, projectCmds); err != nil {
+			if statusErr := p.commitStatusUpdater.UpdateCombined(ctx.Log, baseRepo, pull, models.FailedCommitStatus, command.Plan); statusErr != nil {
+				ctx.Log.Warn("unable to update commit status: %s", statusErr)
+			}
+			p.pullUpdater.updatePull(ctx, cmd, command.Result{Error: err})
+			return
+		}
 	}
 
 	result := runProjectCmdsWithCancellationTracker(ctx, projectCmds, p.cancellationTracker, p.parallelPoolSize, p.isParallelEnabled(projectCmds), p.prjCmdRunner.Plan)
@@ -281,7 +309,9 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 
 	if p.autoMerger.automergeEnabled(projectCmds) && result.HasErrors() {
 		ctx.Log.Info("deleting plans because there were errors and automerge requires all plans succeed")
-		p.deletePlansAndPlanLocks(ctx, projectCmds)
+		if err := p.deletePlansAndPlanLocks(ctx, projectCmds); err != nil {
+			ctx.Log.Err("deleting pending plans: %s", err)
+		}
 		result.PlansDeleted = true
 	}
 
@@ -329,14 +359,22 @@ func (p *PlanCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 	}
 }
 
-func (p *PlanCommandRunner) clearPlansLocksAndPullStatusForNoProjects(ctx *command.Context, pull models.PullRequest) {
-	p.deletePlans(ctx)
-	if _, err := p.lockingLocker.UnlockByPull(pull.BaseRepo.FullName, pull.Num); err != nil {
-		ctx.Log.Err("deleting locks: %s", err)
+func (p *PlanCommandRunner) clearPlansAndPullStatusForNoProjects(ctx *command.Context, pull models.PullRequest) error {
+	if err := p.deletePlans(ctx); err != nil {
+		return err
 	}
 	if _, err := p.dbUpdater.replaceDB(ctx, pull, nil); err != nil {
-		ctx.Log.Err("writing empty plan status: %s", err)
+		return fmt.Errorf("writing empty plan status: %w", err)
 	}
+	return nil
+}
+
+func (p *PlanCommandRunner) handleNoProjectPlanStateError(ctx *command.Context, cmd PullCommand, err error) {
+	ctx.CommandHasErrors = true
+	if statusErr := p.commitStatusUpdater.UpdateCombined(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, command.Plan); statusErr != nil {
+		ctx.Log.Warn("unable to update commit status: %s", statusErr)
+	}
+	p.pullUpdater.updatePull(ctx, cmd, command.Result{Error: err})
 }
 
 func (p *PlanCommandRunner) ShouldSkipPreWorkflowHooks(ctx *command.Context, cmd *CommentCommand) bool {
@@ -409,19 +447,45 @@ func (p *PlanCommandRunner) updateCommitStatus(ctx *command.Context, pullStatus 
 }
 
 // deletePlans deletes all plans generated in this ctx.
-func (p *PlanCommandRunner) deletePlans(ctx *command.Context) {
+func (p *PlanCommandRunner) deletePlans(ctx *command.Context) error {
 	pullDir, err := p.workingDir.GetPullDir(ctx.Pull.BaseRepo, ctx.Pull)
 	if err != nil {
-		ctx.Log.Err("getting pull dir: %s", err)
+		return fmt.Errorf("getting pull dir: %w", err)
 	}
-	if err := p.pendingPlanFinder.DeletePlans(pullDir); err != nil {
-		ctx.Log.Err("deleting pending plans: %s", err)
+	plans, err := p.pendingPlanFinder.Find(pullDir)
+	if err != nil {
+		return fmt.Errorf("finding pending plans: %w", err)
 	}
+
+	var unlocks []func()
+	defer func() {
+		for i := len(unlocks) - 1; i >= 0; i-- {
+			unlocks[i]()
+		}
+	}()
+	for _, plan := range plans {
+		unlockFn, err := p.workingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, plan.Workspace, plan.RepoRelDir, plan.ProjectName, command.Plan)
+		if err != nil {
+			return fmt.Errorf("locking pending plan for dir %q workspace %q project %q before deleting: %w", plan.RepoRelDir, plan.Workspace, plan.ProjectName, err)
+		}
+		unlocks = append(unlocks, unlockFn)
+	}
+
+	for _, plan := range plans {
+		planPath := filepath.Join(plan.RepoDir, plan.RepoRelDir, runtime.GetPlanFilename(plan.Workspace, plan.ProjectName))
+		if err := utils.RemoveIgnoreNonExistent(planPath); err != nil {
+			return fmt.Errorf("deleting plan at %s: %w", planPath, err)
+		}
+	}
+	return nil
 }
 
-func (p *PlanCommandRunner) deletePlansAndPlanLocks(ctx *command.Context, projectCmds []command.ProjectContext) {
-	p.deletePlans(ctx)
+func (p *PlanCommandRunner) deletePlansAndPlanLocks(ctx *command.Context, projectCmds []command.ProjectContext) error {
+	if err := p.deletePlans(ctx); err != nil {
+		return err
+	}
 	p.deletePlanLocks(ctx, projectCmds)
+	return nil
 }
 
 func (p *PlanCommandRunner) deletePlanLocks(ctx *command.Context, projectCmds []command.ProjectContext) {

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -4,8 +4,11 @@
 package events
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
+	"slices"
 
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/core/locking"
@@ -133,7 +136,7 @@ func (p *PlanCommandRunner) runAutoplan(ctx *command.Context) {
 
 	if len(projectCmds) == 0 {
 		ctx.Log.Info("determined there was no project to run plan in")
-		if err := p.clearPlansAndPullStatusForNoProjects(ctx, pull); err != nil {
+		if _, err := p.clearPlansAndPullStatusForNoProjects(ctx, pull); err != nil {
 			p.handleNoProjectPlanStateError(ctx, AutoplanCommand{}, err)
 			return
 		}
@@ -238,13 +241,19 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 		return
 	}
 
-	if len(projectCmds) == 0 && p.SilenceNoProjects {
+	var noProjectPullStatus *models.PullStatus
+	if len(projectCmds) == 0 && !cmd.IsForSpecificProject() {
 		ctx.Log.Info("determined there was no project to run plan in")
-		if !cmd.IsForSpecificProject() {
-			if err := p.clearPlansAndPullStatusForNoProjects(ctx, pull); err != nil {
-				p.handleNoProjectPlanStateError(ctx, cmd, err)
-				return
-			}
+		pullStatus, err := p.clearPlansAndPullStatusForNoProjects(ctx, pull)
+		if err != nil {
+			p.handleNoProjectPlanStateError(ctx, cmd, err)
+			return
+		}
+		noProjectPullStatus = &pullStatus
+	}
+	if len(projectCmds) == 0 && p.SilenceNoProjects {
+		if cmd.IsForSpecificProject() {
+			ctx.Log.Info("determined there was no project to run plan in")
 		}
 		if !p.silenceVCSStatusNoProjects {
 			if cmd.IsForSpecificProject() {
@@ -293,7 +302,7 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 
 	// if the plan is generic, new plans will be generated based on changes
 	// discard previous plans that might not be relevant anymore
-	if !cmd.IsForSpecificProject() {
+	if !cmd.IsForSpecificProject() && len(projectCmds) > 0 {
 		ctx.Log.Debug("deleting previous plans and locks")
 		if err := p.deletePlansAndPlanLocks(ctx, projectCmds); err != nil {
 			if statusErr := p.commitStatusUpdater.UpdateCombined(ctx.Log, baseRepo, pull, models.FailedCommitStatus, command.Plan); statusErr != nil {
@@ -321,7 +330,9 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 		result)
 
 	var pullStatus models.PullStatus
-	if len(projectCmds) == 0 && !cmd.IsForSpecificProject() {
+	if noProjectPullStatus != nil {
+		pullStatus = *noProjectPullStatus
+	} else if len(projectCmds) == 0 && !cmd.IsForSpecificProject() {
 		pullStatus, err = p.dbUpdater.replaceDB(ctx, pull, result.ProjectResults)
 	} else {
 		pullStatus, err = p.dbUpdater.updateDB(ctx, pull, result.ProjectResults)
@@ -359,14 +370,15 @@ func (p *PlanCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 	}
 }
 
-func (p *PlanCommandRunner) clearPlansAndPullStatusForNoProjects(ctx *command.Context, pull models.PullRequest) error {
-	if err := p.deletePlans(ctx); err != nil {
-		return err
+func (p *PlanCommandRunner) clearPlansAndPullStatusForNoProjects(ctx *command.Context, pull models.PullRequest) (models.PullStatus, error) {
+	if _, err := p.deletePlansAndPendingPlanLocks(ctx); err != nil {
+		return models.PullStatus{}, err
 	}
-	if _, err := p.dbUpdater.replaceDB(ctx, pull, nil); err != nil {
-		return fmt.Errorf("writing empty plan status: %w", err)
+	pullStatus, err := p.dbUpdater.replaceDB(ctx, pull, nil)
+	if err != nil {
+		return models.PullStatus{}, fmt.Errorf("writing empty plan status: %w", err)
 	}
-	return nil
+	return pullStatus, nil
 }
 
 func (p *PlanCommandRunner) handleNoProjectPlanStateError(ctx *command.Context, cmd PullCommand, err error) {
@@ -447,26 +459,37 @@ func (p *PlanCommandRunner) updateCommitStatus(ctx *command.Context, pullStatus 
 }
 
 // deletePlans deletes all plans generated in this ctx.
-func (p *PlanCommandRunner) deletePlans(ctx *command.Context) error {
+func (p *PlanCommandRunner) deletePlans(ctx *command.Context) ([]PendingPlan, error) {
+	return p.deletePlansWithPostDelete(ctx, nil)
+}
+
+func (p *PlanCommandRunner) deletePlansAndPendingPlanLocks(ctx *command.Context) ([]PendingPlan, error) {
+	return p.deletePlansWithPostDelete(ctx, p.deletePlanLocksForPendingPlans)
+}
+
+func (p *PlanCommandRunner) deletePlansWithPostDelete(ctx *command.Context, postDelete func(*command.Context, []PendingPlan) error) ([]PendingPlan, error) {
 	pullDir, err := p.workingDir.GetPullDir(ctx.Pull.BaseRepo, ctx.Pull)
 	if err != nil {
-		return fmt.Errorf("getting pull dir: %w", err)
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("getting pull dir: %w", err)
 	}
 	plans, err := p.pendingPlanFinder.Find(pullDir)
 	if err != nil {
-		return fmt.Errorf("finding pending plans: %w", err)
+		return nil, fmt.Errorf("finding pending plans: %w", err)
 	}
 
 	var unlocks []func()
 	defer func() {
-		for i := len(unlocks) - 1; i >= 0; i-- {
-			unlocks[i]()
+		for _, unlock := range slices.Backward(unlocks) {
+			unlock()
 		}
 	}()
 	for _, plan := range plans {
 		unlockFn, err := p.workingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, plan.Workspace, plan.RepoRelDir, plan.ProjectName, command.Plan)
 		if err != nil {
-			return fmt.Errorf("locking pending plan for dir %q workspace %q project %q before deleting: %w", plan.RepoRelDir, plan.Workspace, plan.ProjectName, err)
+			return nil, fmt.Errorf("locking pending plan for dir %q workspace %q project %q before deleting: %w", plan.RepoRelDir, plan.Workspace, plan.ProjectName, err)
 		}
 		unlocks = append(unlocks, unlockFn)
 	}
@@ -474,21 +497,25 @@ func (p *PlanCommandRunner) deletePlans(ctx *command.Context) error {
 	for _, plan := range plans {
 		planPath := filepath.Join(plan.RepoDir, plan.RepoRelDir, runtime.GetPlanFilename(plan.Workspace, plan.ProjectName))
 		if err := utils.RemoveIgnoreNonExistent(planPath); err != nil {
-			return fmt.Errorf("deleting plan at %s: %w", planPath, err)
+			return nil, fmt.Errorf("deleting plan at %s: %w", planPath, err)
 		}
 	}
-	return nil
+	if postDelete != nil {
+		if err := postDelete(ctx, plans); err != nil {
+			return nil, err
+		}
+	}
+	return plans, nil
 }
 
 func (p *PlanCommandRunner) deletePlansAndPlanLocks(ctx *command.Context, projectCmds []command.ProjectContext) error {
-	if err := p.deletePlans(ctx); err != nil {
+	if _, err := p.deletePlans(ctx); err != nil {
 		return err
 	}
-	p.deletePlanLocks(ctx, projectCmds)
-	return nil
+	return p.deletePlanLocks(ctx, projectCmds)
 }
 
-func (p *PlanCommandRunner) deletePlanLocks(ctx *command.Context, projectCmds []command.ProjectContext) {
+func (p *PlanCommandRunner) deletePlanLocks(ctx *command.Context, projectCmds []command.ProjectContext) error {
 	unlocked := make(map[string]bool)
 	for _, projCtx := range projectCmds {
 		if projCtx.RepoLocksMode != valid.RepoLocksOnPlanMode {
@@ -502,14 +529,34 @@ func (p *PlanCommandRunner) deletePlanLocks(ctx *command.Context, projectCmds []
 		unlocked[lockKey] = true
 
 		project := models.NewProject(projCtx.BaseRepo.FullName, projCtx.RepoRelDir, projCtx.ProjectName)
-		p.unlockPlanLockIfOwnedByPull(ctx, project, projCtx.Workspace, lockKey)
+		if err := p.unlockPlanLockIfOwnedByPull(ctx, project, projCtx.Workspace, lockKey); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
-func (p *PlanCommandRunner) unlockPlanLockIfOwnedByPull(ctx *command.Context, project models.Project, workspace string, lockKey string) {
-	if _, err := p.lockingLocker.UnlockIfOwnedByPull(project, workspace, ctx.Pull.Num); err != nil {
-		ctx.Log.Err("deleting lock %q for pull %d: %s", lockKey, ctx.Pull.Num, err)
+func (p *PlanCommandRunner) deletePlanLocksForPendingPlans(ctx *command.Context, plans []PendingPlan) error {
+	unlocked := make(map[string]bool)
+	for _, plan := range plans {
+		project := models.NewProject(ctx.Pull.BaseRepo.FullName, plan.RepoRelDir, plan.ProjectName)
+		lockKey := models.GenerateLockKey(project, plan.Workspace)
+		if unlocked[lockKey] {
+			continue
+		}
+		unlocked[lockKey] = true
+		if err := p.unlockPlanLockIfOwnedByPull(ctx, project, plan.Workspace, lockKey); err != nil {
+			return err
+		}
 	}
+	return nil
+}
+
+func (p *PlanCommandRunner) unlockPlanLockIfOwnedByPull(ctx *command.Context, project models.Project, workspace string, lockKey string) error {
+	if _, err := p.lockingLocker.UnlockIfOwnedByPull(project, workspace, ctx.Pull.Num); err != nil {
+		return fmt.Errorf("deleting lock %q for pull %d: %w", lockKey, ctx.Pull.Num, err)
+	}
+	return nil
 }
 
 func (p *PlanCommandRunner) partitionProjectCmds(

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -112,6 +112,11 @@ type PlanCommandRunner struct {
 func (p *PlanCommandRunner) runAutoplan(ctx *command.Context) {
 	baseRepo := ctx.Pull.BaseRepo
 	pull := ctx.Pull
+	unlockPullPlan, ok := p.lockPullForPlan(ctx, AutoplanCommand{})
+	if !ok {
+		return
+	}
+	defer unlockPullPlan()
 
 	var err error
 	ctx.PullRequestStatus, err = p.pullReqStatusFetcher.FetchPullStatus(ctx.Log, pull)
@@ -212,6 +217,11 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 	var err error
 	baseRepo := ctx.Pull.BaseRepo
 	pull := ctx.Pull
+	unlockPullPlan, ok := p.lockPullForPlan(ctx, cmd)
+	if !ok {
+		return
+	}
+	defer unlockPullPlan()
 
 	ctx.PullRequestStatus, err = p.pullReqStatusFetcher.FetchPullStatus(ctx.Log, pull)
 	if err != nil {
@@ -379,6 +389,18 @@ func (p *PlanCommandRunner) clearPlansAndPullStatusForNoProjects(ctx *command.Co
 		return models.PullStatus{}, fmt.Errorf("writing empty plan status: %w", err)
 	}
 	return pullStatus, nil
+}
+
+func (p *PlanCommandRunner) lockPullForPlan(ctx *command.Context, cmd PullCommand) (func(), bool) {
+	if p.workingDirLocker == nil {
+		return func() {}, true
+	}
+	unlockFn, err := p.workingDirLocker.TryLockPull(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, command.Plan)
+	if err != nil {
+		p.handleNoProjectPlanStateError(ctx, cmd, err)
+		return nil, false
+	}
+	return unlockFn, true
 }
 
 func (p *PlanCommandRunner) handleNoProjectPlanStateError(ctx *command.Context, cmd PullCommand, err error) {

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -125,6 +125,7 @@ func (p *PlanCommandRunner) runAutoplan(ctx *command.Context) {
 
 	if len(projectCmds) == 0 {
 		ctx.Log.Info("determined there was no project to run plan in")
+		p.replacePullStatusWithEmptyProjects(ctx, pull)
 		if !p.silenceVCSStatusNoPlans && !p.silenceVCSStatusNoProjects {
 			// If there were no projects modified, we set successful commit statuses
 			// with 0/0 projects planned/policy_checked/applied successfully because some users require
@@ -220,6 +221,9 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 
 	if len(projectCmds) == 0 && p.SilenceNoProjects {
 		ctx.Log.Info("determined there was no project to run plan in")
+		if !cmd.IsForSpecificProject() {
+			p.replacePullStatusWithEmptyProjects(ctx, pull)
+		}
 		if !p.silenceVCSStatusNoProjects {
 			if cmd.IsForSpecificProject() {
 				// With a specific plan, just reset the status so it's not stuck in pending state
@@ -286,7 +290,12 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 		cmd,
 		result)
 
-	pullStatus, err := p.dbUpdater.updateDB(ctx, pull, result.ProjectResults)
+	var pullStatus models.PullStatus
+	if len(projectCmds) == 0 && !cmd.IsForSpecificProject() {
+		pullStatus, err = p.dbUpdater.replaceDB(ctx, pull, result.ProjectResults)
+	} else {
+		pullStatus, err = p.dbUpdater.updateDB(ctx, pull, result.ProjectResults)
+	}
 	if err != nil {
 		ctx.Log.Err("writing results: %s", err)
 		return
@@ -317,6 +326,12 @@ func (p *PlanCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 		p.runAutoplan(ctx)
 	} else {
 		p.run(ctx, cmd)
+	}
+}
+
+func (p *PlanCommandRunner) replacePullStatusWithEmptyProjects(ctx *command.Context, pull models.PullRequest) {
+	if _, err := p.dbUpdater.replaceDB(ctx, pull, nil); err != nil {
+		ctx.Log.Err("writing empty plan status: %s", err)
 	}
 }
 

--- a/server/events/plan_command_runner_internal_test.go
+++ b/server/events/plan_command_runner_internal_test.go
@@ -4,6 +4,7 @@
 package events
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/runatlantis/atlantis/server/core/config/valid"
@@ -198,10 +199,12 @@ func TestPlanCommandRunner_DeletePlansAndPlanLocksByRepoLockMode(t *testing.T) {
 			if tt.ctxPull.Num != 0 || tt.ctxPull.BaseRepo.FullName != "" {
 				ctxPull = tt.ctxPull
 			}
-			finder := &recordingPendingPlanFinder{}
+			finder := &recordingPendingPlanFinder{plans: pendingPlansForProjectCmds(pullDir, tt.projectCmds)}
 			locker := &recordingPlanCleanupLocker{locksByKey: tt.locksByKey}
+			workingDirLocker := NewDefaultWorkingDirLocker()
 			runner := &PlanCommandRunner{
 				workingDir:        &planCleanupWorkingDir{pullDir: pullDir},
+				workingDirLocker:  workingDirLocker,
 				pendingPlanFinder: finder,
 				lockingLocker:     locker,
 			}
@@ -210,10 +213,12 @@ func TestPlanCommandRunner_DeletePlansAndPlanLocksByRepoLockMode(t *testing.T) {
 				Pull: ctxPull,
 			}
 
-			runner.deletePlansAndPlanLocks(ctx, tt.projectCmds)
+			if err := runner.deletePlansAndPlanLocks(ctx, tt.projectCmds); err != nil {
+				t.Fatalf("deletePlansAndPlanLocks returned error: %s", err)
+			}
 
-			if len(finder.deletedPullDirs) != 1 || finder.deletedPullDirs[0] != pullDir {
-				t.Fatalf("expected DeletePlans(%q), got %#v", pullDir, finder.deletedPullDirs)
+			if len(finder.findPullDirs) != 1 || finder.findPullDirs[0] != pullDir {
+				t.Fatalf("expected Find(%q), got %#v", pullDir, finder.findPullDirs)
 			}
 			if len(locker.unlockByPullCalls) != 0 {
 				t.Fatalf("expected no UnlockByPull calls, got %#v", locker.unlockByPullCalls)
@@ -234,14 +239,63 @@ func TestPlanCommandRunner_DeletePlansAndPlanLocksByRepoLockMode(t *testing.T) {
 	}
 }
 
-type recordingPendingPlanFinder struct {
-	PendingPlanFinder
-	deletedPullDirs []string
+func TestPlanCommandRunner_DeletePlanLocksForPendingPlansReleasesOnlyPendingPlanLocks(t *testing.T) {
+	repo := models.Repo{FullName: "owner/repo"}
+	pull := models.PullRequest{BaseRepo: repo, Num: 1}
+	deletedPlanProject := models.NewProject(repo.FullName, "terraform", "prod")
+	unrelatedProject := models.NewProject(repo.FullName, "terraform/unrelated", "prod")
+	deletedPlanKey := models.GenerateLockKey(deletedPlanProject, "default")
+	unrelatedKey := models.GenerateLockKey(unrelatedProject, "default")
+	locker := &recordingPlanCleanupLocker{
+		locksByKey: map[string]models.ProjectLock{
+			deletedPlanKey: lockForPull(repo, pull.Num),
+			unrelatedKey:   lockForPull(repo, pull.Num),
+		},
+	}
+	runner := &PlanCommandRunner{lockingLocker: locker}
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: pull,
+	}
+	plans := []PendingPlan{
+		{RepoRelDir: "terraform", Workspace: "default", ProjectName: "prod"},
+	}
+
+	if err := runner.deletePlanLocksForPendingPlans(ctx, plans); err != nil {
+		t.Fatalf("deletePlanLocksForPendingPlans returned error: %s", err)
+	}
+
+	expectedCalls := []unlockIfOwnedByPullCall{
+		{
+			key:       deletedPlanKey,
+			project:   deletedPlanProject,
+			workspace: "default",
+			pullNum:   pull.Num,
+		},
+	}
+	if !equalUnlockIfOwnedByPullCalls(locker.unlockIfOwnedByPullCalls, expectedCalls) {
+		t.Fatalf("expected UnlockIfOwnedByPull calls %#v, got %#v", expectedCalls, locker.unlockIfOwnedByPullCalls)
+	}
+	if !equalStringSlices(locker.deletedKeys, []string{deletedPlanKey}) {
+		t.Fatalf("expected deleted keys %#v, got %#v", []string{deletedPlanKey}, locker.deletedKeys)
+	}
+	if _, ok := locker.locksByKey[unrelatedKey]; !ok {
+		t.Fatalf("expected unrelated lock %q to remain", unrelatedKey)
+	}
+	if len(locker.unlockByPullCalls) != 0 {
+		t.Fatalf("expected no UnlockByPull calls, got %#v", locker.unlockByPullCalls)
+	}
 }
 
-func (r *recordingPendingPlanFinder) DeletePlans(pullDir string) error {
-	r.deletedPullDirs = append(r.deletedPullDirs, pullDir)
-	return nil
+type recordingPendingPlanFinder struct {
+	PendingPlanFinder
+	findPullDirs []string
+	plans        []PendingPlan
+}
+
+func (r *recordingPendingPlanFinder) Find(pullDir string) ([]PendingPlan, error) {
+	r.findPullDirs = append(r.findPullDirs, pullDir)
+	return r.plans, nil
 }
 
 type unlockByPullCall struct {
@@ -325,26 +379,29 @@ func expectedUnlockCall(project command.ProjectContext, pullNum int) unlockIfOwn
 	}
 }
 
-func equalStringSlices(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
+func pendingPlansForProjectCmds(pullDir string, projectCmds []command.ProjectContext) []PendingPlan {
+	plans := make([]PendingPlan, 0, len(projectCmds))
+	seen := make(map[string]bool)
+	for _, projectCmd := range projectCmds {
+		key := keyForProject(projectCmd)
+		if seen[key] {
+			continue
 		}
+		seen[key] = true
+		plans = append(plans, PendingPlan{
+			RepoDir:     pullDir,
+			RepoRelDir:  projectCmd.RepoRelDir,
+			Workspace:   projectCmd.Workspace,
+			ProjectName: projectCmd.ProjectName,
+		})
 	}
-	return true
+	return plans
+}
+
+func equalStringSlices(a, b []string) bool {
+	return slices.Equal(a, b)
 }
 
 func equalUnlockIfOwnedByPullCalls(calls []unlockIfOwnedByPullCall, expected []unlockIfOwnedByPullCall) bool {
-	if len(calls) != len(expected) {
-		return false
-	}
-	for i := range calls {
-		if calls[i] != expected[i] {
-			return false
-		}
-	}
-	return true
+	return slices.Equal(calls, expected)
 }

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -1297,7 +1297,7 @@ func ValidatePlansForApply(ctx *command.Context, plans []PendingPlan) error {
 }
 
 func ValidatePlansForApplyWithActivePlan(ctx *command.Context, plans []PendingPlan, hasActivePlan bool) error {
-	return ValidatePlansForApplyWithCurrentHead(ctx, plans, hasActivePlan, ctx.Pull.HeadCommit)
+	return ValidatePlansForApplyWithCurrentPull(ctx, plans, hasActivePlan, ctx.Pull)
 }
 
 // ValidatePlansForApplyWithCurrentHead validates plans against an authoritative
@@ -1305,9 +1305,24 @@ func ValidatePlansForApplyWithActivePlan(ctx *command.Context, plans []PendingPl
 // before generic builder validation instead of trusting the command-start pull
 // snapshot.
 func ValidatePlansForApplyWithCurrentHead(ctx *command.Context, plans []PendingPlan, hasActivePlan bool, currentHead string) error {
-	if currentHead != "" {
+	currentPull := ctx.Pull
+	currentPull.HeadCommit = currentHead
+	return ValidatePlansForApplyWithCurrentPull(ctx, plans, hasActivePlan, currentPull)
+}
+
+// ValidatePlansForApplyWithCurrentPull validates plans against an authoritative
+// current pull identity. This lets apply refresh the live PR head/base under the
+// apply lock before generic builder validation instead of trusting the
+// command-start pull snapshot.
+func ValidatePlansForApplyWithCurrentPull(ctx *command.Context, plans []PendingPlan, hasActivePlan bool, currentPull models.PullRequest) error {
+	if currentPull.HeadCommit != "" || currentPull.BaseBranch != "" {
 		ctxCopy := *ctx
-		ctxCopy.Pull.HeadCommit = currentHead
+		if currentPull.HeadCommit != "" {
+			ctxCopy.Pull.HeadCommit = currentPull.HeadCommit
+		}
+		if currentPull.BaseBranch != "" {
+			ctxCopy.Pull.BaseBranch = currentPull.BaseBranch
+		}
 		ctx = &ctxCopy
 	}
 	if hasActivePlan {

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -1334,10 +1334,7 @@ func validateNoPlansFound(ctx *command.Context) error {
 // pullStatusMatchesHead returns true if PullStatus is for the current PR head.
 // Returns true if either commit is empty (unit test ergonomics or legacy data).
 func pullStatusMatchesHead(ctx *command.Context) bool {
-	if ctx.Pull.HeadCommit == "" || ctx.PullStatus.Pull.HeadCommit == "" {
-		return true
-	}
-	return ctx.PullStatus.Pull.HeadCommit == ctx.Pull.HeadCommit
+	return pullStatusHeadMatchesPull(ctx.Pull, ctx.PullStatus.Pull)
 }
 
 func shortSHA(sha string) string {

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -1244,7 +1244,11 @@ func (p *DefaultProjectCommandBuilder) buildAllProjectCommandsByPlan(ctx *comman
 	}
 
 	if commentCmd.Name == command.Apply {
-		if err := ValidatePlansForApply(ctx, plans); err != nil {
+		hasActivePlan := false
+		if p.WorkingDirLocker != nil {
+			hasActivePlan = p.WorkingDirLocker.HasCommandLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, command.Plan)
+		}
+		if err := ValidatePlansForApplyWithActivePlan(ctx, plans, hasActivePlan); err != nil {
 			return nil, err
 		}
 	}
@@ -1275,10 +1279,14 @@ func (p *DefaultProjectCommandBuilder) buildAllProjectCommandsByPlan(ctx *comman
 // When plans are found, validates each against current-head PullStatus.
 // When no plans are found, fails if no current PullStatus exists or if it is stale.
 func ValidatePlansForApply(ctx *command.Context, plans []PendingPlan) error {
+	return ValidatePlansForApplyWithActivePlan(ctx, plans, false)
+}
+
+func ValidatePlansForApplyWithActivePlan(ctx *command.Context, plans []PendingPlan, hasActivePlan bool) error {
 	if len(plans) > 0 {
 		return validateFoundPlans(ctx, plans)
 	}
-	return validateNoPlansFound(ctx)
+	return validateNoPlansFound(ctx, hasActivePlan)
 }
 
 func validateFoundPlans(ctx *command.Context, plans []PendingPlan) error {
@@ -1315,7 +1323,7 @@ func validateFoundPlans(ctx *command.Context, plans []PendingPlan) error {
 	return validatePullStatusHasPlanFiles(ctx.PullStatus, planKeys)
 }
 
-func validateNoPlansFound(ctx *command.Context) error {
+func validateNoPlansFound(ctx *command.Context, hasActivePlan bool) error {
 	if ctx.PullStatus == nil {
 		return fmt.Errorf("no current plan status found; run `atlantis plan` before apply")
 	}
@@ -1326,6 +1334,10 @@ func validateNoPlansFound(ctx *command.Context) error {
 			shortSHA(ctx.PullStatus.Pull.HeadCommit),
 			shortSHA(ctx.Pull.HeadCommit),
 		)
+	}
+
+	if len(ctx.PullStatus.Projects) == 0 && hasActivePlan {
+		return fmt.Errorf("a plan is currently running for this pull request; wait for it to finish before applying")
 	}
 
 	return validatePullStatusHasPlanFiles(ctx.PullStatus, nil)

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -1297,6 +1297,19 @@ func ValidatePlansForApply(ctx *command.Context, plans []PendingPlan) error {
 }
 
 func ValidatePlansForApplyWithActivePlan(ctx *command.Context, plans []PendingPlan, hasActivePlan bool) error {
+	return ValidatePlansForApplyWithCurrentHead(ctx, plans, hasActivePlan, ctx.Pull.HeadCommit)
+}
+
+// ValidatePlansForApplyWithCurrentHead validates plans against an authoritative
+// current head. This lets apply refresh the live PR head under the apply lock
+// before generic builder validation instead of trusting the command-start pull
+// snapshot.
+func ValidatePlansForApplyWithCurrentHead(ctx *command.Context, plans []PendingPlan, hasActivePlan bool, currentHead string) error {
+	if currentHead != "" {
+		ctxCopy := *ctx
+		ctxCopy.Pull.HeadCommit = currentHead
+		ctx = &ctxCopy
+	}
 	if hasActivePlan {
 		return fmt.Errorf("a plan is currently running for this pull request; wait for it to finish before applying")
 	}

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -1272,6 +1272,8 @@ func (p *DefaultProjectCommandBuilder) buildAllProjectCommandsByPlan(ctx *comman
 }
 
 // ValidatePlansForApply ensures discovered plans are valid for the current PR head.
+// When plans are found, validates each against current-head PullStatus.
+// When no plans are found, fails if no current PullStatus exists or if it is stale.
 func ValidatePlansForApply(ctx *command.Context, plans []PendingPlan) error {
 	if len(plans) > 0 {
 		return validateFoundPlans(ctx, plans)
@@ -1284,12 +1286,11 @@ func validateFoundPlans(ctx *command.Context, plans []PendingPlan) error {
 		return fmt.Errorf("no recorded plan status found; run `atlantis plan` before apply")
 	}
 
-	if ctx.Pull.HeadCommit != "" && ctx.PullStatus.Pull.HeadCommit != "" &&
-		ctx.PullStatus.Pull.HeadCommit != ctx.Pull.HeadCommit {
+	if !pullStatusMatchesHead(ctx) {
 		return fmt.Errorf(
 			"plans are from commit %s but current head is %s; run `atlantis plan` to update",
-			ctx.PullStatus.Pull.HeadCommit[:min(7, len(ctx.PullStatus.Pull.HeadCommit))],
-			ctx.Pull.HeadCommit[:min(7, len(ctx.Pull.HeadCommit))],
+			shortSHA(ctx.PullStatus.Pull.HeadCommit),
+			shortSHA(ctx.Pull.HeadCommit),
 		)
 	}
 
@@ -1297,11 +1298,11 @@ func validateFoundPlans(ctx *command.Context, plans []PendingPlan) error {
 		proj := findProjectInPullStatus(ctx.PullStatus, plan.Workspace, plan.RepoRelDir, plan.ProjectName)
 		if proj == nil {
 			return fmt.Errorf(
-				"plan file found for dir %q workspace %q but no matching plan status exists; run `atlantis plan`",
-				plan.RepoRelDir, plan.Workspace,
+				"plan file found for dir %q workspace %q project %q but no matching plan status exists; run `atlantis plan`",
+				plan.RepoRelDir, plan.Workspace, plan.ProjectName,
 			)
 		}
-		if !isApplyablePlanStatus(proj.Status) {
+		if !statusAllowedForDiscoveredPlan(proj.Status) {
 			return fmt.Errorf(
 				"plan for dir %q workspace %q has status %q and cannot be applied; run `atlantis plan`",
 				plan.RepoRelDir, plan.Workspace, proj.Status.String(),
@@ -1314,29 +1315,45 @@ func validateFoundPlans(ctx *command.Context, plans []PendingPlan) error {
 
 func validateNoPlansFound(ctx *command.Context) error {
 	if ctx.PullStatus == nil {
-		return nil
+		return fmt.Errorf("no current plan status found; run `atlantis plan` before apply")
 	}
 
-	if ctx.Pull.HeadCommit != "" && ctx.PullStatus.Pull.HeadCommit != "" &&
-		ctx.PullStatus.Pull.HeadCommit != ctx.Pull.HeadCommit {
-		return nil
+	if !pullStatusMatchesHead(ctx) {
+		return fmt.Errorf(
+			"recorded plan status is from commit %s but current head is %s; run `atlantis plan` before apply",
+			shortSHA(ctx.PullStatus.Pull.HeadCommit),
+			shortSHA(ctx.Pull.HeadCommit),
+		)
 	}
 
-	for _, proj := range ctx.PullStatus.Projects {
-		if isApplyablePlanStatus(proj.Status) {
-			return fmt.Errorf(
-				"plan file is missing for dir %q workspace %q; run `atlantis plan` again",
-				proj.RepoRelDir, proj.Workspace,
-			)
-		}
-	}
-
+	// Current-head PullStatus exists. Allow empty result — the DB is authoritative
+	// on whether projects need plans. This preserves import/state-rm flows where
+	// plans are intentionally discarded without updating status to DiscardedPlanStatus.
 	return nil
 }
 
-func isApplyablePlanStatus(status models.ProjectPlanStatus) bool {
+// pullStatusMatchesHead returns true if PullStatus is for the current PR head.
+// Returns true if either commit is empty (unit test ergonomics or legacy data).
+func pullStatusMatchesHead(ctx *command.Context) bool {
+	if ctx.Pull.HeadCommit == "" || ctx.PullStatus.Pull.HeadCommit == "" {
+		return true
+	}
+	return ctx.PullStatus.Pull.HeadCommit == ctx.Pull.HeadCommit
+}
+
+func shortSHA(sha string) string {
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	return sha
+}
+
+// statusAllowedForDiscoveredPlan returns true if a discovered .tfplan file
+// with this status is valid to apply. Includes PlannedNoChangesPlanStatus
+// because a no-op plan can still leave a .tfplan file on disk.
+func statusAllowedForDiscoveredPlan(status models.ProjectPlanStatus) bool {
 	switch status {
-	case models.PlannedPlanStatus, models.PassedPolicyCheckStatus, models.ErroredApplyStatus:
+	case models.PlannedPlanStatus, models.PassedPolicyCheckStatus, models.ErroredApplyStatus, models.PlannedNoChangesPlanStatus:
 		return true
 	default:
 		return false

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -1243,6 +1243,12 @@ func (p *DefaultProjectCommandBuilder) buildAllProjectCommandsByPlan(ctx *comman
 		plans = filteredPlans
 	}
 
+	if commentCmd.Name == command.Apply {
+		if err := ValidatePlansForApply(ctx, plans); err != nil {
+			return nil, err
+		}
+	}
+
 	var cmds []command.ProjectContext
 	for _, plan := range plans {
 		// Lock all the directories we need to run the command in
@@ -1263,6 +1269,98 @@ func (p *DefaultProjectCommandBuilder) buildAllProjectCommandsByPlan(ctx *comman
 	})
 
 	return cmds, nil
+}
+
+// ValidatePlansForApply ensures discovered plans are valid for the current PR head.
+func ValidatePlansForApply(ctx *command.Context, plans []PendingPlan) error {
+	if len(plans) > 0 {
+		return validateFoundPlans(ctx, plans)
+	}
+	return validateNoPlansFound(ctx)
+}
+
+func validateFoundPlans(ctx *command.Context, plans []PendingPlan) error {
+	if ctx.PullStatus == nil {
+		return fmt.Errorf("no recorded plan status found; run `atlantis plan` before apply")
+	}
+
+	if ctx.Pull.HeadCommit != "" && ctx.PullStatus.Pull.HeadCommit != "" &&
+		ctx.PullStatus.Pull.HeadCommit != ctx.Pull.HeadCommit {
+		return fmt.Errorf(
+			"plans are from commit %s but current head is %s; run `atlantis plan` to update",
+			ctx.PullStatus.Pull.HeadCommit[:min(7, len(ctx.PullStatus.Pull.HeadCommit))],
+			ctx.Pull.HeadCommit[:min(7, len(ctx.Pull.HeadCommit))],
+		)
+	}
+
+	for _, plan := range plans {
+		proj := findProjectInPullStatus(ctx.PullStatus, plan.Workspace, plan.RepoRelDir, plan.ProjectName)
+		if proj == nil {
+			return fmt.Errorf(
+				"plan file found for dir %q workspace %q but no matching plan status exists; run `atlantis plan`",
+				plan.RepoRelDir, plan.Workspace,
+			)
+		}
+		if !isApplyablePlanStatus(proj.Status) {
+			return fmt.Errorf(
+				"plan for dir %q workspace %q has status %q and cannot be applied; run `atlantis plan`",
+				plan.RepoRelDir, plan.Workspace, proj.Status.String(),
+			)
+		}
+	}
+
+	return nil
+}
+
+func validateNoPlansFound(ctx *command.Context) error {
+	if ctx.PullStatus == nil {
+		return nil
+	}
+
+	if ctx.Pull.HeadCommit != "" && ctx.PullStatus.Pull.HeadCommit != "" &&
+		ctx.PullStatus.Pull.HeadCommit != ctx.Pull.HeadCommit {
+		return nil
+	}
+
+	for _, proj := range ctx.PullStatus.Projects {
+		if isApplyablePlanStatus(proj.Status) {
+			return fmt.Errorf(
+				"plan file is missing for dir %q workspace %q; run `atlantis plan` again",
+				proj.RepoRelDir, proj.Workspace,
+			)
+		}
+	}
+
+	return nil
+}
+
+func isApplyablePlanStatus(status models.ProjectPlanStatus) bool {
+	switch status {
+	case models.PlannedPlanStatus, models.PassedPolicyCheckStatus, models.ErroredApplyStatus:
+		return true
+	default:
+		return false
+	}
+}
+
+func findProjectInPullStatus(pullStatus *models.PullStatus, workspace, repoRelDir, projectName string) *models.ProjectStatus {
+	cleanDir := filepath.Clean(repoRelDir)
+	for i := range pullStatus.Projects {
+		proj := &pullStatus.Projects[i]
+		if proj.Workspace != workspace || filepath.Clean(proj.RepoRelDir) != cleanDir {
+			continue
+		}
+		if projectName != "" {
+			if proj.ProjectName == projectName {
+				return proj
+			}
+			continue
+		}
+		if proj.ProjectName == "" {
+			return proj
+		}
+	}
+	return nil
 }
 
 // buildProjectCommand builds an command for the single project

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -1266,11 +1266,12 @@ func (p *DefaultProjectCommandBuilder) buildAllProjectCommandsByPlan(ctx *comman
 			return nil, fmt.Errorf("building command for dir '%s': %w", plan.RepoRelDir, err)
 		}
 		if commentCmd.Name == command.Apply {
+			planBasePath := filepath.Join(plan.RepoDir, plan.RepoRelDir)
 			planPath, err := pendingPlanFilePath(plan)
 			if err != nil {
 				return nil, fmt.Errorf("validating plan path for dir %q: %w", plan.RepoRelDir, err)
 			}
-			planHash, err := hashFile(planPath)
+			planHash, err := hashFile(planBasePath, planPath)
 			if err != nil {
 				return nil, fmt.Errorf("hashing plan for dir '%s': %w", plan.RepoRelDir, err)
 			}
@@ -1542,11 +1543,12 @@ func (p *DefaultProjectCommandBuilder) setExpectedPlanHashes(ctx *command.Contex
 		if err != nil {
 			return fmt.Errorf("getting working directory for workspace %q: %w", projCtxs[i].Workspace, err)
 		}
-		planPath, err := safePlanFilePath(projCtxs[i], filepath.Join(repoDir, projCtxs[i].RepoRelDir))
+		absPath := filepath.Join(repoDir, projCtxs[i].RepoRelDir)
+		planPath, err := safePlanFilePath(projCtxs[i], absPath)
 		if err != nil {
 			return fmt.Errorf("validating plan path for dir %q: %w", projCtxs[i].RepoRelDir, err)
 		}
-		planHash, err := hashFile(planPath)
+		planHash, err := hashFile(absPath, planPath)
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -1362,10 +1362,28 @@ func statusAllowedForDiscoveredPlan(status models.ProjectPlanStatus) bool {
 	}
 }
 
-func statusRequiresApplyPlanFile(status models.ProjectPlanStatus) bool {
+func statusRequiresPlanFileForGenericApply(status models.ProjectPlanStatus) bool {
 	switch status {
 	case models.PlannedPlanStatus, models.PassedPolicyCheckStatus, models.ErroredApplyStatus,
 		models.ErroredPolicyCheckStatus:
+		return true
+	default:
+		return false
+	}
+}
+
+func statusBlocksGenericApplyWithoutPlan(status models.ProjectPlanStatus) bool {
+	switch status {
+	case models.ErroredPlanStatus:
+		return true
+	default:
+		return false
+	}
+}
+
+func statusIsSafeWithoutPlanFile(status models.ProjectPlanStatus) bool {
+	switch status {
+	case models.PlannedNoChangesPlanStatus, models.AppliedPlanStatus, models.DiscardedPlanStatus:
 		return true
 	default:
 		return false
@@ -1388,14 +1406,26 @@ func newApplyPlanKey(workspace, repoRelDir, projectName string) applyPlanKey {
 
 func validatePullStatusHasPlanFiles(pullStatus *models.PullStatus, planKeys map[applyPlanKey]struct{}) error {
 	for _, proj := range pullStatus.Projects {
-		if !statusRequiresApplyPlanFile(proj.Status) {
-			continue
-		}
 		if _, ok := planKeys[newApplyPlanKey(proj.Workspace, proj.RepoRelDir, proj.ProjectName)]; ok {
 			continue
 		}
+		if statusRequiresPlanFileForGenericApply(proj.Status) {
+			return fmt.Errorf(
+				"plan file is missing for dir %q workspace %q project %q with status %q; run `atlantis plan`",
+				proj.RepoRelDir, proj.Workspace, proj.ProjectName, proj.Status.String(),
+			)
+		}
+		if statusBlocksGenericApplyWithoutPlan(proj.Status) {
+			return fmt.Errorf(
+				"plan for dir %q workspace %q project %q errored and cannot be applied without a plan file; run `atlantis plan`",
+				proj.RepoRelDir, proj.Workspace, proj.ProjectName,
+			)
+		}
+		if statusIsSafeWithoutPlanFile(proj.Status) {
+			continue
+		}
 		return fmt.Errorf(
-			"plan file is missing for dir %q workspace %q project %q with status %q; run `atlantis plan`",
+			"plan for dir %q workspace %q project %q has status %q and cannot be applied without a plan file; run `atlantis plan`",
 			proj.RepoRelDir, proj.Workspace, proj.ProjectName, proj.Status.String(),
 		)
 	}

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -1266,7 +1266,11 @@ func (p *DefaultProjectCommandBuilder) buildAllProjectCommandsByPlan(ctx *comman
 			return nil, fmt.Errorf("building command for dir '%s': %w", plan.RepoRelDir, err)
 		}
 		if commentCmd.Name == command.Apply {
-			planHash, err := hashFile(pendingPlanFilePath(plan))
+			planPath, err := pendingPlanFilePath(plan)
+			if err != nil {
+				return nil, fmt.Errorf("validating plan path for dir %q: %w", plan.RepoRelDir, err)
+			}
+			planHash, err := hashFile(planPath)
 			if err != nil {
 				return nil, fmt.Errorf("hashing plan for dir '%s': %w", plan.RepoRelDir, err)
 			}
@@ -1538,7 +1542,11 @@ func (p *DefaultProjectCommandBuilder) setExpectedPlanHashes(ctx *command.Contex
 		if err != nil {
 			return fmt.Errorf("getting working directory for workspace %q: %w", projCtxs[i].Workspace, err)
 		}
-		planHash, err := hashFile(planFilePath(projCtxs[i], filepath.Join(repoDir, projCtxs[i].RepoRelDir)))
+		planPath, err := safePlanFilePath(projCtxs[i], filepath.Join(repoDir, projCtxs[i].RepoRelDir))
+		if err != nil {
+			return fmt.Errorf("validating plan path for dir %q: %w", projCtxs[i].RepoRelDir, err)
+		}
+		planHash, err := hashFile(planPath)
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -1507,12 +1507,6 @@ func (p *DefaultProjectCommandBuilder) buildProjectCommand(ctx *command.Context,
 		return projCtx, ErrIgnoredTargetedDir
 	}
 
-	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, workspace, DefaultRepoRelDir, cmd.ProjectName, cmd.Name)
-	if err != nil {
-		return projCtx, err
-	}
-	defer unlockFn()
-
 	// use the default repository workspace because it is the only one guaranteed to have an atlantis.yaml,
 	// other workspaces will not have the file if they are using pre_workflow_hooks to generate it dynamically
 	repoDir, err := p.WorkingDir.GetWorkingDir(ctx.Pull.BaseRepo, ctx.Pull, DefaultWorkspace)
@@ -1526,6 +1520,12 @@ func (p *DefaultProjectCommandBuilder) buildProjectCommand(ctx *command.Context,
 		ctx.Log.Debug("ignoring targeted command for dir '%s' due to autodiscover.ignore_paths", repoRelDir)
 		return projCtx, ErrIgnoredTargetedDir
 	}
+
+	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, workspace, DefaultRepoRelDir, cmd.ProjectName, cmd.Name)
+	if err != nil {
+		return projCtx, err
+	}
+	defer unlockFn()
 
 	projCtx, err = p.buildProjectCommandCtx(
 		ctx,

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -1294,7 +1294,9 @@ func validateFoundPlans(ctx *command.Context, plans []PendingPlan) error {
 		)
 	}
 
+	planKeys := make(map[applyPlanKey]struct{}, len(plans))
 	for _, plan := range plans {
+		planKeys[newApplyPlanKey(plan.Workspace, plan.RepoRelDir, plan.ProjectName)] = struct{}{}
 		proj := findProjectInPullStatus(ctx.PullStatus, plan.Workspace, plan.RepoRelDir, plan.ProjectName)
 		if proj == nil {
 			return fmt.Errorf(
@@ -1304,13 +1306,13 @@ func validateFoundPlans(ctx *command.Context, plans []PendingPlan) error {
 		}
 		if !statusAllowedForDiscoveredPlan(proj.Status) {
 			return fmt.Errorf(
-				"plan for dir %q workspace %q has status %q and cannot be applied; run `atlantis plan`",
-				plan.RepoRelDir, plan.Workspace, proj.Status.String(),
+				"plan for dir %q workspace %q project %q has status %q and cannot be applied; run `atlantis plan`",
+				plan.RepoRelDir, plan.Workspace, plan.ProjectName, proj.Status.String(),
 			)
 		}
 	}
 
-	return nil
+	return validatePullStatusHasPlanFiles(ctx.PullStatus, planKeys)
 }
 
 func validateNoPlansFound(ctx *command.Context) error {
@@ -1326,10 +1328,7 @@ func validateNoPlansFound(ctx *command.Context) error {
 		)
 	}
 
-	// Current-head PullStatus exists. Allow empty result — the DB is authoritative
-	// on whether projects need plans. This preserves import/state-rm flows where
-	// plans are intentionally discarded without updating status to DiscardedPlanStatus.
-	return nil
+	return validatePullStatusHasPlanFiles(ctx.PullStatus, nil)
 }
 
 // pullStatusMatchesHead returns true if PullStatus is for the current PR head.
@@ -1361,6 +1360,46 @@ func statusAllowedForDiscoveredPlan(status models.ProjectPlanStatus) bool {
 	default:
 		return false
 	}
+}
+
+func statusRequiresApplyPlanFile(status models.ProjectPlanStatus) bool {
+	switch status {
+	case models.PlannedPlanStatus, models.PassedPolicyCheckStatus, models.ErroredApplyStatus,
+		models.ErroredPolicyCheckStatus:
+		return true
+	default:
+		return false
+	}
+}
+
+type applyPlanKey struct {
+	workspace   string
+	repoRelDir  string
+	projectName string
+}
+
+func newApplyPlanKey(workspace, repoRelDir, projectName string) applyPlanKey {
+	return applyPlanKey{
+		workspace:   workspace,
+		repoRelDir:  filepath.Clean(repoRelDir),
+		projectName: projectName,
+	}
+}
+
+func validatePullStatusHasPlanFiles(pullStatus *models.PullStatus, planKeys map[applyPlanKey]struct{}) error {
+	for _, proj := range pullStatus.Projects {
+		if !statusRequiresApplyPlanFile(proj.Status) {
+			continue
+		}
+		if _, ok := planKeys[newApplyPlanKey(proj.Workspace, proj.RepoRelDir, proj.ProjectName)]; ok {
+			continue
+		}
+		return fmt.Errorf(
+			"plan file is missing for dir %q workspace %q project %q with status %q; run `atlantis plan`",
+			proj.RepoRelDir, proj.Workspace, proj.ProjectName, proj.Status.String(),
+		)
+	}
+	return nil
 }
 
 func findProjectInPullStatus(pullStatus *models.PullStatus, workspace, repoRelDir, projectName string) *models.ProjectStatus {

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -1265,6 +1265,15 @@ func (p *DefaultProjectCommandBuilder) buildAllProjectCommandsByPlan(ctx *comman
 		if err != nil {
 			return nil, fmt.Errorf("building command for dir '%s': %w", plan.RepoRelDir, err)
 		}
+		if commentCmd.Name == command.Apply {
+			planHash, err := hashFile(pendingPlanFilePath(plan))
+			if err != nil {
+				return nil, fmt.Errorf("hashing plan for dir '%s': %w", plan.RepoRelDir, err)
+			}
+			for i := range commentCmds {
+				commentCmds[i].ExpectedPlanHash = planHash
+			}
+		}
 		cmds = append(cmds, commentCmds...)
 	}
 
@@ -1283,6 +1292,9 @@ func ValidatePlansForApply(ctx *command.Context, plans []PendingPlan) error {
 }
 
 func ValidatePlansForApplyWithActivePlan(ctx *command.Context, plans []PendingPlan, hasActivePlan bool) error {
+	if hasActivePlan {
+		return fmt.Errorf("a plan is currently running for this pull request; wait for it to finish before applying")
+	}
 	if len(plans) > 0 {
 		return validateFoundPlans(ctx, plans)
 	}
@@ -1334,10 +1346,6 @@ func validateNoPlansFound(ctx *command.Context, hasActivePlan bool) error {
 			shortSHA(ctx.PullStatus.Pull.HeadCommit),
 			shortSHA(ctx.Pull.HeadCommit),
 		)
-	}
-
-	if len(ctx.PullStatus.Projects) == 0 && hasActivePlan {
-		return fmt.Errorf("a plan is currently running for this pull request; wait for it to finish before applying")
 	}
 
 	return validatePullStatusHasPlanFiles(ctx.PullStatus, nil)
@@ -1500,7 +1508,7 @@ func (p *DefaultProjectCommandBuilder) buildProjectCommand(ctx *command.Context,
 		return projCtx, ErrIgnoredTargetedDir
 	}
 
-	return p.buildProjectCommandCtx(
+	projCtx, err = p.buildProjectCommandCtx(
 		ctx,
 		cmd.Name,
 		cmd.SubName,
@@ -1513,6 +1521,33 @@ func (p *DefaultProjectCommandBuilder) buildProjectCommand(ctx *command.Context,
 		ctx.API && cmd.Workspace != "",
 		cmd.Verbose,
 	)
+	if err != nil {
+		return projCtx, err
+	}
+	if cmd.Name == command.Apply {
+		if err := p.setExpectedPlanHashes(ctx, projCtx); err != nil {
+			return nil, err
+		}
+	}
+	return projCtx, nil
+}
+
+func (p *DefaultProjectCommandBuilder) setExpectedPlanHashes(ctx *command.Context, projCtxs []command.ProjectContext) error {
+	for i := range projCtxs {
+		repoDir, err := p.WorkingDir.GetWorkingDir(ctx.Pull.BaseRepo, ctx.Pull, projCtxs[i].Workspace)
+		if err != nil {
+			return fmt.Errorf("getting working directory for workspace %q: %w", projCtxs[i].Workspace, err)
+		}
+		planHash, err := hashFile(planFilePath(projCtxs[i], filepath.Join(repoDir, projCtxs[i].RepoRelDir)))
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("hashing plan for dir '%s': %w", projCtxs[i].RepoRelDir, err)
+		}
+		projCtxs[i].ExpectedPlanHash = planHash
+	}
+	return nil
 }
 
 // buildProjectCommandCtx builds a context for a single or several projects identified

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -1349,11 +1349,14 @@ func shortSHA(sha string) string {
 }
 
 // statusAllowedForDiscoveredPlan returns true if a discovered .tfplan file
-// with this status is valid to apply. Includes PlannedNoChangesPlanStatus
-// because a no-op plan can still leave a .tfplan file on disk.
+// with this status is valid to build an apply command for. Includes
+// PlannedNoChangesPlanStatus (no-op plan can leave a .tfplan on disk) and
+// ErroredPolicyCheckStatus (let apply build the command and fail through
+// existing per-project apply-requirement handling).
 func statusAllowedForDiscoveredPlan(status models.ProjectPlanStatus) bool {
 	switch status {
-	case models.PlannedPlanStatus, models.PassedPolicyCheckStatus, models.ErroredApplyStatus, models.PlannedNoChangesPlanStatus:
+	case models.PlannedPlanStatus, models.PassedPolicyCheckStatus, models.ErroredApplyStatus,
+		models.PlannedNoChangesPlanStatus, models.ErroredPolicyCheckStatus:
 		return true
 	default:
 		return false

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -1339,7 +1339,7 @@ func validateFoundPlans(ctx *command.Context, plans []PendingPlan) error {
 		return fmt.Errorf("no recorded plan status found; run `atlantis plan` before apply")
 	}
 
-	if err := pullStatusFreshnessError(ctx.Pull, ctx.PullStatus.Pull, "plans"); err != nil {
+	if err := pullStatusApplyEligibilityError(ctx.Pull, ctx.PullStatus.Pull, "plans"); err != nil {
 		return err
 	}
 
@@ -1369,7 +1369,7 @@ func validateNoPlansFound(ctx *command.Context, hasActivePlan bool) error {
 		return fmt.Errorf("no current plan status found; run `atlantis plan` before apply")
 	}
 
-	if err := pullStatusFreshnessError(ctx.Pull, ctx.PullStatus.Pull, "recorded plan status"); err != nil {
+	if err := pullStatusApplyEligibilityError(ctx.Pull, ctx.PullStatus.Pull, "recorded plan status"); err != nil {
 		return err
 	}
 

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -1324,12 +1324,8 @@ func validateFoundPlans(ctx *command.Context, plans []PendingPlan) error {
 		return fmt.Errorf("no recorded plan status found; run `atlantis plan` before apply")
 	}
 
-	if !pullStatusMatchesHead(ctx) {
-		return fmt.Errorf(
-			"plans are from commit %s but current head is %s; run `atlantis plan` to update",
-			shortSHA(ctx.PullStatus.Pull.HeadCommit),
-			shortSHA(ctx.Pull.HeadCommit),
-		)
+	if err := pullStatusFreshnessError(ctx.Pull, ctx.PullStatus.Pull, "plans"); err != nil {
+		return err
 	}
 
 	planKeys := make(map[applyPlanKey]struct{}, len(plans))
@@ -1358,21 +1354,11 @@ func validateNoPlansFound(ctx *command.Context, hasActivePlan bool) error {
 		return fmt.Errorf("no current plan status found; run `atlantis plan` before apply")
 	}
 
-	if !pullStatusMatchesHead(ctx) {
-		return fmt.Errorf(
-			"recorded plan status is from commit %s but current head is %s; run `atlantis plan` before apply",
-			shortSHA(ctx.PullStatus.Pull.HeadCommit),
-			shortSHA(ctx.Pull.HeadCommit),
-		)
+	if err := pullStatusFreshnessError(ctx.Pull, ctx.PullStatus.Pull, "recorded plan status"); err != nil {
+		return err
 	}
 
 	return validatePullStatusHasPlanFiles(ctx.PullStatus, nil)
-}
-
-// pullStatusMatchesHead returns true if PullStatus is for the current PR head.
-// Returns true if either commit is empty (unit test ergonomics or legacy data).
-func pullStatusMatchesHead(ctx *command.Context) bool {
-	return pullStatusHeadMatchesPull(ctx.Pull, ctx.PullStatus.Pull)
 }
 
 func shortSHA(sha string) string {

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -4838,6 +4838,47 @@ func TestValidatePlansForApply_RejectsPlansFromDifferentBaseBranch(t *testing.T)
 	Assert(t, strings.Contains(err.Error(), "main"), "got: %s", err)
 }
 
+func TestValidatePlansForApply_AcceptsFreshReplanAfterBaseRetargetSameHead(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123", BaseBranch: "release"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123", BaseBranch: "release"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	plans := []events.PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default"},
+	}
+
+	err := events.ValidatePlansForApply(ctx, plans)
+
+	Ok(t, err)
+}
+
+func TestValidatePlansForApply_RejectsOldBasePlanAfterBaseRetargetSameHead(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123", BaseBranch: "release"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123", BaseBranch: "main"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	plans := []events.PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default"},
+	}
+
+	err := events.ValidatePlansForApply(ctx, plans)
+
+	Assert(t, err != nil, "expected old-base plan to be rejected")
+	Assert(t, strings.Contains(err.Error(), "base branch"), "got: %s", err)
+}
+
 func TestPullStatusFreshness_AllowsMissingLegacyBaseBranchWhenHeadMatches(t *testing.T) {
 	ctx := &command.Context{
 		Log:  logging.NewNoopLogger(t),

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	. "github.com/petergtz/pegomock/v4"
+	"github.com/runatlantis/atlantis/server/core/runtime"
 	"github.com/runatlantis/atlantis/server/core/terraform"
 	tfclientmocks "github.com/runatlantis/atlantis/server/core/terraform/tfclient/mocks"
 	"github.com/runatlantis/atlantis/server/metrics/metricstest"
@@ -723,6 +724,12 @@ projects:
 				tmpDir := DirStructure(t, map[string]any{
 					"main.tf": nil,
 				})
+				if cmdName == command.Apply && c.ExpErr == "" && !c.ExpNoProjects {
+					planDir := filepath.Join(tmpDir, c.ExpDir)
+					Ok(t, os.MkdirAll(planDir, 0700))
+					planPath := filepath.Join(planDir, runtime.GetPlanFilename(c.ExpWorkspace, c.ExpProjectName))
+					Ok(t, os.WriteFile(planPath, []byte("targeted plan"), 0600))
+				}
 
 				workingDir := mocks.NewMockWorkingDir()
 				When(workingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](),
@@ -771,6 +778,7 @@ projects:
 				var actCtxs []command.ProjectContext
 				var err error
 				cmd := c.Cmd
+				cmd.Name = cmdName
 				if cmdName == command.Plan {
 					actCtxs, err = builder.BuildPlanCommands(&command.Context{
 						Log:   logger,
@@ -800,6 +808,9 @@ projects:
 				Equals(t, c.ExpAutoMerge, actCtx.AutomergeEnabled)
 				Equals(t, c.ExpParallelPlan, actCtx.ParallelPlanEnabled)
 				Equals(t, c.ExpParallelApply, actCtx.ParallelApplyEnabled)
+				if cmdName == command.Apply {
+					Assert(t, actCtx.ExpectedPlanHash != "", "expected targeted apply to record plan hash")
+				}
 			})
 		}
 	}
@@ -3215,22 +3226,22 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply(t *testing.T) {
 	tmpDir := DirStructure(t, map[string]any{
 		"workspace1": map[string]any{
 			"project1": map[string]any{
-				"main.tf":          nil,
-				"workspace.tfplan": nil,
+				"main.tf":           nil,
+				"workspace1.tfplan": nil,
 			},
 			"project2": map[string]any{
-				"main.tf":          nil,
-				"workspace.tfplan": nil,
+				"main.tf":           nil,
+				"workspace1.tfplan": nil,
 			},
 		},
 		"workspace2": map[string]any{
 			"project1": map[string]any{
-				"main.tf":          nil,
-				"workspace.tfplan": nil,
+				"main.tf":           nil,
+				"workspace2.tfplan": nil,
 			},
 			"project2": map[string]any{
-				"main.tf":          nil,
-				"workspace.tfplan": nil,
+				"main.tf":           nil,
+				"workspace2.tfplan": nil,
 			},
 		},
 	})
@@ -3312,6 +3323,10 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply(t *testing.T) {
 	Equals(t, "workspace2", ctxs[2].Workspace)
 	Equals(t, "project2", ctxs[3].RepoRelDir)
 	Equals(t, "workspace2", ctxs[3].Workspace)
+	emptyFileHash := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	for _, ctx := range ctxs {
+		Equals(t, emptyFileHash, ctx.ExpectedPlanHash)
+	}
 }
 
 // Test that autodiscover.ignore_paths is respected during multi-apply.
@@ -4826,7 +4841,7 @@ func TestValidatePlansForApply_NoPlansCurrentEmptyPullStatusPasses(t *testing.T)
 	Ok(t, err)
 }
 
-func TestValidatePlansForApply_NoPlansEmptyPullStatusWithActivePlanFails(t *testing.T) {
+func TestValidatePlansForApply_FailsWhenPlanInFlightEvenWithEmptyPullStatus(t *testing.T) {
 	ctx := &command.Context{
 		Log:  logging.NewNoopLogger(t),
 		Pull: models.PullRequest{HeadCommit: "abc123"},
@@ -4837,6 +4852,40 @@ func TestValidatePlansForApply_NoPlansEmptyPullStatusWithActivePlanFails(t *test
 	}
 	err := events.ValidatePlansForApplyWithActivePlan(ctx, nil, true)
 	Assert(t, err != nil, "expected active in-flight plan to block empty generic apply")
+	Assert(t, strings.Contains(err.Error(), "plan is currently running"), "got: %s", err)
+}
+
+func TestValidatePlansForApply_FailsWhenPlanInFlightEvenWithExistingPlanFiles(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	plans := []events.PendingPlan{{RepoRelDir: "proj1", Workspace: "default"}}
+	err := events.ValidatePlansForApplyWithActivePlan(ctx, plans, true)
+	Assert(t, err != nil, "expected active in-flight plan to block generic apply with existing files")
+	Assert(t, strings.Contains(err.Error(), "plan is currently running"), "got: %s", err)
+}
+
+func TestValidatePlansForApply_FailsWhenPlanInFlightWithNoChangeOrDiscardedStatus(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedNoChangesPlanStatus},
+				{RepoRelDir: "proj2", Workspace: "default", Status: models.DiscardedPlanStatus},
+			},
+		},
+	}
+	err := events.ValidatePlansForApplyWithActivePlan(ctx, nil, true)
+	Assert(t, err != nil, "expected active in-flight plan to block generic apply with terminal statuses")
 	Assert(t, strings.Contains(err.Error(), "plan is currently running"), "got: %s", err)
 }
 

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -4773,16 +4773,47 @@ func TestDefaultProjectCommandBuilder_BuildPlanCommands_with_IncludeGitUntracked
 	}
 }
 
-func TestValidatePlansForApply_NoPlansNoStatus(t *testing.T) {
+func TestValidatePlansForApply_NoPlansNoPullStatusFails(t *testing.T) {
 	ctx := &command.Context{
 		Log:        logging.NewNoopLogger(t),
+		Pull:       models.PullRequest{HeadCommit: "abc123"},
 		PullStatus: nil,
+	}
+	err := events.ValidatePlansForApply(ctx, nil)
+	Assert(t, err != nil, "expected error when no PullStatus")
+	Assert(t, strings.Contains(err.Error(), "no current plan status"), "got: %s", err)
+}
+
+func TestValidatePlansForApply_NoPlansStalePullStatusFails(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "new-sha"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "old-sha"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	err := events.ValidatePlansForApply(ctx, nil)
+	Assert(t, err != nil, "expected error for stale PullStatus")
+	Assert(t, strings.Contains(err.Error(), "current head"), "got: %s", err)
+}
+
+func TestValidatePlansForApply_NoPlansCurrentEmptyProjectsPasses(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull:     models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{},
+		},
 	}
 	err := events.ValidatePlansForApply(ctx, nil)
 	Ok(t, err)
 }
 
-func TestValidatePlansForApply_NoPlansAllNoChanges(t *testing.T) {
+func TestValidatePlansForApply_NoPlansCurrentAllNoChangesPasses(t *testing.T) {
 	ctx := &command.Context{
 		Log:  logging.NewNoopLogger(t),
 		Pull: models.PullRequest{HeadCommit: "abc123"},
@@ -4798,7 +4829,9 @@ func TestValidatePlansForApply_NoPlansAllNoChanges(t *testing.T) {
 	Ok(t, err)
 }
 
-func TestValidatePlansForApply_NoPlansWithPendingStatus(t *testing.T) {
+func TestValidatePlansForApply_NoPlansCurrentApplyableStatusPasses(t *testing.T) {
+	// After import discards a plan, DB may still show PlannedPlanStatus.
+	// Allow empty result when PullStatus is current (no reverse check).
 	ctx := &command.Context{
 		Log:  logging.NewNoopLogger(t),
 		Pull: models.PullRequest{HeadCommit: "abc123"},
@@ -4810,13 +4843,13 @@ func TestValidatePlansForApply_NoPlansWithPendingStatus(t *testing.T) {
 		},
 	}
 	err := events.ValidatePlansForApply(ctx, nil)
-	Assert(t, err != nil, "expected error for missing plan file")
-	Assert(t, strings.Contains(err.Error(), "plan file is missing"), "expected missing plan message, got: %s", err)
+	Ok(t, err)
 }
 
-func TestValidatePlansForApply_PlansButNoPullStatus(t *testing.T) {
+func TestValidatePlansForApply_PlansButNoPullStatusFails(t *testing.T) {
 	ctx := &command.Context{
 		Log:        logging.NewNoopLogger(t),
+		Pull:       models.PullRequest{HeadCommit: "abc123"},
 		PullStatus: nil,
 	}
 	plans := []events.PendingPlan{
@@ -4827,7 +4860,7 @@ func TestValidatePlansForApply_PlansButNoPullStatus(t *testing.T) {
 	Assert(t, strings.Contains(err.Error(), "no recorded plan status"), "got: %s", err)
 }
 
-func TestValidatePlansForApply_PlansStaleCommit(t *testing.T) {
+func TestValidatePlansForApply_PlansStaleCommitFails(t *testing.T) {
 	ctx := &command.Context{
 		Log:  logging.NewNoopLogger(t),
 		Pull: models.PullRequest{HeadCommit: "new-sha"},
@@ -4846,7 +4879,7 @@ func TestValidatePlansForApply_PlansStaleCommit(t *testing.T) {
 	Assert(t, strings.Contains(err.Error(), "plans are from commit"), "got: %s", err)
 }
 
-func TestValidatePlansForApply_PlansMissingFromStatus(t *testing.T) {
+func TestValidatePlansForApply_PlanMissingFromStatusFails(t *testing.T) {
 	ctx := &command.Context{
 		Log:  logging.NewNoopLogger(t),
 		Pull: models.PullRequest{HeadCommit: "abc123"},
@@ -4866,7 +4899,7 @@ func TestValidatePlansForApply_PlansMissingFromStatus(t *testing.T) {
 	Assert(t, strings.Contains(err.Error(), "proj2"), "got: %s", err)
 }
 
-func TestValidatePlansForApply_PlansMatchCurrentStatus(t *testing.T) {
+func TestValidatePlansForApply_PlansMatchCurrentStatusPasses(t *testing.T) {
 	ctx := &command.Context{
 		Log:  logging.NewNoopLogger(t),
 		Pull: models.PullRequest{HeadCommit: "abc123"},
@@ -4881,6 +4914,176 @@ func TestValidatePlansForApply_PlansMatchCurrentStatus(t *testing.T) {
 	plans := []events.PendingPlan{
 		{RepoRelDir: "proj1", Workspace: "default"},
 		{RepoRelDir: "proj2", Workspace: "staging"},
+	}
+	err := events.ValidatePlansForApply(ctx, plans)
+	Ok(t, err)
+}
+
+func TestValidatePlansForApply_FoundNoChangePlanPasses(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedNoChangesPlanStatus},
+			},
+		},
+	}
+	plans := []events.PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default"},
+	}
+	err := events.ValidatePlansForApply(ctx, plans)
+	Ok(t, err)
+}
+
+func TestValidatePlansForApply_FoundPlanWithInvalidStatusFails(t *testing.T) {
+	invalidStatuses := []models.ProjectPlanStatus{
+		models.AppliedPlanStatus,
+		models.DiscardedPlanStatus,
+		models.ErroredPlanStatus,
+		models.ErroredPolicyCheckStatus,
+	}
+	for _, status := range invalidStatuses {
+		t.Run(status.String(), func(t *testing.T) {
+			ctx := &command.Context{
+				Log:  logging.NewNoopLogger(t),
+				Pull: models.PullRequest{HeadCommit: "abc123"},
+				PullStatus: &models.PullStatus{
+					Pull: models.PullRequest{HeadCommit: "abc123"},
+					Projects: []models.ProjectStatus{
+						{RepoRelDir: "proj1", Workspace: "default", Status: status},
+					},
+				},
+			}
+			plans := []events.PendingPlan{
+				{RepoRelDir: "proj1", Workspace: "default"},
+			}
+			err := events.ValidatePlansForApply(ctx, plans)
+			Assert(t, err != nil, "expected error for status %s", status.String())
+		})
+	}
+}
+
+func TestValidatePlansForApply_FoundPlanWithAllowedStatusPasses(t *testing.T) {
+	allowedStatuses := []models.ProjectPlanStatus{
+		models.PlannedPlanStatus,
+		models.PassedPolicyCheckStatus,
+		models.ErroredApplyStatus,
+		models.PlannedNoChangesPlanStatus,
+	}
+	for _, status := range allowedStatuses {
+		t.Run(status.String(), func(t *testing.T) {
+			ctx := &command.Context{
+				Log:  logging.NewNoopLogger(t),
+				Pull: models.PullRequest{HeadCommit: "abc123"},
+				PullStatus: &models.PullStatus{
+					Pull: models.PullRequest{HeadCommit: "abc123"},
+					Projects: []models.ProjectStatus{
+						{RepoRelDir: "proj1", Workspace: "default", Status: status},
+					},
+				},
+			}
+			plans := []events.PendingPlan{
+				{RepoRelDir: "proj1", Workspace: "default"},
+			}
+			err := events.ValidatePlansForApply(ctx, plans)
+			Ok(t, err)
+		})
+	}
+}
+
+func TestValidatePlansForApply_NamedProjectMustMatch(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "dir1", Workspace: "default", ProjectName: "projA", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	// Plan has different project name → no match
+	plans := []events.PendingPlan{
+		{RepoRelDir: "dir1", Workspace: "default", ProjectName: "projB"},
+	}
+	err := events.ValidatePlansForApply(ctx, plans)
+	Assert(t, err != nil, "expected error for mismatched project name")
+}
+
+func TestValidatePlansForApply_NamedProjectsSameDirWorkspace(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "dir1", Workspace: "default", ProjectName: "projA", Status: models.PlannedPlanStatus},
+				{RepoRelDir: "dir1", Workspace: "default", ProjectName: "projB", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	plans := []events.PendingPlan{
+		{RepoRelDir: "dir1", Workspace: "default", ProjectName: "projA"},
+		{RepoRelDir: "dir1", Workspace: "default", ProjectName: "projB"},
+	}
+	err := events.ValidatePlansForApply(ctx, plans)
+	Ok(t, err)
+}
+
+func TestValidatePlansForApply_UnnamedPlanDoesNotMatchNamedProject(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "dir1", Workspace: "default", ProjectName: "projA", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	// Unnamed plan should not match named project
+	plans := []events.PendingPlan{
+		{RepoRelDir: "dir1", Workspace: "default", ProjectName: ""},
+	}
+	err := events.ValidatePlansForApply(ctx, plans)
+	Assert(t, err != nil, "unnamed plan should not match named project")
+}
+
+func TestValidatePlansForApply_NamedPlanDoesNotMatchUnnamedProject(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "dir1", Workspace: "default", ProjectName: "", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	// Named plan should not match unnamed project
+	plans := []events.PendingPlan{
+		{RepoRelDir: "dir1", Workspace: "default", ProjectName: "projA"},
+	}
+	err := events.ValidatePlansForApply(ctx, plans)
+	Assert(t, err != nil, "named plan should not match unnamed project")
+}
+
+func TestValidatePlansForApply_EmptyHeadCommitAllowsValidation(t *testing.T) {
+	// For backward compat: if HeadCommit is empty, skip head check
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: ""},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: ""},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	plans := []events.PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default"},
 	}
 	err := events.ValidatePlansForApply(ctx, plans)
 	Ok(t, err)

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -4822,6 +4822,7 @@ func TestValidatePlansForApply_NoPlansCurrentAllNoChangesPasses(t *testing.T) {
 			Projects: []models.ProjectStatus{
 				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedNoChangesPlanStatus},
 				{RepoRelDir: "proj2", Workspace: "default", Status: models.AppliedPlanStatus},
+				{RepoRelDir: "proj3", Workspace: "default", Status: models.DiscardedPlanStatus},
 			},
 		},
 	}
@@ -4829,9 +4830,7 @@ func TestValidatePlansForApply_NoPlansCurrentAllNoChangesPasses(t *testing.T) {
 	Ok(t, err)
 }
 
-func TestValidatePlansForApply_NoPlansCurrentApplyableStatusPasses(t *testing.T) {
-	// After import discards a plan, DB may still show PlannedPlanStatus.
-	// Allow empty result when PullStatus is current (no reverse check).
+func TestValidatePlansForApply_NoPlansCurrentApplyableStatusFails(t *testing.T) {
 	ctx := &command.Context{
 		Log:  logging.NewNoopLogger(t),
 		Pull: models.PullRequest{HeadCommit: "abc123"},
@@ -4843,7 +4842,9 @@ func TestValidatePlansForApply_NoPlansCurrentApplyableStatusPasses(t *testing.T)
 		},
 	}
 	err := events.ValidatePlansForApply(ctx, nil)
-	Ok(t, err)
+	Assert(t, err != nil, "expected missing plan error")
+	Assert(t, strings.Contains(err.Error(), "plan file is missing"), "got: %s", err)
+	Assert(t, strings.Contains(err.Error(), "proj1"), "got: %s", err)
 }
 
 func TestValidatePlansForApply_PlansButNoPullStatusFails(t *testing.T) {
@@ -4917,6 +4918,26 @@ func TestValidatePlansForApply_PlansMatchCurrentStatusPasses(t *testing.T) {
 	}
 	err := events.ValidatePlansForApply(ctx, plans)
 	Ok(t, err)
+}
+
+func TestValidatePlansForApply_FoundSubsetOfCurrentStatusFails(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+				{RepoRelDir: "proj2", Workspace: "default", Status: models.PassedPolicyCheckStatus},
+			},
+		},
+	}
+	plans := []events.PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default"},
+	}
+	err := events.ValidatePlansForApply(ctx, plans)
+	Assert(t, err != nil, "expected missing plan error for DB project without plan file")
+	Assert(t, strings.Contains(err.Error(), "proj2"), "got: %s", err)
 }
 
 func TestValidatePlansForApply_FoundNoChangePlanPasses(t *testing.T) {
@@ -5032,6 +5053,48 @@ func TestValidatePlansForApply_NamedProjectsSameDirWorkspace(t *testing.T) {
 	Ok(t, err)
 }
 
+func TestValidatePlansForApply_NamedProjectUsesOwnStatusWhenSameDirWorkspace(t *testing.T) {
+	t.Run("pending plan for valid project passes when sibling project status is invalid", func(t *testing.T) {
+		ctx := &command.Context{
+			Log:  logging.NewNoopLogger(t),
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			PullStatus: &models.PullStatus{
+				Pull: models.PullRequest{HeadCommit: "abc123"},
+				Projects: []models.ProjectStatus{
+					{RepoRelDir: "dir1", Workspace: "default", ProjectName: "projA", Status: models.AppliedPlanStatus},
+					{RepoRelDir: "dir1", Workspace: "default", ProjectName: "projB", Status: models.PlannedPlanStatus},
+				},
+			},
+		}
+		plans := []events.PendingPlan{
+			{RepoRelDir: "dir1", Workspace: "default", ProjectName: "projB"},
+		}
+		err := events.ValidatePlansForApply(ctx, plans)
+		Ok(t, err)
+	})
+
+	t.Run("pending plan for invalid project fails when sibling project status is valid", func(t *testing.T) {
+		ctx := &command.Context{
+			Log:  logging.NewNoopLogger(t),
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			PullStatus: &models.PullStatus{
+				Pull: models.PullRequest{HeadCommit: "abc123"},
+				Projects: []models.ProjectStatus{
+					{RepoRelDir: "dir1", Workspace: "default", ProjectName: "projA", Status: models.PlannedPlanStatus},
+					{RepoRelDir: "dir1", Workspace: "default", ProjectName: "projB", Status: models.DiscardedPlanStatus},
+				},
+			},
+		}
+		plans := []events.PendingPlan{
+			{RepoRelDir: "dir1", Workspace: "default", ProjectName: "projB"},
+		}
+		err := events.ValidatePlansForApply(ctx, plans)
+		Assert(t, err != nil, "expected projB invalid status error")
+		Assert(t, strings.Contains(err.Error(), "projB"), "got: %s", err)
+		Assert(t, strings.Contains(err.Error(), models.DiscardedPlanStatus.String()), "got: %s", err)
+	})
+}
+
 func TestValidatePlansForApply_UnnamedPlanDoesNotMatchNamedProject(t *testing.T) {
 	ctx := &command.Context{
 		Log:  logging.NewNoopLogger(t),
@@ -5075,6 +5138,42 @@ func TestValidatePlansForApply_EmptyHeadCommitAllowsValidation(t *testing.T) {
 	ctx := &command.Context{
 		Log:  logging.NewNoopLogger(t),
 		Pull: models.PullRequest{HeadCommit: ""},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: ""},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	plans := []events.PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default"},
+	}
+	err := events.ValidatePlansForApply(ctx, plans)
+	Ok(t, err)
+}
+
+func TestValidatePlansForApply_CurrentHeadEmptyAllowsValidation(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: ""},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	plans := []events.PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default"},
+	}
+	err := events.ValidatePlansForApply(ctx, plans)
+	Ok(t, err)
+}
+
+func TestValidatePlansForApply_StatusHeadEmptyAllowsValidation(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
 		PullStatus: &models.PullStatus{
 			Pull: models.PullRequest{HeadCommit: ""},
 			Projects: []models.ProjectStatus{

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -57,6 +57,14 @@ var defaultUserConfig = struct {
 	AutoDiscoverMode:         "auto",
 }
 
+type checkoutMergeWorkingDir struct {
+	events.WorkingDir
+}
+
+func (w checkoutMergeWorkingDir) CheckoutMergeEnabled() bool {
+	return true
+}
+
 func ChangedFiles(dirStructure map[string]any, parent string) []string {
 	var files []string
 	for k, v := range dirStructure {
@@ -2249,6 +2257,90 @@ autodiscover:
 	}
 	workingDir := mocks.NewMockWorkingDir()
 	When(workingDir.GetWorkingDir(repo, pull, events.DefaultWorkspace)).ThenReturn(tmpDir, nil)
+
+	logger := logging.NewNoopLogger(t)
+	scope := metricstest.NewLoggingScope(t, logger, "atlantis")
+	globalCfgArgs := valid.GlobalCfgArgs{AllowAllRepoSettings: true}
+	globalCfg := valid.NewGlobalCfgFromArgs(globalCfgArgs)
+	terraformClient := tfclientmocks.NewMockClient()
+	userConfig := defaultUserConfig
+	locker := events.NewDefaultWorkingDirLocker()
+	unlockPlan, err := locker.TryLock(repo.FullName, pull.Num, events.DefaultWorkspace, events.DefaultRepoRelDir, "", command.Plan)
+	Ok(t, err)
+	defer unlockPlan()
+
+	builder := events.NewProjectCommandBuilder(
+		false,
+		&config.ParserValidator{},
+		&events.DefaultProjectFinder{},
+		nil,
+		workingDir,
+		locker,
+		globalCfg,
+		&events.DefaultPendingPlanFinder{},
+		&events.CommentParser{ExecutableName: "atlantis"},
+		userConfig.SkipCloneNoChanges,
+		userConfig.EnableRegExpCmd,
+		userConfig.EnableAutoMerge,
+		userConfig.EnableParallelPlan,
+		userConfig.EnableParallelApply,
+		userConfig.AutoDetectModuleFiles,
+		userConfig.AutoplanFileList,
+		userConfig.RestrictFileList,
+		userConfig.DefaultTFDistribution,
+		userConfig.SilenceNoProjects,
+		userConfig.IncludeGitUntrackedFiles,
+		userConfig.AutoDiscoverMode,
+		scope,
+		terraformClient,
+	)
+	cmdCtx := &command.Context{Log: logger, Scope: scope, Pull: pull, HeadRepo: repo}
+
+	applyCtxs, err := builder.BuildApplyCommands(cmdCtx, &events.CommentCommand{
+		Name:       command.Apply,
+		RepoRelDir: "environments/prod",
+		Workspace:  events.DefaultWorkspace,
+	})
+
+	Assert(t, errors.Is(err, events.ErrIgnoredTargetedDir), "expected ignored targeted dir error, got %v", err)
+	Equals(t, 0, len(applyCtxs))
+}
+
+func TestDefaultProjectCommandBuilder_BuildTargetedApply_MergeCheckoutIgnoredTargetSkipsBeforeProjectLock(t *testing.T) {
+	RegisterMockTestingT(t)
+
+	atlantisYAML := "version: 3\n" +
+		"autodiscover:\n" +
+		"  mode: enabled\n" +
+		"  ignore_paths:\n" +
+		"  - \"environments/prod/**\"\n"
+	tmpDir := DirStructure(t, map[string]any{
+		"atlantis.yaml": atlantisYAML,
+		"environments": map[string]any{
+			"prod": map[string]any{
+				"main.tf": nil,
+			},
+		},
+	})
+
+	repo := models.Repo{
+		FullName: "runatlantis/atlantis",
+		Owner:    "runatlantis",
+		Name:     "atlantis",
+		VCSHost: models.VCSHost{
+			Hostname: "github.com",
+			Type:     models.Github,
+		},
+	}
+	pull := models.PullRequest{
+		Num:        1,
+		BaseBranch: "main",
+		HeadBranch: "feature",
+		BaseRepo:   repo,
+	}
+	baseWorkingDir := mocks.NewMockWorkingDir()
+	When(baseWorkingDir.GetWorkingDir(repo, pull, events.DefaultWorkspace)).ThenReturn(tmpDir, nil)
+	workingDir := checkoutMergeWorkingDir{WorkingDir: baseWorkingDir}
 
 	logger := logging.NewNoopLogger(t)
 	scope := metricstest.NewLoggingScope(t, logger, "atlantis")
@@ -4939,6 +5031,29 @@ func TestValidatePlansForApply_AcceptsFreshReplanAfterBaseRetargetSameHead(t *te
 	err := events.ValidatePlansForApply(ctx, plans)
 
 	Ok(t, err)
+}
+
+func TestValidatePlansForApply_GenericRejectsLegacyOldBaseProjectAfterTargetedReplanNewBase(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123", BaseBranch: "release"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123", BaseBranch: "release"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", ProjectName: "proj1", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	plans := []events.PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default", ProjectName: "proj1"},
+		{RepoRelDir: "proj2", Workspace: "default", ProjectName: "proj2"},
+	}
+
+	err := events.ValidatePlansForApply(ctx, plans)
+
+	Assert(t, err != nil, "expected old-base project without current PullStatus to be rejected")
+	Assert(t, strings.Contains(err.Error(), "no matching plan status exists"), "got: %s", err)
+	Assert(t, strings.Contains(err.Error(), "proj2"), "got: %s", err)
 }
 
 func TestValidatePlansForApply_RejectsOldBasePlanAfterBaseRetargetSameHead(t *testing.T) {

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -4973,6 +4973,28 @@ func TestValidatePlansForApply_PlansStaleCommitFails(t *testing.T) {
 	Assert(t, strings.Contains(err.Error(), "plans are from commit"), "got: %s", err)
 }
 
+func TestValidatePlansForApply_GenericAcceptsPullStatusMatchingLiveHeadWhenCommandHeadIsStale(t *testing.T) {
+	oldHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	liveHead := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: oldHead},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: liveHead},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	plans := []events.PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default"},
+	}
+
+	err := events.ValidatePlansForApplyWithCurrentHead(ctx, plans, false, liveHead)
+
+	Ok(t, err)
+}
+
 func TestValidatePlansForApply_PlanMissingFromStatusFails(t *testing.T) {
 	ctx := &command.Context{
 		Log:  logging.NewNoopLogger(t),

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -4813,6 +4813,19 @@ func TestValidatePlansForApply_NoPlansCurrentEmptyProjectsPasses(t *testing.T) {
 	Ok(t, err)
 }
 
+func TestValidatePlansForApply_NoPlansCurrentEmptyPullStatusPasses(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull:     models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{},
+		},
+	}
+	err := events.ValidatePlansForApply(ctx, nil)
+	Ok(t, err)
+}
+
 func TestValidatePlansForApply_NoPlansCurrentAllNoChangesPasses(t *testing.T) {
 	ctx := &command.Context{
 		Log:  logging.NewNoopLogger(t),
@@ -4845,6 +4858,23 @@ func TestValidatePlansForApply_NoPlansCurrentApplyableStatusFails(t *testing.T) 
 	Assert(t, err != nil, "expected missing plan error")
 	Assert(t, strings.Contains(err.Error(), "plan file is missing"), "got: %s", err)
 	Assert(t, strings.Contains(err.Error(), "proj1"), "got: %s", err)
+}
+
+func TestValidatePlansForApply_NoPlansCurrentErroredPlanStatusFails(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.ErroredPlanStatus},
+			},
+		},
+	}
+	err := events.ValidatePlansForApply(ctx, nil)
+	Assert(t, err != nil, "expected errored plan status to block generic apply")
+	Assert(t, strings.Contains(err.Error(), "errored"), "got: %s", err)
+	Assert(t, strings.Contains(err.Error(), "atlantis plan"), "got: %s", err)
 }
 
 func TestValidatePlansForApply_PlansButNoPullStatusFails(t *testing.T) {
@@ -4938,6 +4968,28 @@ func TestValidatePlansForApply_FoundSubsetOfCurrentStatusFails(t *testing.T) {
 	err := events.ValidatePlansForApply(ctx, plans)
 	Assert(t, err != nil, "expected missing plan error for DB project without plan file")
 	Assert(t, strings.Contains(err.Error(), "proj2"), "got: %s", err)
+}
+
+func TestValidatePlansForApply_FoundSubsetWithErroredPlanStatusFails(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+				{RepoRelDir: "proj2", Workspace: "default", Status: models.ErroredPlanStatus},
+			},
+		},
+	}
+	plans := []events.PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default"},
+	}
+	err := events.ValidatePlansForApply(ctx, plans)
+	Assert(t, err != nil, "expected errored plan status without plan file to block generic apply")
+	Assert(t, strings.Contains(err.Error(), "proj2"), "got: %s", err)
+	Assert(t, strings.Contains(err.Error(), "errored"), "got: %s", err)
+	Assert(t, strings.Contains(err.Error(), "atlantis plan"), "got: %s", err)
 }
 
 func TestValidatePlansForApply_FoundNoChangePlanPasses(t *testing.T) {

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -5077,7 +5077,7 @@ func TestValidatePlansForApply_RejectsOldBasePlanAfterBaseRetargetSameHead(t *te
 	Assert(t, strings.Contains(err.Error(), "base branch"), "got: %s", err)
 }
 
-func TestPullStatusFreshness_AllowsMissingLegacyBaseBranchWhenHeadMatches(t *testing.T) {
+func TestValidatePlansForApply_RejectsEmptyBasePullStatusWhenCurrentBaseKnown(t *testing.T) {
 	ctx := &command.Context{
 		Log:  logging.NewNoopLogger(t),
 		Pull: models.PullRequest{HeadCommit: "abc123", BaseBranch: "main"},
@@ -5094,7 +5094,29 @@ func TestPullStatusFreshness_AllowsMissingLegacyBaseBranchWhenHeadMatches(t *tes
 
 	err := events.ValidatePlansForApply(ctx, plans)
 
-	Ok(t, err)
+	Assert(t, err != nil, "expected missing recorded base branch to be rejected")
+	Assert(t, strings.Contains(err.Error(), "missing a recorded base branch"), "got: %s", err)
+}
+
+func TestValidatePlansForApply_RejectsEmptyHeadPullStatusWhenCurrentHeadKnown(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	plans := []events.PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default"},
+	}
+
+	err := events.ValidatePlansForApply(ctx, plans)
+
+	Assert(t, err != nil, "expected missing recorded head commit to be rejected")
+	Assert(t, strings.Contains(err.Error(), "missing a recorded head commit"), "got: %s", err)
 }
 
 func TestValidatePlansForApply_NoPlansCurrentEmptyProjectsPasses(t *testing.T) {
@@ -5121,6 +5143,42 @@ func TestValidatePlansForApply_NoPlansCurrentEmptyPullStatusPasses(t *testing.T)
 	}
 	err := events.ValidatePlansForApply(ctx, nil)
 	Ok(t, err)
+}
+
+func TestValidatePlansForApply_NoPlansRejectsEmptyHeadPullStatusWhenCurrentHeadKnown(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.AppliedPlanStatus},
+			},
+		},
+	}
+
+	err := events.ValidatePlansForApply(ctx, nil)
+
+	Assert(t, err != nil, "expected no-plan PullStatus with empty head to fail")
+	Assert(t, strings.Contains(err.Error(), "missing a recorded head commit"), "got: %s", err)
+}
+
+func TestValidatePlansForApply_NoPlansRejectsEmptyBasePullStatusWhenCurrentBaseKnown(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123", BaseBranch: "release"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.AppliedPlanStatus},
+			},
+		},
+	}
+
+	err := events.ValidatePlansForApply(ctx, nil)
+
+	Assert(t, err != nil, "expected no-plan PullStatus with empty base to fail")
+	Assert(t, strings.Contains(err.Error(), "missing a recorded base branch"), "got: %s", err)
 }
 
 func TestValidatePlansForApply_FailsWhenPlanInFlightEvenWithEmptyPullStatus(t *testing.T) {
@@ -5589,7 +5647,7 @@ func TestValidatePlansForApply_CurrentHeadEmptyAllowsValidation(t *testing.T) {
 	Ok(t, err)
 }
 
-func TestValidatePlansForApply_StatusHeadEmptyAllowsValidation(t *testing.T) {
+func TestValidatePlansForApply_StatusHeadEmptyFailsWhenCurrentHeadKnown(t *testing.T) {
 	ctx := &command.Context{
 		Log:  logging.NewNoopLogger(t),
 		Pull: models.PullRequest{HeadCommit: "abc123"},
@@ -5604,5 +5662,6 @@ func TestValidatePlansForApply_StatusHeadEmptyAllowsValidation(t *testing.T) {
 		{RepoRelDir: "proj1", Workspace: "default"},
 	}
 	err := events.ValidatePlansForApply(ctx, plans)
-	Ok(t, err)
+	Assert(t, err != nil, "expected empty recorded head to fail when current head is known")
+	Assert(t, strings.Contains(err.Error(), "missing a recorded head commit"), "got: %s", err)
 }

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -2215,6 +2215,89 @@ autodiscover:
 	Equals(t, "environments/nonprod", applyCtxs[0].RepoRelDir)
 }
 
+func TestDefaultProjectCommandBuilder_BuildTargetedApply_LocalConfigIgnoredTargetSkipsBeforeProjectLock(t *testing.T) {
+	RegisterMockTestingT(t)
+
+	atlantisYAML := `
+version: 3
+autodiscover:
+  mode: enabled
+  ignore_paths:
+  - "environments/prod/**"
+`
+	tmpDir := DirStructure(t, map[string]any{
+		"atlantis.yaml": atlantisYAML,
+		"environments": map[string]any{
+			"prod": map[string]any{
+				"main.tf": nil,
+			},
+		},
+	})
+
+	repo := models.Repo{
+		FullName: "runatlantis/atlantis",
+		Owner:    "runatlantis",
+		Name:     "atlantis",
+		VCSHost: models.VCSHost{
+			Hostname: "github.com",
+			Type:     models.Github,
+		},
+	}
+	pull := models.PullRequest{
+		Num:      1,
+		BaseRepo: repo,
+	}
+	workingDir := mocks.NewMockWorkingDir()
+	When(workingDir.GetWorkingDir(repo, pull, events.DefaultWorkspace)).ThenReturn(tmpDir, nil)
+
+	logger := logging.NewNoopLogger(t)
+	scope := metricstest.NewLoggingScope(t, logger, "atlantis")
+	globalCfgArgs := valid.GlobalCfgArgs{AllowAllRepoSettings: true}
+	globalCfg := valid.NewGlobalCfgFromArgs(globalCfgArgs)
+	terraformClient := tfclientmocks.NewMockClient()
+	userConfig := defaultUserConfig
+	locker := events.NewDefaultWorkingDirLocker()
+	unlockPlan, err := locker.TryLock(repo.FullName, pull.Num, events.DefaultWorkspace, events.DefaultRepoRelDir, "", command.Plan)
+	Ok(t, err)
+	defer unlockPlan()
+
+	builder := events.NewProjectCommandBuilder(
+		false,
+		&config.ParserValidator{},
+		&events.DefaultProjectFinder{},
+		nil,
+		workingDir,
+		locker,
+		globalCfg,
+		&events.DefaultPendingPlanFinder{},
+		&events.CommentParser{ExecutableName: "atlantis"},
+		userConfig.SkipCloneNoChanges,
+		userConfig.EnableRegExpCmd,
+		userConfig.EnableAutoMerge,
+		userConfig.EnableParallelPlan,
+		userConfig.EnableParallelApply,
+		userConfig.AutoDetectModuleFiles,
+		userConfig.AutoplanFileList,
+		userConfig.RestrictFileList,
+		userConfig.DefaultTFDistribution,
+		userConfig.SilenceNoProjects,
+		userConfig.IncludeGitUntrackedFiles,
+		userConfig.AutoDiscoverMode,
+		scope,
+		terraformClient,
+	)
+	cmdCtx := &command.Context{Log: logger, Scope: scope, Pull: pull, HeadRepo: repo}
+
+	applyCtxs, err := builder.BuildApplyCommands(cmdCtx, &events.CommentCommand{
+		Name:       command.Apply,
+		RepoRelDir: "environments/prod",
+		Workspace:  events.DefaultWorkspace,
+	})
+
+	Assert(t, errors.Is(err, events.ErrIgnoredTargetedDir), "expected ignored targeted dir error, got %v", err)
+	Equals(t, 0, len(applyCtxs))
+}
+
 // Test that targeted -d commands to a path with an explicit project config
 // are NOT blocked by ignore_paths.
 func TestDefaultProjectCommandBuilder_BuildTargetedCommand_IgnorePathsExplicitProjectAllowed(t *testing.T) {

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -4815,6 +4815,49 @@ func TestValidatePlansForApply_NoPlansStalePullStatusFails(t *testing.T) {
 	Assert(t, strings.Contains(err.Error(), "current head"), "got: %s", err)
 }
 
+func TestValidatePlansForApply_RejectsPlansFromDifferentBaseBranch(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123", BaseBranch: "main"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123", BaseBranch: "release"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	plans := []events.PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default"},
+	}
+
+	err := events.ValidatePlansForApply(ctx, plans)
+
+	Assert(t, err != nil, "expected base branch mismatch error")
+	Assert(t, strings.Contains(err.Error(), "base branch"), "got: %s", err)
+	Assert(t, strings.Contains(err.Error(), "release"), "got: %s", err)
+	Assert(t, strings.Contains(err.Error(), "main"), "got: %s", err)
+}
+
+func TestPullStatusFreshness_AllowsMissingLegacyBaseBranchWhenHeadMatches(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123", BaseBranch: "main"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	plans := []events.PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default"},
+	}
+
+	err := events.ValidatePlansForApply(ctx, plans)
+
+	Ok(t, err)
+}
+
 func TestValidatePlansForApply_NoPlansCurrentEmptyProjectsPasses(t *testing.T) {
 	ctx := &command.Context{
 		Log:  logging.NewNoopLogger(t),

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -4942,7 +4942,6 @@ func TestValidatePlansForApply_FoundPlanWithInvalidStatusFails(t *testing.T) {
 		models.AppliedPlanStatus,
 		models.DiscardedPlanStatus,
 		models.ErroredPlanStatus,
-		models.ErroredPolicyCheckStatus,
 	}
 	for _, status := range invalidStatuses {
 		t.Run(status.String(), func(t *testing.T) {
@@ -4971,6 +4970,7 @@ func TestValidatePlansForApply_FoundPlanWithAllowedStatusPasses(t *testing.T) {
 		models.PassedPolicyCheckStatus,
 		models.ErroredApplyStatus,
 		models.PlannedNoChangesPlanStatus,
+		models.ErroredPolicyCheckStatus,
 	}
 	for _, status := range allowedStatuses {
 		t.Run(status.String(), func(t *testing.T) {

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -4826,6 +4826,20 @@ func TestValidatePlansForApply_NoPlansCurrentEmptyPullStatusPasses(t *testing.T)
 	Ok(t, err)
 }
 
+func TestValidatePlansForApply_NoPlansEmptyPullStatusWithActivePlanFails(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull:     models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{},
+		},
+	}
+	err := events.ValidatePlansForApplyWithActivePlan(ctx, nil, true)
+	Assert(t, err != nil, "expected active in-flight plan to block empty generic apply")
+	Assert(t, strings.Contains(err.Error(), "plan is currently running"), "got: %s", err)
+}
+
 func TestValidatePlansForApply_NoPlansCurrentAllNoChangesPasses(t *testing.T) {
 	ctx := &command.Context{
 		Log:  logging.NewNoopLogger(t),

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -3283,6 +3283,16 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply(t *testing.T) {
 		&command.Context{
 			Log:   logger,
 			Scope: scope,
+			Pull:  models.PullRequest{HeadCommit: "abc123"},
+			PullStatus: &models.PullStatus{
+				Pull: models.PullRequest{HeadCommit: "abc123"},
+				Projects: []models.ProjectStatus{
+					{RepoRelDir: "project1", Workspace: "workspace1", Status: models.PlannedPlanStatus},
+					{RepoRelDir: "project2", Workspace: "workspace1", Status: models.PlannedPlanStatus},
+					{RepoRelDir: "project1", Workspace: "workspace2", Status: models.PlannedPlanStatus},
+					{RepoRelDir: "project2", Workspace: "workspace2", Status: models.PlannedPlanStatus},
+				},
+			},
 		},
 		&events.CommentCommand{
 			RepoRelDir:  "",
@@ -3391,6 +3401,14 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply_IgnorePaths(t *testing.T) 
 		&command.Context{
 			Log:   logger,
 			Scope: scope,
+			Pull:  models.PullRequest{HeadCommit: "abc123"},
+			PullStatus: &models.PullStatus{
+				Pull: models.PullRequest{HeadCommit: "abc123"},
+				Projects: []models.ProjectStatus{
+					{RepoRelDir: "project1", Workspace: "default", Status: models.PlannedPlanStatus},
+					{RepoRelDir: "project2", Workspace: "default", Status: models.PlannedPlanStatus},
+				},
+			},
 		},
 		&events.CommentCommand{
 			RepoRelDir:  "",
@@ -3499,6 +3517,14 @@ autodiscover:
 		&command.Context{
 			Log:   logger,
 			Scope: scope,
+			Pull:  models.PullRequest{HeadCommit: "abc123"},
+			PullStatus: &models.PullStatus{
+				Pull: models.PullRequest{HeadCommit: "abc123"},
+				Projects: []models.ProjectStatus{
+					{RepoRelDir: "project1", Workspace: "default", Status: models.PlannedPlanStatus},
+					{RepoRelDir: "project2", Workspace: "default", Status: models.PlannedPlanStatus},
+				},
+			},
 		},
 		&events.CommentCommand{
 			RepoRelDir:  "",
@@ -3608,6 +3634,13 @@ autodiscover:
 		&command.Context{
 			Log:   logger,
 			Scope: scope,
+			Pull:  models.PullRequest{HeadCommit: "abc123"},
+			PullStatus: &models.PullStatus{
+				Pull: models.PullRequest{HeadCommit: "abc123"},
+				Projects: []models.ProjectStatus{
+					{RepoRelDir: "project1", Workspace: "default", Status: models.PlannedPlanStatus},
+				},
+			},
 		},
 		&events.CommentCommand{
 			RepoRelDir:  "",
@@ -4738,4 +4771,117 @@ func TestDefaultProjectCommandBuilder_BuildPlanCommands_with_IncludeGitUntracked
 			Equals(t, c.ExpRepoRelDir, actCtx.RepoRelDir)
 		})
 	}
+}
+
+func TestValidatePlansForApply_NoPlansNoStatus(t *testing.T) {
+	ctx := &command.Context{
+		Log:        logging.NewNoopLogger(t),
+		PullStatus: nil,
+	}
+	err := events.ValidatePlansForApply(ctx, nil)
+	Ok(t, err)
+}
+
+func TestValidatePlansForApply_NoPlansAllNoChanges(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedNoChangesPlanStatus},
+				{RepoRelDir: "proj2", Workspace: "default", Status: models.AppliedPlanStatus},
+			},
+		},
+	}
+	err := events.ValidatePlansForApply(ctx, nil)
+	Ok(t, err)
+}
+
+func TestValidatePlansForApply_NoPlansWithPendingStatus(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	err := events.ValidatePlansForApply(ctx, nil)
+	Assert(t, err != nil, "expected error for missing plan file")
+	Assert(t, strings.Contains(err.Error(), "plan file is missing"), "expected missing plan message, got: %s", err)
+}
+
+func TestValidatePlansForApply_PlansButNoPullStatus(t *testing.T) {
+	ctx := &command.Context{
+		Log:        logging.NewNoopLogger(t),
+		PullStatus: nil,
+	}
+	plans := []events.PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default"},
+	}
+	err := events.ValidatePlansForApply(ctx, plans)
+	Assert(t, err != nil, "expected error when no pull status")
+	Assert(t, strings.Contains(err.Error(), "no recorded plan status"), "got: %s", err)
+}
+
+func TestValidatePlansForApply_PlansStaleCommit(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "new-sha"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "old-sha"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	plans := []events.PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default"},
+	}
+	err := events.ValidatePlansForApply(ctx, plans)
+	Assert(t, err != nil, "expected stale plan error")
+	Assert(t, strings.Contains(err.Error(), "plans are from commit"), "got: %s", err)
+}
+
+func TestValidatePlansForApply_PlansMissingFromStatus(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	plans := []events.PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default"},
+		{RepoRelDir: "proj2", Workspace: "default"},
+	}
+	err := events.ValidatePlansForApply(ctx, plans)
+	Assert(t, err != nil, "expected error for unmatched plan")
+	Assert(t, strings.Contains(err.Error(), "proj2"), "got: %s", err)
+}
+
+func TestValidatePlansForApply_PlansMatchCurrentStatus(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+				{RepoRelDir: "proj2", Workspace: "staging", Status: models.PassedPolicyCheckStatus},
+			},
+		},
+	}
+	plans := []events.PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default"},
+		{RepoRelDir: "proj2", Workspace: "staging"},
+	}
+	err := events.ValidatePlansForApply(ctx, plans)
+	Ok(t, err)
 }

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -895,6 +895,9 @@ func (p *DefaultProjectCommandRunner) doApply(ctx command.ProjectContext) (apply
 
 	outputs, err := p.runSteps(ctx.Steps, ctx, absPath)
 	if err == nil {
+		err = ValidateNonPRAPIRefUnchanged(ctx, repoDir)
+	}
+	if err == nil {
 		if validator, ok := p.ApplyPlanValidator.(ApplyCommandStartValidator); ok {
 			err = validator.ValidateCommandStartHead(ctx)
 		}

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -842,6 +842,12 @@ func (p *DefaultProjectCommandRunner) doApply(ctx command.ProjectContext) (apply
 		return "", "", DirNotExistErr{RepoRelDir: ctx.RepoRelDir}
 	}
 
+	if validator, ok := p.ApplyPlanValidator.(ApplyCommandStartValidator); ok {
+		if err := validator.ValidateCommandStartHead(ctx); err != nil {
+			return "", "", err
+		}
+	}
+
 	failure, err = p.CommandRequirementHandler.ValidateApplyProject(repoDir, ctx)
 	if failure != "" || err != nil {
 		return "", failure, err

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -880,7 +880,7 @@ func (p *DefaultProjectCommandRunner) doApply(ctx command.ProjectContext) (apply
 		if err != nil {
 			return "", "", err
 		}
-		planHash, err := hashFile(planPath)
+		planHash, err := hashFile(absPath, planPath)
 		if err != nil {
 			return "", "", fmt.Errorf("hashing plan file for dir %q workspace %q project %q: %w", ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName, err)
 		}

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -305,6 +305,7 @@ type DefaultProjectCommandRunner struct {
 	WorkingDirLocker          WorkingDirLocker
 	CommandRequirementHandler CommandRequirementHandler
 	CancellationTracker       CancellationTracker
+	ApplyPlanValidator        ApplyPlanValidator
 }
 
 // Plan runs terraform plan for the project described by ctx.
@@ -867,6 +868,12 @@ func (p *DefaultProjectCommandRunner) doApply(ctx command.ProjectContext) (apply
 		return "", "", err
 	}
 	defer unlockFn()
+
+	if p.ApplyPlanValidator != nil {
+		if err := p.ApplyPlanValidator.ValidateProjectPlan(ctx, absPath); err != nil {
+			return "", "", err
+		}
+	}
 
 	outputs, err := p.runSteps(ctx.Steps, ctx, absPath)
 

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -894,6 +894,11 @@ func (p *DefaultProjectCommandRunner) doApply(ctx command.ProjectContext) (apply
 	}
 
 	outputs, err := p.runSteps(ctx.Steps, ctx, absPath)
+	if err == nil {
+		if validator, ok := p.ApplyPlanValidator.(ApplyCommandStartValidator); ok {
+			err = validator.ValidateCommandStartHead(ctx)
+		}
+	}
 
 	if !ctx.SuppressApplyWebhooks && p.Webhooks != nil {
 		p.Webhooks.Send(ctx.Log, webhooks.ApplyResult{ // nolint: errcheck

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -893,6 +893,10 @@ func (p *DefaultProjectCommandRunner) doApply(ctx command.ProjectContext) (apply
 		ctx.ExpectedPlanHash = planHash
 	}
 
+	if err := ValidateNonPRAPIRefUnchanged(ctx, repoDir); err != nil {
+		return "", "", err
+	}
+
 	outputs, err := p.runSteps(ctx.Steps, ctx, absPath)
 	if err == nil {
 		err = ValidateNonPRAPIRefUnchanged(ctx, repoDir)
@@ -1067,6 +1071,9 @@ func (p *DefaultProjectCommandRunner) runSteps(steps []valid.Step, ctx command.P
 		case "policy_check":
 			out, err = p.PolicyCheckStepRunner.Run(ctx, step.ExtraArgs, absPath, envs)
 		case "apply":
+			if err = ValidateNonPRAPIRefUnchanged(ctx, absPath); err != nil {
+				return outputs, err
+			}
 			if ctx.CommandName == command.Apply && p.ApplyPlanValidator != nil {
 				if err = p.ApplyPlanValidator.ValidateProjectPlan(ctx, absPath); err != nil {
 					return outputs, err

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -876,7 +876,11 @@ func (p *DefaultProjectCommandRunner) doApply(ctx command.ProjectContext) (apply
 	}
 	_, usingDefaultApplyPlanValidator := p.ApplyPlanValidator.(*DefaultApplyPlanValidator)
 	if ctx.CommandName == command.Apply && ctx.ExpectedPlanHash == "" && usingDefaultApplyPlanValidator {
-		planHash, err := hashFile(planFilePath(ctx, absPath))
+		planPath, err := safePlanFilePath(ctx, absPath)
+		if err != nil {
+			return "", "", err
+		}
+		planHash, err := hashFile(planPath)
 		if err != nil {
 			return "", "", fmt.Errorf("hashing plan file for dir %q workspace %q project %q: %w", ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName, err)
 		}

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -1041,6 +1041,11 @@ func (p *DefaultProjectCommandRunner) runSteps(steps []valid.Step, ctx command.P
 		case "policy_check":
 			out, err = p.PolicyCheckStepRunner.Run(ctx, step.ExtraArgs, absPath, envs)
 		case "apply":
+			if ctx.CommandName == command.Apply && p.ApplyPlanValidator != nil {
+				if err = p.ApplyPlanValidator.ValidateProjectPlan(ctx, absPath); err != nil {
+					return outputs, err
+				}
+			}
 			out, err = p.ApplyStepRunner.Run(ctx, step.ExtraArgs, absPath, envs)
 		case "version":
 			out, err = p.VersionStepRunner.Run(ctx, step.ExtraArgs, absPath, envs)

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -330,11 +330,12 @@ func (p *DefaultProjectCommandRunner) PolicyCheck(ctx command.ProjectContext) co
 
 // Apply runs terraform apply for the project described by ctx.
 func (p *DefaultProjectCommandRunner) Apply(ctx command.ProjectContext) command.ProjectCommandOutput {
-	applyOut, failure, err := p.doApply(ctx)
+	applyOut, applyURL, failure, err := p.doApply(ctx)
 	return command.ProjectCommandOutput{
-		Failure:      failure,
-		Error:        err,
-		ApplySuccess: applyOut,
+		Failure:         failure,
+		Error:           err,
+		ApplySuccess:    applyOut,
+		ApplySuccessURL: applyURL,
 	}
 }
 
@@ -826,77 +827,81 @@ func (p *DefaultProjectCommandRunner) doPlan(ctx command.ProjectContext) (*model
 	}, "", nil
 }
 
-func (p *DefaultProjectCommandRunner) doApply(ctx command.ProjectContext) (applyOut string, failure string, err error) {
+func (p *DefaultProjectCommandRunner) doApply(ctx command.ProjectContext) (applyOut string, applyURL string, failure string, err error) {
+	var remoteApplyRunURL string
 	if validator, ok := p.ApplyPlanValidator.(ApplyCommandStartValidator); ok {
 		if err := validator.ValidateCommandStartHead(ctx); err != nil {
-			return "", "", err
+			return "", "", "", err
 		}
 	}
 
 	repoDir, err := p.WorkingDir.GetWorkingDir(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return "", "", errors.New("project has not been cloned–did you run plan?")
+			return "", "", "", errors.New("project has not been cloned–did you run plan?")
 		}
-		return "", "", err
+		return "", "", "", err
 	}
 	absPath := filepath.Join(repoDir, ctx.RepoRelDir)
 	if err := utils.EnsureSubPath(repoDir, absPath); err != nil {
-		return "", "", fmt.Errorf("project path traversal detected: %w", err)
+		return "", "", "", fmt.Errorf("project path traversal detected: %w", err)
 	}
 	if _, err = os.Stat(absPath); os.IsNotExist(err) {
-		return "", "", DirNotExistErr{RepoRelDir: ctx.RepoRelDir}
+		return "", "", "", DirNotExistErr{RepoRelDir: ctx.RepoRelDir}
 	}
 
 	failure, err = p.CommandRequirementHandler.ValidateApplyProject(repoDir, ctx)
 	if failure != "" || err != nil {
-		return "", failure, err
+		return "", "", failure, err
 	}
 
 	failure, err = p.CommandRequirementHandler.ValidateProjectDependencies(ctx)
 	if failure != "" || err != nil {
-		return "", failure, err
+		return "", "", failure, err
 	}
 
 	// Acquire Atlantis lock for this repo/dir/workspace.
 	lockAttempt, err := p.Locker.TryLock(ctx.Log, ctx.Pull, ctx.User, ctx.Workspace, models.NewProject(ctx.Pull.BaseRepo.FullName, ctx.RepoRelDir, ctx.ProjectName), ctx.RepoLocksMode == valid.RepoLocksOnApplyMode)
 	if err != nil {
-		return "", "", fmt.Errorf("acquiring lock: %w", err)
+		return "", "", "", fmt.Errorf("acquiring lock: %w", err)
 	}
 	if !lockAttempt.LockAcquired {
-		return "", lockAttempt.LockFailureReason, nil
+		return "", "", lockAttempt.LockFailureReason, nil
 	}
 	ctx.Log.Debug("acquired lock for project")
 
 	// Acquire internal lock for the directory we're going to operate in.
 	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.Apply)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 	defer unlockFn()
 
 	if p.ApplyPlanValidator != nil {
 		if err := p.ApplyPlanValidator.ValidateProjectPlan(ctx, absPath); err != nil {
-			return "", "", err
+			return "", "", "", err
 		}
 	}
 	_, usingDefaultApplyPlanValidator := p.ApplyPlanValidator.(*DefaultApplyPlanValidator)
 	if ctx.CommandName == command.Apply && ctx.ExpectedPlanHash == "" && usingDefaultApplyPlanValidator {
 		planPath, err := safePlanFilePath(ctx, absPath)
 		if err != nil {
-			return "", "", err
+			return "", "", "", err
 		}
 		planHash, err := hashFile(absPath, planPath)
 		if err != nil {
-			return "", "", fmt.Errorf("hashing plan file for dir %q workspace %q project %q: %w", ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName, err)
+			return "", "", "", fmt.Errorf("hashing plan file for dir %q workspace %q project %q: %w", ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName, err)
 		}
 		ctx.ExpectedPlanHash = planHash
 	}
 
 	if err := ValidateNonPRAPIRefUnchanged(ctx, repoDir); err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 
+	if _, ok := p.ApplyStepRunner.(*runtime.ApplyStepRunner); ok {
+		ctx.RemoteApplyRunURL = &remoteApplyRunURL
+	}
 	outputs, err := p.runSteps(ctx.Steps, ctx, absPath)
 	if err == nil {
 		err = ValidateNonPRAPIRefUnchanged(ctx, repoDir)
@@ -920,10 +925,10 @@ func (p *DefaultProjectCommandRunner) doApply(ctx command.ProjectContext) (apply
 	}
 
 	if err != nil {
-		return "", "", errorWithStepOutput(err, outputs)
+		return "", remoteApplyRunURL, "", errorWithStepOutput(err, outputs)
 	}
 
-	return strings.Join(outputs, "\n"), "", nil
+	return strings.Join(outputs, "\n"), remoteApplyRunURL, "", nil
 }
 
 func (p *DefaultProjectCommandRunner) doVersion(ctx command.ProjectContext) (versionOut string, failure string, err error) {

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -827,6 +827,12 @@ func (p *DefaultProjectCommandRunner) doPlan(ctx command.ProjectContext) (*model
 }
 
 func (p *DefaultProjectCommandRunner) doApply(ctx command.ProjectContext) (applyOut string, failure string, err error) {
+	if validator, ok := p.ApplyPlanValidator.(ApplyCommandStartValidator); ok {
+		if err := validator.ValidateCommandStartHead(ctx); err != nil {
+			return "", "", err
+		}
+	}
+
 	repoDir, err := p.WorkingDir.GetWorkingDir(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -840,12 +846,6 @@ func (p *DefaultProjectCommandRunner) doApply(ctx command.ProjectContext) (apply
 	}
 	if _, err = os.Stat(absPath); os.IsNotExist(err) {
 		return "", "", DirNotExistErr{RepoRelDir: ctx.RepoRelDir}
-	}
-
-	if validator, ok := p.ApplyPlanValidator.(ApplyCommandStartValidator); ok {
-		if err := validator.ValidateCommandStartHead(ctx); err != nil {
-			return "", "", err
-		}
 	}
 
 	failure, err = p.CommandRequirementHandler.ValidateApplyProject(repoDir, ctx)

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -161,6 +161,10 @@ type JobURLSetter interface {
 	SetJobURLWithStatus(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus, res *command.ProjectCommandOutput) error
 }
 
+type DeferredApplyStatusPublisher interface {
+	PublishDeferredApplyStatuses(projectCmds []command.ProjectContext, result command.Result, status models.CommitStatus)
+}
+
 //go:generate go tool pegomock generate --package mocks -o mocks/mock_job_message_sender.go JobMessageSender
 
 type JobMessageSender interface {
@@ -216,11 +220,43 @@ func (p *ProjectOutputWrapper) updateProjectPRStatus(commandName command.Name, c
 		return result
 	}
 
+	if commandName == command.Apply {
+		return result
+	}
+
 	if err := p.JobURLSetter.SetJobURLWithStatus(ctx, commandName, models.SuccessCommitStatus, &result); err != nil {
 		ctx.Log.Err("updating project PR status: %s", err)
 	}
 
 	return result
+}
+
+func (p *ProjectOutputWrapper) PublishDeferredApplyStatuses(projectCmds []command.ProjectContext, result command.Result, status models.CommitStatus) {
+	for _, projectResult := range result.ProjectResults {
+		if projectResult.Command != command.Apply || projectResult.ApplySuccess == "" || projectResult.Error != nil || projectResult.Failure != "" {
+			continue
+		}
+		ctx, ok := deferredApplyProjectContext(projectCmds, projectResult)
+		if !ok || ctx.SuppressVCSStatus {
+			continue
+		}
+		projectOutput := projectResult.ProjectCommandOutput
+		if err := p.JobURLSetter.SetJobURLWithStatus(ctx, command.Apply, status, &projectOutput); err != nil {
+			ctx.Log.Err("updating project PR status: %s", err)
+		}
+	}
+}
+
+func deferredApplyProjectContext(projectCmds []command.ProjectContext, result command.ProjectResult) (command.ProjectContext, bool) {
+	for _, ctx := range projectCmds {
+		if ctx.CommandName == command.Apply &&
+			ctx.RepoRelDir == result.RepoRelDir &&
+			ctx.Workspace == result.Workspace &&
+			ctx.ProjectName == result.ProjectName {
+			return ctx, true
+		}
+	}
+	return command.ProjectContext{}, false
 }
 
 // streamFailureToJob emits the project's error and/or failure text to the job

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -874,6 +874,14 @@ func (p *DefaultProjectCommandRunner) doApply(ctx command.ProjectContext) (apply
 			return "", "", err
 		}
 	}
+	_, usingDefaultApplyPlanValidator := p.ApplyPlanValidator.(*DefaultApplyPlanValidator)
+	if ctx.CommandName == command.Apply && ctx.ExpectedPlanHash == "" && usingDefaultApplyPlanValidator {
+		planHash, err := hashFile(planFilePath(ctx, absPath))
+		if err != nil {
+			return "", "", fmt.Errorf("hashing plan file for dir %q workspace %q project %q: %w", ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName, err)
+		}
+		ctx.ExpectedPlanHash = planHash
+	}
 
 	outputs, err := p.runSteps(ctx.Steps, ctx, absPath)
 

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -1057,6 +1057,74 @@ func TestApplyPlanValidator_RejectsPullStatusFromDifferentBaseBranch(t *testing.
 	Assert(t, os.IsNotExist(err), "expected stale-base plan file to be deleted")
 }
 
+func TestApplyPlanValidator_RejectsWhenLiveBaseChangedSinceCommandStart(t *testing.T) {
+	db := newTestBoltDB(t)
+	repoDir := t.TempDir()
+	head := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	ctx := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		Workspace:   "default",
+		RepoRelDir:  ".",
+		ProjectName: "projA",
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: head,
+			BaseBranch: "main",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	_, err := db.UpdatePullWithResults(ctx.Pull, []command.ProjectResult{plannedProjectResult(ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName)})
+	Ok(t, err)
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, []byte("old-base plan"), 0600))
+	validator := &events.DefaultApplyPlanValidator{
+		PullStatusFetcher:   db,
+		LivePullHeadFetcher: fakeLivePullHeadFetcher{head: head, base: "release"},
+	}
+
+	err = validator.ValidateProjectPlan(ctx, repoDir)
+
+	Assert(t, err != nil, "expected live base change to reject apply")
+	Assert(t, strings.Contains(err.Error(), "base branch"), "got: %s", err)
+	_, err = os.Stat(planPath)
+	Ok(t, err)
+}
+
+func TestApplyPlanValidator_UsesLiveBaseBranchNotCommandStartBase(t *testing.T) {
+	db := newTestBoltDB(t)
+	repoDir := t.TempDir()
+	head := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	commandStartPull := models.PullRequest{
+		Num:        1,
+		HeadCommit: head,
+		BaseBranch: "main",
+		BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+	}
+	livePull := commandStartPull
+	livePull.BaseBranch = "release"
+	_, err := db.UpdatePullWithResults(livePull, []command.ProjectResult{plannedProjectResult(".", "default", "projA")})
+	Ok(t, err)
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename("default", "projA"))
+	Ok(t, os.WriteFile(planPath, []byte("current-base plan"), 0600))
+	validator := &events.DefaultApplyPlanValidator{
+		PullStatusFetcher:   db,
+		LivePullHeadFetcher: fakeLivePullHeadFetcher{head: livePull.HeadCommit, base: livePull.BaseBranch},
+	}
+	ctx := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		Workspace:   "default",
+		RepoRelDir:  ".",
+		ProjectName: "projA",
+		Pull:        commandStartPull,
+	}
+
+	err = validator.ValidateProjectPlan(ctx, repoDir)
+
+	Ok(t, err)
+}
+
 func TestProjectCommandRunner_TargetedStaleCommandClassifiedBeforeApplyRequirements(t *testing.T) {
 	assertTargetedStaleCommandClassifiedBeforeApplyValidation(t)
 }
@@ -1215,7 +1283,7 @@ func TestApplyPlanValidator_FailsClosedWhenLiveHeadFetchFails(t *testing.T) {
 	err = validator.ValidateProjectPlan(ctx, repoDir)
 
 	Assert(t, err != nil, "expected live head fetch failure")
-	Assert(t, strings.Contains(err.Error(), "fetching live pull request head"), "got: %s", err)
+	Assert(t, strings.Contains(err.Error(), "fetching live pull request"), "got: %s", err)
 	_, err = os.Stat(planPath)
 	Ok(t, err)
 }
@@ -2187,11 +2255,12 @@ func planHashForContent(contents []byte) string {
 
 type fakeLivePullHeadFetcher struct {
 	head string
+	base string
 	err  error
 }
 
-func (f fakeLivePullHeadFetcher) GetLiveHeadCommit(command.ProjectContext) (string, error) {
-	return f.head, f.err
+func (f fakeLivePullHeadFetcher) GetLivePullIdentity(command.ProjectContext) (models.PullRequest, error) {
+	return models.PullRequest{HeadCommit: f.head, BaseBranch: f.base}, f.err
 }
 
 func (l *trackingWorkingDirLocker) TryLock(string, int, string, string, string, command.Name) (func(), error) {

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -842,10 +843,11 @@ func TestProjectCommandRunner_ApplyRevalidatesPlanUnderLock(t *testing.T) {
 	}
 	repoDir := t.TempDir()
 	ctx := command.ProjectContext{
-		Log:        logging.NewNoopLogger(t),
-		Steps:      valid.DefaultApplyStage.Steps,
-		Workspace:  "default",
-		RepoRelDir: ".",
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		Steps:       valid.DefaultApplyStage.Steps,
+		Workspace:   "default",
+		RepoRelDir:  ".",
 		Pull: models.PullRequest{
 			Num:      1,
 			BaseRepo: models.Repo{FullName: "runatlantis/atlantis"},
@@ -863,6 +865,94 @@ func TestProjectCommandRunner_ApplyRevalidatesPlanUnderLock(t *testing.T) {
 	Equals(t, "apply", res.ApplySuccess)
 	Assert(t, validator.called, "expected apply plan validator to run")
 	mockApply.VerifyWasCalledOnce().Run(ctx, nil, repoDir, map[string]string{})
+}
+
+func TestProjectCommandRunner_ApplyRevalidatesImmediatelyBeforeApplyStep(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockLocker := mocks.NewMockProjectLocker()
+	workingDirLocker := &trackingWorkingDirLocker{}
+	calls := []string{}
+	runner := &events.DefaultProjectCommandRunner{
+		Locker:                    mockLocker,
+		LockURLGenerator:          mockURLGenerator{},
+		ApplyStepRunner:           &recordingStepRunner{name: "apply", calls: &calls},
+		RunStepRunner:             &mutatingCustomStepRunner{calls: &calls},
+		WorkingDir:                mockWorkingDir,
+		WorkingDirLocker:          workingDirLocker,
+		CommandRequirementHandler: &events.DefaultCommandRequirementHandler{WorkingDir: mockWorkingDir},
+		ApplyPlanValidator:        &sequencedApplyPlanValidator{t: t, locker: workingDirLocker, calls: &calls},
+	}
+	repoDir := t.TempDir()
+	ctx := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		Steps: []valid.Step{
+			{StepName: "run"},
+			{StepName: "apply"},
+		},
+		Workspace:  "default",
+		RepoRelDir: ".",
+		Pull: models.PullRequest{
+			Num:      1,
+			BaseRepo: models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	When(mockWorkingDir.GetWorkingDir(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(repoDir, nil)
+	When(mockWorkingDir.GitReadLock(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(func() {})
+	When(mockLocker.TryLock(Any[logging.SimpleLogging](), Eq(ctx.Pull), Any[models.User](), Eq(ctx.Workspace), Any[models.Project](), AnyBool())).
+		ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key"}, nil)
+
+	res := runner.Apply(ctx)
+
+	Ok(t, res.Error)
+	Equals(t, "run\napply", res.ApplySuccess)
+	Equals(t, []string{"validate", "run", "validate", "apply"}, calls)
+}
+
+func TestProjectCommandRunner_ApplyDoesNotCallApplyStepWhenFinalValidationFails(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockLocker := mocks.NewMockProjectLocker()
+	calls := []string{}
+	runner := &events.DefaultProjectCommandRunner{
+		Locker:                    mockLocker,
+		LockURLGenerator:          mockURLGenerator{},
+		ApplyStepRunner:           &recordingStepRunner{name: "apply", calls: &calls},
+		RunStepRunner:             &mutatingCustomStepRunner{calls: &calls},
+		WorkingDir:                mockWorkingDir,
+		WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: &events.DefaultCommandRequirementHandler{WorkingDir: mockWorkingDir},
+		ApplyPlanValidator: &sequencedApplyPlanValidator{
+			calls: &calls,
+			errs:  []error{nil, errors.New("final validation failed; rerun plan")},
+		},
+	}
+	repoDir := t.TempDir()
+	ctx := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		Steps: []valid.Step{
+			{StepName: "run"},
+			{StepName: "apply"},
+		},
+		Workspace:  "default",
+		RepoRelDir: ".",
+		Pull: models.PullRequest{
+			Num:      1,
+			BaseRepo: models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	When(mockWorkingDir.GetWorkingDir(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(repoDir, nil)
+	When(mockWorkingDir.GitReadLock(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(func() {})
+	When(mockLocker.TryLock(Any[logging.SimpleLogging](), Eq(ctx.Pull), Any[models.User](), Eq(ctx.Workspace), Any[models.Project](), AnyBool())).
+		ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key"}, nil)
+
+	res := runner.Apply(ctx)
+
+	Assert(t, res.Error != nil, "expected final validation error")
+	Assert(t, strings.Contains(res.Error.Error(), "final validation failed"), "got: %s", res.Error)
+	Equals(t, []string{"validate", "run", "validate"}, calls)
 }
 
 func TestProjectCommandRunner_ApplyRejectsPlanDeletedAfterBuilderValidation(t *testing.T) {
@@ -883,6 +973,7 @@ func TestProjectCommandRunner_ApplyRejectsPlanDeletedAfterBuilderValidation(t *t
 	repoDir := t.TempDir()
 	ctx := command.ProjectContext{
 		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
 		Steps:       valid.DefaultApplyStage.Steps,
 		Workspace:   "default",
 		RepoRelDir:  ".",
@@ -922,6 +1013,175 @@ func TestProjectCommandRunner_ApplyRejectsPlanDeletedAfterBuilderValidation(t *t
 	mockApply.VerifyWasCalled(Never()).Run(Any[command.ProjectContext](), Any[[]string](), Any[string](), Any[map[string]string]())
 }
 
+func TestProjectCommandRunner_ApplyRejectsPlanMutatedByPreApplyRunStep(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockLocker := mocks.NewMockProjectLocker()
+	db := newTestBoltDB(t)
+	calls := []string{}
+	runner := &events.DefaultProjectCommandRunner{
+		Locker:                    mockLocker,
+		LockURLGenerator:          mockURLGenerator{},
+		ApplyStepRunner:           &recordingStepRunner{name: "apply", calls: &calls},
+		WorkingDir:                mockWorkingDir,
+		WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: &events.DefaultCommandRequirementHandler{WorkingDir: mockWorkingDir},
+		ApplyPlanValidator:        &events.DefaultApplyPlanValidator{PullStatusFetcher: db},
+	}
+	repoDir := t.TempDir()
+	ctx := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		Steps: []valid.Step{
+			{StepName: "run"},
+			{StepName: "apply"},
+		},
+		Workspace:   "default",
+		RepoRelDir:  ".",
+		ProjectName: "projA",
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: "abc123",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{Workspace: "default", RepoRelDir: ".", ProjectName: "projA", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	_, err := db.UpdatePullWithResults(ctx.Pull, []command.ProjectResult{plannedProjectResult(ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName)})
+	Ok(t, err)
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, []byte("plan"), 0600))
+	runner.RunStepRunner = &mutatingCustomStepRunner{
+		calls: &calls,
+		mutate: func() error {
+			return os.Remove(planPath)
+		},
+	}
+	When(mockWorkingDir.GetWorkingDir(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(repoDir, nil)
+	When(mockWorkingDir.GitReadLock(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(func() {})
+	When(mockLocker.TryLock(Any[logging.SimpleLogging](), Eq(ctx.Pull), Any[models.User](), Eq(ctx.Workspace), Any[models.Project](), AnyBool())).
+		ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key"}, nil)
+
+	res := runner.Apply(ctx)
+
+	Assert(t, res.Error != nil, "expected final missing plan error")
+	Assert(t, strings.Contains(res.Error.Error(), "plan file is missing"), "got: %s", res.Error)
+	Equals(t, []string{"run"}, calls)
+}
+
+func TestProjectCommandRunner_ApplyRejectsFreshErroredPolicyCheckStatus(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockApply := mocks.NewMockStepRunner()
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockLocker := mocks.NewMockProjectLocker()
+	db := newTestBoltDB(t)
+	runner := &events.DefaultProjectCommandRunner{
+		Locker:                    mockLocker,
+		LockURLGenerator:          mockURLGenerator{},
+		ApplyStepRunner:           mockApply,
+		WorkingDir:                mockWorkingDir,
+		WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: &events.DefaultCommandRequirementHandler{WorkingDir: mockWorkingDir},
+		ApplyPlanValidator:        &events.DefaultApplyPlanValidator{PullStatusFetcher: db},
+	}
+	repoDir := t.TempDir()
+	ctx := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		Steps:       valid.DefaultApplyStage.Steps,
+		Workspace:   "default",
+		RepoRelDir:  ".",
+		ProjectName: "projA",
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: "abc123",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	_, err := db.UpdatePullWithResults(ctx.Pull, []command.ProjectResult{plannedProjectResult(ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName)})
+	Ok(t, err)
+	_, err = db.UpdatePullWithResults(ctx.Pull, []command.ProjectResult{erroredPolicyProjectResult(ctx)})
+	Ok(t, err)
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, []byte("plan"), 0600))
+	When(mockWorkingDir.GetWorkingDir(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(repoDir, nil)
+	When(mockLocker.TryLock(Any[logging.SimpleLogging](), Eq(ctx.Pull), Any[models.User](), Eq(ctx.Workspace), Any[models.Project](), AnyBool())).
+		ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key"}, nil)
+
+	res := runner.Apply(ctx)
+
+	Assert(t, res.Error != nil, "expected policy-check status error")
+	Assert(t, strings.Contains(res.Error.Error(), "policy checks have errored"), "got: %s", res.Error)
+	_, err = os.Stat(planPath)
+	Assert(t, os.IsNotExist(err), "expected rejected plan file to be deleted")
+	mockApply.VerifyWasCalled(Never()).Run(Any[command.ProjectContext](), Any[[]string](), Any[string](), Any[map[string]string]())
+}
+
+func TestProjectCommandRunner_ApplyDoesNotRunTerraformWhenPolicyStatusChangesAfterBuild(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockLocker := mocks.NewMockProjectLocker()
+	db := newTestBoltDB(t)
+	calls := []string{}
+	runner := &events.DefaultProjectCommandRunner{
+		Locker:                    mockLocker,
+		LockURLGenerator:          mockURLGenerator{},
+		ApplyStepRunner:           &recordingStepRunner{name: "apply", calls: &calls},
+		WorkingDir:                mockWorkingDir,
+		WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: &events.DefaultCommandRequirementHandler{WorkingDir: mockWorkingDir},
+		ApplyPlanValidator:        &events.DefaultApplyPlanValidator{PullStatusFetcher: db},
+	}
+	repoDir := t.TempDir()
+	ctx := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		Steps: []valid.Step{
+			{StepName: "run"},
+			{StepName: "apply"},
+		},
+		Workspace:   "default",
+		RepoRelDir:  ".",
+		ProjectName: "projA",
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: "abc123",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{Workspace: "default", RepoRelDir: ".", ProjectName: "projA", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	_, err := db.UpdatePullWithResults(ctx.Pull, []command.ProjectResult{plannedProjectResult(ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName)})
+	Ok(t, err)
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, []byte("plan"), 0600))
+	runner.RunStepRunner = &mutatingCustomStepRunner{
+		calls: &calls,
+		mutate: func() error {
+			_, err := db.UpdatePullWithResults(ctx.Pull, []command.ProjectResult{erroredPolicyProjectResult(ctx)})
+			return err
+		},
+	}
+	When(mockWorkingDir.GetWorkingDir(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(repoDir, nil)
+	When(mockWorkingDir.GitReadLock(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(func() {})
+	When(mockLocker.TryLock(Any[logging.SimpleLogging](), Eq(ctx.Pull), Any[models.User](), Eq(ctx.Workspace), Any[models.Project](), AnyBool())).
+		ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key"}, nil)
+
+	res := runner.Apply(ctx)
+
+	Assert(t, res.Error != nil, "expected policy-check status error")
+	Assert(t, strings.Contains(res.Error.Error(), "policy checks have errored"), "got: %s", res.Error)
+	Equals(t, []string{"run"}, calls)
+}
+
 func TestProjectCommandRunner_ApplyRejectsStalePullStatusAfterBuilderValidation(t *testing.T) {
 	RegisterMockTestingT(t)
 	mockApply := mocks.NewMockStepRunner()
@@ -940,6 +1200,7 @@ func TestProjectCommandRunner_ApplyRejectsStalePullStatusAfterBuilderValidation(
 	repoDir := t.TempDir()
 	ctx := command.ProjectContext{
 		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
 		Steps:       valid.DefaultApplyStage.Steps,
 		Workspace:   "default",
 		RepoRelDir:  ".",
@@ -980,6 +1241,72 @@ func TestProjectCommandRunner_ApplyRejectsStalePullStatusAfterBuilderValidation(
 
 	Assert(t, res.Error != nil, "expected stale PullStatus error")
 	Assert(t, strings.Contains(res.Error.Error(), "recorded plan status is from commit"), "got: %s", res.Error)
+	_, err = os.Stat(planPath)
+	Assert(t, os.IsNotExist(err), "expected stale plan file to be deleted")
+	mockApply.VerifyWasCalled(Never()).Run(Any[command.ProjectContext](), Any[[]string](), Any[string](), Any[map[string]string]())
+}
+
+func TestProjectCommandRunner_ApplyValidationFailureDoesNotLaunderStalePlanAsErroredApply(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockApply := mocks.NewMockStepRunner()
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockLocker := mocks.NewMockProjectLocker()
+	db := newTestBoltDB(t)
+	runner := &events.DefaultProjectCommandRunner{
+		Locker:                    mockLocker,
+		LockURLGenerator:          mockURLGenerator{},
+		ApplyStepRunner:           mockApply,
+		WorkingDir:                mockWorkingDir,
+		WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: &events.DefaultCommandRequirementHandler{WorkingDir: mockWorkingDir},
+		ApplyPlanValidator:        &events.DefaultApplyPlanValidator{PullStatusFetcher: db},
+	}
+	repoDir := t.TempDir()
+	ctx := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		Steps:       valid.DefaultApplyStage.Steps,
+		Workspace:   "default",
+		RepoRelDir:  ".",
+		ProjectName: "projA",
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: "new123",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	stalePull := ctx.Pull
+	stalePull.HeadCommit = "old123"
+	_, err := db.UpdatePullWithResults(stalePull, []command.ProjectResult{plannedProjectResult(ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName)})
+	Ok(t, err)
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, []byte("plan"), 0600))
+	When(mockWorkingDir.GetWorkingDir(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(repoDir, nil)
+	When(mockLocker.TryLock(Any[logging.SimpleLogging](), Eq(ctx.Pull), Any[models.User](), Eq(ctx.Workspace), Any[models.Project](), AnyBool())).
+		ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key"}, nil)
+
+	res := runner.Apply(ctx)
+
+	Assert(t, res.Error != nil, "expected stale PullStatus error")
+	_, err = os.Stat(planPath)
+	Assert(t, os.IsNotExist(err), "expected stale plan file to be deleted")
+	_, err = db.UpdatePullWithResults(ctx.Pull, []command.ProjectResult{
+		{
+			Command:     command.Apply,
+			Workspace:   ctx.Workspace,
+			RepoRelDir:  ctx.RepoRelDir,
+			ProjectName: ctx.ProjectName,
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				Error: errors.New("validation rejected plan"),
+			},
+		},
+	})
+	Ok(t, err)
+	pullStatus, err := db.GetPullStatus(ctx.Pull)
+	Ok(t, err)
+	err = events.ValidatePlansForApply(&command.Context{Log: logging.NewNoopLogger(t), Pull: ctx.Pull, PullStatus: pullStatus}, nil)
+	Assert(t, err != nil, "expected later generic apply to reject errored apply status without plan file")
+	Assert(t, strings.Contains(err.Error(), "plan file is missing"), "got: %s", err)
 	mockApply.VerifyWasCalled(Never()).Run(Any[command.ProjectContext](), Any[[]string](), Any[string](), Any[map[string]string]())
 }
 
@@ -990,6 +1317,10 @@ type trackingWorkingDirLocker struct {
 func (l *trackingWorkingDirLocker) TryLock(string, int, string, string, string, command.Name) (func(), error) {
 	l.locked = true
 	return func() { l.locked = false }, nil
+}
+
+func (l *trackingWorkingDirLocker) HasCommandLock(string, int, command.Name) bool {
+	return l.locked
 }
 
 func (l *trackingWorkingDirLocker) UnlockByPull(string, int) {
@@ -1006,6 +1337,79 @@ func (v *assertLockedApplyPlanValidator) ValidateProjectPlan(command.ProjectCont
 	v.called = true
 	Assert(v.t, v.locker.locked, "expected apply plan validation to run while working dir lock is held")
 	return nil
+}
+
+type sequencedApplyPlanValidator struct {
+	t      *testing.T
+	locker *trackingWorkingDirLocker
+	calls  *[]string
+	errs   []error
+	count  int
+}
+
+func (v *sequencedApplyPlanValidator) ValidateProjectPlan(command.ProjectContext, string) error {
+	if v.calls != nil {
+		*v.calls = append(*v.calls, "validate")
+	}
+	if v.locker != nil {
+		Assert(v.t, v.locker.locked, "expected apply plan validation to run while working dir lock is held")
+	}
+	defer func() { v.count++ }()
+	if v.count < len(v.errs) {
+		return v.errs[v.count]
+	}
+	return nil
+}
+
+type recordingStepRunner struct {
+	name  string
+	calls *[]string
+	err   error
+}
+
+func (r *recordingStepRunner) Run(command.ProjectContext, []string, string, map[string]string) (string, error) {
+	if r.calls != nil {
+		*r.calls = append(*r.calls, r.name)
+	}
+	return r.name, r.err
+}
+
+type mutatingCustomStepRunner struct {
+	calls  *[]string
+	mutate func() error
+}
+
+func (r *mutatingCustomStepRunner) Run(
+	command.ProjectContext,
+	*valid.CommandShell,
+	string,
+	string,
+	map[string]string,
+	bool,
+	[]valid.PostProcessRunOutputOption,
+	[]*regexp.Regexp,
+) (string, error) {
+	if r.calls != nil {
+		*r.calls = append(*r.calls, "run")
+	}
+	if r.mutate != nil {
+		if err := r.mutate(); err != nil {
+			return "", err
+		}
+	}
+	return "run", nil
+}
+
+func erroredPolicyProjectResult(ctx command.ProjectContext) command.ProjectResult {
+	return command.ProjectResult{
+		Command:     command.PolicyCheck,
+		Workspace:   ctx.Workspace,
+		RepoRelDir:  ctx.RepoRelDir,
+		ProjectName: ctx.ProjectName,
+		ProjectCommandOutput: command.ProjectCommandOutput{
+			Error: errors.New("policy check errored"),
+		},
+	}
 }
 
 func newTestBoltDB(t *testing.T) *boltdb.BoltDB {

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -2049,6 +2049,121 @@ func TestProjectCommandRunner_ApplyUsesExpectedPlanHash(t *testing.T) {
 	Equals(t, []string{"apply"}, calls)
 }
 
+func TestProjectCommandRunner_RechecksLiveIdentityAfterApplyStep(t *testing.T) {
+	res, _, calls := runProjectApplyWithBaseChangeAfterApplyStep(t)
+
+	Assert(t, res.Error != nil, "expected post-apply live identity error")
+	Assert(t, strings.Contains(res.Error.Error(), "pull request base branch changed"), "got: %s", res.Error)
+	Equals(t, []string{"apply"}, calls)
+}
+
+func TestProjectCommandRunner_BaseRetargetDuringApplyFailsBeforeSuccessOutput(t *testing.T) {
+	res, _, _ := runProjectApplyWithBaseChangeAfterApplyStep(t)
+
+	Assert(t, res.Error != nil, "expected post-apply live identity error")
+	Equals(t, "", res.ApplySuccess)
+}
+
+func TestProjectCommandRunner_BaseRetargetDuringApplyDoesNotRunSuccessWebhooks(t *testing.T) {
+	_, mockSender, _ := runProjectApplyWithBaseChangeAfterApplyStep(t)
+
+	_, results := mockSender.VerifyWasCalledOnce().Send(Any[logging.SimpleLogging](), Any[webhooks.ApplyResult]()).GetCapturedArguments()
+	Assert(t, !results.Success, "expected stale post-apply webhook to be unsuccessful")
+}
+
+func TestProjectCommandRunner_UnchangedIdentityApplyStillSucceeds(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockLocker := mocks.NewMockProjectLocker()
+	mockSender := mocks.NewMockWebhooksSender()
+	initialPull := models.PullRequest{
+		Num:        1,
+		HeadCommit: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		BaseBranch: "main",
+		BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+	}
+	fetcher := &sequenceLivePullIdentityFetcher{identities: []models.PullRequest{initialPull, initialPull}}
+	calls := []string{}
+	runner := &events.DefaultProjectCommandRunner{
+		Locker:                    mockLocker,
+		LockURLGenerator:          mockURLGenerator{},
+		ApplyStepRunner:           &recordingStepRunner{name: "apply", calls: &calls},
+		WorkingDir:                mockWorkingDir,
+		WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: &events.DefaultCommandRequirementHandler{WorkingDir: mockWorkingDir},
+		ApplyPlanValidator:        &events.DefaultApplyPlanValidator{LivePullHeadFetcher: fetcher},
+		Webhooks:                  mockSender,
+	}
+	repoDir := t.TempDir()
+	ctx := command.ProjectContext{
+		Log:              logging.NewNoopLogger(t),
+		CommandName:      command.Apply,
+		Steps:            valid.DefaultApplyStage.Steps,
+		Workspace:        "default",
+		RepoRelDir:       ".",
+		ProjectName:      "projA",
+		ExpectedPlanHash: "already-captured",
+		Pull:             initialPull,
+	}
+	When(mockWorkingDir.GetWorkingDir(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(repoDir, nil)
+	When(mockWorkingDir.GitReadLock(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(func() {})
+	When(mockLocker.TryLock(Any[logging.SimpleLogging](), Eq(ctx.Pull), Any[models.User](), Eq(ctx.Workspace), Any[models.Project](), AnyBool())).
+		ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key"}, nil)
+
+	res := runner.Apply(ctx)
+
+	Ok(t, res.Error)
+	Equals(t, "apply", res.ApplySuccess)
+	Equals(t, []string{"apply"}, calls)
+	_, results := mockSender.VerifyWasCalledOnce().Send(Any[logging.SimpleLogging](), Any[webhooks.ApplyResult]()).GetCapturedArguments()
+	Assert(t, results.Success, "expected unchanged identity apply webhook to be successful")
+}
+
+func runProjectApplyWithBaseChangeAfterApplyStep(t *testing.T) (command.ProjectCommandOutput, *mocks.MockWebhooksSender, []string) {
+	t.Helper()
+	RegisterMockTestingT(t)
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockLocker := mocks.NewMockProjectLocker()
+	mockSender := mocks.NewMockWebhooksSender()
+	initialPull := models.PullRequest{
+		Num:        1,
+		HeadCommit: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		BaseBranch: "main",
+		BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+	}
+	finalPull := initialPull
+	finalPull.BaseBranch = "release"
+	fetcher := &sequenceLivePullIdentityFetcher{identities: []models.PullRequest{initialPull, finalPull}}
+	calls := []string{}
+	runner := &events.DefaultProjectCommandRunner{
+		Locker:                    mockLocker,
+		LockURLGenerator:          mockURLGenerator{},
+		ApplyStepRunner:           &recordingStepRunner{name: "apply", calls: &calls},
+		WorkingDir:                mockWorkingDir,
+		WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: &events.DefaultCommandRequirementHandler{WorkingDir: mockWorkingDir},
+		ApplyPlanValidator:        &events.DefaultApplyPlanValidator{LivePullHeadFetcher: fetcher},
+		Webhooks:                  mockSender,
+	}
+	repoDir := t.TempDir()
+	ctx := command.ProjectContext{
+		Log:              logging.NewNoopLogger(t),
+		CommandName:      command.Apply,
+		Steps:            valid.DefaultApplyStage.Steps,
+		Workspace:        "default",
+		RepoRelDir:       ".",
+		ProjectName:      "projA",
+		ExpectedPlanHash: "already-captured",
+		Pull:             initialPull,
+	}
+	When(mockWorkingDir.GetWorkingDir(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(repoDir, nil)
+	When(mockWorkingDir.GitReadLock(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(func() {})
+	When(mockLocker.TryLock(Any[logging.SimpleLogging](), Eq(ctx.Pull), Any[models.User](), Eq(ctx.Workspace), Any[models.Project](), AnyBool())).
+		ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key"}, nil)
+
+	return runner.Apply(ctx), mockSender, calls
+}
+
 func TestProjectCommandRunner_ApplyRejectsFreshErroredPolicyCheckStatus(t *testing.T) {
 	RegisterMockTestingT(t)
 	mockApply := mocks.NewMockStepRunner()

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -1025,6 +1025,54 @@ func TestApplyPlanValidator_StaleCommandHeadDoesNotDeleteCurrentLivePlan(t *test
 	Equals(t, "current plan", string(contents))
 }
 
+func TestProjectCommandRunner_TargetedStaleCommandClassifiedBeforeApplyRequirements(t *testing.T) {
+	assertTargetedStaleCommandClassifiedBeforeApplyValidation(t)
+}
+
+func TestProjectCommandRunner_TargetedStaleCommandClassifiedBeforeDependencyValidation(t *testing.T) {
+	assertTargetedStaleCommandClassifiedBeforeApplyValidation(t)
+}
+
+func assertTargetedStaleCommandClassifiedBeforeApplyValidation(t *testing.T) {
+	t.Helper()
+	RegisterMockTestingT(t)
+	mockApply := mocks.NewMockStepRunner()
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockRequirementHandler := mocks.NewMockCommandRequirementHandler()
+	oldHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	liveHead := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	runner := &events.DefaultProjectCommandRunner{
+		ApplyStepRunner:           mockApply,
+		WorkingDir:                mockWorkingDir,
+		WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: mockRequirementHandler,
+		ApplyPlanValidator:        &events.DefaultApplyPlanValidator{LivePullHeadFetcher: fakeLivePullHeadFetcher{head: liveHead}},
+	}
+	repoDir := t.TempDir()
+	ctx := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		Steps:       valid.DefaultApplyStage.Steps,
+		Workspace:   "default",
+		RepoRelDir:  ".",
+		ProjectName: "projA",
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: oldHead,
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	When(mockWorkingDir.GetWorkingDir(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(repoDir, nil)
+
+	res := runner.Apply(ctx)
+
+	Assert(t, res.Error != nil, "expected stale command-head error")
+	Assert(t, strings.Contains(res.Error.Error(), "pull request head changed"), "got: %s", res.Error)
+	mockRequirementHandler.VerifyWasCalled(Never()).ValidateApplyProject(Any[string](), Any[command.ProjectContext]())
+	mockRequirementHandler.VerifyWasCalled(Never()).ValidateProjectDependencies(Any[command.ProjectContext]())
+	mockApply.VerifyWasCalled(Never()).Run(Any[command.ProjectContext](), Any[[]string](), Any[string](), Any[map[string]string]())
+}
+
 func TestValidatePlansForApply_CurrentPlanStillApplyableAfterStaleTargetedApplyFails(t *testing.T) {
 	db := newTestBoltDB(t)
 	repoDir := t.TempDir()
@@ -1636,7 +1684,7 @@ func TestProjectCommandRunner_ApplyDoesNotRunTerraformWhenLiveHeadChangedAfterCo
 	res := runner.Apply(ctx)
 
 	Assert(t, res.Error != nil, "expected live head change error")
-	Assert(t, strings.Contains(res.Error.Error(), "recorded plan status is from commit"), "got: %s", res.Error)
+	Assert(t, strings.Contains(res.Error.Error(), "pull request head changed"), "got: %s", res.Error)
 	_, err = os.Stat(planPath)
 	Ok(t, err)
 	mockApply.VerifyWasCalled(Never()).Run(Any[command.ProjectContext](), Any[[]string](), Any[string](), Any[map[string]string]())

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	. "github.com/petergtz/pegomock/v4"
+	"github.com/runatlantis/atlantis/server/core/boltdb"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/core/runtime"
 	"github.com/runatlantis/atlantis/server/core/terraform"
@@ -821,6 +822,200 @@ func TestDefaultProjectCommandRunner_ApplyDiverged(t *testing.T) {
 
 	res := runner.Apply(ctx)
 	Equals(t, "Default branch must be rebased onto pull request before running apply.", res.Failure)
+}
+
+func TestProjectCommandRunner_ApplyRevalidatesPlanUnderLock(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockApply := mocks.NewMockStepRunner()
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockLocker := mocks.NewMockProjectLocker()
+	workingDirLocker := &trackingWorkingDirLocker{}
+	validator := &assertLockedApplyPlanValidator{t: t, locker: workingDirLocker}
+	runner := &events.DefaultProjectCommandRunner{
+		Locker:                    mockLocker,
+		LockURLGenerator:          mockURLGenerator{},
+		ApplyStepRunner:           mockApply,
+		WorkingDir:                mockWorkingDir,
+		WorkingDirLocker:          workingDirLocker,
+		CommandRequirementHandler: &events.DefaultCommandRequirementHandler{WorkingDir: mockWorkingDir},
+		ApplyPlanValidator:        validator,
+	}
+	repoDir := t.TempDir()
+	ctx := command.ProjectContext{
+		Log:        logging.NewNoopLogger(t),
+		Steps:      valid.DefaultApplyStage.Steps,
+		Workspace:  "default",
+		RepoRelDir: ".",
+		Pull: models.PullRequest{
+			Num:      1,
+			BaseRepo: models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	When(mockWorkingDir.GetWorkingDir(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(repoDir, nil)
+	When(mockWorkingDir.GitReadLock(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(func() {})
+	When(mockLocker.TryLock(Any[logging.SimpleLogging](), Eq(ctx.Pull), Any[models.User](), Eq(ctx.Workspace), Any[models.Project](), AnyBool())).
+		ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key"}, nil)
+	When(mockApply.Run(ctx, nil, repoDir, map[string]string{})).ThenReturn("apply", nil)
+
+	res := runner.Apply(ctx)
+
+	Ok(t, res.Error)
+	Equals(t, "apply", res.ApplySuccess)
+	Assert(t, validator.called, "expected apply plan validator to run")
+	mockApply.VerifyWasCalledOnce().Run(ctx, nil, repoDir, map[string]string{})
+}
+
+func TestProjectCommandRunner_ApplyRejectsPlanDeletedAfterBuilderValidation(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockApply := mocks.NewMockStepRunner()
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockLocker := mocks.NewMockProjectLocker()
+	db := newTestBoltDB(t)
+	runner := &events.DefaultProjectCommandRunner{
+		Locker:                    mockLocker,
+		LockURLGenerator:          mockURLGenerator{},
+		ApplyStepRunner:           mockApply,
+		WorkingDir:                mockWorkingDir,
+		WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: &events.DefaultCommandRequirementHandler{WorkingDir: mockWorkingDir},
+		ApplyPlanValidator:        &events.DefaultApplyPlanValidator{PullStatusFetcher: db},
+	}
+	repoDir := t.TempDir()
+	ctx := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		Steps:       valid.DefaultApplyStage.Steps,
+		Workspace:   "default",
+		RepoRelDir:  ".",
+		ProjectName: "projA",
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: "abc123",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{Workspace: "default", RepoRelDir: ".", ProjectName: "projA", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	_, err := db.UpdatePullWithResults(ctx.Pull, []command.ProjectResult{
+		{
+			Command:     command.Plan,
+			Workspace:   ctx.Workspace,
+			RepoRelDir:  ctx.RepoRelDir,
+			ProjectName: ctx.ProjectName,
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PlanSuccess: &models.PlanSuccess{},
+			},
+		},
+	})
+	Ok(t, err)
+	When(mockWorkingDir.GetWorkingDir(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(repoDir, nil)
+	When(mockLocker.TryLock(Any[logging.SimpleLogging](), Eq(ctx.Pull), Any[models.User](), Eq(ctx.Workspace), Any[models.Project](), AnyBool())).
+		ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key"}, nil)
+
+	res := runner.Apply(ctx)
+
+	Assert(t, res.Error != nil, "expected missing plan file error")
+	Assert(t, strings.Contains(res.Error.Error(), "plan file is missing"), "got: %s", res.Error)
+	mockApply.VerifyWasCalled(Never()).Run(Any[command.ProjectContext](), Any[[]string](), Any[string](), Any[map[string]string]())
+}
+
+func TestProjectCommandRunner_ApplyRejectsStalePullStatusAfterBuilderValidation(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockApply := mocks.NewMockStepRunner()
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockLocker := mocks.NewMockProjectLocker()
+	db := newTestBoltDB(t)
+	runner := &events.DefaultProjectCommandRunner{
+		Locker:                    mockLocker,
+		LockURLGenerator:          mockURLGenerator{},
+		ApplyStepRunner:           mockApply,
+		WorkingDir:                mockWorkingDir,
+		WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: &events.DefaultCommandRequirementHandler{WorkingDir: mockWorkingDir},
+		ApplyPlanValidator:        &events.DefaultApplyPlanValidator{PullStatusFetcher: db},
+	}
+	repoDir := t.TempDir()
+	ctx := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		Steps:       valid.DefaultApplyStage.Steps,
+		Workspace:   "default",
+		RepoRelDir:  ".",
+		ProjectName: "projA",
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: "new123",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "new123"},
+			Projects: []models.ProjectStatus{
+				{Workspace: "default", RepoRelDir: ".", ProjectName: "projA", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	stalePull := ctx.Pull
+	stalePull.HeadCommit = "old123"
+	_, err := db.UpdatePullWithResults(stalePull, []command.ProjectResult{
+		{
+			Command:     command.Plan,
+			Workspace:   ctx.Workspace,
+			RepoRelDir:  ctx.RepoRelDir,
+			ProjectName: ctx.ProjectName,
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PlanSuccess: &models.PlanSuccess{},
+			},
+		},
+	})
+	Ok(t, err)
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, []byte("plan"), 0600))
+	When(mockWorkingDir.GetWorkingDir(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(repoDir, nil)
+	When(mockLocker.TryLock(Any[logging.SimpleLogging](), Eq(ctx.Pull), Any[models.User](), Eq(ctx.Workspace), Any[models.Project](), AnyBool())).
+		ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key"}, nil)
+
+	res := runner.Apply(ctx)
+
+	Assert(t, res.Error != nil, "expected stale PullStatus error")
+	Assert(t, strings.Contains(res.Error.Error(), "recorded plan status is from commit"), "got: %s", res.Error)
+	mockApply.VerifyWasCalled(Never()).Run(Any[command.ProjectContext](), Any[[]string](), Any[string](), Any[map[string]string]())
+}
+
+type trackingWorkingDirLocker struct {
+	locked bool
+}
+
+func (l *trackingWorkingDirLocker) TryLock(string, int, string, string, string, command.Name) (func(), error) {
+	l.locked = true
+	return func() { l.locked = false }, nil
+}
+
+func (l *trackingWorkingDirLocker) UnlockByPull(string, int) {
+	l.locked = false
+}
+
+type assertLockedApplyPlanValidator struct {
+	t      *testing.T
+	locker *trackingWorkingDirLocker
+	called bool
+}
+
+func (v *assertLockedApplyPlanValidator) ValidateProjectPlan(command.ProjectContext, string) error {
+	v.called = true
+	Assert(v.t, v.locker.locked, "expected apply plan validation to run while working dir lock is held")
+	return nil
+}
+
+func newTestBoltDB(t *testing.T) *boltdb.BoltDB {
+	t.Helper()
+	db, err := boltdb.New(t.TempDir())
+	Ok(t, err)
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+	return db
 }
 
 // Test that it runs the expected apply steps.

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -339,6 +339,34 @@ func TestProjectOutputWrapper(t *testing.T) {
 	}
 }
 
+func TestProjectOutputWrapper_PassesRemoteApplyURLToDeferredSuccessStatus(t *testing.T) {
+	RegisterMockTestingT(t)
+	ctx := command.ProjectContext{
+		Log:        logging.NewNoopLogger(t),
+		Workspace:  "default",
+		RepoRelDir: ".",
+	}
+	prjResult := command.ProjectCommandOutput{
+		ApplySuccess:    "apply complete",
+		ApplySuccessURL: "https://app.terraform.io/app/org/workspace/runs/run-123",
+	}
+	mockJobURLSetter := mocks.NewMockJobURLSetter()
+	mockJobMessageSender := mocks.NewMockJobMessageSender()
+	mockProjectCommandRunner := mocks.NewMockProjectCommandRunner()
+	runner := &events.ProjectOutputWrapper{
+		JobURLSetter:         mockJobURLSetter,
+		JobMessageSender:     mockJobMessageSender,
+		ProjectCommandRunner: mockProjectCommandRunner,
+	}
+	When(mockProjectCommandRunner.Apply(Any[command.ProjectContext]())).ThenReturn(prjResult)
+
+	runner.Apply(ctx)
+
+	mockJobURLSetter.VerifyWasCalled(Once()).SetJobURLWithStatus(ctx, command.Apply, models.PendingCommitStatus, nil)
+	mockJobURLSetter.VerifyWasCalled(Once()).SetJobURLWithStatus(ctx, command.Apply, models.SuccessCommitStatus, &prjResult)
+	mockJobMessageSender.VerifyWasCalledOnce().Send(ctx, "", true)
+}
+
 func TestProjectOutputWrapperSuppressesJobOutput(t *testing.T) {
 	RegisterMockTestingT(t)
 	mockProjectCommandRunner := mocks.NewMockProjectCommandRunner()
@@ -1214,6 +1242,36 @@ func TestProjectCommandRunner_NonPRMutableRefChangedBeforeApplyDoesNotRunApply(t
 	res := runner.Apply(ctx)
 
 	Assert(t, res.Error != nil, "expected changed mutable ref to fail before apply")
+	Assert(t, strings.Contains(res.Error.Error(), "changed"), "got: %s", res.Error)
+	mockApply.VerifyWasCalled(Never()).Run(Any[command.ProjectContext](), Any[[]string](), Any[string](), Any[map[string]string]())
+}
+
+func TestProjectCommandRunner_NonPRReleaseBranchChangedBeforeApplyDoesNotRunApply(t *testing.T) {
+	repoDir, initialCommit := initProjectRunnerAPIRefGitRepo(t)
+	createProjectRunnerAPIRefGitBranch(t, repoDir, "release", initialCommit)
+	advanceProjectRunnerAPIRefGitBranch(t, repoDir, "release")
+	runner, mockApply := newNonPRAPIApplyRunner(t, repoDir)
+	ctx := nonPRAPIApplyContext(t, initialCommit)
+	ctx.Pull.HeadBranch = "release"
+
+	res := runner.Apply(ctx)
+
+	Assert(t, res.Error != nil, "expected changed release branch to fail before apply")
+	Assert(t, strings.Contains(res.Error.Error(), "changed"), "got: %s", res.Error)
+	mockApply.VerifyWasCalled(Never()).Run(Any[command.ProjectContext](), Any[[]string](), Any[string](), Any[map[string]string]())
+}
+
+func TestProjectCommandRunner_NonPRStableBranchChangedBeforeApplyDoesNotRunApply(t *testing.T) {
+	repoDir, initialCommit := initProjectRunnerAPIRefGitRepo(t)
+	createProjectRunnerAPIRefGitBranch(t, repoDir, "stable", initialCommit)
+	advanceProjectRunnerAPIRefGitBranch(t, repoDir, "stable")
+	runner, mockApply := newNonPRAPIApplyRunner(t, repoDir)
+	ctx := nonPRAPIApplyContext(t, initialCommit)
+	ctx.Pull.HeadBranch = "stable"
+
+	res := runner.Apply(ctx)
+
+	Assert(t, res.Error != nil, "expected changed stable branch to fail before apply")
 	Assert(t, strings.Contains(res.Error.Error(), "changed"), "got: %s", res.Error)
 	mockApply.VerifyWasCalled(Never()).Run(Any[command.ProjectContext](), Any[[]string](), Any[string](), Any[map[string]string]())
 }
@@ -2720,10 +2778,28 @@ func initProjectRunnerAPIRefGitRepo(t *testing.T) (string, string) {
 
 func advanceProjectRunnerAPIRefGitMain(t *testing.T, repoDir string) string {
 	t.Helper()
+	runProjectRunnerAPIRefGit(t, repoDir, "checkout", "-q", "main")
 	Ok(t, os.WriteFile(filepath.Join(repoDir, "main.tf"), []byte("resource \"null_resource\" \"changed\" {}\n"), 0600))
 	runProjectRunnerAPIRefGit(t, repoDir, "add", "main.tf")
 	runProjectRunnerAPIRefGit(t, repoDir, "commit", "-q", "-m", "advance main")
 	runProjectRunnerAPIRefGit(t, repoDir, "push", "-q", "origin", "HEAD:main")
+	return strings.TrimSpace(runProjectRunnerAPIRefGit(t, repoDir, "rev-parse", "HEAD"))
+}
+
+func createProjectRunnerAPIRefGitBranch(t *testing.T, repoDir string, branch string, commit string) {
+	t.Helper()
+	runProjectRunnerAPIRefGit(t, repoDir, "checkout", "-q", "-B", branch, commit)
+	runProjectRunnerAPIRefGit(t, repoDir, "push", "-q", "-u", "origin", "HEAD:"+branch)
+	runProjectRunnerAPIRefGit(t, repoDir, "checkout", "-q", "main")
+}
+
+func advanceProjectRunnerAPIRefGitBranch(t *testing.T, repoDir string, branch string) string {
+	t.Helper()
+	runProjectRunnerAPIRefGit(t, repoDir, "checkout", "-q", branch)
+	Ok(t, os.WriteFile(filepath.Join(repoDir, "main.tf"), []byte("resource \"null_resource\" \""+branch+"\" {}\n"), 0600))
+	runProjectRunnerAPIRefGit(t, repoDir, "add", "main.tf")
+	runProjectRunnerAPIRefGit(t, repoDir, "commit", "-q", "-m", "advance "+branch)
+	runProjectRunnerAPIRefGit(t, repoDir, "push", "-q", "origin", "HEAD:"+branch)
 	return strings.TrimSpace(runProjectRunnerAPIRefGit(t, repoDir, "rev-parse", "HEAD"))
 }
 

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -1025,12 +1025,82 @@ func TestApplyPlanValidator_StaleCommandHeadDoesNotDeleteCurrentLivePlan(t *test
 	Equals(t, "current plan", string(contents))
 }
 
+func TestApplyPlanValidator_RejectsPullStatusFromDifferentBaseBranch(t *testing.T) {
+	db := newTestBoltDB(t)
+	repoDir := t.TempDir()
+	ctx := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		Workspace:   "default",
+		RepoRelDir:  ".",
+		ProjectName: "projA",
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: "abc123",
+			BaseBranch: "main",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	statusPull := ctx.Pull
+	statusPull.BaseBranch = "release"
+	_, err := db.UpdatePullWithResults(statusPull, []command.ProjectResult{plannedProjectResult(ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName)})
+	Ok(t, err)
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, []byte("plan"), 0600))
+	validator := &events.DefaultApplyPlanValidator{PullStatusFetcher: db}
+
+	err = validator.ValidateProjectPlan(ctx, repoDir)
+
+	Assert(t, err != nil, "expected base branch mismatch")
+	Assert(t, strings.Contains(err.Error(), "base branch"), "got: %s", err)
+	_, err = os.Stat(planPath)
+	Assert(t, os.IsNotExist(err), "expected stale-base plan file to be deleted")
+}
+
 func TestProjectCommandRunner_TargetedStaleCommandClassifiedBeforeApplyRequirements(t *testing.T) {
 	assertTargetedStaleCommandClassifiedBeforeApplyValidation(t)
 }
 
 func TestProjectCommandRunner_TargetedStaleCommandClassifiedBeforeDependencyValidation(t *testing.T) {
 	assertTargetedStaleCommandClassifiedBeforeApplyValidation(t)
+}
+
+func TestProjectCommandRunner_TargetedStaleCommandClassifiedBeforeDirNotExist(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockApply := mocks.NewMockStepRunner()
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockRequirementHandler := mocks.NewMockCommandRequirementHandler()
+	oldHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	liveHead := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	runner := &events.DefaultProjectCommandRunner{
+		ApplyStepRunner:           mockApply,
+		WorkingDir:                mockWorkingDir,
+		WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: mockRequirementHandler,
+		ApplyPlanValidator:        &events.DefaultApplyPlanValidator{LivePullHeadFetcher: fakeLivePullHeadFetcher{head: liveHead}},
+	}
+	ctx := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		Steps:       valid.DefaultApplyStage.Steps,
+		Workspace:   "default",
+		RepoRelDir:  "deleted-dir",
+		ProjectName: "projA",
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: oldHead,
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+
+	res := runner.Apply(ctx)
+
+	Assert(t, res.Error != nil, "expected stale command-head error")
+	Assert(t, strings.Contains(res.Error.Error(), "pull request head changed"), "got: %s", res.Error)
+	mockWorkingDir.VerifyWasCalled(Never()).GetWorkingDir(Any[models.Repo](), Any[models.PullRequest](), Any[string]())
+	mockRequirementHandler.VerifyWasCalled(Never()).ValidateApplyProject(Any[string](), Any[command.ProjectContext]())
+	mockRequirementHandler.VerifyWasCalled(Never()).ValidateProjectDependencies(Any[command.ProjectContext]())
+	mockApply.VerifyWasCalled(Never()).Run(Any[command.ProjectContext](), Any[[]string](), Any[string](), Any[map[string]string]())
 }
 
 func assertTargetedStaleCommandClassifiedBeforeApplyValidation(t *testing.T) {

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -1091,7 +1091,7 @@ func TestApplyPlanValidator_RejectsWhenLiveBaseChangedSinceCommandStart(t *testi
 	Ok(t, err)
 }
 
-func TestApplyPlanValidator_UsesLiveBaseBranchNotCommandStartBase(t *testing.T) {
+func TestApplyPlanValidator_TargetedApplySameHeadDifferentBaseReturnsStaleCommandError(t *testing.T) {
 	db := newTestBoltDB(t)
 	repoDir := t.TempDir()
 	head := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
@@ -1122,7 +1122,11 @@ func TestApplyPlanValidator_UsesLiveBaseBranchNotCommandStartBase(t *testing.T) 
 
 	err = validator.ValidateProjectPlan(ctx, repoDir)
 
-	Ok(t, err)
+	Assert(t, err != nil, "expected same-head base retarget to be stale")
+	Assert(t, strings.Contains(err.Error(), "pull request base branch changed"), "got: %s", err)
+	contents, readErr := os.ReadFile(planPath)
+	Ok(t, readErr)
+	Equals(t, "current-base plan", string(contents))
 }
 
 func TestProjectCommandRunner_TargetedStaleCommandClassifiedBeforeApplyRequirements(t *testing.T) {
@@ -1131,6 +1135,44 @@ func TestProjectCommandRunner_TargetedStaleCommandClassifiedBeforeApplyRequireme
 
 func TestProjectCommandRunner_TargetedStaleCommandClassifiedBeforeDependencyValidation(t *testing.T) {
 	assertTargetedStaleCommandClassifiedBeforeApplyValidation(t)
+}
+
+func TestProjectCommandRunner_TargetedBaseRetargetClassifiedBeforeRequirements(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockApply := mocks.NewMockStepRunner()
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockRequirementHandler := mocks.NewMockCommandRequirementHandler()
+	head := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	runner := &events.DefaultProjectCommandRunner{
+		ApplyStepRunner:           mockApply,
+		WorkingDir:                mockWorkingDir,
+		WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: mockRequirementHandler,
+		ApplyPlanValidator:        &events.DefaultApplyPlanValidator{LivePullHeadFetcher: fakeLivePullHeadFetcher{head: head, base: "release"}},
+	}
+	ctx := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		Steps:       valid.DefaultApplyStage.Steps,
+		Workspace:   "default",
+		RepoRelDir:  ".",
+		ProjectName: "projA",
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: head,
+			BaseBranch: "main",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+
+	res := runner.Apply(ctx)
+
+	Assert(t, res.Error != nil, "expected stale base command error")
+	Assert(t, strings.Contains(res.Error.Error(), "pull request base branch changed"), "got: %s", res.Error)
+	mockWorkingDir.VerifyWasCalled(Never()).GetWorkingDir(Any[models.Repo](), Any[models.PullRequest](), Any[string]())
+	mockRequirementHandler.VerifyWasCalled(Never()).ValidateApplyProject(Any[string](), Any[command.ProjectContext]())
+	mockRequirementHandler.VerifyWasCalled(Never()).ValidateProjectDependencies(Any[command.ProjectContext]())
+	mockApply.VerifyWasCalled(Never()).Run(Any[command.ProjectContext](), Any[[]string](), Any[string](), Any[map[string]string]())
 }
 
 func TestProjectCommandRunner_TargetedStaleCommandClassifiedBeforeDirNotExist(t *testing.T) {

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -1057,6 +1058,77 @@ func TestApplyPlanValidator_RejectsPullStatusFromDifferentBaseBranch(t *testing.
 	Assert(t, os.IsNotExist(err), "expected stale-base plan file to be deleted")
 }
 
+func TestApplyPlanValidator_RejectsRecordedPlanStatusWithEmptyBaseWhenLiveBaseKnown(t *testing.T) {
+	db := newTestBoltDB(t)
+	repoDir := t.TempDir()
+	head := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	ctx := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		Workspace:   "default",
+		RepoRelDir:  ".",
+		ProjectName: "projA",
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: head,
+			BaseBranch: "release",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	statusPull := ctx.Pull
+	statusPull.BaseBranch = ""
+	_, err := db.UpdatePullWithResults(statusPull, []command.ProjectResult{plannedProjectResult(ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName)})
+	Ok(t, err)
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, []byte("legacy-base plan"), 0600))
+	validator := &events.DefaultApplyPlanValidator{
+		PullStatusFetcher:   db,
+		LivePullHeadFetcher: fakeLivePullHeadFetcher{head: head, base: ctx.Pull.BaseBranch},
+	}
+
+	err = validator.ValidateProjectPlan(ctx, repoDir)
+
+	Assert(t, err != nil, "expected empty recorded base to be rejected")
+	Assert(t, strings.Contains(err.Error(), "missing a recorded base branch"), "got: %s", err)
+	_, err = os.Stat(planPath)
+	Ok(t, err)
+}
+
+func TestApplyPlanValidator_RejectsRecordedPlanStatusWithEmptyHeadWhenLiveHeadKnown(t *testing.T) {
+	db := newTestBoltDB(t)
+	repoDir := t.TempDir()
+	liveHead := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	ctx := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		Workspace:   "default",
+		RepoRelDir:  ".",
+		ProjectName: "projA",
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: liveHead,
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	statusPull := ctx.Pull
+	statusPull.HeadCommit = ""
+	_, err := db.UpdatePullWithResults(statusPull, []command.ProjectResult{plannedProjectResult(ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName)})
+	Ok(t, err)
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, []byte("legacy-head plan"), 0600))
+	validator := &events.DefaultApplyPlanValidator{
+		PullStatusFetcher:   db,
+		LivePullHeadFetcher: fakeLivePullHeadFetcher{head: liveHead},
+	}
+
+	err = validator.ValidateProjectPlan(ctx, repoDir)
+
+	Assert(t, err != nil, "expected empty recorded head to be rejected")
+	Assert(t, strings.Contains(err.Error(), "missing a recorded head commit"), "got: %s", err)
+	_, err = os.Stat(planPath)
+	Ok(t, err)
+}
+
 func TestApplyPlanValidator_RejectsWhenLiveBaseChangedSinceCommandStart(t *testing.T) {
 	db := newTestBoltDB(t)
 	repoDir := t.TempDir()
@@ -1131,6 +1203,53 @@ func TestApplyPlanValidator_TargetedApplySameHeadDifferentBaseReturnsStaleComman
 
 func TestProjectCommandRunner_TargetedStaleCommandClassifiedBeforeApplyRequirements(t *testing.T) {
 	assertTargetedStaleCommandClassifiedBeforeApplyValidation(t)
+}
+
+func TestProjectCommandRunner_NonPRMutableRefChangedBeforeApplyDoesNotRunApply(t *testing.T) {
+	repoDir, initialCommit := initProjectRunnerAPIRefGitRepo(t)
+	advanceProjectRunnerAPIRefGitMain(t, repoDir)
+	runner, mockApply := newNonPRAPIApplyRunner(t, repoDir)
+	ctx := nonPRAPIApplyContext(t, initialCommit)
+
+	res := runner.Apply(ctx)
+
+	Assert(t, res.Error != nil, "expected changed mutable ref to fail before apply")
+	Assert(t, strings.Contains(res.Error.Error(), "changed"), "got: %s", res.Error)
+	mockApply.VerifyWasCalled(Never()).Run(Any[command.ProjectContext](), Any[[]string](), Any[string](), Any[map[string]string]())
+}
+
+func TestProjectCommandRunner_NonPRMutableRefChangedBetweenRunStepAndApplyDoesNotRunApply(t *testing.T) {
+	repoDir, initialCommit := initProjectRunnerAPIRefGitRepo(t)
+	runner, mockApply := newNonPRAPIApplyRunner(t, repoDir)
+	runner.RunStepRunner = &mutatingCustomStepRunner{mutate: func() error {
+		advanceProjectRunnerAPIRefGitMain(t, repoDir)
+		return nil
+	}}
+	ctx := nonPRAPIApplyContext(t, initialCommit)
+	ctx.Steps = []valid.Step{{StepName: "run"}, {StepName: "apply"}}
+
+	res := runner.Apply(ctx)
+
+	Assert(t, res.Error != nil, "expected changed mutable ref to fail before built-in apply")
+	Assert(t, strings.Contains(res.Error.Error(), "changed"), "got: %s", res.Error)
+	mockApply.VerifyWasCalled(Never()).Run(Any[command.ProjectContext](), Any[[]string](), Any[string](), Any[map[string]string]())
+}
+
+func TestProjectCommandRunner_NonPRMutableRefChangedDuringApplyFailsClosed(t *testing.T) {
+	repoDir, initialCommit := initProjectRunnerAPIRefGitRepo(t)
+	runner, mockApply := newNonPRAPIApplyRunner(t, repoDir)
+	When(mockApply.Run(Any[command.ProjectContext](), Any[[]string](), Any[string](), Any[map[string]string]())).
+		Then(func([]Param) ReturnValues {
+			advanceProjectRunnerAPIRefGitMain(t, repoDir)
+			return ReturnValues{"applied", nil}
+		})
+	ctx := nonPRAPIApplyContext(t, initialCommit)
+
+	res := runner.Apply(ctx)
+
+	Assert(t, res.Error != nil, "expected changed mutable ref during apply to fail closed")
+	Assert(t, strings.Contains(res.Error.Error(), "changed"), "got: %s", res.Error)
+	mockApply.VerifyWasCalledOnce().Run(Any[command.ProjectContext](), Any[[]string](), Any[string](), Any[map[string]string]())
 }
 
 func TestProjectCommandRunner_TargetedStaleCommandClassifiedBeforeDependencyValidation(t *testing.T) {
@@ -2531,6 +2650,99 @@ func newTestBoltDB(t *testing.T) *boltdb.BoltDB {
 		_ = db.Close()
 	})
 	return db
+}
+
+func nonPRAPIApplyContext(t *testing.T, headCommit string) command.ProjectContext {
+	t.Helper()
+	return command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		API:         true,
+		Steps:       []valid.Step{{StepName: "apply"}},
+		Workspace:   "default",
+		RepoRelDir:  ".",
+		ProjectName: "projA",
+		Pull: models.PullRequest{
+			Num:        -1,
+			HeadBranch: "main",
+			HeadCommit: headCommit,
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+}
+
+func newNonPRAPIApplyRunner(t *testing.T, repoDir string) (*events.DefaultProjectCommandRunner, *mocks.MockStepRunner) {
+	t.Helper()
+	RegisterMockTestingT(t)
+	mockApply := mocks.NewMockStepRunner()
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockLocker := mocks.NewMockProjectLocker()
+	mockRequirementHandler := mocks.NewMockCommandRequirementHandler()
+	When(mockWorkingDir.GetWorkingDir(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).ThenReturn(repoDir, nil)
+	When(mockWorkingDir.GitReadLock(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).ThenReturn(func() {})
+	When(mockLocker.TryLock(Any[logging.SimpleLogging](), Any[models.PullRequest](), Any[models.User](), Any[string](), Any[models.Project](), AnyBool())).
+		ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key"}, nil)
+	When(mockRequirementHandler.ValidateApplyProject(Any[string](), Any[command.ProjectContext]())).ThenReturn("", nil)
+	When(mockRequirementHandler.ValidateProjectDependencies(Any[command.ProjectContext]())).ThenReturn("", nil)
+	When(mockApply.Run(Any[command.ProjectContext](), Any[[]string](), Any[string](), Any[map[string]string]())).ThenReturn("applied", nil)
+	return &events.DefaultProjectCommandRunner{
+		Locker:                    mockLocker,
+		ApplyStepRunner:           mockApply,
+		WorkingDir:                mockWorkingDir,
+		WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: mockRequirementHandler,
+	}, mockApply
+}
+
+func initProjectRunnerAPIRefGitRepo(t *testing.T) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	originDir := filepath.Join(root, "origin.git")
+	repoDir := filepath.Join(root, "work")
+	runProjectRunnerAPIRefGit(t, "", "init", "--bare", originDir)
+	runProjectRunnerAPIRefGit(t, originDir, "config", "gc.auto", "0")
+	runProjectRunnerAPIRefGit(t, originDir, "config", "maintenance.auto", "false")
+	runProjectRunnerAPIRefGit(t, originDir, "config", "receive.autogc", "false")
+	runProjectRunnerAPIRefGit(t, "", "init", "--initial-branch=main", repoDir)
+	runProjectRunnerAPIRefGit(t, repoDir, "config", "gc.auto", "0")
+	runProjectRunnerAPIRefGit(t, repoDir, "config", "maintenance.auto", "false")
+	runProjectRunnerAPIRefGit(t, repoDir, "config", "user.email", "atlantisbot@runatlantis.io")
+	runProjectRunnerAPIRefGit(t, repoDir, "config", "user.name", "atlantisbot")
+	runProjectRunnerAPIRefGit(t, repoDir, "config", "commit.gpgsign", "false")
+	Ok(t, os.WriteFile(filepath.Join(repoDir, "main.tf"), []byte("resource \"null_resource\" \"main\" {}\n"), 0600))
+	runProjectRunnerAPIRefGit(t, repoDir, "add", "main.tf")
+	runProjectRunnerAPIRefGit(t, repoDir, "commit", "-q", "-m", "initial")
+	initialCommit := strings.TrimSpace(runProjectRunnerAPIRefGit(t, repoDir, "rev-parse", "HEAD"))
+	runProjectRunnerAPIRefGit(t, repoDir, "remote", "add", "origin", "file://"+originDir)
+	runProjectRunnerAPIRefGit(t, repoDir, "push", "-q", "-u", "origin", "main")
+	return repoDir, initialCommit
+}
+
+func advanceProjectRunnerAPIRefGitMain(t *testing.T, repoDir string) string {
+	t.Helper()
+	Ok(t, os.WriteFile(filepath.Join(repoDir, "main.tf"), []byte("resource \"null_resource\" \"changed\" {}\n"), 0600))
+	runProjectRunnerAPIRefGit(t, repoDir, "add", "main.tf")
+	runProjectRunnerAPIRefGit(t, repoDir, "commit", "-q", "-m", "advance main")
+	runProjectRunnerAPIRefGit(t, repoDir, "push", "-q", "origin", "HEAD:main")
+	return strings.TrimSpace(runProjectRunnerAPIRefGit(t, repoDir, "rev-parse", "HEAD"))
+}
+
+func runProjectRunnerAPIRefGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	args = append([]string{
+		"-c", "protocol.file.allow=always",
+		"-c", "gc.auto=0",
+		"-c", "maintenance.auto=false",
+		"-c", "receive.autogc=false",
+	}, args...)
+	cmd := exec.Command("git", args...) //nolint:gosec
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null", "GIT_TERMINAL_PROMPT=0")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running git %s: %s: %v", strings.Join(args, " "), output, err)
+	}
+	return string(output)
 }
 
 // Test that it runs the expected apply steps.

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -5,6 +5,8 @@
 package events_test
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -955,6 +957,64 @@ func TestProjectCommandRunner_ApplyDoesNotCallApplyStepWhenFinalValidationFails(
 	Equals(t, []string{"validate", "run", "validate"}, calls)
 }
 
+func TestApplyPlanValidator_RejectsWhenLivePullHeadChanged(t *testing.T) {
+	db := newTestBoltDB(t)
+	repoDir := t.TempDir()
+	ctx := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		Workspace:   "default",
+		RepoRelDir:  ".",
+		ProjectName: "projA",
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: "old123",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	_, err := db.UpdatePullWithResults(ctx.Pull, []command.ProjectResult{plannedProjectResult(ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName)})
+	Ok(t, err)
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, []byte("plan"), 0600))
+	validator := &events.DefaultApplyPlanValidator{PullStatusFetcher: db, LivePullHeadFetcher: fakeLivePullHeadFetcher{head: "new123"}}
+
+	err = validator.ValidateProjectPlan(ctx, repoDir)
+
+	Assert(t, err != nil, "expected live head change error")
+	Assert(t, strings.Contains(err.Error(), "pull request head changed"), "got: %s", err)
+	_, err = os.Stat(planPath)
+	Assert(t, os.IsNotExist(err), "expected stale plan file to be deleted")
+}
+
+func TestApplyPlanValidator_FailsClosedWhenLiveHeadFetchFails(t *testing.T) {
+	db := newTestBoltDB(t)
+	repoDir := t.TempDir()
+	ctx := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		Workspace:   "default",
+		RepoRelDir:  ".",
+		ProjectName: "projA",
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: "abc123",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	_, err := db.UpdatePullWithResults(ctx.Pull, []command.ProjectResult{plannedProjectResult(ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName)})
+	Ok(t, err)
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, []byte("plan"), 0600))
+	validator := &events.DefaultApplyPlanValidator{PullStatusFetcher: db, LivePullHeadFetcher: fakeLivePullHeadFetcher{err: errors.New("vcs unavailable")}}
+
+	err = validator.ValidateProjectPlan(ctx, repoDir)
+
+	Assert(t, err != nil, "expected live head fetch failure")
+	Assert(t, strings.Contains(err.Error(), "fetching live pull request head"), "got: %s", err)
+	_, err = os.Stat(planPath)
+	Ok(t, err)
+}
+
 func TestProjectCommandRunner_ApplyRejectsPlanDeletedAfterBuilderValidation(t *testing.T) {
 	RegisterMockTestingT(t)
 	mockApply := mocks.NewMockStepRunner()
@@ -1010,6 +1070,52 @@ func TestProjectCommandRunner_ApplyRejectsPlanDeletedAfterBuilderValidation(t *t
 
 	Assert(t, res.Error != nil, "expected missing plan file error")
 	Assert(t, strings.Contains(res.Error.Error(), "plan file is missing"), "got: %s", res.Error)
+	mockApply.VerifyWasCalled(Never()).Run(Any[command.ProjectContext](), Any[[]string](), Any[string](), Any[map[string]string]())
+}
+
+func TestProjectCommandRunner_ApplyDoesNotRunTerraformWhenLiveHeadChangedAfterCommandStart(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockApply := mocks.NewMockStepRunner()
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockLocker := mocks.NewMockProjectLocker()
+	db := newTestBoltDB(t)
+	runner := &events.DefaultProjectCommandRunner{
+		Locker:                    mockLocker,
+		LockURLGenerator:          mockURLGenerator{},
+		ApplyStepRunner:           mockApply,
+		WorkingDir:                mockWorkingDir,
+		WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: &events.DefaultCommandRequirementHandler{WorkingDir: mockWorkingDir},
+		ApplyPlanValidator:        &events.DefaultApplyPlanValidator{PullStatusFetcher: db, LivePullHeadFetcher: fakeLivePullHeadFetcher{head: "new123"}},
+	}
+	repoDir := t.TempDir()
+	ctx := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		Steps:       valid.DefaultApplyStage.Steps,
+		Workspace:   "default",
+		RepoRelDir:  ".",
+		ProjectName: "projA",
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: "old123",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	_, err := db.UpdatePullWithResults(ctx.Pull, []command.ProjectResult{plannedProjectResult(ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName)})
+	Ok(t, err)
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, []byte("plan"), 0600))
+	When(mockWorkingDir.GetWorkingDir(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(repoDir, nil)
+	When(mockLocker.TryLock(Any[logging.SimpleLogging](), Eq(ctx.Pull), Any[models.User](), Eq(ctx.Workspace), Any[models.Project](), AnyBool())).
+		ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key"}, nil)
+
+	res := runner.Apply(ctx)
+
+	Assert(t, res.Error != nil, "expected live head change error")
+	Assert(t, strings.Contains(res.Error.Error(), "pull request head changed"), "got: %s", res.Error)
+	_, err = os.Stat(planPath)
+	Assert(t, os.IsNotExist(err), "expected stale plan file to be deleted")
 	mockApply.VerifyWasCalled(Never()).Run(Any[command.ProjectContext](), Any[[]string](), Any[string](), Any[map[string]string]())
 }
 
@@ -1071,6 +1177,116 @@ func TestProjectCommandRunner_ApplyRejectsPlanMutatedByPreApplyRunStep(t *testin
 	Assert(t, res.Error != nil, "expected final missing plan error")
 	Assert(t, strings.Contains(res.Error.Error(), "plan file is missing"), "got: %s", res.Error)
 	Equals(t, []string{"run"}, calls)
+}
+
+func TestProjectCommandRunner_ApplyRejectsPlanOverwrittenByPreApplyRunStep(t *testing.T) {
+	testProjectCommandRunnerRejectsPlanContentMutation(t, []byte("changed plan"), "plan file changed")
+}
+
+func TestProjectCommandRunner_ApplyRejectsPlanTruncatedByPreApplyRunStep(t *testing.T) {
+	testProjectCommandRunnerRejectsPlanContentMutation(t, nil, "plan file changed")
+}
+
+func testProjectCommandRunnerRejectsPlanContentMutation(t *testing.T, newContents []byte, expectedErr string) {
+	RegisterMockTestingT(t)
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockLocker := mocks.NewMockProjectLocker()
+	db := newTestBoltDB(t)
+	calls := []string{}
+	runner := &events.DefaultProjectCommandRunner{
+		Locker:                    mockLocker,
+		LockURLGenerator:          mockURLGenerator{},
+		ApplyStepRunner:           &recordingStepRunner{name: "apply", calls: &calls},
+		WorkingDir:                mockWorkingDir,
+		WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: &events.DefaultCommandRequirementHandler{WorkingDir: mockWorkingDir},
+		ApplyPlanValidator:        &events.DefaultApplyPlanValidator{PullStatusFetcher: db},
+	}
+	repoDir := t.TempDir()
+	ctx := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		Steps: []valid.Step{
+			{StepName: "run"},
+			{StepName: "apply"},
+		},
+		Workspace:   "default",
+		RepoRelDir:  ".",
+		ProjectName: "projA",
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: "abc123",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	_, err := db.UpdatePullWithResults(ctx.Pull, []command.ProjectResult{plannedProjectResult(ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName)})
+	Ok(t, err)
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, []byte("original plan"), 0600))
+	runner.RunStepRunner = &mutatingCustomStepRunner{
+		calls: &calls,
+		mutate: func() error {
+			return os.WriteFile(planPath, newContents, 0600)
+		},
+	}
+	When(mockWorkingDir.GetWorkingDir(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(repoDir, nil)
+	When(mockWorkingDir.GitReadLock(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(func() {})
+	When(mockLocker.TryLock(Any[logging.SimpleLogging](), Eq(ctx.Pull), Any[models.User](), Eq(ctx.Workspace), Any[models.Project](), AnyBool())).
+		ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key"}, nil)
+
+	res := runner.Apply(ctx)
+
+	Assert(t, res.Error != nil, "expected plan hash mismatch")
+	Assert(t, strings.Contains(res.Error.Error(), expectedErr), "got: %s", res.Error)
+	_, err = os.Stat(planPath)
+	Assert(t, os.IsNotExist(err), "expected rejected plan file to be deleted")
+	Equals(t, []string{"run"}, calls)
+}
+
+func TestProjectCommandRunner_ApplyUsesExpectedPlanHash(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockLocker := mocks.NewMockProjectLocker()
+	db := newTestBoltDB(t)
+	calls := []string{}
+	runner := &events.DefaultProjectCommandRunner{
+		Locker:                    mockLocker,
+		LockURLGenerator:          mockURLGenerator{},
+		ApplyStepRunner:           &recordingStepRunner{name: "apply", calls: &calls},
+		WorkingDir:                mockWorkingDir,
+		WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: &events.DefaultCommandRequirementHandler{WorkingDir: mockWorkingDir},
+		ApplyPlanValidator:        &events.DefaultApplyPlanValidator{PullStatusFetcher: db},
+	}
+	repoDir := t.TempDir()
+	planContents := []byte("original plan")
+	ctx := command.ProjectContext{
+		Log:              logging.NewNoopLogger(t),
+		CommandName:      command.Apply,
+		Steps:            valid.DefaultApplyStage.Steps,
+		Workspace:        "default",
+		RepoRelDir:       ".",
+		ProjectName:      "projA",
+		ExpectedPlanHash: planHashForContent(planContents),
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: "abc123",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	_, err := db.UpdatePullWithResults(ctx.Pull, []command.ProjectResult{plannedProjectResult(ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName)})
+	Ok(t, err)
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, planContents, 0600))
+	When(mockWorkingDir.GetWorkingDir(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(repoDir, nil)
+	When(mockWorkingDir.GitReadLock(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(func() {})
+	When(mockLocker.TryLock(Any[logging.SimpleLogging](), Eq(ctx.Pull), Any[models.User](), Eq(ctx.Workspace), Any[models.Project](), AnyBool())).
+		ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key"}, nil)
+
+	res := runner.Apply(ctx)
+
+	Ok(t, res.Error)
+	Equals(t, []string{"apply"}, calls)
 }
 
 func TestProjectCommandRunner_ApplyRejectsFreshErroredPolicyCheckStatus(t *testing.T) {
@@ -1314,7 +1530,26 @@ type trackingWorkingDirLocker struct {
 	locked bool
 }
 
+func planHashForContent(contents []byte) string {
+	hash := sha256.Sum256(contents)
+	return hex.EncodeToString(hash[:])
+}
+
+type fakeLivePullHeadFetcher struct {
+	head string
+	err  error
+}
+
+func (f fakeLivePullHeadFetcher) GetLiveHeadCommit(command.ProjectContext) (string, error) {
+	return f.head, f.err
+}
+
 func (l *trackingWorkingDirLocker) TryLock(string, int, string, string, string, command.Name) (func(), error) {
+	l.locked = true
+	return func() { l.locked = false }, nil
+}
+
+func (l *trackingWorkingDirLocker) TryLockPull(string, int, command.Name) (func(), error) {
 	l.locked = true
 	return func() { l.locked = false }, nil
 }

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -960,6 +960,8 @@ func TestProjectCommandRunner_ApplyDoesNotCallApplyStepWhenFinalValidationFails(
 func TestApplyPlanValidator_RejectsWhenLivePullHeadChanged(t *testing.T) {
 	db := newTestBoltDB(t)
 	repoDir := t.TempDir()
+	oldHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	newHead := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	ctx := command.ProjectContext{
 		Log:         logging.NewNoopLogger(t),
 		CommandName: command.Apply,
@@ -968,7 +970,7 @@ func TestApplyPlanValidator_RejectsWhenLivePullHeadChanged(t *testing.T) {
 		ProjectName: "projA",
 		Pull: models.PullRequest{
 			Num:        1,
-			HeadCommit: "old123",
+			HeadCommit: oldHead,
 			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
 		},
 	}
@@ -976,12 +978,12 @@ func TestApplyPlanValidator_RejectsWhenLivePullHeadChanged(t *testing.T) {
 	Ok(t, err)
 	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
 	Ok(t, os.WriteFile(planPath, []byte("plan"), 0600))
-	validator := &events.DefaultApplyPlanValidator{PullStatusFetcher: db, LivePullHeadFetcher: fakeLivePullHeadFetcher{head: "new123"}}
+	validator := &events.DefaultApplyPlanValidator{PullStatusFetcher: db, LivePullHeadFetcher: fakeLivePullHeadFetcher{head: newHead}}
 
 	err = validator.ValidateProjectPlan(ctx, repoDir)
 
 	Assert(t, err != nil, "expected live head change error")
-	Assert(t, strings.Contains(err.Error(), "pull request head changed"), "got: %s", err)
+	Assert(t, strings.Contains(err.Error(), "recorded plan status is from commit"), "got: %s", err)
 	_, err = os.Stat(planPath)
 	Ok(t, err)
 }
@@ -989,9 +991,11 @@ func TestApplyPlanValidator_RejectsWhenLivePullHeadChanged(t *testing.T) {
 func TestApplyPlanValidator_StaleCommandHeadDoesNotDeleteCurrentLivePlan(t *testing.T) {
 	db := newTestBoltDB(t)
 	repoDir := t.TempDir()
+	oldHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	newHead := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	currentPull := models.PullRequest{
 		Num:        1,
-		HeadCommit: "new123",
+		HeadCommit: newHead,
 		BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
 	}
 	ctx := command.ProjectContext{
@@ -1002,7 +1006,7 @@ func TestApplyPlanValidator_StaleCommandHeadDoesNotDeleteCurrentLivePlan(t *test
 		ProjectName: "projA",
 		Pull: models.PullRequest{
 			Num:        currentPull.Num,
-			HeadCommit: "old123",
+			HeadCommit: oldHead,
 			BaseRepo:   currentPull.BaseRepo,
 		},
 	}
@@ -1024,9 +1028,11 @@ func TestApplyPlanValidator_StaleCommandHeadDoesNotDeleteCurrentLivePlan(t *test
 func TestValidatePlansForApply_CurrentPlanStillApplyableAfterStaleTargetedApplyFails(t *testing.T) {
 	db := newTestBoltDB(t)
 	repoDir := t.TempDir()
+	oldHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	newHead := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	currentPull := models.PullRequest{
 		Num:        1,
-		HeadCommit: "new123",
+		HeadCommit: newHead,
 		BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
 	}
 	project := command.ProjectContext{
@@ -1037,7 +1043,7 @@ func TestValidatePlansForApply_CurrentPlanStillApplyableAfterStaleTargetedApplyF
 		ProjectName: "projA",
 		Pull: models.PullRequest{
 			Num:        currentPull.Num,
-			HeadCommit: "old123",
+			HeadCommit: oldHead,
 			BaseRepo:   currentPull.BaseRepo,
 		},
 	}
@@ -1131,6 +1137,180 @@ func TestApplyPlanValidator_UsesInMemoryPullStatusForAPIApply(t *testing.T) {
 	}
 
 	err := validator.ValidateProjectPlan(ctx, repoDir)
+
+	Ok(t, err)
+}
+
+func TestApplyPlanValidator_APIApplyWithBranchRefDoesNotCompareRefStringToLiveSHA(t *testing.T) {
+	db := newTestBoltDB(t)
+	repoDir := t.TempDir()
+	liveHead := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	planContents := []byte("api branch plan")
+	ctx := command.ProjectContext{
+		Log:              logging.NewNoopLogger(t),
+		CommandName:      command.Apply,
+		API:              true,
+		Workspace:        "default",
+		RepoRelDir:       ".",
+		ProjectName:      "projA",
+		ExpectedPlanHash: planHashForContent(planContents),
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: "main",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	ctx.PullStatus = &models.PullStatus{
+		Pull: models.PullRequest{
+			Num:        ctx.Pull.Num,
+			HeadCommit: liveHead,
+			BaseRepo:   ctx.Pull.BaseRepo,
+		},
+		Projects: []models.ProjectStatus{{
+			Workspace:   ctx.Workspace,
+			RepoRelDir:  ctx.RepoRelDir,
+			ProjectName: ctx.ProjectName,
+			Status:      models.PlannedPlanStatus,
+		}},
+	}
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, planContents, 0600))
+	validator := &events.DefaultApplyPlanValidator{
+		PullStatusFetcher:   db,
+		LivePullHeadFetcher: fakeLivePullHeadFetcher{head: liveHead},
+	}
+
+	err := validator.ValidateProjectPlan(ctx, repoDir)
+
+	Ok(t, err)
+}
+
+func TestApplyPlanValidator_APIApplyWithResolvedCommitComparesToLiveSHA(t *testing.T) {
+	db := newTestBoltDB(t)
+	repoDir := t.TempDir()
+	oldHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	liveHead := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	planContents := []byte("api resolved plan")
+	ctx := command.ProjectContext{
+		Log:              logging.NewNoopLogger(t),
+		CommandName:      command.Apply,
+		API:              true,
+		Workspace:        "default",
+		RepoRelDir:       ".",
+		ProjectName:      "projA",
+		ExpectedPlanHash: planHashForContent(planContents),
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: oldHead,
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	ctx.PullStatus = &models.PullStatus{
+		Pull: models.PullRequest{
+			Num:        ctx.Pull.Num,
+			HeadCommit: liveHead,
+			BaseRepo:   ctx.Pull.BaseRepo,
+		},
+		Projects: []models.ProjectStatus{{
+			Workspace:   ctx.Workspace,
+			RepoRelDir:  ctx.RepoRelDir,
+			ProjectName: ctx.ProjectName,
+			Status:      models.PlannedPlanStatus,
+		}},
+	}
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, planContents, 0600))
+	validator := &events.DefaultApplyPlanValidator{
+		PullStatusFetcher:   db,
+		LivePullHeadFetcher: fakeLivePullHeadFetcher{head: liveHead},
+	}
+
+	err := validator.ValidateProjectPlan(ctx, repoDir)
+
+	Assert(t, err != nil, "expected stale resolved API commit to fail")
+	Assert(t, strings.Contains(err.Error(), "pull request head changed"), "got: %s", err)
+	contents, readErr := os.ReadFile(planPath)
+	Ok(t, readErr)
+	Equals(t, string(planContents), string(contents))
+}
+
+func TestApplyPlanValidator_APIApplyPrefersSeededPullStatusOverStaleDB(t *testing.T) {
+	db := newTestBoltDB(t)
+	repoDir := t.TempDir()
+	staleHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	liveHead := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	planContents := []byte("fresh api plan")
+	stalePull := models.PullRequest{
+		Num:        1,
+		HeadCommit: staleHead,
+		BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+	}
+	_, err := db.UpdatePullWithResults(stalePull, []command.ProjectResult{plannedProjectResult(".", "default", "projA")})
+	Ok(t, err)
+	ctx := command.ProjectContext{
+		Log:              logging.NewNoopLogger(t),
+		CommandName:      command.Apply,
+		API:              true,
+		Workspace:        "default",
+		RepoRelDir:       ".",
+		ProjectName:      "projA",
+		ExpectedPlanHash: planHashForContent(planContents),
+		Pull: models.PullRequest{
+			Num:        stalePull.Num,
+			HeadCommit: liveHead,
+			BaseRepo:   stalePull.BaseRepo,
+		},
+	}
+	ctx.PullStatus = &models.PullStatus{
+		Pull: ctx.Pull,
+		Projects: []models.ProjectStatus{{
+			Workspace:   ctx.Workspace,
+			RepoRelDir:  ctx.RepoRelDir,
+			ProjectName: ctx.ProjectName,
+			Status:      models.PlannedPlanStatus,
+		}},
+	}
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, planContents, 0600))
+	validator := &events.DefaultApplyPlanValidator{
+		PullStatusFetcher:   db,
+		LivePullHeadFetcher: fakeLivePullHeadFetcher{head: liveHead},
+	}
+
+	err = validator.ValidateProjectPlan(ctx, repoDir)
+
+	Ok(t, err)
+}
+
+func TestApplyPlanValidator_APIApplyUsesDBWhenNoSeededPullStatusExists(t *testing.T) {
+	db := newTestBoltDB(t)
+	repoDir := t.TempDir()
+	liveHead := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	planContents := []byte("api db plan")
+	ctx := command.ProjectContext{
+		Log:              logging.NewNoopLogger(t),
+		CommandName:      command.Apply,
+		API:              true,
+		Workspace:        "default",
+		RepoRelDir:       ".",
+		ProjectName:      "projA",
+		ExpectedPlanHash: planHashForContent(planContents),
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: liveHead,
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	_, err := db.UpdatePullWithResults(ctx.Pull, []command.ProjectResult{plannedProjectResult(ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName)})
+	Ok(t, err)
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, planContents, 0600))
+	validator := &events.DefaultApplyPlanValidator{
+		PullStatusFetcher:   db,
+		LivePullHeadFetcher: fakeLivePullHeadFetcher{head: liveHead},
+	}
+
+	err = validator.ValidateProjectPlan(ctx, repoDir)
 
 	Ok(t, err)
 }
@@ -1379,6 +1559,8 @@ func TestProjectCommandRunner_ApplyDoesNotRunTerraformWhenLiveHeadChangedAfterCo
 	mockWorkingDir := mocks.NewMockWorkingDir()
 	mockLocker := mocks.NewMockProjectLocker()
 	db := newTestBoltDB(t)
+	oldHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	newHead := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	runner := &events.DefaultProjectCommandRunner{
 		Locker:                    mockLocker,
 		LockURLGenerator:          mockURLGenerator{},
@@ -1386,7 +1568,7 @@ func TestProjectCommandRunner_ApplyDoesNotRunTerraformWhenLiveHeadChangedAfterCo
 		WorkingDir:                mockWorkingDir,
 		WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
 		CommandRequirementHandler: &events.DefaultCommandRequirementHandler{WorkingDir: mockWorkingDir},
-		ApplyPlanValidator:        &events.DefaultApplyPlanValidator{PullStatusFetcher: db, LivePullHeadFetcher: fakeLivePullHeadFetcher{head: "new123"}},
+		ApplyPlanValidator:        &events.DefaultApplyPlanValidator{PullStatusFetcher: db, LivePullHeadFetcher: fakeLivePullHeadFetcher{head: newHead}},
 	}
 	repoDir := t.TempDir()
 	ctx := command.ProjectContext{
@@ -1398,7 +1580,7 @@ func TestProjectCommandRunner_ApplyDoesNotRunTerraformWhenLiveHeadChangedAfterCo
 		ProjectName: "projA",
 		Pull: models.PullRequest{
 			Num:        1,
-			HeadCommit: "old123",
+			HeadCommit: oldHead,
 			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
 		},
 	}
@@ -1413,7 +1595,7 @@ func TestProjectCommandRunner_ApplyDoesNotRunTerraformWhenLiveHeadChangedAfterCo
 	res := runner.Apply(ctx)
 
 	Assert(t, res.Error != nil, "expected live head change error")
-	Assert(t, strings.Contains(res.Error.Error(), "pull request head changed"), "got: %s", res.Error)
+	Assert(t, strings.Contains(res.Error.Error(), "recorded plan status is from commit"), "got: %s", res.Error)
 	_, err = os.Stat(planPath)
 	Ok(t, err)
 	mockApply.VerifyWasCalled(Never()).Run(Any[command.ProjectContext](), Any[[]string](), Any[string](), Any[map[string]string]())

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -983,7 +983,88 @@ func TestApplyPlanValidator_RejectsWhenLivePullHeadChanged(t *testing.T) {
 	Assert(t, err != nil, "expected live head change error")
 	Assert(t, strings.Contains(err.Error(), "pull request head changed"), "got: %s", err)
 	_, err = os.Stat(planPath)
-	Assert(t, os.IsNotExist(err), "expected stale plan file to be deleted")
+	Ok(t, err)
+}
+
+func TestApplyPlanValidator_StaleCommandHeadDoesNotDeleteCurrentLivePlan(t *testing.T) {
+	db := newTestBoltDB(t)
+	repoDir := t.TempDir()
+	currentPull := models.PullRequest{
+		Num:        1,
+		HeadCommit: "new123",
+		BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+	}
+	ctx := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		Workspace:   "default",
+		RepoRelDir:  ".",
+		ProjectName: "projA",
+		Pull: models.PullRequest{
+			Num:        currentPull.Num,
+			HeadCommit: "old123",
+			BaseRepo:   currentPull.BaseRepo,
+		},
+	}
+	_, err := db.UpdatePullWithResults(currentPull, []command.ProjectResult{plannedProjectResult(ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName)})
+	Ok(t, err)
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, []byte("current plan"), 0600))
+	validator := &events.DefaultApplyPlanValidator{PullStatusFetcher: db, LivePullHeadFetcher: fakeLivePullHeadFetcher{head: currentPull.HeadCommit}}
+
+	err = validator.ValidateProjectPlan(ctx, repoDir)
+
+	Assert(t, err != nil, "expected stale command head to be rejected")
+	Assert(t, strings.Contains(err.Error(), "pull request head changed"), "got: %s", err)
+	contents, readErr := os.ReadFile(planPath)
+	Ok(t, readErr)
+	Equals(t, "current plan", string(contents))
+}
+
+func TestValidatePlansForApply_CurrentPlanStillApplyableAfterStaleTargetedApplyFails(t *testing.T) {
+	db := newTestBoltDB(t)
+	repoDir := t.TempDir()
+	currentPull := models.PullRequest{
+		Num:        1,
+		HeadCommit: "new123",
+		BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+	}
+	project := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		Workspace:   "default",
+		RepoRelDir:  ".",
+		ProjectName: "projA",
+		Pull: models.PullRequest{
+			Num:        currentPull.Num,
+			HeadCommit: "old123",
+			BaseRepo:   currentPull.BaseRepo,
+		},
+	}
+	_, err := db.UpdatePullWithResults(currentPull, []command.ProjectResult{plannedProjectResult(project.RepoRelDir, project.Workspace, project.ProjectName)})
+	Ok(t, err)
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(project.Workspace, project.ProjectName))
+	Ok(t, os.WriteFile(planPath, []byte("current plan"), 0600))
+	validator := &events.DefaultApplyPlanValidator{PullStatusFetcher: db, LivePullHeadFetcher: fakeLivePullHeadFetcher{head: currentPull.HeadCommit}}
+
+	err = validator.ValidateProjectPlan(project, repoDir)
+	Assert(t, err != nil, "expected stale targeted apply to fail")
+
+	_, err = os.Stat(planPath)
+	Ok(t, err)
+	pullStatus, err := db.GetPullStatus(currentPull)
+	Ok(t, err)
+	err = events.ValidatePlansForApply(&command.Context{
+		Log:        logging.NewNoopLogger(t),
+		Pull:       currentPull,
+		PullStatus: pullStatus,
+	}, []events.PendingPlan{{
+		RepoDir:     repoDir,
+		RepoRelDir:  project.RepoRelDir,
+		Workspace:   project.Workspace,
+		ProjectName: project.ProjectName,
+	}})
+	Ok(t, err)
 }
 
 func TestApplyPlanValidator_FailsClosedWhenLiveHeadFetchFails(t *testing.T) {
@@ -1012,6 +1093,118 @@ func TestApplyPlanValidator_FailsClosedWhenLiveHeadFetchFails(t *testing.T) {
 	Assert(t, err != nil, "expected live head fetch failure")
 	Assert(t, strings.Contains(err.Error(), "fetching live pull request head"), "got: %s", err)
 	_, err = os.Stat(planPath)
+	Ok(t, err)
+}
+
+func TestApplyPlanValidator_UsesInMemoryPullStatusForAPIApply(t *testing.T) {
+	db := newTestBoltDB(t)
+	repoDir := t.TempDir()
+	planContents := []byte("api plan")
+	ctx := command.ProjectContext{
+		Log:              logging.NewNoopLogger(t),
+		CommandName:      command.Apply,
+		API:              true,
+		Workspace:        "default",
+		RepoRelDir:       ".",
+		ProjectName:      "projA",
+		ExpectedPlanHash: planHashForContent(planContents),
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: "abc123",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	ctx.PullStatus = &models.PullStatus{
+		Pull: ctx.Pull,
+		Projects: []models.ProjectStatus{{
+			Workspace:   ctx.Workspace,
+			RepoRelDir:  ctx.RepoRelDir,
+			ProjectName: ctx.ProjectName,
+			Status:      models.PlannedPlanStatus,
+		}},
+	}
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, planContents, 0600))
+	validator := &events.DefaultApplyPlanValidator{
+		PullStatusFetcher:   db,
+		LivePullHeadFetcher: fakeLivePullHeadFetcher{head: ctx.Pull.HeadCommit},
+	}
+
+	err := validator.ValidateProjectPlan(ctx, repoDir)
+
+	Ok(t, err)
+}
+
+func TestApplyPlanValidator_CommentApplyStillFailsWhenDBPullStatusMissing(t *testing.T) {
+	db := newTestBoltDB(t)
+	repoDir := t.TempDir()
+	ctx := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		Workspace:   "default",
+		RepoRelDir:  ".",
+		ProjectName: "projA",
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: "abc123",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	ctx.PullStatus = &models.PullStatus{
+		Pull: ctx.Pull,
+		Projects: []models.ProjectStatus{{
+			Workspace:   ctx.Workspace,
+			RepoRelDir:  ctx.RepoRelDir,
+			ProjectName: ctx.ProjectName,
+			Status:      models.PlannedPlanStatus,
+		}},
+	}
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, []byte("comment plan"), 0600))
+	validator := &events.DefaultApplyPlanValidator{PullStatusFetcher: db}
+
+	err := validator.ValidateProjectPlan(ctx, repoDir)
+
+	Assert(t, err != nil, "expected comment apply to require DB pull status")
+	Assert(t, strings.Contains(err.Error(), "no current plan status found"), "got: %s", err)
+}
+
+func TestApplyPlanValidator_DriftApplyUsesInMemoryPullStatusWithoutLiveHeadFetch(t *testing.T) {
+	db := newTestBoltDB(t)
+	repoDir := t.TempDir()
+	planContents := []byte("drift plan")
+	ctx := command.ProjectContext{
+		Log:              logging.NewNoopLogger(t),
+		CommandName:      command.Apply,
+		API:              true,
+		Workspace:        "default",
+		RepoRelDir:       ".",
+		ProjectName:      "projA",
+		ExpectedPlanHash: planHashForContent(planContents),
+		Pull: models.PullRequest{
+			Num:        -1,
+			HeadCommit: "abc123",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	ctx.PullStatus = &models.PullStatus{
+		Pull: ctx.Pull,
+		Projects: []models.ProjectStatus{{
+			Workspace:   ctx.Workspace,
+			RepoRelDir:  ctx.RepoRelDir,
+			ProjectName: ctx.ProjectName,
+			Status:      models.PlannedPlanStatus,
+		}},
+	}
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, planContents, 0600))
+	validator := &events.DefaultApplyPlanValidator{
+		PullStatusFetcher:   db,
+		LivePullHeadFetcher: fakeLivePullHeadFetcher{err: errors.New("live head should not be fetched")},
+	}
+
+	err := validator.ValidateProjectPlan(ctx, repoDir)
+
 	Ok(t, err)
 }
 
@@ -1063,7 +1256,7 @@ func TestApplyPlanValidator_RejectsTraversalPlanPathBeforeHashing(t *testing.T) 
 	Assert(t, strings.Contains(err.Error(), "plan path traversal detected"), "got: %s", err)
 }
 
-func TestApplyPlanValidator_HashesOnlySubpathUnderProjectDir(t *testing.T) {
+func TestApplyPlanValidator_HashesOnlyContainedPlanPath(t *testing.T) {
 	db := newTestBoltDB(t)
 	repoDir := t.TempDir()
 	planContents := []byte("plan")
@@ -1222,7 +1415,7 @@ func TestProjectCommandRunner_ApplyDoesNotRunTerraformWhenLiveHeadChangedAfterCo
 	Assert(t, res.Error != nil, "expected live head change error")
 	Assert(t, strings.Contains(res.Error.Error(), "pull request head changed"), "got: %s", res.Error)
 	_, err = os.Stat(planPath)
-	Assert(t, os.IsNotExist(err), "expected stale plan file to be deleted")
+	Ok(t, err)
 	mockApply.VerifyWasCalled(Never()).Run(Any[command.ProjectContext](), Any[[]string](), Any[string](), Any[map[string]string]())
 }
 

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -1015,6 +1015,113 @@ func TestApplyPlanValidator_FailsClosedWhenLiveHeadFetchFails(t *testing.T) {
 	Ok(t, err)
 }
 
+func TestApplyPlanValidator_RejectsPlanPathOutsideProjectDir(t *testing.T) {
+	db := newTestBoltDB(t)
+	repoDir := t.TempDir()
+	ctx := command.ProjectContext{
+		Log:              logging.NewNoopLogger(t),
+		CommandName:      command.Apply,
+		Workspace:        "../escape",
+		RepoRelDir:       ".",
+		ProjectName:      "",
+		ExpectedPlanHash: planHashForContent([]byte("plan")),
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: "abc123",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	validator := &events.DefaultApplyPlanValidator{PullStatusFetcher: db}
+
+	err := validator.ValidateProjectPlan(ctx, repoDir)
+
+	Assert(t, err != nil, "expected plan path traversal error")
+	Assert(t, strings.Contains(err.Error(), "plan path traversal detected"), "got: %s", err)
+}
+
+func TestApplyPlanValidator_RejectsTraversalPlanPathBeforeHashing(t *testing.T) {
+	db := newTestBoltDB(t)
+	repoDir := t.TempDir()
+	ctx := command.ProjectContext{
+		Log:              logging.NewNoopLogger(t),
+		CommandName:      command.Apply,
+		Workspace:        "../escape",
+		RepoRelDir:       ".",
+		ProjectName:      "",
+		ExpectedPlanHash: planHashForContent([]byte("plan")),
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: "abc123",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	validator := &events.DefaultApplyPlanValidator{PullStatusFetcher: db}
+
+	err := validator.ValidateProjectPlan(ctx, repoDir)
+
+	Assert(t, err != nil, "expected traversal to fail before hashing")
+	Assert(t, strings.Contains(err.Error(), "plan path traversal detected"), "got: %s", err)
+}
+
+func TestApplyPlanValidator_HashesOnlySubpathUnderProjectDir(t *testing.T) {
+	db := newTestBoltDB(t)
+	repoDir := t.TempDir()
+	planContents := []byte("plan")
+	ctx := command.ProjectContext{
+		Log:              logging.NewNoopLogger(t),
+		CommandName:      command.Apply,
+		Workspace:        "default",
+		RepoRelDir:       ".",
+		ProjectName:      "projA",
+		ExpectedPlanHash: planHashForContent(planContents),
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: "abc123",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	_, err := db.UpdatePullWithResults(ctx.Pull, []command.ProjectResult{plannedProjectResult(ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName)})
+	Ok(t, err)
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, planContents, 0600))
+	validator := &events.DefaultApplyPlanValidator{PullStatusFetcher: db}
+
+	err = validator.ValidateProjectPlan(ctx, repoDir)
+
+	Ok(t, err)
+}
+
+func TestApplyPlanValidator_HashMismatchDoesNotDeleteNewerCurrentPlan(t *testing.T) {
+	db := newTestBoltDB(t)
+	repoDir := t.TempDir()
+	ctx := command.ProjectContext{
+		Log:              logging.NewNoopLogger(t),
+		CommandName:      command.Apply,
+		Workspace:        "default",
+		RepoRelDir:       ".",
+		ProjectName:      "projA",
+		ExpectedPlanHash: planHashForContent([]byte("old plan")),
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: "abc123",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	_, err := db.UpdatePullWithResults(ctx.Pull, []command.ProjectResult{plannedProjectResult(ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName)})
+	Ok(t, err)
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, []byte("new plan"), 0600))
+	validator := &events.DefaultApplyPlanValidator{PullStatusFetcher: db}
+
+	err = validator.ValidateProjectPlan(ctx, repoDir)
+
+	Assert(t, err != nil, "expected plan hash mismatch")
+	Assert(t, strings.Contains(err.Error(), "plan file changed"), "got: %s", err)
+	contents, readErr := os.ReadFile(planPath)
+	Ok(t, readErr)
+	Equals(t, "new plan", string(contents))
+}
+
 func TestProjectCommandRunner_ApplyRejectsPlanDeletedAfterBuilderValidation(t *testing.T) {
 	RegisterMockTestingT(t)
 	mockApply := mocks.NewMockStepRunner()
@@ -1183,6 +1290,14 @@ func TestProjectCommandRunner_ApplyRejectsPlanOverwrittenByPreApplyRunStep(t *te
 	testProjectCommandRunnerRejectsPlanContentMutation(t, []byte("changed plan"), "plan file changed")
 }
 
+func TestProjectCommandRunner_ApplyRejectsPlanMutatedBeforeBuiltInApplyStep(t *testing.T) {
+	testProjectCommandRunnerRejectsPlanContentMutation(t, []byte("changed plan"), "plan file changed")
+}
+
+func TestProjectCommandRunner_PreApplyRunStepPlanfileExposureIsDocumented(t *testing.T) {
+	testProjectCommandRunnerRejectsPlanContentMutation(t, []byte("changed plan"), "plan file changed")
+}
+
 func TestProjectCommandRunner_ApplyRejectsPlanTruncatedByPreApplyRunStep(t *testing.T) {
 	testProjectCommandRunnerRejectsPlanContentMutation(t, nil, "plan file changed")
 }
@@ -1238,8 +1353,9 @@ func testProjectCommandRunnerRejectsPlanContentMutation(t *testing.T, newContent
 
 	Assert(t, res.Error != nil, "expected plan hash mismatch")
 	Assert(t, strings.Contains(res.Error.Error(), expectedErr), "got: %s", res.Error)
-	_, err = os.Stat(planPath)
-	Assert(t, os.IsNotExist(err), "expected rejected plan file to be deleted")
+	contents, err := os.ReadFile(planPath)
+	Ok(t, err)
+	Equals(t, string(newContents), string(contents))
 	Equals(t, []string{"run"}, calls)
 }
 

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -302,7 +302,11 @@ func TestProjectOutputWrapper(t *testing.T) {
 			}
 
 			mockJobURLSetter.VerifyWasCalled(Once()).SetJobURLWithStatus(ctx, c.CommandName, models.PendingCommitStatus, nil)
-			mockJobURLSetter.VerifyWasCalled(Once()).SetJobURLWithStatus(ctx, c.CommandName, expCommitStatus, &prjResult)
+			if c.CommandName == command.Apply && c.Success {
+				mockJobURLSetter.VerifyWasCalled(Never()).SetJobURLWithStatus(ctx, c.CommandName, models.SuccessCommitStatus, &prjResult)
+			} else {
+				mockJobURLSetter.VerifyWasCalled(Once()).SetJobURLWithStatus(ctx, c.CommandName, expCommitStatus, &prjResult)
+			}
 
 			switch c.CommandName {
 			case command.Plan:
@@ -339,7 +343,7 @@ func TestProjectOutputWrapper(t *testing.T) {
 	}
 }
 
-func TestProjectOutputWrapper_PassesRemoteApplyURLToDeferredSuccessStatus(t *testing.T) {
+func TestProjectOutputWrapper_DefersRemoteApplyURLSuccessStatus(t *testing.T) {
 	RegisterMockTestingT(t)
 	ctx := command.ProjectContext{
 		Log:        logging.NewNoopLogger(t),
@@ -363,8 +367,17 @@ func TestProjectOutputWrapper_PassesRemoteApplyURLToDeferredSuccessStatus(t *tes
 	runner.Apply(ctx)
 
 	mockJobURLSetter.VerifyWasCalled(Once()).SetJobURLWithStatus(ctx, command.Apply, models.PendingCommitStatus, nil)
-	mockJobURLSetter.VerifyWasCalled(Once()).SetJobURLWithStatus(ctx, command.Apply, models.SuccessCommitStatus, &prjResult)
+	mockJobURLSetter.VerifyWasCalled(Never()).SetJobURLWithStatus(ctx, command.Apply, models.SuccessCommitStatus, &prjResult)
 	mockJobMessageSender.VerifyWasCalledOnce().Send(ctx, "", true)
+
+	runner.PublishDeferredApplyStatuses([]command.ProjectContext{ctx}, command.Result{ProjectResults: []command.ProjectResult{{
+		ProjectCommandOutput: prjResult,
+		Command:              command.Apply,
+		RepoRelDir:           ctx.RepoRelDir,
+		Workspace:            ctx.Workspace,
+	}}}, models.SuccessCommitStatus)
+
+	mockJobURLSetter.VerifyWasCalled(Once()).SetJobURLWithStatus(ctx, command.Apply, models.SuccessCommitStatus, &prjResult)
 }
 
 func TestProjectOutputWrapperSuppressesJobOutput(t *testing.T) {

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -1282,6 +1282,47 @@ func TestApplyPlanValidator_APIApplyPrefersSeededPullStatusOverStaleDB(t *testin
 	Ok(t, err)
 }
 
+func TestApplyPlanValidator_APIInMemoryErroredPolicyCheckStatusRejectsApply(t *testing.T) {
+	db := newTestBoltDB(t)
+	repoDir := t.TempDir()
+	liveHead := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	planContents := []byte("api policy errored plan")
+	ctx := command.ProjectContext{
+		Log:              logging.NewNoopLogger(t),
+		CommandName:      command.Apply,
+		API:              true,
+		Workspace:        "default",
+		RepoRelDir:       ".",
+		ProjectName:      "projA",
+		ExpectedPlanHash: planHashForContent(planContents),
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: liveHead,
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+	ctx.PullStatus = &models.PullStatus{
+		Pull: ctx.Pull,
+		Projects: []models.ProjectStatus{{
+			Workspace:   ctx.Workspace,
+			RepoRelDir:  ctx.RepoRelDir,
+			ProjectName: ctx.ProjectName,
+			Status:      models.ErroredPolicyCheckStatus,
+		}},
+	}
+	planPath := filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	Ok(t, os.WriteFile(planPath, planContents, 0600))
+	validator := &events.DefaultApplyPlanValidator{
+		PullStatusFetcher:   db,
+		LivePullHeadFetcher: fakeLivePullHeadFetcher{head: liveHead},
+	}
+
+	err := validator.ValidateProjectPlan(ctx, repoDir)
+
+	Assert(t, err != nil, "expected policy-check errored status to reject API apply")
+	Assert(t, strings.Contains(err.Error(), "policy checks have errored"), "got: %s", err)
+}
+
 func TestApplyPlanValidator_APIApplyUsesDBWhenNoSeededPullStatusExists(t *testing.T) {
 	db := newTestBoltDB(t)
 	repoDir := t.TempDir()

--- a/server/events/state_command_runner.go
+++ b/server/events/state_command_runner.go
@@ -43,10 +43,11 @@ func (v *StateCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 	if ctx.CommandSkipped {
 		return
 	}
-	v.pullUpdater.updatePull(ctx, cmd, result)
 	if err := v.dbUpdater.updateDBForDiscardedPlans(ctx, ctx.Pull, result.ProjectResults); err != nil {
-		ctx.Log.Err("writing discarded plan status: %s", err)
+		result.Error = fmt.Errorf("writing discarded plan status: %w", err)
+		ctx.CommandHasErrors = true
 	}
+	v.pullUpdater.updatePull(ctx, cmd, result)
 }
 
 func (v *StateCommandRunner) runRm(ctx *command.Context, cmd *CommentCommand) command.Result {

--- a/server/events/state_command_runner.go
+++ b/server/events/state_command_runner.go
@@ -11,11 +11,13 @@ import (
 
 func NewStateCommandRunner(
 	pullUpdater *PullUpdater,
+	dbUpdater *DBUpdater,
 	prjCmdBuilder ProjectStateCommandBuilder,
 	prjCmdRunner ProjectStateCommandRunner,
 ) *StateCommandRunner {
 	return &StateCommandRunner{
 		pullUpdater:   pullUpdater,
+		dbUpdater:     dbUpdater,
 		prjCmdBuilder: prjCmdBuilder,
 		prjCmdRunner:  prjCmdRunner,
 	}
@@ -23,6 +25,7 @@ func NewStateCommandRunner(
 
 type StateCommandRunner struct {
 	pullUpdater   *PullUpdater
+	dbUpdater     *DBUpdater
 	prjCmdBuilder ProjectStateCommandBuilder
 	prjCmdRunner  ProjectStateCommandRunner
 }
@@ -41,6 +44,9 @@ func (v *StateCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 		return
 	}
 	v.pullUpdater.updatePull(ctx, cmd, result)
+	if err := v.dbUpdater.updateDBForDiscardedPlans(ctx, ctx.Pull, result.ProjectResults); err != nil {
+		ctx.Log.Err("writing discarded plan status: %s", err)
+	}
 }
 
 func (v *StateCommandRunner) runRm(ctx *command.Context, cmd *CommentCommand) command.Result {

--- a/server/events/vcs/bitbucketcloud/client.go
+++ b/server/events/vcs/bitbucketcloud/client.go
@@ -240,6 +240,22 @@ func (b *Client) PullIsApproved(logger logging.SimpleLogging, repo models.Repo, 
 	return approvalStatus, nil
 }
 
+func (b *Client) GetPullRequestHeadCommit(logger logging.SimpleLogging, repo models.Repo, pull models.PullRequest) (string, error) {
+	path := fmt.Sprintf("%s/2.0/repositories/%s/pullrequests/%d", b.BaseURL, repo.FullName, pull.Num)
+	resp, err := b.makeRequest("GET", path, nil)
+	if err != nil {
+		return "", err
+	}
+	var pullResp PullRequest
+	if err := json.Unmarshal(resp, &pullResp); err != nil {
+		return "", fmt.Errorf("parsing response %q: %w", string(resp), err)
+	}
+	if err := validator.New().Struct(pullResp); err != nil {
+		return "", fmt.Errorf("response %q was missing fields: %w", string(resp), err)
+	}
+	return *pullResp.Source.Commit.Hash, nil
+}
+
 // PullIsMergeable returns true if the merge request has no conflicts and can be merged.
 func (b *Client) PullIsMergeable(logger logging.SimpleLogging, repo models.Repo, pull models.PullRequest, _ string, _ []string) (models.MergeableStatus, error) {
 	nextPageURL := fmt.Sprintf("%s/2.0/repositories/%s/pullrequests/%d/diffstat", b.BaseURL, repo.FullName, pull.Num)

--- a/server/events/vcs/bitbucketcloud/client.go
+++ b/server/events/vcs/bitbucketcloud/client.go
@@ -241,19 +241,29 @@ func (b *Client) PullIsApproved(logger logging.SimpleLogging, repo models.Repo, 
 }
 
 func (b *Client) GetPullRequestHeadCommit(logger logging.SimpleLogging, repo models.Repo, pull models.PullRequest) (string, error) {
-	path := fmt.Sprintf("%s/2.0/repositories/%s/pullrequests/%d", b.BaseURL, repo.FullName, pull.Num)
-	resp, err := b.makeRequest("GET", path, nil)
+	livePull, err := b.GetPullRequestIdentity(logger, repo, pull)
 	if err != nil {
 		return "", err
 	}
+	return livePull.HeadCommit, nil
+}
+
+func (b *Client) GetPullRequestIdentity(logger logging.SimpleLogging, repo models.Repo, pull models.PullRequest) (models.PullRequest, error) {
+	path := fmt.Sprintf("%s/2.0/repositories/%s/pullrequests/%d", b.BaseURL, repo.FullName, pull.Num)
+	resp, err := b.makeRequest("GET", path, nil)
+	if err != nil {
+		return models.PullRequest{}, err
+	}
 	var pullResp PullRequest
 	if err := json.Unmarshal(resp, &pullResp); err != nil {
-		return "", fmt.Errorf("parsing response %q: %w", string(resp), err)
+		return models.PullRequest{}, fmt.Errorf("parsing response %q: %w", string(resp), err)
 	}
 	if err := validator.New().Struct(pullResp); err != nil {
-		return "", fmt.Errorf("response %q was missing fields: %w", string(resp), err)
+		return models.PullRequest{}, fmt.Errorf("response %q was missing fields: %w", string(resp), err)
 	}
-	return *pullResp.Source.Commit.Hash, nil
+	pull.HeadCommit = *pullResp.Source.Commit.Hash
+	pull.BaseBranch = *pullResp.Destination.Branch.Name
+	return pull, nil
 }
 
 // PullIsMergeable returns true if the merge request has no conflicts and can be merged.

--- a/server/events/vcs/bitbucketcloud/client_test.go
+++ b/server/events/vcs/bitbucketcloud/client_test.go
@@ -230,6 +230,52 @@ func TestClient_PullIsApproved(t *testing.T) {
 	}
 }
 
+func TestBitbucketCloud_GetPullRequestIdentityMapsDestinationBranch(t *testing.T) {
+	assertBitbucketCloudPullRequestIdentityIncludesBaseBranch(t)
+}
+
+func TestLivePullIdentityFetcher_BitbucketCloudIncludesBaseBranch(t *testing.T) {
+	assertBitbucketCloudPullRequestIdentityIncludesBaseBranch(t)
+}
+
+func assertBitbucketCloudPullRequestIdentityIncludesBaseBranch(t *testing.T) {
+	t.Helper()
+	logger := logging.NewNoopLogger(t)
+	pullRequest, err := os.ReadFile(filepath.Join("testdata", "pull-approved.json"))
+	Ok(t, err)
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.RequestURI {
+		case "/2.0/repositories/owner/repo/pullrequests/1":
+			w.Write(pullRequest) // nolint: errcheck
+			return
+		default:
+			t.Errorf("got unexpected request at %q", r.RequestURI)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+	}))
+	defer testServer.Close()
+
+	client := bitbucketcloud.New(http.DefaultClient, "user", "pass", "", "runatlantis.io")
+	client.BaseURL = testServer.URL
+	repo := models.Repo{
+		FullName: "owner/repo",
+		Owner:    "owner",
+		Name:     "repo",
+		VCSHost: models.VCSHost{
+			Type:     models.BitbucketCloud,
+			Hostname: "bitbucket.org",
+		},
+	}
+	pull := models.PullRequest{Num: 1, BaseRepo: repo}
+
+	identity, err := client.GetPullRequestIdentity(logger, repo, pull)
+
+	Ok(t, err)
+	Equals(t, "75d1e7c57cd9", identity.HeadCommit)
+	Equals(t, "main", identity.BaseBranch)
+}
+
 func TestClient_PullIsMergeable(t *testing.T) {
 	logger := logging.NewNoopLogger(t)
 	cases := map[string]struct {

--- a/server/events/vcs/bitbucketserver/client.go
+++ b/server/events/vcs/bitbucketserver/client.go
@@ -198,23 +198,33 @@ func (b *Client) PullIsApproved(logger logging.SimpleLogging, repo models.Repo, 
 }
 
 func (b *Client) GetPullRequestHeadCommit(logger logging.SimpleLogging, repo models.Repo, pull models.PullRequest) (string, error) {
-	projectKey, err := b.GetProjectKey(repo.Name, repo.SanitizedCloneURL)
+	livePull, err := b.GetPullRequestIdentity(logger, repo, pull)
 	if err != nil {
 		return "", err
+	}
+	return livePull.HeadCommit, nil
+}
+
+func (b *Client) GetPullRequestIdentity(logger logging.SimpleLogging, repo models.Repo, pull models.PullRequest) (models.PullRequest, error) {
+	projectKey, err := b.GetProjectKey(repo.Name, repo.SanitizedCloneURL)
+	if err != nil {
+		return models.PullRequest{}, err
 	}
 	path := fmt.Sprintf("%s/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d", b.BaseURL, projectKey, repo.Name, pull.Num)
 	resp, err := b.makeRequest("GET", path, nil)
 	if err != nil {
-		return "", err
+		return models.PullRequest{}, err
 	}
 	var pullResp PullRequest
 	if err := json.Unmarshal(resp, &pullResp); err != nil {
-		return "", fmt.Errorf("parsing response %q: %w", string(resp), err)
+		return models.PullRequest{}, fmt.Errorf("parsing response %q: %w", string(resp), err)
 	}
 	if err := validator.New().Struct(pullResp); err != nil {
-		return "", fmt.Errorf("response %q was missing fields: %w", string(resp), err)
+		return models.PullRequest{}, fmt.Errorf("response %q was missing fields: %w", string(resp), err)
 	}
-	return *pullResp.FromRef.LatestCommit, nil
+	pull.HeadCommit = *pullResp.FromRef.LatestCommit
+	pull.BaseBranch = *pullResp.ToRef.DisplayID
+	return pull, nil
 }
 
 func (b *Client) DiscardReviews(_ logging.SimpleLogging, _ models.Repo, _ models.PullRequest) error {

--- a/server/events/vcs/bitbucketserver/client.go
+++ b/server/events/vcs/bitbucketserver/client.go
@@ -197,6 +197,26 @@ func (b *Client) PullIsApproved(logger logging.SimpleLogging, repo models.Repo, 
 	return approvalStatus, nil
 }
 
+func (b *Client) GetPullRequestHeadCommit(logger logging.SimpleLogging, repo models.Repo, pull models.PullRequest) (string, error) {
+	projectKey, err := b.GetProjectKey(repo.Name, repo.SanitizedCloneURL)
+	if err != nil {
+		return "", err
+	}
+	path := fmt.Sprintf("%s/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d", b.BaseURL, projectKey, repo.Name, pull.Num)
+	resp, err := b.makeRequest("GET", path, nil)
+	if err != nil {
+		return "", err
+	}
+	var pullResp PullRequest
+	if err := json.Unmarshal(resp, &pullResp); err != nil {
+		return "", fmt.Errorf("parsing response %q: %w", string(resp), err)
+	}
+	if err := validator.New().Struct(pullResp); err != nil {
+		return "", fmt.Errorf("response %q was missing fields: %w", string(resp), err)
+	}
+	return *pullResp.FromRef.LatestCommit, nil
+}
+
 func (b *Client) DiscardReviews(_ logging.SimpleLogging, _ models.Repo, _ models.PullRequest) error {
 	// TODO implement
 	return nil

--- a/server/events/vcs/bitbucketserver/client_test.go
+++ b/server/events/vcs/bitbucketserver/client_test.go
@@ -267,3 +267,50 @@ func TestClient_MarkdownPullLink(t *testing.T) {
 	exp := "#1"
 	Equals(t, exp, s)
 }
+
+func TestBitbucketServer_GetPullRequestIdentityMapsDestinationBranch(t *testing.T) {
+	assertBitbucketServerPullRequestIdentityIncludesBaseBranch(t)
+}
+
+func TestLivePullIdentityFetcher_BitbucketServerIncludesBaseBranch(t *testing.T) {
+	assertBitbucketServerPullRequestIdentityIncludesBaseBranch(t)
+}
+
+func assertBitbucketServerPullRequestIdentityIncludesBaseBranch(t *testing.T) {
+	t.Helper()
+	logger := logging.NewNoopLogger(t)
+	pullRequest, err := os.ReadFile(filepath.Join("testdata", "pull-request.json"))
+	Ok(t, err)
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.RequestURI {
+		case "/rest/api/1.0/projects/ow/repos/repo/pull-requests/1":
+			w.Write(pullRequest) // nolint: errcheck
+			return
+		default:
+			t.Errorf("got unexpected request at %q", r.RequestURI)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+	}))
+	defer testServer.Close()
+
+	client, err := bitbucketserver.NewClient(http.DefaultClient, "user", "pass", testServer.URL, "runatlantis.io")
+	Ok(t, err)
+	repo := models.Repo{
+		FullName:          "owner/repo",
+		Owner:             "owner",
+		Name:              "repo",
+		SanitizedCloneURL: fmt.Sprintf("%s/scm/ow/repo.git", testServer.URL),
+		VCSHost: models.VCSHost{
+			Type:     models.BitbucketServer,
+			Hostname: "bitbucket.org",
+		},
+	}
+	pull := models.PullRequest{Num: 1, BaseRepo: repo}
+
+	identity, err := client.GetPullRequestIdentity(logger, repo, pull)
+
+	Ok(t, err)
+	Equals(t, "bdcaa224f4b65edb853a689404ef79cf47d8cdda", identity.HeadCommit)
+	Equals(t, "main", identity.BaseBranch)
+}

--- a/server/events/vcs/mocks/mock_client.go
+++ b/server/events/vcs/mocks/mock_client.go
@@ -56,6 +56,25 @@ func (mock *MockClient) DiscardReviews(logger logging.SimpleLogging, repo models
 	return _ret0
 }
 
+func (mock *MockClient) GetChildTeams(logger logging.SimpleLogging, repo models.Repo, teamSlug string) ([]string, error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockClient().")
+	}
+	_params := []pegomock.Param{logger, repo, teamSlug}
+	_result := pegomock.GetGenericMockFrom(mock).Invoke("GetChildTeams", _params, []reflect.Type{reflect.TypeOf((*[]string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var _ret0 []string
+	var _ret1 error
+	if len(_result) != 0 {
+		if _result[0] != nil {
+			_ret0 = _result[0].([]string)
+		}
+		if _result[1] != nil {
+			_ret1 = _result[1].(error)
+		}
+	}
+	return _ret0, _ret1
+}
+
 func (mock *MockClient) GetCloneURL(logger logging.SimpleLogging, VCSHostType models.VCSHostType, repo string) (string, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockClient().")
@@ -104,25 +123,6 @@ func (mock *MockClient) GetModifiedFiles(logger logging.SimpleLogging, repo mode
 	}
 	_params := []pegomock.Param{logger, repo, pull}
 	_result := pegomock.GetGenericMockFrom(mock).Invoke("GetModifiedFiles", _params, []reflect.Type{reflect.TypeOf((*[]string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
-	var _ret0 []string
-	var _ret1 error
-	if len(_result) != 0 {
-		if _result[0] != nil {
-			_ret0 = _result[0].([]string)
-		}
-		if _result[1] != nil {
-			_ret1 = _result[1].(error)
-		}
-	}
-	return _ret0, _ret1
-}
-
-func (mock *MockClient) GetChildTeams(logger logging.SimpleLogging, repo models.Repo, teamSlug string) ([]string, error) {
-	if mock == nil {
-		panic("mock must not be nil. Use myMock := NewMockClient().")
-	}
-	_params := []pegomock.Param{logger, repo, teamSlug}
-	_result := pegomock.GetGenericMockFrom(mock).Invoke("GetChildTeams", _params, []reflect.Type{reflect.TypeOf((*[]string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
 	var _ret0 []string
 	var _ret1 error
 	if len(_result) != 0 {
@@ -437,6 +437,47 @@ func (c *MockClient_DiscardReviews_OngoingVerification) GetAllCapturedArguments(
 	return
 }
 
+func (verifier *VerifierMockClient) GetChildTeams(logger logging.SimpleLogging, repo models.Repo, teamSlug string) *MockClient_GetChildTeams_OngoingVerification {
+	_params := []pegomock.Param{logger, repo, teamSlug}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "GetChildTeams", _params, verifier.timeout)
+	return &MockClient_GetChildTeams_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockClient_GetChildTeams_OngoingVerification struct {
+	mock              *MockClient
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockClient_GetChildTeams_OngoingVerification) GetCapturedArguments() (logging.SimpleLogging, models.Repo, string) {
+	logger, repo, teamSlug := c.GetAllCapturedArguments()
+	return logger[len(logger)-1], repo[len(repo)-1], teamSlug[len(teamSlug)-1]
+}
+
+func (c *MockClient_GetChildTeams_OngoingVerification) GetAllCapturedArguments() (_param0 []logging.SimpleLogging, _param1 []models.Repo, _param2 []string) {
+	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(_params) > 0 {
+		if len(_params) > 0 {
+			_param0 = make([]logging.SimpleLogging, len(c.methodInvocations))
+			for u, param := range _params[0] {
+				_param0[u] = param.(logging.SimpleLogging)
+			}
+		}
+		if len(_params) > 1 {
+			_param1 = make([]models.Repo, len(c.methodInvocations))
+			for u, param := range _params[1] {
+				_param1[u] = param.(models.Repo)
+			}
+		}
+		if len(_params) > 2 {
+			_param2 = make([]string, len(c.methodInvocations))
+			for u, param := range _params[2] {
+				_param2[u] = param.(string)
+			}
+		}
+	}
+	return
+}
+
 func (verifier *VerifierMockClient) GetCloneURL(logger logging.SimpleLogging, VCSHostType models.VCSHostType, repo string) *MockClient_GetCloneURL_OngoingVerification {
 	_params := []pegomock.Param{logger, VCSHostType, repo}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "GetCloneURL", _params, verifier.timeout)
@@ -560,47 +601,6 @@ func (c *MockClient_GetModifiedFiles_OngoingVerification) GetAllCapturedArgument
 			_param2 = make([]models.PullRequest, len(c.methodInvocations))
 			for u, param := range _params[2] {
 				_param2[u] = param.(models.PullRequest)
-			}
-		}
-	}
-	return
-}
-
-func (verifier *VerifierMockClient) GetChildTeams(logger logging.SimpleLogging, repo models.Repo, teamSlug string) *MockClient_GetChildTeams_OngoingVerification {
-	_params := []pegomock.Param{logger, repo, teamSlug}
-	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "GetChildTeams", _params, verifier.timeout)
-	return &MockClient_GetChildTeams_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
-}
-
-type MockClient_GetChildTeams_OngoingVerification struct {
-	mock              *MockClient
-	methodInvocations []pegomock.MethodInvocation
-}
-
-func (c *MockClient_GetChildTeams_OngoingVerification) GetCapturedArguments() (logging.SimpleLogging, models.Repo, string) {
-	logger, repo, teamSlug := c.GetAllCapturedArguments()
-	return logger[len(logger)-1], repo[len(repo)-1], teamSlug[len(teamSlug)-1]
-}
-
-func (c *MockClient_GetChildTeams_OngoingVerification) GetAllCapturedArguments() (_param0 []logging.SimpleLogging, _param1 []models.Repo, _param2 []string) {
-	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
-	if len(_params) > 0 {
-		if len(_params) > 0 {
-			_param0 = make([]logging.SimpleLogging, len(c.methodInvocations))
-			for u, param := range _params[0] {
-				_param0[u] = param.(logging.SimpleLogging)
-			}
-		}
-		if len(_params) > 1 {
-			_param1 = make([]models.Repo, len(c.methodInvocations))
-			for u, param := range _params[1] {
-				_param1[u] = param.(models.Repo)
-			}
-		}
-		if len(_params) > 2 {
-			_param2 = make([]string, len(c.methodInvocations))
-			for u, param := range _params[2] {
-				_param2[u] = param.(string)
 			}
 		}
 	}

--- a/server/events/working_dir_locker.go
+++ b/server/events/working_dir_locker.go
@@ -25,6 +25,8 @@ type WorkingDirLocker interface {
 	// an error if the workspace is already locked. The error is expected to
 	// be printed to the pull request.
 	TryLock(repoFullName string, pullNum int, workspace string, path string, projectName string, cmdName command.Name) (func(), error)
+	// HasCommandLock reports whether this pull request has an active lock for cmdName.
+	HasCommandLock(repoFullName string, pullNum int, cmdName command.Name) bool
 	// UnlockByPull unlocks all workspaces for a specific pull request
 	UnlockByPull(repoFullName string, pullNum int)
 }
@@ -56,6 +58,19 @@ func (d *DefaultWorkingDirLocker) TryLock(repoFullName string, pullNum int, work
 	return func() {
 		d.unlock(repoFullName, pullNum, workspace, path, projectName)
 	}, nil
+}
+
+func (d *DefaultWorkingDirLocker) HasCommandLock(repoFullName string, pullNum int, cmdName command.Name) bool {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	prefix := fmt.Sprintf("%s/%d/", repoFullName, pullNum)
+	for key, currentLock := range d.locks {
+		if strings.HasPrefix(key, prefix) && currentLock == cmdName {
+			return true
+		}
+	}
+	return false
 }
 
 // UnlockByPull unlocks all workspaces for a specific pull request

--- a/server/events/working_dir_locker.go
+++ b/server/events/working_dir_locker.go
@@ -20,6 +20,9 @@ import (
 // on disk and we haven't written Atlantis (yet) to handle concurrent execution
 // within this workspace.
 type WorkingDirLocker interface {
+	// TryLockPull tries to acquire a pull-level lock for a command. It is used to
+	// coordinate commands that can make pull-wide plan state inconsistent.
+	TryLockPull(repoFullName string, pullNum int, cmdName command.Name) (func(), error)
 	// TryLock tries to acquire a lock for this repo, pull, workspace, and path.
 	// It returns a function that should be used to unlock the workspace and
 	// an error if the workspace is already locked. The error is expected to
@@ -60,17 +63,41 @@ func (d *DefaultWorkingDirLocker) TryLock(repoFullName string, pullNum int, work
 	}, nil
 }
 
+func (d *DefaultWorkingDirLocker) TryLockPull(repoFullName string, pullNum int, cmdName command.Name) (func(), error) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	pullKey := d.pullKey(repoFullName, pullNum)
+	if currentLock, exists := d.locks[pullKey]; exists {
+		return func() {}, fmt.Errorf("cannot run %q: pull request %d is currently locked by %q.\n"+
+			"Wait until the previous command is complete and try again", cmdName, pullNum, currentLock)
+	}
+	if currentLock, exists := d.findCommandLock(repoFullName, pullNum, command.Plan); exists {
+		return func() {}, fmt.Errorf("cannot run %q: pull request %d is currently locked by %q.\n"+
+			"Wait until the previous command is complete and try again", cmdName, pullNum, currentLock)
+	}
+	d.locks[pullKey] = cmdName
+	return func() {
+		d.unlockPull(repoFullName, pullNum)
+	}, nil
+}
+
 func (d *DefaultWorkingDirLocker) HasCommandLock(repoFullName string, pullNum int, cmdName command.Name) bool {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
+	_, exists := d.findCommandLock(repoFullName, pullNum, cmdName)
+	return exists
+}
+
+func (d *DefaultWorkingDirLocker) findCommandLock(repoFullName string, pullNum int, cmdName command.Name) (command.Name, bool) {
 	prefix := fmt.Sprintf("%s/%d/", repoFullName, pullNum)
 	for key, currentLock := range d.locks {
 		if strings.HasPrefix(key, prefix) && currentLock == cmdName {
-			return true
+			return currentLock, true
 		}
 	}
-	return false
+	return cmdName, false
 }
 
 // UnlockByPull unlocks all workspaces for a specific pull request
@@ -96,6 +123,17 @@ func (d *DefaultWorkingDirLocker) unlock(repoFullName string, pullNum int, works
 	delete(d.locks, workspaceKey)
 }
 
+func (d *DefaultWorkingDirLocker) unlockPull(repoFullName string, pullNum int) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	delete(d.locks, d.pullKey(repoFullName, pullNum))
+}
+
 func (d *DefaultWorkingDirLocker) workspaceKey(repo string, pull int, workspace string, path string, projectName string) string {
 	return strings.TrimRight(fmt.Sprintf("%s/%d/%s/%s/%s", repo, pull, workspace, path, projectName), "/")
+}
+
+func (d *DefaultWorkingDirLocker) pullKey(repo string, pull int) string {
+	return fmt.Sprintf("%s/%d/.pull", repo, pull)
 }

--- a/server/events/working_dir_locker.go
+++ b/server/events/working_dir_locker.go
@@ -91,7 +91,7 @@ func (d *DefaultWorkingDirLocker) HasCommandLock(repoFullName string, pullNum in
 }
 
 func (d *DefaultWorkingDirLocker) findCommandLock(repoFullName string, pullNum int, cmdName command.Name) (command.Name, bool) {
-	prefix := fmt.Sprintf("%s/%d/", repoFullName, pullNum)
+	prefix := d.pullLockPrefix(repoFullName, pullNum)
 	for key, currentLock := range d.locks {
 		if strings.HasPrefix(key, prefix) && currentLock == cmdName {
 			return currentLock, true
@@ -106,7 +106,7 @@ func (d *DefaultWorkingDirLocker) UnlockByPull(repoFullName string, pullNum int)
 	defer d.mutex.Unlock()
 
 	// Find and remove all locks for this pull request
-	prefix := fmt.Sprintf("%s/%d/", repoFullName, pullNum)
+	prefix := d.pullLockPrefix(repoFullName, pullNum)
 	for key := range d.locks {
 		if strings.HasPrefix(key, prefix) {
 			delete(d.locks, key)
@@ -131,9 +131,13 @@ func (d *DefaultWorkingDirLocker) unlockPull(repoFullName string, pullNum int) {
 }
 
 func (d *DefaultWorkingDirLocker) workspaceKey(repo string, pull int, workspace string, path string, projectName string) string {
-	return strings.TrimRight(fmt.Sprintf("%s/%d/%s/%s/%s", repo, pull, workspace, path, projectName), "/")
+	return strings.TrimRight(fmt.Sprintf("%s%s/%s/%s", d.pullLockPrefix(repo, pull), workspace, path, projectName), "/")
 }
 
 func (d *DefaultWorkingDirLocker) pullKey(repo string, pull int) string {
-	return fmt.Sprintf("%s/%d/.pull", repo, pull)
+	return d.pullLockPrefix(repo, pull) + ".pull"
+}
+
+func (d *DefaultWorkingDirLocker) pullLockPrefix(repo string, pull int) string {
+	return fmt.Sprintf("%d:%s/%d/", len(repo), repo, pull)
 }

--- a/server/events/working_dir_locker_test.go
+++ b/server/events/working_dir_locker_test.go
@@ -215,3 +215,55 @@ func TestUnlockDifferentProjectNames(t *testing.T) {
 	_, err = locker.TryLock(repo, 1, workspace, path, newProjectName, cmd)
 	Ok(t, err)
 }
+
+func TestWorkingDirLocker_HasCommandLockDoesNotCrossMatchSlashNestedRepoNames(t *testing.T) {
+	locker := events.NewDefaultWorkingDirLocker()
+
+	unlock, err := locker.TryLockPull("group/repo/1", 2, command.Plan)
+	Ok(t, err)
+	defer unlock()
+
+	Assert(t, locker.HasCommandLock("group/repo/1", 2, command.Plan), "expected exact nested repo lock")
+	Assert(t, !locker.HasCommandLock("group/repo", 1, command.Plan), "did not expect parent repo/pull prefix to match nested repo lock")
+}
+
+func TestWorkingDirLocker_TryLockPullDoesNotCrossMatchSlashNestedRepoNames(t *testing.T) {
+	locker := events.NewDefaultWorkingDirLocker()
+
+	unlock, err := locker.TryLockPull("group/repo/1", 2, command.Plan)
+	Ok(t, err)
+	defer unlock()
+
+	unlockParent, err := locker.TryLockPull("group/repo", 1, command.Apply)
+	Ok(t, err)
+	defer unlockParent()
+}
+
+func TestWorkingDirLocker_PullLockExactRepoAndPullIsolation(t *testing.T) {
+	locker := events.NewDefaultWorkingDirLocker()
+
+	unlock, err := locker.TryLockPull("group/repo/12", 3, command.Plan)
+	Ok(t, err)
+	defer unlock()
+
+	Assert(t, locker.HasCommandLock("group/repo/12", 3, command.Plan), "expected exact repo/pull lock")
+	Assert(t, !locker.HasCommandLock("group/repo", 12, command.Plan), "did not expect pull prefix to match nested repo path")
+	unlockOther, err := locker.TryLockPull("group/repo", 12, command.Apply)
+	Ok(t, err)
+	defer unlockOther()
+}
+
+func TestWorkingDirLocker_ProjectLocksStillUseExactWorkspaceDirProjectIdentity(t *testing.T) {
+	locker := events.NewDefaultWorkingDirLocker()
+
+	unlock, err := locker.TryLock("group/repo/1", 2, "default", "dir", "proj", command.Plan)
+	Ok(t, err)
+	defer unlock()
+
+	Assert(t, locker.HasCommandLock("group/repo/1", 2, command.Plan), "expected exact project lock to count as command lock")
+	Assert(t, !locker.HasCommandLock("group/repo", 1, command.Plan), "did not expect nested repo project lock to match parent repo/pull")
+	_, err = locker.TryLock("group/repo/1", 2, "default", "dir", "proj", command.Apply)
+	ErrContains(t, "currently locked", err)
+	_, err = locker.TryLock("group/repo/1", 2, "default", "dir", "other", command.Apply)
+	Ok(t, err)
+}

--- a/server/jobs/job_url_setter.go
+++ b/server/jobs/job_url_setter.go
@@ -45,5 +45,8 @@ func (j *JobURLSetter) SetJobURLWithStatus(ctx command.ProjectContext, cmdName c
 	if err != nil {
 		return err
 	}
+	if cmdName == command.Apply && result != nil && result.ApplySuccessURL != "" {
+		url = result.ApplySuccessURL
+	}
 	return j.projectStatusUpdater.UpdateProject(ctx, cmdName, status, url, result)
 }

--- a/server/jobs/job_url_setter_test.go
+++ b/server/jobs/job_url_setter_test.go
@@ -35,6 +35,23 @@ func TestJobURLSetter(t *testing.T) {
 		projectStatusUpdater.VerifyWasCalledOnce().UpdateProject(ctx, command.Plan, models.PendingCommitStatus, "url-to-project-jobs", result)
 	})
 
+	t.Run("update deferred remote apply status with remote run url", func(t *testing.T) {
+		RegisterMockTestingT(t)
+		projectStatusUpdater := mocks.NewMockProjectStatusUpdater()
+		projectJobURLGenerator := mocks.NewMockProjectJobURLGenerator()
+		jobURLSetter := jobs.NewJobURLSetter(projectJobURLGenerator, projectStatusUpdater)
+		result := &command.ProjectCommandOutput{
+			ApplySuccess:    "apply complete",
+			ApplySuccessURL: "https://app.terraform.io/app/org/workspace/runs/run-123",
+		}
+
+		When(projectJobURLGenerator.GenerateProjectJobURL(Eq[command.ProjectContext](ctx))).ThenReturn("url-to-project-jobs", nil)
+		err := jobURLSetter.SetJobURLWithStatus(ctx, command.Apply, models.SuccessCommitStatus, result)
+		Ok(t, err)
+
+		projectStatusUpdater.VerifyWasCalledOnce().UpdateProject(ctx, command.Apply, models.SuccessCommitStatus, result.ApplySuccessURL, result)
+	})
+
 	t.Run("update project status with project jobs url error", func(t *testing.T) {
 		RegisterMockTestingT(t)
 		projectStatusUpdater := mocks.NewMockProjectStatusUpdater()

--- a/server/server.go
+++ b/server/server.go
@@ -881,6 +881,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 
 	importCommandRunner := events.NewImportCommandRunner(
 		pullUpdater,
+		dbUpdater,
 		pullReqStatusFetcher,
 		projectCommandBuilder,
 		instrumentedProjectCmdRunner,
@@ -889,6 +890,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 
 	stateCommandRunner := events.NewStateCommandRunner(
 		pullUpdater,
+		dbUpdater,
 		projectCommandBuilder,
 		instrumentedProjectCmdRunner,
 	)

--- a/server/server.go
+++ b/server/server.go
@@ -772,6 +772,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		WorkingDirLocker:          workingDirLocker,
 		CommandRequirementHandler: applyRequirementHandler,
 		CancellationTracker:       cancellationTracker,
+		ApplyPlanValidator:        &events.DefaultApplyPlanValidator{PullStatusFetcher: database},
 	}
 
 	dbUpdater := &events.DBUpdater{
@@ -817,6 +818,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		vcsClient,
 		pendingPlanFinder,
 		workingDir,
+		workingDirLocker,
 		commitStatusUpdater,
 		projectCommandBuilder,
 		instrumentedProjectCmdRunner,

--- a/server/server.go
+++ b/server/server.go
@@ -626,6 +626,15 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		AzureDevopsUser:    userConfig.AzureDevopsUser,
 		AzureDevopsToken:   userConfig.AzureDevopsToken,
 	}
+	livePullHeadFetcher := &events.DefaultLivePullHeadFetcher{
+		EventParser:               eventParser,
+		GithubPullGetter:          githubClient,
+		GitlabMergeRequestGetter:  gitlabClient,
+		AzureDevopsPullGetter:     azuredevopsClient,
+		GiteaPullGetter:           giteaClient,
+		BitbucketCloudPullGetter:  bitbucketCloudClient,
+		BitbucketServerPullGetter: bitbucketServerClient,
+	}
 	commentParser := events.NewCommentParser(
 		userConfig.GithubUser,
 		userConfig.GitlabUser,
@@ -772,7 +781,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		WorkingDirLocker:          workingDirLocker,
 		CommandRequirementHandler: applyRequirementHandler,
 		CancellationTracker:       cancellationTracker,
-		ApplyPlanValidator:        &events.DefaultApplyPlanValidator{PullStatusFetcher: database},
+		ApplyPlanValidator:        &events.DefaultApplyPlanValidator{PullStatusFetcher: database, LivePullHeadFetcher: livePullHeadFetcher},
 	}
 
 	dbUpdater := &events.DBUpdater{
@@ -851,6 +860,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		userConfig.ParallelPoolSize,
 		userConfig.SilenceNoProjects,
 		userConfig.SilenceVCSStatusNoProjects,
+		workingDirLocker,
 		pullReqStatusFetcher,
 		userConfig.DisableAutomergeLabel,
 	)

--- a/server/server.go
+++ b/server/server.go
@@ -1036,6 +1036,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		WorkingDirLocker:                workingDirLocker,
 		CommitStatusUpdater:             commitStatusUpdater,
 		PullReqStatusFetcher:            pullReqStatusFetcher,
+		LivePullHeadFetcher:             livePullHeadFetcher,
 		SilenceVCSStatusNoProjects:      userConfig.SilenceVCSStatusNoProjects,
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -862,6 +862,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		userConfig.SilenceVCSStatusNoProjects,
 		workingDirLocker,
 		pullReqStatusFetcher,
+		livePullHeadFetcher,
 		userConfig.DisableAutomergeLabel,
 	)
 


### PR DESCRIPTION
## Summary

Fixes #6529.

This hardens Atlantis-managed apply paths so stale, missing, partial, mutated, or non-current head/base/ref plan state cannot be applied, reported as current success, written as current applied state, or used for automerge.

## Fix

Adds current plan-state validation and cleanup hardening across generic, targeted, API/in-process, and Atlantis-managed apply paths:

- generic and targeted apply acquire the pull-level apply lock before refreshing PullStatus, refreshing live PR identity, building commands, capturing plan hashes, and executing apply
- live PR identity includes both head commit and base branch where supported
- generic builder validation uses refreshed live/current head and base instead of a stale command-start snapshot
- apply eligibility now requires recorded PullStatus head/base to be present when current live head/base are known
- generic apply rejects legacy empty-head/base PullStatus rows for both discovered-plan and no-plan paths
- no-plan legacy empty-identity rows cannot publish successful 0/0 apply status or automerge
- silenced no-project apply status publication also requires a current recorded PullStatus identity
- synthetic non-PR API/drift no-project apply validates mutable refs before publishing 0/0 success
- targeted apply preserves command-start head/ref so old commands cannot silently apply a newer head/base plan
- apply freshness compares base branch when both stored and current base values are known
- project apply checks mutable non-PR API refs before apply execution, immediately before the built-in apply step, and after apply
- ambiguous branch-like API refs such as `release`, `stable`, and tag-like branch names are revalidated against `refs/heads/<ref>`
- annotated API tag refs are peeled to commits before freshness comparison
- project apply rechecks live head/base immediately after the built-in apply step succeeds, before success output/webhooks are treated as current
- post-apply command-level freshness rechecks live head/base before DB writes, commit status success, and automerge
- stale apply result/errors are checked before any successful apply status/count publication
- remote/TFC apply success status is deferred until final apply freshness validation passes, while preserving the Terraform Cloud/Enterprise run URL for the final success status
- remote/TFC apply failures can still publish failure status with the remote run URL when available
- same-head PR retargets reject old-base plan state until a fresh replan records the new base
- BoltDB and Redis replace legacy empty-base PullStatus rows with fresh non-empty-base plan state instead of promoting unreplanned old-base projects
- stale apply results cannot overwrite newer PullStatus, including same-head/different-base and missing-dir failures
- stale apply errors suppress automerge and success status updates
- ignored targeted dirs remain no-op before pull/apply locks and project locks, including local/merged config ignore detection
- API PR requests without `base_branch` seed base branch from live PR metadata before clone/merge checkout, not from the request head ref
- API PR branch refs resolve to the checked-out commit SHA before seeded in-memory PullStatus validation
- API setup refreshes PR status after resolving checked-out head/base
- API/in-process apply prefers seeded PullStatus only for API paths; comment applies still require DB-backed PullStatus
- seeded API PullStatus records fresh policy-check execution errors as `ErroredPolicyCheckStatus`
- plan hashes are captured under the apply lock and rechecked immediately before each Atlantis-managed apply step
- plan paths are constrained to the project directory before hash/open/delete operations
- same-PR plan-in-flight state blocks generic and targeted apply
- no-project plan/autoplan deletes stale plan files, releases only exact stale plan locks for deleted plans, avoids broad `UnlockByPull`, and writes current empty PullStatus
- import/state rm writes `DiscardedPlanStatus` only for exact projects already present in current PullStatus
- `ErroredPolicyCheckStatus` remains accepted at builder validation so existing per-project apply-requirement handling is preserved when present during command build

## Custom Workflow Boundary

Atlantis enforces plan identity immediately before its built-in `apply` step. User-authored `run` steps that manually invoke Terraform/OpenTofu apply against `PLANFILE` are outside Atlantis-managed apply-step validation; those workflows should use the built-in apply step to get this protection.

## Backward Compatibility

- no-change plans are preserved
- targeted apply participates in the same pull-level plan/apply lock as generic apply
- ignored targeted dirs preserve existing no-op behavior
- API apply and drift remediation preserve their in-process plan-then-apply flow
- no-project apply after a recorded current empty PullStatus still no-ops safely when no plan is in flight
- no DB schema or plan filename format changes

## Validation

Passed locally:

- `go test ./server/events/ -run "RemoteApply|ProjectOutputWrapper|FinalFreshness|SuccessStatus|ApplyCommandRunner|NoProject|ZeroZero|ValidateNonPRAPIRef" -count=1`
- `go test ./server/controllers -run "APIApply|DriftApply|NoProject|MutableRef|Ambiguous|Release|Stable|ImmutableSHA" -count=1`
- `go test ./server/core/runtime -run "RemoteApply|RunURL|TFC" -count=1`
- `go test ./server/jobs -run "JobURLSetter" -count=1`
- `golangci-lint run ./server/events/...`
- `golangci-lint run ./server/controllers/... ./server/core/runtime ./server/jobs`
- `go vet ./server/events/...`
- `make check-fmt`
- `make go-generate`
- `go test ./server/events/...`
- `go test ./server/controllers`
- `go test ./server/core/runtime`
- `go test ./server/jobs`
- `go test ./server/core/boltdb ./server/core/redis`
- `go test ./server ./server/controllers/events -run "^$"`

Local `make test-coverage` and `make test-all` were not claimed as passing here because this machine is missing `conftest`; CI runs the full environment-backed suite.
