### PR TITLE
fix: preserve on_apply locks during plan cleanup

### DIFF
--- a/server/core/boltdb/boltdb.go
+++ b/server/core/boltdb/boltdb.go
@@ -202,6 +202,38 @@ func (b *BoltDB) Unlock(p models.Project, workspace string) (*models.ProjectLock
 	return nil, err
 }
 
+// UnlockIfOwnedByPull deletes a lock only if it is still owned by pullNum.
+func (b *BoltDB) UnlockIfOwnedByPull(p models.Project, workspace string, pullNum int) (*models.ProjectLock, error) {
+	var lock models.ProjectLock
+	foundLock := false
+	key := b.lockKey(p, workspace)
+	err := b.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(b.locksBucketName)
+		serialized := bucket.Get([]byte(key))
+		if serialized == nil {
+			return nil
+		}
+		if err := json.Unmarshal(serialized, &lock); err != nil {
+			return fmt.Errorf("failed to deserialize lock: %w", err)
+		}
+		if lock.Pull.Num != pullNum {
+			return nil
+		}
+		if err := bucket.Delete([]byte(key)); err != nil {
+			return err
+		}
+		foundLock = true
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("DB transaction failed: %w", err)
+	}
+	if foundLock {
+		return &lock, nil
+	}
+	return nil, nil
+}
+
 // List lists all current locks.
 func (b *BoltDB) List() ([]models.ProjectLock, error) {
 	var locks []models.ProjectLock

--- a/server/core/boltdb/boltdb_test.go
+++ b/server/core/boltdb/boltdb_test.go
@@ -449,6 +449,55 @@ func TestUnlockingMultiple(t *testing.T) {
 	Equals(t, 0, len(ls))
 }
 
+func TestUnlockIfOwnedByPullMissingLock(t *testing.T) {
+	t.Log("UnlockIfOwnedByPull should ignore missing locks")
+	db, b := newTestDB()
+	defer cleanupDB(db)
+
+	deleted, err := b.UnlockIfOwnedByPull(project, workspace, pullNum)
+	Ok(t, err)
+	Equals(t, (*models.ProjectLock)(nil), deleted)
+}
+
+func TestUnlockIfOwnedByPullOtherPull(t *testing.T) {
+	t.Log("UnlockIfOwnedByPull should not delete another pull's lock")
+	db, b := newTestDB()
+	defer cleanupDB(db)
+
+	_, _, err := b.TryLock(lock)
+	Ok(t, err)
+
+	deleted, err := b.UnlockIfOwnedByPull(project, workspace, pullNum+1)
+	Ok(t, err)
+	Equals(t, (*models.ProjectLock)(nil), deleted)
+
+	existing, err := b.GetLock(project, workspace)
+	Ok(t, err)
+	Assert(t, existing != nil, "expected lock to remain")
+	Equals(t, pullNum, existing.Pull.Num)
+}
+
+func TestUnlockIfOwnedByPullCurrentPull(t *testing.T) {
+	t.Log("UnlockIfOwnedByPull should delete the current pull's lock")
+	db, b := newTestDB()
+	defer cleanupDB(db)
+
+	_, _, err := b.TryLock(lock)
+	Ok(t, err)
+
+	deleted, err := b.UnlockIfOwnedByPull(project, workspace, pullNum)
+	Ok(t, err)
+	Assert(t, deleted != nil, "expected deleted lock")
+	Equals(t, lock.Project, deleted.Project)
+	Equals(t, lock.Workspace, deleted.Workspace)
+	Equals(t, lock.Pull, deleted.Pull)
+	Equals(t, lock.User, deleted.User)
+
+	existing, err := b.GetLock(project, workspace)
+	Ok(t, err)
+	Equals(t, (*models.ProjectLock)(nil), existing)
+}
+
 func TestUnlockByPullNone(t *testing.T) {
 	t.Log("UnlockByPull should be successful when there are no locks")
 	db, b := newTestDB()

--- a/server/core/db/db.go
+++ b/server/core/db/db.go
@@ -18,6 +18,7 @@ import (
 type Database interface {
 	TryLock(lock models.ProjectLock) (bool, models.ProjectLock, error)
 	Unlock(project models.Project, workspace string) (*models.ProjectLock, error)
+	UnlockIfOwnedByPull(project models.Project, workspace string, pullNum int) (*models.ProjectLock, error)
 	List() ([]models.ProjectLock, error)
 	GetLock(project models.Project, workspace string) (*models.ProjectLock, error)
 	UnlockByPull(repoFullName string, pullNum int) ([]models.ProjectLock, error)

--- a/server/core/db/mocks/mock_database.go
+++ b/server/core/db/mocks/mock_database.go
@@ -219,6 +219,21 @@ func (mr *MockDatabaseMockRecorder) UnlockCommand(cmdName any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlockCommand", reflect.TypeOf((*MockDatabase)(nil).UnlockCommand), cmdName)
 }
 
+// UnlockIfOwnedByPull mocks base method.
+func (m *MockDatabase) UnlockIfOwnedByPull(project models.Project, workspace string, pullNum int) (*models.ProjectLock, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnlockIfOwnedByPull", project, workspace, pullNum)
+	ret0, _ := ret[0].(*models.ProjectLock)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UnlockIfOwnedByPull indicates an expected call of UnlockIfOwnedByPull.
+func (mr *MockDatabaseMockRecorder) UnlockIfOwnedByPull(project, workspace, pullNum any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlockIfOwnedByPull", reflect.TypeOf((*MockDatabase)(nil).UnlockIfOwnedByPull), project, workspace, pullNum)
+}
+
 // UpdateProjectStatus mocks base method.
 func (m *MockDatabase) UpdateProjectStatus(pull models.PullRequest, workspace, repoRelDir string, newStatus models.ProjectPlanStatus) error {
 	m.ctrl.T.Helper()

--- a/server/core/locking/locking.go
+++ b/server/core/locking/locking.go
@@ -34,7 +34,7 @@ type Client struct {
 type Locker interface {
 	TryLock(p models.Project, workspace string, pull models.PullRequest, user models.User) (TryLockResponse, error)
 	Unlock(key string) (*models.ProjectLock, error)
-	UnlockIfOwnedByPull(key string, repoFullName string, pullNum int) (*models.ProjectLock, error)
+	UnlockIfOwnedByPull(project models.Project, workspace string, pullNum int) (*models.ProjectLock, error)
 	List() (map[string]models.ProjectLock, error)
 	UnlockByPull(repoFullName string, pullNum int) ([]models.ProjectLock, error)
 	GetLock(key string) (*models.ProjectLock, error)
@@ -78,15 +78,8 @@ func (c *Client) Unlock(key string) (*models.ProjectLock, error) {
 	return c.database.Unlock(project, workspace)
 }
 
-// UnlockIfOwnedByPull unlocks key only when it belongs to repoFullName and is still owned by pullNum.
-func (c *Client) UnlockIfOwnedByPull(key string, repoFullName string, pullNum int) (*models.ProjectLock, error) {
-	project, workspace, err := c.lockKeyToProjectWorkspace(key)
-	if err != nil {
-		return nil, err
-	}
-	if project.RepoFullName != repoFullName {
-		return nil, nil
-	}
+// UnlockIfOwnedByPull unlocks project and workspace only when it is still owned by pullNum.
+func (c *Client) UnlockIfOwnedByPull(project models.Project, workspace string, pullNum int) (*models.ProjectLock, error) {
 	return c.database.UnlockIfOwnedByPull(project, workspace, pullNum)
 }
 
@@ -168,7 +161,7 @@ func (c *NoOpLocker) Unlock(_ string) (*models.ProjectLock, error) {
 }
 
 // UnlockIfOwnedByPull is a no-op for commands that do not use repository locks.
-func (c *NoOpLocker) UnlockIfOwnedByPull(_ string, _ string, _ int) (*models.ProjectLock, error) {
+func (c *NoOpLocker) UnlockIfOwnedByPull(_ models.Project, _ string, _ int) (*models.ProjectLock, error) {
 	return nil, nil
 }
 

--- a/server/core/locking/locking.go
+++ b/server/core/locking/locking.go
@@ -34,6 +34,7 @@ type Client struct {
 type Locker interface {
 	TryLock(p models.Project, workspace string, pull models.PullRequest, user models.User) (TryLockResponse, error)
 	Unlock(key string) (*models.ProjectLock, error)
+	UnlockIfOwnedByPull(key string, repoFullName string, pullNum int) (*models.ProjectLock, error)
 	List() (map[string]models.ProjectLock, error)
 	UnlockByPull(repoFullName string, pullNum int) ([]models.ProjectLock, error)
 	GetLock(key string) (*models.ProjectLock, error)
@@ -75,6 +76,18 @@ func (c *Client) Unlock(key string) (*models.ProjectLock, error) {
 		return nil, err
 	}
 	return c.database.Unlock(project, workspace)
+}
+
+// UnlockIfOwnedByPull unlocks key only when it belongs to repoFullName and is still owned by pullNum.
+func (c *Client) UnlockIfOwnedByPull(key string, repoFullName string, pullNum int) (*models.ProjectLock, error) {
+	project, workspace, err := c.lockKeyToProjectWorkspace(key)
+	if err != nil {
+		return nil, err
+	}
+	if project.RepoFullName != repoFullName {
+		return nil, nil
+	}
+	return c.database.UnlockIfOwnedByPull(project, workspace, pullNum)
 }
 
 // List returns a map of all locks with their lock key as the map key.
@@ -152,6 +165,11 @@ func (c *NoOpLocker) TryLock(p models.Project, workspace string, _ models.PullRe
 // an error deleting the lock (i.e. not if there was no lock).
 func (c *NoOpLocker) Unlock(_ string) (*models.ProjectLock, error) {
 	return &models.ProjectLock{}, nil
+}
+
+// UnlockIfOwnedByPull is a no-op for commands that do not use repository locks.
+func (c *NoOpLocker) UnlockIfOwnedByPull(_ string, _ string, _ int) (*models.ProjectLock, error) {
+	return nil, nil
 }
 
 // List returns a map of all locks with their lock key as the map key.

--- a/server/core/locking/locking_test.go
+++ b/server/core/locking/locking_test.go
@@ -77,6 +77,48 @@ func TestUnlock(t *testing.T) {
 	Equals(t, &pl, lock)
 }
 
+func TestUnlockIfOwnedByPull_InvalidKey(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	database := mocks.NewMockDatabase(ctrl)
+	l := locking.NewClient(database)
+
+	_, err := l.UnlockIfOwnedByPull("invalidkey", "owner/repo", 1)
+	Assert(t, err != nil, "expected err")
+	Assert(t, strings.Contains(err.Error(), "invalid key format"), "expected err")
+}
+
+func TestUnlockIfOwnedByPull_RepoMismatch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	database := mocks.NewMockDatabase(ctrl)
+	l := locking.NewClient(database)
+
+	lock, err := l.UnlockIfOwnedByPull("owner/repo/path/workspace/projectName", "other/repo", 1)
+	Ok(t, err)
+	var expected *models.ProjectLock
+	Equals(t, expected, lock)
+}
+
+func TestUnlockIfOwnedByPull_Err(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	database := mocks.NewMockDatabase(ctrl)
+	database.EXPECT().UnlockIfOwnedByPull(project, workspace, 1).Return(nil, errExpected)
+	l := locking.NewClient(database)
+
+	_, err := l.UnlockIfOwnedByPull("owner/repo/path/workspace/projectName", "owner/repo", 1)
+	Equals(t, errExpected, err)
+}
+
+func TestUnlockIfOwnedByPull(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	database := mocks.NewMockDatabase(ctrl)
+	database.EXPECT().UnlockIfOwnedByPull(project, workspace, 1).Return(&pl, nil)
+	l := locking.NewClient(database)
+
+	lock, err := l.UnlockIfOwnedByPull("owner/repo/path/workspace/projectName", "owner/repo", 1)
+	Ok(t, err)
+	Equals(t, &pl, lock)
+}
+
 func TestList_Err(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	database := mocks.NewMockDatabase(ctrl)
@@ -161,6 +203,14 @@ func TestUnlockByPull_NoOpLocker(t *testing.T) {
 	l := locking.NewNoOpLocker()
 	_, err := l.UnlockByPull("owner/repo", 1)
 	Ok(t, err)
+}
+
+func TestUnlockIfOwnedByPull_NoOpLocker(t *testing.T) {
+	l := locking.NewNoOpLocker()
+	lock, err := l.UnlockIfOwnedByPull("owner/repo/path/workspace/projectName", "owner/repo", 1)
+	Ok(t, err)
+	var expected *models.ProjectLock
+	Equals(t, expected, lock)
 }
 
 func TestGetLock_NoOpLocker(t *testing.T) {

--- a/server/core/locking/locking_test.go
+++ b/server/core/locking/locking_test.go
@@ -77,34 +77,13 @@ func TestUnlock(t *testing.T) {
 	Equals(t, &pl, lock)
 }
 
-func TestUnlockIfOwnedByPull_InvalidKey(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	database := mocks.NewMockDatabase(ctrl)
-	l := locking.NewClient(database)
-
-	_, err := l.UnlockIfOwnedByPull("invalidkey", "owner/repo", 1)
-	Assert(t, err != nil, "expected err")
-	Assert(t, strings.Contains(err.Error(), "invalid key format"), "expected err")
-}
-
-func TestUnlockIfOwnedByPull_RepoMismatch(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	database := mocks.NewMockDatabase(ctrl)
-	l := locking.NewClient(database)
-
-	lock, err := l.UnlockIfOwnedByPull("owner/repo/path/workspace/projectName", "other/repo", 1)
-	Ok(t, err)
-	var expected *models.ProjectLock
-	Equals(t, expected, lock)
-}
-
 func TestUnlockIfOwnedByPull_Err(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	database := mocks.NewMockDatabase(ctrl)
 	database.EXPECT().UnlockIfOwnedByPull(project, workspace, 1).Return(nil, errExpected)
 	l := locking.NewClient(database)
 
-	_, err := l.UnlockIfOwnedByPull("owner/repo/path/workspace/projectName", "owner/repo", 1)
+	_, err := l.UnlockIfOwnedByPull(project, workspace, 1)
 	Equals(t, errExpected, err)
 }
 
@@ -114,9 +93,22 @@ func TestUnlockIfOwnedByPull(t *testing.T) {
 	database.EXPECT().UnlockIfOwnedByPull(project, workspace, 1).Return(&pl, nil)
 	l := locking.NewClient(database)
 
-	lock, err := l.UnlockIfOwnedByPull("owner/repo/path/workspace/projectName", "owner/repo", 1)
+	lock, err := l.UnlockIfOwnedByPull(project, workspace, 1)
 	Ok(t, err)
 	Equals(t, &pl, lock)
+}
+
+func TestUnlockIfOwnedByPull_SlashfulRepo(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	database := mocks.NewMockDatabase(ctrl)
+	slashfulProject := models.NewProject("group/subgroup/repo", "terraform", "prod")
+	slashfulLock := models.ProjectLock{Project: slashfulProject, Workspace: "default"}
+	database.EXPECT().UnlockIfOwnedByPull(slashfulProject, "default", 1).Return(&slashfulLock, nil)
+	l := locking.NewClient(database)
+
+	lock, err := l.UnlockIfOwnedByPull(slashfulProject, "default", 1)
+	Ok(t, err)
+	Equals(t, &slashfulLock, lock)
 }
 
 func TestList_Err(t *testing.T) {
@@ -207,7 +199,7 @@ func TestUnlockByPull_NoOpLocker(t *testing.T) {
 
 func TestUnlockIfOwnedByPull_NoOpLocker(t *testing.T) {
 	l := locking.NewNoOpLocker()
-	lock, err := l.UnlockIfOwnedByPull("owner/repo/path/workspace/projectName", "owner/repo", 1)
+	lock, err := l.UnlockIfOwnedByPull(project, workspace, 1)
 	Ok(t, err)
 	var expected *models.ProjectLock
 	Equals(t, expected, lock)

--- a/server/core/locking/mocks/mock_locker.go
+++ b/server/core/locking/mocks/mock_locker.go
@@ -117,16 +117,16 @@ func (mr *MockLockerMockRecorder) UnlockByPull(repoFullName, pullNum any) *gomoc
 }
 
 // UnlockIfOwnedByPull mocks base method.
-func (m *MockLocker) UnlockIfOwnedByPull(key, repoFullName string, pullNum int) (*models.ProjectLock, error) {
+func (m *MockLocker) UnlockIfOwnedByPull(project models.Project, workspace string, pullNum int) (*models.ProjectLock, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnlockIfOwnedByPull", key, repoFullName, pullNum)
+	ret := m.ctrl.Call(m, "UnlockIfOwnedByPull", project, workspace, pullNum)
 	ret0, _ := ret[0].(*models.ProjectLock)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UnlockIfOwnedByPull indicates an expected call of UnlockIfOwnedByPull.
-func (mr *MockLockerMockRecorder) UnlockIfOwnedByPull(key, repoFullName, pullNum any) *gomock.Call {
+func (mr *MockLockerMockRecorder) UnlockIfOwnedByPull(project, workspace, pullNum any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlockIfOwnedByPull", reflect.TypeOf((*MockLocker)(nil).UnlockIfOwnedByPull), key, repoFullName, pullNum)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlockIfOwnedByPull", reflect.TypeOf((*MockLocker)(nil).UnlockIfOwnedByPull), project, workspace, pullNum)
 }

--- a/server/core/locking/mocks/mock_locker.go
+++ b/server/core/locking/mocks/mock_locker.go
@@ -115,3 +115,18 @@ func (mr *MockLockerMockRecorder) UnlockByPull(repoFullName, pullNum any) *gomoc
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlockByPull", reflect.TypeOf((*MockLocker)(nil).UnlockByPull), repoFullName, pullNum)
 }
+
+// UnlockIfOwnedByPull mocks base method.
+func (m *MockLocker) UnlockIfOwnedByPull(key, repoFullName string, pullNum int) (*models.ProjectLock, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnlockIfOwnedByPull", key, repoFullName, pullNum)
+	ret0, _ := ret[0].(*models.ProjectLock)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UnlockIfOwnedByPull indicates an expected call of UnlockIfOwnedByPull.
+func (mr *MockLockerMockRecorder) UnlockIfOwnedByPull(key, repoFullName, pullNum any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlockIfOwnedByPull", reflect.TypeOf((*MockLocker)(nil).UnlockIfOwnedByPull), key, repoFullName, pullNum)
+}

--- a/server/core/redis/redis.go
+++ b/server/core/redis/redis.go
@@ -31,6 +31,24 @@ const (
 	pullKeySeparator = "::"
 )
 
+const unlockIfOwnedByPullScript = "" +
+	"local value = redis.call(\"GET\", KEYS[1])\n" +
+	"if not value then\n" +
+	"  return nil\n" +
+	"end\n" +
+	"\n" +
+	"local ok, lock = pcall(cjson.decode, value)\n" +
+	"if not ok then\n" +
+	"  return redis.error_reply(\"failed to deserialize current lock\")\n" +
+	"end\n" +
+	"\n" +
+	"if not lock[\"Pull\"] or tonumber(lock[\"Pull\"][\"Num\"]) ~= tonumber(ARGV[1]) then\n" +
+	"  return nil\n" +
+	"end\n" +
+	"\n" +
+	"redis.call(\"DEL\", KEYS[1])\n" +
+	"return value\n"
+
 // Config holds configuration for Redis connections.
 type Config struct {
 	Hostname           string
@@ -225,6 +243,31 @@ func (r *RedisDB) Unlock(project models.Project, workspace string) (*models.Proj
 		return nil, fmt.Errorf("failed to deserialize current lock: %w", err)
 	}
 	r.client.Del(ctx, key)
+	return &lock, nil
+}
+
+// UnlockIfOwnedByPull deletes a lock only if it is still owned by pullNum.
+func (r *RedisDB) UnlockIfOwnedByPull(project models.Project, workspace string, pullNum int) (*models.ProjectLock, error) {
+	key := r.lockKey(project, workspace)
+	val, err := r.client.Eval(ctx, unlockIfOwnedByPullScript, []string{key}, pullNum).Result()
+	if err == redis.Nil {
+		return nil, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("db transaction failed: %w", err)
+	}
+	if val == nil {
+		return nil, nil
+	}
+
+	serializedLock, ok := val.(string)
+	if !ok {
+		return nil, fmt.Errorf("unexpected unlock script result type %T", val)
+	}
+
+	var lock models.ProjectLock
+	if err := json.Unmarshal([]byte(serializedLock), &lock); err != nil {
+		return nil, fmt.Errorf("failed to deserialize current lock: %w", err)
+	}
 	return &lock, nil
 }
 

--- a/server/core/redis/redis_test.go
+++ b/server/core/redis/redis_test.go
@@ -502,6 +502,55 @@ func TestUnlockingMultiple(t *testing.T) {
 	Equals(t, 0, len(ls))
 }
 
+func TestUnlockIfOwnedByPullMissingLock(t *testing.T) {
+	t.Log("UnlockIfOwnedByPull should ignore missing locks")
+	s := miniredis.RunT(t)
+	rdb := newTestRedis(s)
+
+	deleted, err := rdb.UnlockIfOwnedByPull(project, workspace, pullNum)
+	Ok(t, err)
+	Equals(t, (*models.ProjectLock)(nil), deleted)
+}
+
+func TestUnlockIfOwnedByPullOtherPull(t *testing.T) {
+	t.Log("UnlockIfOwnedByPull should not delete another pull's lock")
+	s := miniredis.RunT(t)
+	rdb := newTestRedis(s)
+
+	_, _, err := rdb.TryLock(lock)
+	Ok(t, err)
+
+	deleted, err := rdb.UnlockIfOwnedByPull(project, workspace, pullNum+1)
+	Ok(t, err)
+	Equals(t, (*models.ProjectLock)(nil), deleted)
+
+	existing, err := rdb.GetLock(project, workspace)
+	Ok(t, err)
+	Assert(t, existing != nil, "expected lock to remain")
+	Equals(t, pullNum, existing.Pull.Num)
+}
+
+func TestUnlockIfOwnedByPullCurrentPull(t *testing.T) {
+	t.Log("UnlockIfOwnedByPull should delete the current pull's lock")
+	s := miniredis.RunT(t)
+	rdb := newTestRedis(s)
+
+	_, _, err := rdb.TryLock(lock)
+	Ok(t, err)
+
+	deleted, err := rdb.UnlockIfOwnedByPull(project, workspace, pullNum)
+	Ok(t, err)
+	Assert(t, deleted != nil, "expected deleted lock")
+	Equals(t, lock.Project, deleted.Project)
+	Equals(t, lock.Workspace, deleted.Workspace)
+	Equals(t, lock.Pull, deleted.Pull)
+	Equals(t, lock.User, deleted.User)
+
+	existing, err := rdb.GetLock(project, workspace)
+	Ok(t, err)
+	Equals(t, (*models.ProjectLock)(nil), existing)
+}
+
 func TestUnlockByPullNone(t *testing.T) {
 	t.Log("UnlockByPull should be successful when there are no locks")
 	s := miniredis.RunT(t)

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -140,8 +140,8 @@ func setup(t *testing.T, options ...func(testConfig *TestConfig)) *vcsmocks.Mock
 	// Allow incidental calls to CheckApplyLock (called internally during apply operations).
 	// Tests that need specific return values should set applyLockCheckerReturn/applyLockCheckerErr in TestConfig.
 	applyLockChecker.EXPECT().CheckApplyLock().Return(testConfig.applyLockCheckerReturn, testConfig.applyLockCheckerErr).AnyTimes()
-	// Allow incidental calls to UnlockByPull (called during plan operations to clean up locks)
-	lockingLocker.EXPECT().UnlockByPull(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	// Plan cleanup checks selected on_plan locks before deciding whether to unlock them.
+	lockingLocker.EXPECT().GetLock(gomock.Any()).Return(nil, nil).AnyTimes()
 
 	dbUpdater = &events.DBUpdater{
 		Database: testConfig.database,

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -140,8 +140,8 @@ func setup(t *testing.T, options ...func(testConfig *TestConfig)) *vcsmocks.Mock
 	// Allow incidental calls to CheckApplyLock (called internally during apply operations).
 	// Tests that need specific return values should set applyLockCheckerReturn/applyLockCheckerErr in TestConfig.
 	applyLockChecker.EXPECT().CheckApplyLock().Return(testConfig.applyLockCheckerReturn, testConfig.applyLockCheckerErr).AnyTimes()
-	// Plan cleanup checks selected on_plan locks before deciding whether to unlock them.
-	lockingLocker.EXPECT().GetLock(gomock.Any()).Return(nil, nil).AnyTimes()
+	// Plan cleanup only deletes selected on_plan locks through owner-scoped cleanup.
+	lockingLocker.EXPECT().UnlockIfOwnedByPull(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
 	dbUpdater = &events.DBUpdater{
 		Database: testConfig.database,

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -406,27 +406,12 @@ func (p *PlanCommandRunner) deletePlansAndPlanLocks(ctx *command.Context, projec
 }
 
 func (p *PlanCommandRunner) deletePlanLocks(ctx *command.Context, projectCmds []command.ProjectContext) {
-	var onPlanProjectCmds []command.ProjectContext
+	unlocked := make(map[string]bool)
 	for _, projCtx := range projectCmds {
-		if projCtx.RepoLocksMode == valid.RepoLocksOnPlanMode {
-			onPlanProjectCmds = append(onPlanProjectCmds, projCtx)
+		if projCtx.RepoLocksMode != valid.RepoLocksOnPlanMode {
+			continue
 		}
-	}
 
-	if len(onPlanProjectCmds) == 0 {
-		return
-	}
-
-	if len(onPlanProjectCmds) == len(projectCmds) {
-		_, err := p.lockingLocker.UnlockByPull(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num)
-		if err != nil {
-			ctx.Log.Err("deleting locks: %s", err)
-		}
-		return
-	}
-
-	unlocked := make(map[string]bool, len(onPlanProjectCmds))
-	for _, projCtx := range onPlanProjectCmds {
 		lockKey := GenerateLockID(projCtx)
 		if unlocked[lockKey] {
 			continue

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -422,21 +422,8 @@ func (p *PlanCommandRunner) deletePlanLocks(ctx *command.Context, projectCmds []
 }
 
 func (p *PlanCommandRunner) unlockPlanLockIfOwnedByPull(ctx *command.Context, lockKey string) {
-	lock, err := p.lockingLocker.GetLock(lockKey)
-	if err != nil {
-		ctx.Log.Err("getting lock %q: %s", lockKey, err)
-		return
-	}
-	if lock == nil {
-		return
-	}
-	if lock.Pull.Num != ctx.Pull.Num {
-		ctx.Log.Debug("not deleting lock %q because it is owned by pull %d, not pull %d", lockKey, lock.Pull.Num, ctx.Pull.Num)
-		return
-	}
-
-	if _, err := p.lockingLocker.Unlock(lockKey); err != nil {
-		ctx.Log.Err("deleting lock %q: %s", lockKey, err)
+	if _, err := p.lockingLocker.UnlockIfOwnedByPull(lockKey, ctx.Pull.BaseRepo.FullName, ctx.Pull.Num); err != nil {
+		ctx.Log.Err("deleting lock %q for pull %d: %s", lockKey, ctx.Pull.Num, err)
 	}
 }
 

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -417,12 +417,14 @@ func (p *PlanCommandRunner) deletePlanLocks(ctx *command.Context, projectCmds []
 			continue
 		}
 		unlocked[lockKey] = true
-		p.unlockPlanLockIfOwnedByPull(ctx, lockKey)
+
+		project := models.NewProject(projCtx.BaseRepo.FullName, projCtx.RepoRelDir, projCtx.ProjectName)
+		p.unlockPlanLockIfOwnedByPull(ctx, project, projCtx.Workspace, lockKey)
 	}
 }
 
-func (p *PlanCommandRunner) unlockPlanLockIfOwnedByPull(ctx *command.Context, lockKey string) {
-	if _, err := p.lockingLocker.UnlockIfOwnedByPull(lockKey, ctx.Pull.BaseRepo.FullName, ctx.Pull.Num); err != nil {
+func (p *PlanCommandRunner) unlockPlanLockIfOwnedByPull(ctx *command.Context, project models.Project, workspace string, lockKey string) {
+	if _, err := p.lockingLocker.UnlockIfOwnedByPull(project, workspace, ctx.Pull.Num); err != nil {
 		ctx.Log.Err("deleting lock %q for pull %d: %s", lockKey, ctx.Pull.Num, err)
 	}
 }

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -417,9 +417,26 @@ func (p *PlanCommandRunner) deletePlanLocks(ctx *command.Context, projectCmds []
 			continue
 		}
 		unlocked[lockKey] = true
-		if _, err := p.lockingLocker.Unlock(lockKey); err != nil {
-			ctx.Log.Err("deleting lock %q: %s", lockKey, err)
-		}
+		p.unlockPlanLockIfOwnedByPull(ctx, lockKey)
+	}
+}
+
+func (p *PlanCommandRunner) unlockPlanLockIfOwnedByPull(ctx *command.Context, lockKey string) {
+	lock, err := p.lockingLocker.GetLock(lockKey)
+	if err != nil {
+		ctx.Log.Err("getting lock %q: %s", lockKey, err)
+		return
+	}
+	if lock == nil {
+		return
+	}
+	if lock.Pull.Num != ctx.Pull.Num {
+		ctx.Log.Debug("not deleting lock %q because it is owned by pull %d, not pull %d", lockKey, lock.Pull.Num, ctx.Pull.Num)
+		return
+	}
+
+	if _, err := p.lockingLocker.Unlock(lockKey); err != nil {
+		ctx.Log.Err("deleting lock %q: %s", lockKey, err)
 	}
 }
 

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -4,6 +4,7 @@
 package events
 
 import (
+	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/core/locking"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
@@ -14,7 +15,7 @@ import (
 // This ensures the same format is used for both locking and unlocking operations.
 func GenerateLockID(projCtx command.ProjectContext) string {
 	// Use models.NewProject to ensure consistent path cleaning
-	project := models.NewProject(projCtx.BaseRepo.FullName, projCtx.RepoRelDir, "")
+	project := models.NewProject(projCtx.BaseRepo.FullName, projCtx.RepoRelDir, projCtx.ProjectName)
 	return models.GenerateLockKey(project, projCtx.Workspace)
 }
 
@@ -148,21 +149,13 @@ func (p *PlanCommandRunner) runAutoplan(ctx *command.Context) {
 
 	// discard previous plans that might not be relevant anymore
 	ctx.Log.Debug("deleting previous plans and locks")
-	p.deletePlans(ctx)
-	_, err = p.lockingLocker.UnlockByPull(baseRepo.FullName, pull.Num)
-	if err != nil {
-		ctx.Log.Err("deleting locks: %s", err)
-	}
+	p.deletePlansAndPlanLocks(ctx, projectCmds)
 
 	result := runProjectCmdsWithCancellationTracker(ctx, projectCmds, p.cancellationTracker, p.parallelPoolSize, p.isParallelEnabled(projectCmds), p.prjCmdRunner.Plan)
 
 	if p.autoMerger.automergeEnabled(projectCmds) && result.HasErrors() {
 		ctx.Log.Info("deleting plans because there were errors and automerge requires all plans succeed")
-		p.deletePlans(ctx)
-		_, err := p.lockingLocker.UnlockByPull(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num)
-		if err != nil {
-			ctx.Log.Err("deleting locks: %s", err)
-		}
+		p.deletePlansAndPlanLocks(ctx, projectCmds)
 		result.PlansDeleted = true
 	}
 
@@ -276,11 +269,7 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 	// discard previous plans that might not be relevant anymore
 	if !cmd.IsForSpecificProject() {
 		ctx.Log.Debug("deleting previous plans and locks")
-		p.deletePlans(ctx)
-		_, err := p.lockingLocker.UnlockByPull(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num)
-		if err != nil {
-			ctx.Log.Err("deleting locks: %s", err)
-		}
+		p.deletePlansAndPlanLocks(ctx, projectCmds)
 	}
 
 	result := runProjectCmdsWithCancellationTracker(ctx, projectCmds, p.cancellationTracker, p.parallelPoolSize, p.isParallelEnabled(projectCmds), p.prjCmdRunner.Plan)
@@ -288,11 +277,7 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 
 	if p.autoMerger.automergeEnabled(projectCmds) && result.HasErrors() {
 		ctx.Log.Info("deleting plans because there were errors and automerge requires all plans succeed")
-		p.deletePlans(ctx)
-		_, err := p.lockingLocker.UnlockByPull(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num)
-		if err != nil {
-			ctx.Log.Err("deleting locks: %s", err)
-		}
+		p.deletePlansAndPlanLocks(ctx, projectCmds)
 		result.PlansDeleted = true
 	}
 
@@ -412,6 +397,44 @@ func (p *PlanCommandRunner) deletePlans(ctx *command.Context) {
 	}
 	if err := p.pendingPlanFinder.DeletePlans(pullDir); err != nil {
 		ctx.Log.Err("deleting pending plans: %s", err)
+	}
+}
+
+func (p *PlanCommandRunner) deletePlansAndPlanLocks(ctx *command.Context, projectCmds []command.ProjectContext) {
+	p.deletePlans(ctx)
+	p.deletePlanLocks(ctx, projectCmds)
+}
+
+func (p *PlanCommandRunner) deletePlanLocks(ctx *command.Context, projectCmds []command.ProjectContext) {
+	var onPlanProjectCmds []command.ProjectContext
+	for _, projCtx := range projectCmds {
+		if projCtx.RepoLocksMode == valid.RepoLocksOnPlanMode {
+			onPlanProjectCmds = append(onPlanProjectCmds, projCtx)
+		}
+	}
+
+	if len(onPlanProjectCmds) == 0 {
+		return
+	}
+
+	if len(onPlanProjectCmds) == len(projectCmds) {
+		_, err := p.lockingLocker.UnlockByPull(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num)
+		if err != nil {
+			ctx.Log.Err("deleting locks: %s", err)
+		}
+		return
+	}
+
+	unlocked := make(map[string]bool, len(onPlanProjectCmds))
+	for _, projCtx := range onPlanProjectCmds {
+		lockKey := GenerateLockID(projCtx)
+		if unlocked[lockKey] {
+			continue
+		}
+		unlocked[lockKey] = true
+		if _, err := p.lockingLocker.Unlock(lockKey); err != nil {
+			ctx.Log.Err("deleting lock %q: %s", lockKey, err)
+		}
 	}
 }
 

--- a/server/events/plan_command_runner_internal_test.go
+++ b/server/events/plan_command_runner_internal_test.go
@@ -27,62 +27,110 @@ func TestPlanCommandRunner_DeletePlansAndPlanLocksByRepoLockMode(t *testing.T) {
 	}
 	onApplyProject := command.ProjectContext{
 		BaseRepo:      repo,
-		RepoRelDir:    "terraform",
-		ProjectName:   "prod",
+		RepoRelDir:    "terraform/apply",
+		ProjectName:   "apply-prod",
 		Workspace:     "default",
 		RepoLocksMode: valid.RepoLocksOnApplyMode,
 	}
 	disabledProject := command.ProjectContext{
 		BaseRepo:      repo,
-		RepoRelDir:    "terraform",
-		ProjectName:   "prod",
+		RepoRelDir:    "terraform/disabled",
+		ProjectName:   "disabled-prod",
 		Workspace:     "default",
 		RepoLocksMode: valid.RepoLocksDisabledMode,
 	}
+	secondOnPlanProject := command.ProjectContext{
+		BaseRepo:      repo,
+		RepoRelDir:    "terraform",
+		ProjectName:   "stage",
+		Workspace:     "staging",
+		RepoLocksMode: valid.RepoLocksOnPlanMode,
+	}
+	onPlanKey := keyForProject(onPlanProject)
+	onApplyKey := keyForProject(onApplyProject)
+	disabledKey := keyForProject(disabledProject)
+	secondOnPlanKey := keyForProject(secondOnPlanProject)
 
 	tests := []struct {
-		name               string
-		projectCmds        []command.ProjectContext
-		expectedUnlockKeys []string
+		name                string
+		projectCmds         []command.ProjectContext
+		locksByKey          map[string]models.ProjectLock
+		expectedGetLockKeys []string
+		expectedUnlockKeys  []string
 	}{
 		{
 			name: "empty selection deletes plans without deleting locks",
 		},
 		{
-			name:        "on_apply deletes plans without deleting pull locks",
+			name:        "on_apply deletes plans without deleting locks",
 			projectCmds: []command.ProjectContext{onApplyProject},
+			locksByKey: map[string]models.ProjectLock{
+				onApplyKey: lockForPull(repo, pull.Num),
+			},
 		},
 		{
-			name:        "disabled deletes plans without deleting pull locks",
+			name:        "disabled deletes plans without deleting locks",
 			projectCmds: []command.ProjectContext{disabledProject},
+			locksByKey: map[string]models.ProjectLock{
+				disabledKey: lockForPull(repo, pull.Num),
+			},
 		},
 		{
-			name:        "all selected on_plan unlocks selected keys only",
+			name:        "selected on_plan lock owned by current pull is unlocked",
 			projectCmds: []command.ProjectContext{onPlanProject},
-			expectedUnlockKeys: []string{
-				"owner/repo/terraform/default/prod",
+			locksByKey: map[string]models.ProjectLock{
+				onPlanKey: lockForPull(repo, pull.Num),
 			},
+			expectedGetLockKeys: []string{onPlanKey},
+			expectedUnlockKeys:  []string{onPlanKey},
 		},
 		{
-			name:        "mixed mode unlocks only on_plan project",
-			projectCmds: []command.ProjectContext{onPlanProject, onApplyProject},
-			expectedUnlockKeys: []string{
-				"owner/repo/terraform/default/prod",
+			name:                "selected on_plan lock owned by another pull is not unlocked",
+			projectCmds:         []command.ProjectContext{onPlanProject},
+			locksByKey:          map[string]models.ProjectLock{onPlanKey: lockForPull(repo, 2)},
+			expectedGetLockKeys: []string{onPlanKey},
+		},
+		{
+			name:                "selected on_plan lock missing is ignored",
+			projectCmds:         []command.ProjectContext{onPlanProject},
+			expectedGetLockKeys: []string{onPlanKey},
+		},
+		{
+			name:        "mixed mode unlocks only current-pull selected on_plan project",
+			projectCmds: []command.ProjectContext{onPlanProject, onApplyProject, disabledProject},
+			locksByKey: map[string]models.ProjectLock{
+				onPlanKey:   lockForPull(repo, pull.Num),
+				onApplyKey:  lockForPull(repo, pull.Num),
+				disabledKey: lockForPull(repo, pull.Num),
 			},
+			expectedGetLockKeys: []string{onPlanKey},
+			expectedUnlockKeys:  []string{onPlanKey},
+		},
+		{
+			name:        "multiple selected on_plan keys are unlocked",
+			projectCmds: []command.ProjectContext{onPlanProject, secondOnPlanProject},
+			locksByKey: map[string]models.ProjectLock{
+				onPlanKey:       lockForPull(repo, pull.Num),
+				secondOnPlanKey: lockForPull(repo, pull.Num),
+			},
+			expectedGetLockKeys: []string{onPlanKey, secondOnPlanKey},
+			expectedUnlockKeys:  []string{onPlanKey, secondOnPlanKey},
 		},
 		{
 			name:        "duplicate selected on_plan lock key unlocks once",
 			projectCmds: []command.ProjectContext{onPlanProject, onPlanProject},
-			expectedUnlockKeys: []string{
-				"owner/repo/terraform/default/prod",
+			locksByKey: map[string]models.ProjectLock{
+				onPlanKey: lockForPull(repo, pull.Num),
 			},
+			expectedGetLockKeys: []string{onPlanKey},
+			expectedUnlockKeys:  []string{onPlanKey},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			finder := &recordingPendingPlanFinder{}
-			locker := &recordingPlanCleanupLocker{}
+			locker := &recordingPlanCleanupLocker{locksByKey: tt.locksByKey}
 			runner := &PlanCommandRunner{
 				workingDir:        &planCleanupWorkingDir{pullDir: pullDir},
 				pendingPlanFinder: finder,
@@ -100,6 +148,9 @@ func TestPlanCommandRunner_DeletePlansAndPlanLocksByRepoLockMode(t *testing.T) {
 			}
 			if len(locker.unlockByPullCalls) != 0 {
 				t.Fatalf("expected no UnlockByPull calls, got %#v", locker.unlockByPullCalls)
+			}
+			if !equalStringSlices(locker.getLockKeys, tt.expectedGetLockKeys) {
+				t.Fatalf("expected GetLock keys %#v, got %#v", tt.expectedGetLockKeys, locker.getLockKeys)
 			}
 			if !equalStringSlices(locker.unlockKeys, tt.expectedUnlockKeys) {
 				t.Fatalf("expected Unlock keys %#v, got %#v", tt.expectedUnlockKeys, locker.unlockKeys)
@@ -125,12 +176,24 @@ type unlockByPullCall struct {
 
 type recordingPlanCleanupLocker struct {
 	locking.Locker
+	locksByKey        map[string]models.ProjectLock
+	getLockKeys       []string
 	unlockKeys        []string
 	unlockByPullCalls []unlockByPullCall
 }
 
+func (r *recordingPlanCleanupLocker) GetLock(key string) (*models.ProjectLock, error) {
+	r.getLockKeys = append(r.getLockKeys, key)
+	lock, ok := r.locksByKey[key]
+	if !ok {
+		return nil, nil
+	}
+	return &lock, nil
+}
+
 func (r *recordingPlanCleanupLocker) Unlock(key string) (*models.ProjectLock, error) {
 	r.unlockKeys = append(r.unlockKeys, key)
+	delete(r.locksByKey, key)
 	return nil, nil
 }
 
@@ -146,6 +209,19 @@ type planCleanupWorkingDir struct {
 
 func (p *planCleanupWorkingDir) GetPullDir(models.Repo, models.PullRequest) (string, error) {
 	return p.pullDir, nil
+}
+
+func keyForProject(project command.ProjectContext) string {
+	return GenerateLockID(project)
+}
+
+func lockForPull(repo models.Repo, pullNum int) models.ProjectLock {
+	return models.ProjectLock{
+		Pull: models.PullRequest{
+			BaseRepo: repo,
+			Num:      pullNum,
+		},
+	}
 }
 
 func equalStringSlices(a, b []string) bool {

--- a/server/events/plan_command_runner_internal_test.go
+++ b/server/events/plan_command_runner_internal_test.go
@@ -1,0 +1,162 @@
+// Copyright 2025 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package events
+
+import (
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/core/locking"
+	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/logging"
+)
+
+func TestPlanCommandRunner_DeletePlansAndPlanLocksByRepoLockMode(t *testing.T) {
+	repo := models.Repo{FullName: "owner/repo"}
+	pull := models.PullRequest{BaseRepo: repo, Num: 1}
+	pullDir := "/tmp/pull-dir"
+
+	onPlanProject := command.ProjectContext{
+		BaseRepo:      repo,
+		RepoRelDir:    "terraform",
+		ProjectName:   "prod",
+		Workspace:     "default",
+		RepoLocksMode: valid.RepoLocksOnPlanMode,
+	}
+	onApplyProject := command.ProjectContext{
+		BaseRepo:      repo,
+		RepoRelDir:    "terraform",
+		ProjectName:   "prod",
+		Workspace:     "default",
+		RepoLocksMode: valid.RepoLocksOnApplyMode,
+	}
+	disabledProject := command.ProjectContext{
+		BaseRepo:      repo,
+		RepoRelDir:    "terraform",
+		ProjectName:   "prod",
+		Workspace:     "default",
+		RepoLocksMode: valid.RepoLocksDisabledMode,
+	}
+
+	tests := []struct {
+		name                     string
+		projectCmds              []command.ProjectContext
+		expectUnlockByPull       bool
+		expectedUnlockByPullRepo string
+		expectedUnlockByPullNum  int
+		expectedUnlockKeys       []string
+	}{
+		{
+			name:        "on_apply deletes plans without deleting pull locks",
+			projectCmds: []command.ProjectContext{onApplyProject},
+		},
+		{
+			name:        "disabled deletes plans without deleting pull locks",
+			projectCmds: []command.ProjectContext{disabledProject},
+		},
+		{
+			name:                     "on_plan keeps pull-wide cleanup",
+			projectCmds:              []command.ProjectContext{onPlanProject},
+			expectUnlockByPull:       true,
+			expectedUnlockByPullRepo: repo.FullName,
+			expectedUnlockByPullNum:  pull.Num,
+		},
+		{
+			name:        "mixed mode unlocks only on_plan project",
+			projectCmds: []command.ProjectContext{onPlanProject, onApplyProject},
+			expectedUnlockKeys: []string{
+				"owner/repo/terraform/default/prod",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			finder := &recordingPendingPlanFinder{}
+			locker := &recordingPlanCleanupLocker{}
+			runner := &PlanCommandRunner{
+				workingDir:        &planCleanupWorkingDir{pullDir: pullDir},
+				pendingPlanFinder: finder,
+				lockingLocker:     locker,
+			}
+			ctx := &command.Context{
+				Log:  logging.NewNoopLogger(t),
+				Pull: pull,
+			}
+
+			runner.deletePlansAndPlanLocks(ctx, tt.projectCmds)
+
+			if len(finder.deletedPullDirs) != 1 || finder.deletedPullDirs[0] != pullDir {
+				t.Fatalf("expected DeletePlans(%q), got %#v", pullDir, finder.deletedPullDirs)
+			}
+			if tt.expectUnlockByPull {
+				if len(locker.unlockByPullCalls) != 1 {
+					t.Fatalf("expected one UnlockByPull call, got %#v", locker.unlockByPullCalls)
+				}
+				call := locker.unlockByPullCalls[0]
+				if call.repoFullName != tt.expectedUnlockByPullRepo || call.pullNum != tt.expectedUnlockByPullNum {
+					t.Fatalf("expected UnlockByPull(%q, %d), got UnlockByPull(%q, %d)", tt.expectedUnlockByPullRepo, tt.expectedUnlockByPullNum, call.repoFullName, call.pullNum)
+				}
+			} else if len(locker.unlockByPullCalls) != 0 {
+				t.Fatalf("expected no UnlockByPull calls, got %#v", locker.unlockByPullCalls)
+			}
+			if !equalStringSlices(locker.unlockKeys, tt.expectedUnlockKeys) {
+				t.Fatalf("expected Unlock keys %#v, got %#v", tt.expectedUnlockKeys, locker.unlockKeys)
+			}
+		})
+	}
+}
+
+type recordingPendingPlanFinder struct {
+	PendingPlanFinder
+	deletedPullDirs []string
+}
+
+func (r *recordingPendingPlanFinder) DeletePlans(pullDir string) error {
+	r.deletedPullDirs = append(r.deletedPullDirs, pullDir)
+	return nil
+}
+
+type unlockByPullCall struct {
+	repoFullName string
+	pullNum      int
+}
+
+type recordingPlanCleanupLocker struct {
+	locking.Locker
+	unlockKeys        []string
+	unlockByPullCalls []unlockByPullCall
+}
+
+func (r *recordingPlanCleanupLocker) Unlock(key string) (*models.ProjectLock, error) {
+	r.unlockKeys = append(r.unlockKeys, key)
+	return nil, nil
+}
+
+func (r *recordingPlanCleanupLocker) UnlockByPull(repoFullName string, pullNum int) ([]models.ProjectLock, error) {
+	r.unlockByPullCalls = append(r.unlockByPullCalls, unlockByPullCall{repoFullName: repoFullName, pullNum: pullNum})
+	return nil, nil
+}
+
+type planCleanupWorkingDir struct {
+	WorkingDir
+	pullDir string
+}
+
+func (p *planCleanupWorkingDir) GetPullDir(models.Repo, models.PullRequest) (string, error) {
+	return p.pullDir, nil
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/server/events/plan_command_runner_internal_test.go
+++ b/server/events/plan_command_runner_internal_test.go
@@ -53,18 +53,29 @@ func TestPlanCommandRunner_DeletePlansAndPlanLocksByRepoLockMode(t *testing.T) {
 		Workspace:     "default",
 		RepoLocksMode: valid.RepoLocksOnPlanMode,
 	}
+	slashfulRepo := models.Repo{FullName: "group/subgroup/repo"}
+	slashfulPull := models.PullRequest{BaseRepo: slashfulRepo, Num: pull.Num}
+	slashfulOnPlanProject := command.ProjectContext{
+		BaseRepo:      slashfulRepo,
+		RepoRelDir:    "terraform",
+		ProjectName:   "prod",
+		Workspace:     "default",
+		RepoLocksMode: valid.RepoLocksOnPlanMode,
+	}
 	onPlanKey := "owner/repo/terraform/default/prod"
 	onApplyKey := keyForProject(onApplyProject)
 	disabledKey := keyForProject(disabledProject)
 	secondOnPlanKey := keyForProject(secondOnPlanProject)
 	sameWorkspaceOnPlanKey := "owner/repo/terraform/default/stage"
+	slashfulOnPlanKey := "group/subgroup/repo/terraform/default/prod"
 
 	tests := []struct {
-		name                            string
-		projectCmds                     []command.ProjectContext
-		locksByKey                      map[string]models.ProjectLock
-		expectedUnlockIfOwnedByPullKeys []string
-		expectedDeletedKeys             []string
+		name                             string
+		ctxPull                          models.PullRequest
+		projectCmds                      []command.ProjectContext
+		locksByKey                       map[string]models.ProjectLock
+		expectedUnlockIfOwnedByPullCalls []unlockIfOwnedByPullCall
+		expectedDeletedKeys              []string
 	}{
 		{
 			name: "empty selection deletes plans without deleting locks",
@@ -89,19 +100,19 @@ func TestPlanCommandRunner_DeletePlansAndPlanLocksByRepoLockMode(t *testing.T) {
 			locksByKey: map[string]models.ProjectLock{
 				onPlanKey: lockForPull(repo, pull.Num),
 			},
-			expectedUnlockIfOwnedByPullKeys: []string{onPlanKey},
-			expectedDeletedKeys:             []string{onPlanKey},
+			expectedUnlockIfOwnedByPullCalls: []unlockIfOwnedByPullCall{expectedUnlockCall(onPlanProject, pull.Num)},
+			expectedDeletedKeys:              []string{onPlanKey},
 		},
 		{
-			name:                            "selected on_plan lock owned by another pull is not unlocked",
-			projectCmds:                     []command.ProjectContext{onPlanProject},
-			locksByKey:                      map[string]models.ProjectLock{onPlanKey: lockForPull(repo, 2)},
-			expectedUnlockIfOwnedByPullKeys: []string{onPlanKey},
+			name:                             "selected on_plan lock owned by another pull is not unlocked",
+			projectCmds:                      []command.ProjectContext{onPlanProject},
+			locksByKey:                       map[string]models.ProjectLock{onPlanKey: lockForPull(repo, 2)},
+			expectedUnlockIfOwnedByPullCalls: []unlockIfOwnedByPullCall{expectedUnlockCall(onPlanProject, pull.Num)},
 		},
 		{
-			name:                            "selected on_plan lock missing is ignored",
-			projectCmds:                     []command.ProjectContext{onPlanProject},
-			expectedUnlockIfOwnedByPullKeys: []string{onPlanKey},
+			name:                             "selected on_plan lock missing is ignored",
+			projectCmds:                      []command.ProjectContext{onPlanProject},
+			expectedUnlockIfOwnedByPullCalls: []unlockIfOwnedByPullCall{expectedUnlockCall(onPlanProject, pull.Num)},
 		},
 		{
 			name:        "mixed mode unlocks only current-pull selected on_plan project",
@@ -111,8 +122,8 @@ func TestPlanCommandRunner_DeletePlansAndPlanLocksByRepoLockMode(t *testing.T) {
 				onApplyKey:  lockForPull(repo, pull.Num),
 				disabledKey: lockForPull(repo, pull.Num),
 			},
-			expectedUnlockIfOwnedByPullKeys: []string{onPlanKey},
-			expectedDeletedKeys:             []string{onPlanKey},
+			expectedUnlockIfOwnedByPullCalls: []unlockIfOwnedByPullCall{expectedUnlockCall(onPlanProject, pull.Num)},
+			expectedDeletedKeys:              []string{onPlanKey},
 		},
 		{
 			name:        "multiple selected on_plan keys are unlocked",
@@ -121,8 +132,11 @@ func TestPlanCommandRunner_DeletePlansAndPlanLocksByRepoLockMode(t *testing.T) {
 				onPlanKey:       lockForPull(repo, pull.Num),
 				secondOnPlanKey: lockForPull(repo, pull.Num),
 			},
-			expectedUnlockIfOwnedByPullKeys: []string{onPlanKey, secondOnPlanKey},
-			expectedDeletedKeys:             []string{onPlanKey, secondOnPlanKey},
+			expectedUnlockIfOwnedByPullCalls: []unlockIfOwnedByPullCall{
+				expectedUnlockCall(onPlanProject, pull.Num),
+				expectedUnlockCall(secondOnPlanProject, pull.Num),
+			},
+			expectedDeletedKeys: []string{onPlanKey, secondOnPlanKey},
 		},
 		{
 			name:        "duplicate selected on_plan lock key unlocks once",
@@ -130,8 +144,8 @@ func TestPlanCommandRunner_DeletePlansAndPlanLocksByRepoLockMode(t *testing.T) {
 			locksByKey: map[string]models.ProjectLock{
 				onPlanKey: lockForPull(repo, pull.Num),
 			},
-			expectedUnlockIfOwnedByPullKeys: []string{onPlanKey},
-			expectedDeletedKeys:             []string{onPlanKey},
+			expectedUnlockIfOwnedByPullCalls: []unlockIfOwnedByPullCall{expectedUnlockCall(onPlanProject, pull.Num)},
+			expectedDeletedKeys:              []string{onPlanKey},
 		},
 		{
 			name:        "same dir and workspace with different project names unlocks both keys",
@@ -140,19 +154,50 @@ func TestPlanCommandRunner_DeletePlansAndPlanLocksByRepoLockMode(t *testing.T) {
 				onPlanKey:              lockForPull(repo, pull.Num),
 				sameWorkspaceOnPlanKey: lockForPull(repo, pull.Num),
 			},
-			expectedUnlockIfOwnedByPullKeys: []string{
-				"owner/repo/terraform/default/prod",
-				"owner/repo/terraform/default/stage",
+			expectedUnlockIfOwnedByPullCalls: []unlockIfOwnedByPullCall{
+				{
+					key:       "owner/repo/terraform/default/prod",
+					project:   models.NewProject("owner/repo", "terraform", "prod"),
+					workspace: "default",
+					pullNum:   pull.Num,
+				},
+				{
+					key:       "owner/repo/terraform/default/stage",
+					project:   models.NewProject("owner/repo", "terraform", "stage"),
+					workspace: "default",
+					pullNum:   pull.Num,
+				},
 			},
 			expectedDeletedKeys: []string{
 				"owner/repo/terraform/default/prod",
 				"owner/repo/terraform/default/stage",
 			},
 		},
+		{
+			name:        "slashful repo name unlocks selected project without parsing lock key",
+			ctxPull:     slashfulPull,
+			projectCmds: []command.ProjectContext{slashfulOnPlanProject},
+			locksByKey: map[string]models.ProjectLock{
+				slashfulOnPlanKey: lockForPull(slashfulRepo, slashfulPull.Num),
+			},
+			expectedUnlockIfOwnedByPullCalls: []unlockIfOwnedByPullCall{
+				{
+					key:       "group/subgroup/repo/terraform/default/prod",
+					project:   models.NewProject("group/subgroup/repo", "terraform", "prod"),
+					workspace: "default",
+					pullNum:   slashfulPull.Num,
+				},
+			},
+			expectedDeletedKeys: []string{"group/subgroup/repo/terraform/default/prod"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctxPull := pull
+			if tt.ctxPull.Num != 0 || tt.ctxPull.BaseRepo.FullName != "" {
+				ctxPull = tt.ctxPull
+			}
 			finder := &recordingPendingPlanFinder{}
 			locker := &recordingPlanCleanupLocker{locksByKey: tt.locksByKey}
 			runner := &PlanCommandRunner{
@@ -162,7 +207,7 @@ func TestPlanCommandRunner_DeletePlansAndPlanLocksByRepoLockMode(t *testing.T) {
 			}
 			ctx := &command.Context{
 				Log:  logging.NewNoopLogger(t),
-				Pull: pull,
+				Pull: ctxPull,
 			}
 
 			runner.deletePlansAndPlanLocks(ctx, tt.projectCmds)
@@ -179,8 +224,8 @@ func TestPlanCommandRunner_DeletePlansAndPlanLocksByRepoLockMode(t *testing.T) {
 			if len(locker.unlockKeys) != 0 {
 				t.Fatalf("expected no Unlock calls, got %#v", locker.unlockKeys)
 			}
-			if !equalUnlockIfOwnedByPullCalls(locker.unlockIfOwnedByPullCalls, tt.expectedUnlockIfOwnedByPullKeys, repo.FullName, pull.Num) {
-				t.Fatalf("expected UnlockIfOwnedByPull keys %#v for repo %q pull %d, got %#v", tt.expectedUnlockIfOwnedByPullKeys, repo.FullName, pull.Num, locker.unlockIfOwnedByPullCalls)
+			if !equalUnlockIfOwnedByPullCalls(locker.unlockIfOwnedByPullCalls, tt.expectedUnlockIfOwnedByPullCalls) {
+				t.Fatalf("expected UnlockIfOwnedByPull calls %#v, got %#v", tt.expectedUnlockIfOwnedByPullCalls, locker.unlockIfOwnedByPullCalls)
 			}
 			if !equalStringSlices(locker.deletedKeys, tt.expectedDeletedKeys) {
 				t.Fatalf("expected deleted keys %#v, got %#v", tt.expectedDeletedKeys, locker.deletedKeys)
@@ -205,9 +250,10 @@ type unlockByPullCall struct {
 }
 
 type unlockIfOwnedByPullCall struct {
-	lockKey      string
-	repoFullName string
-	pullNum      int
+	key       string
+	project   models.Project
+	workspace string
+	pullNum   int
 }
 
 type recordingPlanCleanupLocker struct {
@@ -230,14 +276,15 @@ func (r *recordingPlanCleanupLocker) Unlock(key string) (*models.ProjectLock, er
 	return nil, nil
 }
 
-func (r *recordingPlanCleanupLocker) UnlockIfOwnedByPull(lockKey string, repoFullName string, pullNum int) (*models.ProjectLock, error) {
-	r.unlockIfOwnedByPullCalls = append(r.unlockIfOwnedByPullCalls, unlockIfOwnedByPullCall{lockKey: lockKey, repoFullName: repoFullName, pullNum: pullNum})
-	lock, ok := r.locksByKey[lockKey]
+func (r *recordingPlanCleanupLocker) UnlockIfOwnedByPull(project models.Project, workspace string, pullNum int) (*models.ProjectLock, error) {
+	key := models.GenerateLockKey(project, workspace)
+	r.unlockIfOwnedByPullCalls = append(r.unlockIfOwnedByPullCalls, unlockIfOwnedByPullCall{key: key, project: project, workspace: workspace, pullNum: pullNum})
+	lock, ok := r.locksByKey[key]
 	if !ok || lock.Pull.Num != pullNum {
 		return nil, nil
 	}
-	delete(r.locksByKey, lockKey)
-	r.deletedKeys = append(r.deletedKeys, lockKey)
+	delete(r.locksByKey, key)
+	r.deletedKeys = append(r.deletedKeys, key)
 	return &lock, nil
 }
 
@@ -268,6 +315,16 @@ func lockForPull(repo models.Repo, pullNum int) models.ProjectLock {
 	}
 }
 
+func expectedUnlockCall(project command.ProjectContext, pullNum int) unlockIfOwnedByPullCall {
+	modelProject := models.NewProject(project.BaseRepo.FullName, project.RepoRelDir, project.ProjectName)
+	return unlockIfOwnedByPullCall{
+		key:       models.GenerateLockKey(modelProject, project.Workspace),
+		project:   modelProject,
+		workspace: project.Workspace,
+		pullNum:   pullNum,
+	}
+}
+
 func equalStringSlices(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
@@ -280,12 +337,12 @@ func equalStringSlices(a, b []string) bool {
 	return true
 }
 
-func equalUnlockIfOwnedByPullCalls(calls []unlockIfOwnedByPullCall, keys []string, repoFullName string, pullNum int) bool {
-	if len(calls) != len(keys) {
+func equalUnlockIfOwnedByPullCalls(calls []unlockIfOwnedByPullCall, expected []unlockIfOwnedByPullCall) bool {
+	if len(calls) != len(expected) {
 		return false
 	}
 	for i := range calls {
-		if calls[i].lockKey != keys[i] || calls[i].repoFullName != repoFullName || calls[i].pullNum != pullNum {
+		if calls[i] != expected[i] {
 			return false
 		}
 	}

--- a/server/events/plan_command_runner_internal_test.go
+++ b/server/events/plan_command_runner_internal_test.go
@@ -41,13 +41,13 @@ func TestPlanCommandRunner_DeletePlansAndPlanLocksByRepoLockMode(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                     string
-		projectCmds              []command.ProjectContext
-		expectUnlockByPull       bool
-		expectedUnlockByPullRepo string
-		expectedUnlockByPullNum  int
-		expectedUnlockKeys       []string
+		name               string
+		projectCmds        []command.ProjectContext
+		expectedUnlockKeys []string
 	}{
+		{
+			name: "empty selection deletes plans without deleting locks",
+		},
 		{
 			name:        "on_apply deletes plans without deleting pull locks",
 			projectCmds: []command.ProjectContext{onApplyProject},
@@ -57,15 +57,22 @@ func TestPlanCommandRunner_DeletePlansAndPlanLocksByRepoLockMode(t *testing.T) {
 			projectCmds: []command.ProjectContext{disabledProject},
 		},
 		{
-			name:                     "on_plan keeps pull-wide cleanup",
-			projectCmds:              []command.ProjectContext{onPlanProject},
-			expectUnlockByPull:       true,
-			expectedUnlockByPullRepo: repo.FullName,
-			expectedUnlockByPullNum:  pull.Num,
+			name:        "all selected on_plan unlocks selected keys only",
+			projectCmds: []command.ProjectContext{onPlanProject},
+			expectedUnlockKeys: []string{
+				"owner/repo/terraform/default/prod",
+			},
 		},
 		{
 			name:        "mixed mode unlocks only on_plan project",
 			projectCmds: []command.ProjectContext{onPlanProject, onApplyProject},
+			expectedUnlockKeys: []string{
+				"owner/repo/terraform/default/prod",
+			},
+		},
+		{
+			name:        "duplicate selected on_plan lock key unlocks once",
+			projectCmds: []command.ProjectContext{onPlanProject, onPlanProject},
 			expectedUnlockKeys: []string{
 				"owner/repo/terraform/default/prod",
 			},
@@ -91,15 +98,7 @@ func TestPlanCommandRunner_DeletePlansAndPlanLocksByRepoLockMode(t *testing.T) {
 			if len(finder.deletedPullDirs) != 1 || finder.deletedPullDirs[0] != pullDir {
 				t.Fatalf("expected DeletePlans(%q), got %#v", pullDir, finder.deletedPullDirs)
 			}
-			if tt.expectUnlockByPull {
-				if len(locker.unlockByPullCalls) != 1 {
-					t.Fatalf("expected one UnlockByPull call, got %#v", locker.unlockByPullCalls)
-				}
-				call := locker.unlockByPullCalls[0]
-				if call.repoFullName != tt.expectedUnlockByPullRepo || call.pullNum != tt.expectedUnlockByPullNum {
-					t.Fatalf("expected UnlockByPull(%q, %d), got UnlockByPull(%q, %d)", tt.expectedUnlockByPullRepo, tt.expectedUnlockByPullNum, call.repoFullName, call.pullNum)
-				}
-			} else if len(locker.unlockByPullCalls) != 0 {
+			if len(locker.unlockByPullCalls) != 0 {
 				t.Fatalf("expected no UnlockByPull calls, got %#v", locker.unlockByPullCalls)
 			}
 			if !equalStringSlices(locker.unlockKeys, tt.expectedUnlockKeys) {

--- a/server/events/plan_command_runner_internal_test.go
+++ b/server/events/plan_command_runner_internal_test.go
@@ -46,17 +46,25 @@ func TestPlanCommandRunner_DeletePlansAndPlanLocksByRepoLockMode(t *testing.T) {
 		Workspace:     "staging",
 		RepoLocksMode: valid.RepoLocksOnPlanMode,
 	}
-	onPlanKey := keyForProject(onPlanProject)
+	sameWorkspaceOnPlanProject := command.ProjectContext{
+		BaseRepo:      repo,
+		RepoRelDir:    "terraform",
+		ProjectName:   "stage",
+		Workspace:     "default",
+		RepoLocksMode: valid.RepoLocksOnPlanMode,
+	}
+	onPlanKey := "owner/repo/terraform/default/prod"
 	onApplyKey := keyForProject(onApplyProject)
 	disabledKey := keyForProject(disabledProject)
 	secondOnPlanKey := keyForProject(secondOnPlanProject)
+	sameWorkspaceOnPlanKey := "owner/repo/terraform/default/stage"
 
 	tests := []struct {
-		name                string
-		projectCmds         []command.ProjectContext
-		locksByKey          map[string]models.ProjectLock
-		expectedGetLockKeys []string
-		expectedUnlockKeys  []string
+		name                            string
+		projectCmds                     []command.ProjectContext
+		locksByKey                      map[string]models.ProjectLock
+		expectedUnlockIfOwnedByPullKeys []string
+		expectedDeletedKeys             []string
 	}{
 		{
 			name: "empty selection deletes plans without deleting locks",
@@ -81,19 +89,19 @@ func TestPlanCommandRunner_DeletePlansAndPlanLocksByRepoLockMode(t *testing.T) {
 			locksByKey: map[string]models.ProjectLock{
 				onPlanKey: lockForPull(repo, pull.Num),
 			},
-			expectedGetLockKeys: []string{onPlanKey},
-			expectedUnlockKeys:  []string{onPlanKey},
+			expectedUnlockIfOwnedByPullKeys: []string{onPlanKey},
+			expectedDeletedKeys:             []string{onPlanKey},
 		},
 		{
-			name:                "selected on_plan lock owned by another pull is not unlocked",
-			projectCmds:         []command.ProjectContext{onPlanProject},
-			locksByKey:          map[string]models.ProjectLock{onPlanKey: lockForPull(repo, 2)},
-			expectedGetLockKeys: []string{onPlanKey},
+			name:                            "selected on_plan lock owned by another pull is not unlocked",
+			projectCmds:                     []command.ProjectContext{onPlanProject},
+			locksByKey:                      map[string]models.ProjectLock{onPlanKey: lockForPull(repo, 2)},
+			expectedUnlockIfOwnedByPullKeys: []string{onPlanKey},
 		},
 		{
-			name:                "selected on_plan lock missing is ignored",
-			projectCmds:         []command.ProjectContext{onPlanProject},
-			expectedGetLockKeys: []string{onPlanKey},
+			name:                            "selected on_plan lock missing is ignored",
+			projectCmds:                     []command.ProjectContext{onPlanProject},
+			expectedUnlockIfOwnedByPullKeys: []string{onPlanKey},
 		},
 		{
 			name:        "mixed mode unlocks only current-pull selected on_plan project",
@@ -103,8 +111,8 @@ func TestPlanCommandRunner_DeletePlansAndPlanLocksByRepoLockMode(t *testing.T) {
 				onApplyKey:  lockForPull(repo, pull.Num),
 				disabledKey: lockForPull(repo, pull.Num),
 			},
-			expectedGetLockKeys: []string{onPlanKey},
-			expectedUnlockKeys:  []string{onPlanKey},
+			expectedUnlockIfOwnedByPullKeys: []string{onPlanKey},
+			expectedDeletedKeys:             []string{onPlanKey},
 		},
 		{
 			name:        "multiple selected on_plan keys are unlocked",
@@ -113,8 +121,8 @@ func TestPlanCommandRunner_DeletePlansAndPlanLocksByRepoLockMode(t *testing.T) {
 				onPlanKey:       lockForPull(repo, pull.Num),
 				secondOnPlanKey: lockForPull(repo, pull.Num),
 			},
-			expectedGetLockKeys: []string{onPlanKey, secondOnPlanKey},
-			expectedUnlockKeys:  []string{onPlanKey, secondOnPlanKey},
+			expectedUnlockIfOwnedByPullKeys: []string{onPlanKey, secondOnPlanKey},
+			expectedDeletedKeys:             []string{onPlanKey, secondOnPlanKey},
 		},
 		{
 			name:        "duplicate selected on_plan lock key unlocks once",
@@ -122,8 +130,24 @@ func TestPlanCommandRunner_DeletePlansAndPlanLocksByRepoLockMode(t *testing.T) {
 			locksByKey: map[string]models.ProjectLock{
 				onPlanKey: lockForPull(repo, pull.Num),
 			},
-			expectedGetLockKeys: []string{onPlanKey},
-			expectedUnlockKeys:  []string{onPlanKey},
+			expectedUnlockIfOwnedByPullKeys: []string{onPlanKey},
+			expectedDeletedKeys:             []string{onPlanKey},
+		},
+		{
+			name:        "same dir and workspace with different project names unlocks both keys",
+			projectCmds: []command.ProjectContext{onPlanProject, sameWorkspaceOnPlanProject},
+			locksByKey: map[string]models.ProjectLock{
+				onPlanKey:              lockForPull(repo, pull.Num),
+				sameWorkspaceOnPlanKey: lockForPull(repo, pull.Num),
+			},
+			expectedUnlockIfOwnedByPullKeys: []string{
+				"owner/repo/terraform/default/prod",
+				"owner/repo/terraform/default/stage",
+			},
+			expectedDeletedKeys: []string{
+				"owner/repo/terraform/default/prod",
+				"owner/repo/terraform/default/stage",
+			},
 		},
 	}
 
@@ -149,11 +173,17 @@ func TestPlanCommandRunner_DeletePlansAndPlanLocksByRepoLockMode(t *testing.T) {
 			if len(locker.unlockByPullCalls) != 0 {
 				t.Fatalf("expected no UnlockByPull calls, got %#v", locker.unlockByPullCalls)
 			}
-			if !equalStringSlices(locker.getLockKeys, tt.expectedGetLockKeys) {
-				t.Fatalf("expected GetLock keys %#v, got %#v", tt.expectedGetLockKeys, locker.getLockKeys)
+			if len(locker.getLockKeys) != 0 {
+				t.Fatalf("expected no GetLock calls, got %#v", locker.getLockKeys)
 			}
-			if !equalStringSlices(locker.unlockKeys, tt.expectedUnlockKeys) {
-				t.Fatalf("expected Unlock keys %#v, got %#v", tt.expectedUnlockKeys, locker.unlockKeys)
+			if len(locker.unlockKeys) != 0 {
+				t.Fatalf("expected no Unlock calls, got %#v", locker.unlockKeys)
+			}
+			if !equalUnlockIfOwnedByPullCalls(locker.unlockIfOwnedByPullCalls, tt.expectedUnlockIfOwnedByPullKeys, repo.FullName, pull.Num) {
+				t.Fatalf("expected UnlockIfOwnedByPull keys %#v for repo %q pull %d, got %#v", tt.expectedUnlockIfOwnedByPullKeys, repo.FullName, pull.Num, locker.unlockIfOwnedByPullCalls)
+			}
+			if !equalStringSlices(locker.deletedKeys, tt.expectedDeletedKeys) {
+				t.Fatalf("expected deleted keys %#v, got %#v", tt.expectedDeletedKeys, locker.deletedKeys)
 			}
 		})
 	}
@@ -174,27 +204,41 @@ type unlockByPullCall struct {
 	pullNum      int
 }
 
+type unlockIfOwnedByPullCall struct {
+	lockKey      string
+	repoFullName string
+	pullNum      int
+}
+
 type recordingPlanCleanupLocker struct {
 	locking.Locker
-	locksByKey        map[string]models.ProjectLock
-	getLockKeys       []string
-	unlockKeys        []string
-	unlockByPullCalls []unlockByPullCall
+	locksByKey               map[string]models.ProjectLock
+	unlockIfOwnedByPullCalls []unlockIfOwnedByPullCall
+	deletedKeys              []string
+	getLockKeys              []string
+	unlockKeys               []string
+	unlockByPullCalls        []unlockByPullCall
 }
 
 func (r *recordingPlanCleanupLocker) GetLock(key string) (*models.ProjectLock, error) {
 	r.getLockKeys = append(r.getLockKeys, key)
-	lock, ok := r.locksByKey[key]
-	if !ok {
-		return nil, nil
-	}
-	return &lock, nil
+	return nil, nil
 }
 
 func (r *recordingPlanCleanupLocker) Unlock(key string) (*models.ProjectLock, error) {
 	r.unlockKeys = append(r.unlockKeys, key)
-	delete(r.locksByKey, key)
 	return nil, nil
+}
+
+func (r *recordingPlanCleanupLocker) UnlockIfOwnedByPull(lockKey string, repoFullName string, pullNum int) (*models.ProjectLock, error) {
+	r.unlockIfOwnedByPullCalls = append(r.unlockIfOwnedByPullCalls, unlockIfOwnedByPullCall{lockKey: lockKey, repoFullName: repoFullName, pullNum: pullNum})
+	lock, ok := r.locksByKey[lockKey]
+	if !ok || lock.Pull.Num != pullNum {
+		return nil, nil
+	}
+	delete(r.locksByKey, lockKey)
+	r.deletedKeys = append(r.deletedKeys, lockKey)
+	return &lock, nil
 }
 
 func (r *recordingPlanCleanupLocker) UnlockByPull(repoFullName string, pullNum int) ([]models.ProjectLock, error) {
@@ -230,6 +274,18 @@ func equalStringSlices(a, b []string) bool {
 	}
 	for i := range a {
 		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func equalUnlockIfOwnedByPullCalls(calls []unlockIfOwnedByPullCall, keys []string, repoFullName string, pullNum int) bool {
+	if len(calls) != len(keys) {
+		return false
+	}
+	for i := range calls {
+		if calls[i].lockKey != keys[i] || calls[i].repoFullName != repoFullName || calls[i].pullNum != pullNum {
 			return false
 		}
 	}

--- a/server/events/project_locker.go
+++ b/server/events/project_locker.go
@@ -80,7 +80,7 @@ func (p *DefaultProjectLocker) TryLock(log logging.SimpleLogging, pull models.Pu
 	return &TryLockResponse{
 		LockAcquired: true,
 		UnlockFn: func() error {
-			_, err := p.Locker.Unlock(lockAttempt.LockKey)
+			_, err := locker.Unlock(lockAttempt.LockKey)
 			return err
 		},
 		LockKey: lockAttempt.LockKey,

--- a/server/events/project_locker.go
+++ b/server/events/project_locker.go
@@ -80,7 +80,7 @@ func (p *DefaultProjectLocker) TryLock(log logging.SimpleLogging, pull models.Pu
 	return &TryLockResponse{
 		LockAcquired: true,
 		UnlockFn: func() error {
-			_, err := locker.Unlock(lockAttempt.LockKey)
+			_, err := locker.UnlockIfOwnedByPull(project, workspace, pull.Num)
 			return err
 		},
 		LockKey: lockAttempt.LockKey,

--- a/server/events/project_locker_test.go
+++ b/server/events/project_locker_test.go
@@ -174,6 +174,42 @@ func TestDefaultProjectLocker_TryLockUnlocked(t *testing.T) {
 	Ok(t, err)
 }
 
+func TestDefaultProjectLocker_TryLockRepoLockingDisabledUnlockUsesNoOpLocker(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	var githubClient *github.Client
+	mockClient := vcs.NewClientProxy(githubClient, nil, nil, nil, nil, nil)
+	mockLocker := mocks.NewMockLocker(ctrl)
+	mockNoOpLocker := mocks.NewMockLocker(ctrl)
+	locker := events.DefaultProjectLocker{
+		Locker:         mockLocker,
+		NoOpLocker:     mockNoOpLocker,
+		VCSClient:      mockClient,
+		ExecutableName: "atlantis",
+	}
+	expProject := models.Project{}
+	expWorkspace := "default"
+	expPull := models.PullRequest{Num: 2}
+	expUser := models.User{}
+	lockKey := "key"
+
+	mockNoOpLocker.EXPECT().TryLock(expProject, expWorkspace, expPull, expUser).Return(
+		locking.TryLockResponse{
+			LockAcquired: true,
+			CurrLock:     models.ProjectLock{},
+			LockKey:      lockKey,
+		},
+		nil,
+	)
+	mockNoOpLocker.EXPECT().Unlock(lockKey).Return(nil, nil)
+
+	res, err := locker.TryLock(logging.NewNoopLogger(t), expPull, expUser, expWorkspace, expProject, false)
+	Ok(t, err)
+	Equals(t, true, res.LockAcquired)
+
+	err = res.UnlockFn()
+	Ok(t, err)
+}
+
 func TestDefaultProjectLocker_RepoLocking(t *testing.T) {
 	var githubClient *github.Client
 	mockClient := vcs.NewClientProxy(githubClient, nil, nil, nil, nil, nil)

--- a/server/events/project_locker_test.go
+++ b/server/events/project_locker_test.go
@@ -123,8 +123,7 @@ func TestDefaultProjectLocker_TryLockWhenLockedSamePull(t *testing.T) {
 		},
 		nil,
 	)
-	// Unlock will be called once when UnlockFn is invoked
-	mockLocker.EXPECT().Unlock(lockKey).Return(nil, nil)
+	mockLocker.EXPECT().UnlockIfOwnedByPull(expProject, expWorkspace, expPull.Num).Return(nil, nil)
 	res, err := locker.TryLock(logging.NewNoopLogger(t), expPull, expUser, expWorkspace, expProject, true)
 	Ok(t, err)
 	Equals(t, true, res.LockAcquired)
@@ -163,8 +162,7 @@ func TestDefaultProjectLocker_TryLockUnlocked(t *testing.T) {
 		},
 		nil,
 	)
-	// Unlock will be called once when UnlockFn is invoked
-	mockLocker.EXPECT().Unlock(lockKey).Return(nil, nil)
+	mockLocker.EXPECT().UnlockIfOwnedByPull(expProject, expWorkspace, expPull.Num).Return(nil, nil)
 	res, err := locker.TryLock(logging.NewNoopLogger(t), expPull, expUser, expWorkspace, expProject, true)
 	Ok(t, err)
 	Equals(t, true, res.LockAcquired)
@@ -200,7 +198,7 @@ func TestDefaultProjectLocker_TryLockRepoLockingDisabledUnlockUsesNoOpLocker(t *
 		},
 		nil,
 	)
-	mockNoOpLocker.EXPECT().Unlock(lockKey).Return(nil, nil)
+	mockNoOpLocker.EXPECT().UnlockIfOwnedByPull(expProject, expWorkspace, expPull.Num).Return(nil, nil)
 
 	res, err := locker.TryLock(logging.NewNoopLogger(t), expPull, expUser, expWorkspace, expProject, false)
 	Ok(t, err)


### PR DESCRIPTION
Fixes #6531.

## What changed

When repo locking is disabled for a command, `DefaultProjectLocker.TryLock` uses `NoOpLocker`, but its returned `UnlockFn` still called the real locker. In `repo_locks.mode: on_apply`, a later plan could therefore delete an apply-created project lock if the plan path invoked cleanup.

This changes the `UnlockFn` to use the same locker that was used for `TryLock`.

The fix also covers plan-level cleanup paths in `PlanCommandRunner` that bypass `DefaultProjectLocker.TryLock` and previously called pull-wide `UnlockByPull` directly. Plan cleanup now always deletes stale plan files, but lock cleanup is selected-project and owner scoped: it skips `on_apply` and `disabled` projects, and for selected `on_plan` projects it removes the exact project lock only through an atomic project/workspace-based backend operation when that lock is owned by the current pull. Passing project/workspace directly also avoids reparsing slash-delimited lock keys for repo full names that contain additional slashes.

The same atomic owner-scoped cleanup is used by project-level error cleanup so a stale command cannot delete another PR's lock if ownership changes before cleanup runs.

## Why

For `repo_locks.mode: on_apply`, apply-created locks should persist until the PR is merged/closed or the lock is explicitly deleted. A later plan should not delete that lock merely because plan itself does not acquire repository locks in `on_apply` mode.

## Tests

- `go test ./server/events -run 'TestPlanCommandRunner_DeletePlansAndPlanLocksByRepoLockMode' -count=1`
- `go test ./server/events -run 'TestDefaultProjectLocker|PlanCommandRunner|plan.*lock|lock.*plan' -count=1`
- `go test ./server/events -run 'TestDefaultProjectLocker_TryLockRepoLockingDisabledUnlockUsesNoOpLocker' -count=1`
- `go test ./server/events -run 'TestRunGenericPlanCommand_DeletePlans' -count=1`
- `go test ./server/core/locking -count=1`
- `go test ./server/core/boltdb -run 'UnlockIfOwnedByPull|Unlock' -count=1`
- `go test ./server/core/redis -run 'UnlockIfOwnedByPull|Unlock' -count=1`
- `make check-fmt`
- `grep -R "UnlockByPull" -n server/events server/core | cat`
- `grep -R "GetLock(lockKey)" -n server/events server/core | cat`
- `grep -R "Unlock(lockKey)" -n server/events server/core | cat`
- `grep -R "UnlockIfOwnedByPull" -n server/events server/core | cat`

Note: `go test ./server/events ./server/core/locking ./server/core/boltdb ./server/core/redis -count=1` was attempted locally in an earlier pass and failed only in unrelated macOS `t.TempDir` cleanup failures around working-dir/`HasDiverged` git temp directories. The core packages in that run passed.
