### PR TITLE
test: add on_apply lock preservation scenario

### DIFF
--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -38,6 +38,17 @@ const (
 )
 
 func (t *E2ETester) Start(ctx context.Context) (*E2EResult, error) {
+	switch t.testCase.Scenario {
+	case ScenarioPlanOnly:
+		return t.runPlanOnly(ctx)
+	case ScenarioOnApplyLockPreservation:
+		return t.runOnApplyLockPreservation(ctx)
+	default:
+		return nil, fmt.Errorf("unknown E2E scenario %d", t.testCase.Scenario)
+	}
+}
+
+func (t *E2ETester) runPlanOnly(ctx context.Context) (*E2EResult, error) {
 	tc := t.testCase
 	cloneDir := fmt.Sprintf("%s/%s-test", t.cloneDirRoot, tc.Name)
 	branchName := fmt.Sprintf("e2e-%s-%s", tc.Name, time.Now().Format("20060102150405"))

--- a/e2e/github.go
+++ b/e2e/github.go
@@ -191,21 +191,53 @@ func (g GithubClient) CreatePullRequest(ctx context.Context, title, branchName s
 	return pull.GetHTMLURL(), pull.GetNumber(), nil
 }
 
+// PostPRComment posts an issue comment on the pull request.
+func (g GithubClient) PostPRComment(ctx context.Context, pullNumber int, body string) error {
+	_, _, err := g.client.Issues.CreateComment(ctx, g.ownerName, g.repoName, pullNumber, &github.IssueComment{
+		Body: github.Ptr(body),
+	})
+	if err != nil {
+		return fmt.Errorf("creating PR comment: %w", err)
+	}
+	return nil
+}
+
 // GetAtlantisStatus polls the aggregate "atlantis/plan" commit status.
 // Used only for the polling loop to detect terminal state.
 func (g GithubClient) GetAtlantisStatus(ctx context.Context, branchName string) (string, error) {
-	combinedStatus, _, err := g.client.Repositories.GetCombinedStatus(ctx, g.ownerName, g.repoName, branchName, nil)
+	return g.GetAtlantisCommandStatus(ctx, branchName, "plan")
+}
+
+func (g GithubClient) GetAtlantisCommandStatus(ctx context.Context, branchName string, command string) (string, error) {
+	status, err := g.GetCommitStatus(ctx, branchName, atlantisCommandStatusContext(command))
 	if err != nil {
 		return "", err
 	}
+	return status.State, nil
+}
 
+func (g GithubClient) GetCommitStatus(ctx context.Context, branchName, statusContext string) (CommitStatus, error) {
+	combinedStatus, _, err := g.client.Repositories.GetCombinedStatus(ctx, g.ownerName, g.repoName, branchName, nil)
+	if err != nil {
+		return CommitStatus{}, err
+	}
+
+	var result CommitStatus
 	for _, status := range combinedStatus.Statuses {
-		if status.GetContext() == "atlantis/plan" {
-			return status.GetState(), nil
+		if status.GetContext() != statusContext {
+			continue
+		}
+		candidate := CommitStatus{
+			State:     status.GetState(),
+			ID:        status.GetID(),
+			UpdatedAt: status.GetUpdatedAt().Time,
+		}
+		if result.ID == 0 || candidate.UpdatedAt.After(result.UpdatedAt) || (candidate.UpdatedAt.Equal(result.UpdatedAt) && candidate.ID > result.ID) {
+			result = candidate
 		}
 	}
 
-	return "", nil
+	return result, nil
 }
 
 // GetProjectStatuses returns all per-project Atlantis plan status contexts

--- a/e2e/gitlab.go
+++ b/e2e/gitlab.go
@@ -110,6 +110,16 @@ func (g GitlabClient) CreatePullRequest(ctx context.Context, title, branchName s
 	return mr.WebURL, mr.IID, nil
 }
 
+func (g GitlabClient) PostPRComment(ctx context.Context, pullNumber int, body string) error {
+	_, _, err := g.client.Notes.CreateMergeRequestNote(g.projectId, pullNumber, &gitlab.CreateMergeRequestNoteOptions{
+		Body: gitlab.Ptr(body),
+	})
+	if err != nil {
+		return fmt.Errorf("creating MR note: %w", err)
+	}
+	return nil
+}
+
 // GetAtlantisStatus polls pipeline status for the merge request.
 // Selects the newest pipeline by highest ID to avoid stale results.
 func (g GitlabClient) GetAtlantisStatus(ctx context.Context, branchName string) (string, error) {
@@ -135,6 +145,14 @@ func (g GitlabClient) GetAtlantisStatus(ctx context.Context, branchName string) 
 	}
 
 	return pipeline.Status, nil
+}
+
+func (g GitlabClient) GetAtlantisCommandStatus(ctx context.Context, branchName string, command string) (string, error) {
+	return "", fmt.Errorf("atlantis command status %q is not supported for GitLab E2E", command)
+}
+
+func (g GitlabClient) GetCommitStatus(ctx context.Context, branchName, statusContext string) (CommitStatus, error) {
+	return CommitStatus{}, fmt.Errorf("commit status context %q is not supported for GitLab E2E", statusContext)
 }
 
 // GetProjectStatuses is not supported on GitLab.

--- a/e2e/on_apply_lock.go
+++ b/e2e/on_apply_lock.go
@@ -191,7 +191,10 @@ func (t *E2ETester) createOnApplyLockPR(ctx context.Context, label, branchName, 
 	title := fmt.Sprintf("[E2E] %s %s", tc.Name, label)
 	url, pullID, err := t.vcsClient.CreatePullRequest(ctx, title, branchName)
 	if err != nil {
-		if deleteErr := deleteRemoteBranch(cloneDir, branchName); deleteErr != nil {
+		cleanupCtx, cancel := newLifecycleCleanupContext(ctx)
+		defer cancel()
+
+		if deleteErr := deleteRemoteBranch(cleanupCtx, cloneDir, branchName); deleteErr != nil {
 			return nil, fmt.Errorf("creating pull request after pushing branch %q: %w; additionally failed to delete pushed branch: %v", branchName, err, deleteErr)
 		}
 		return nil, err
@@ -269,8 +272,18 @@ func runGit(dir string, args ...string) error {
 	return nil
 }
 
-func deleteRemoteBranch(cloneDir, branchName string) error {
-	return runGit(cloneDir, "push", "origin", "--delete", branchName)
+func runGitContext(ctx context.Context, dir string, args ...string) error {
+	cmd := exec.CommandContext(ctx, "git", args...) //nolint:gosec // arguments are test-controlled branch/file names.
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, string(output))
+	}
+	return nil
+}
+
+func deleteRemoteBranch(ctx context.Context, cloneDir, branchName string) error {
+	return runGitContext(ctx, cloneDir, "push", "origin", "--delete", branchName)
 }
 
 func e2eRunNonce() string {

--- a/e2e/on_apply_lock.go
+++ b/e2e/on_apply_lock.go
@@ -223,7 +223,7 @@ func pollAtlantisCommandStatusAfter(ctx context.Context, client VCSClient, branc
 	statusContext := atlantisCommandStatusContext(command)
 	state := "not started"
 	var statusErr error
-	for i := 0; i < lifecycleCommandMaxPolls; i++ {
+	for range lifecycleCommandMaxPolls {
 		time.Sleep(pollInterval)
 		status, err := client.GetCommitStatus(ctx, branchName, statusContext)
 		if err != nil {
@@ -284,7 +284,7 @@ func enableOnApplyRepoLocksForFixture(cloneDir string) error {
 	if patched == string(contents) {
 		return nil
 	}
-	if err := os.WriteFile(path, []byte(patched), info.Mode().Perm()); err != nil {
+	if err := os.WriteFile(path, []byte(patched), info.Mode().Perm()); err != nil { //nolint:gosec // path is the fixed atlantis.yaml file in an E2E temp clone.
 		return fmt.Errorf("writing atlantis.yaml: %w", err)
 	}
 	return nil
@@ -331,7 +331,7 @@ func enableOnApplyRepoLocksForFixtureContent(contents string) (string, error) {
 func findProjectBlock(lines []string, projectName string) (int, int, error) {
 	start := -1
 	end := -1
-	for i := 0; i < len(lines); i++ {
+	for i := range len(lines) {
 		if !strings.HasPrefix(lines[i], "  - ") {
 			continue
 		}
@@ -367,7 +367,7 @@ func isTopLevelYAMLSection(line string) bool {
 func assertLockConflictComment(ctx context.Context, client VCSClient, pullNumber int, caseName string) error {
 	var comments []string
 	var commentsErr error
-	for i := 0; i < lifecycleCommandMaxPolls; i++ {
+	for range lifecycleCommandMaxPolls {
 		comments, commentsErr = client.GetPRComments(ctx, pullNumber)
 		if commentsErr != nil {
 			log.Printf("[%s] error polling PR comments for lock conflict: %v", caseName, commentsErr)

--- a/e2e/on_apply_lock.go
+++ b/e2e/on_apply_lock.go
@@ -124,6 +124,7 @@ func (t *E2ETester) runOnApplyLockPreservationBody(ctx context.Context, result *
 		return err
 	}
 	*prs = append(*prs, pr2)
+	result.pullRequestURL = fmt.Sprintf("PR1: %s PR2: %s", pr1.url, pr2.url)
 	log.Printf("[%s] PR2 branch %q pull request %s", tc.Name, pr2.branchName, pr2.url)
 	time.Sleep(initialWait)
 

--- a/e2e/on_apply_lock.go
+++ b/e2e/on_apply_lock.go
@@ -21,6 +21,7 @@ const (
 	onApplyLockApplyCommand  = "atlantis apply -p " + onApplyLockProjectName
 	onApplyLockPlanCommand   = "atlantis plan"
 	lifecycleCommandMaxPolls = 60
+	lifecycleCleanupTimeout  = 30 * time.Second
 )
 
 type lockPreservationPR struct {
@@ -38,7 +39,10 @@ func (t *E2ETester) runOnApplyLockPreservation(ctx context.Context) (result *E2E
 	result = &E2EResult{testCase: tc.Name}
 	var prs []*lockPreservationPR
 	defer func() {
-		cleanupErr := cleanUpLockPRs(ctx, t, prs...)
+		cleanupCtx, cancel := newLifecycleCleanupContext(ctx)
+		defer cancel()
+
+		cleanupErr := cleanUpLockPRs(cleanupCtx, t, prs...)
 		switch {
 		case err != nil && cleanupErr != nil:
 			err = fmt.Errorf("%w; cleanup failed: %v", err, cleanupErr)
@@ -209,6 +213,14 @@ func cleanUpLockPRs(ctx context.Context, t *E2ETester, prs ...*lockPreservationP
 		}
 	}
 	return cleanupErr
+}
+
+func newLifecycleCleanupContext(parent context.Context) (context.Context, context.CancelFunc) {
+	base := context.Background()
+	if parent != nil {
+		base = context.WithoutCancel(parent)
+	}
+	return context.WithTimeout(base, lifecycleCleanupTimeout)
 }
 
 func cleanUpLockPR(ctx context.Context, t *E2ETester, pr *lockPreservationPR) error {
@@ -459,20 +471,56 @@ func assertLockConflictComment(ctx context.Context, client VCSClient, pullNumber
 }
 
 func findLockConflictComment(comments []string, lockOwnerPullNumber int) (string, bool) {
-	ownerRef := fmt.Sprintf("#%d", lockOwnerPullNumber)
-	lockPhrase := "this project is currently locked by an unapplied plan from pull"
-	deletePhrase := "delete the lock from " + ownerRef
+	lockPhrase := "this project is currently locked by an unapplied plan from pull "
+	deletePhrase := "delete the lock from "
 	applyPhrase := "apply that plan and merge the pull request"
 	for _, comment := range comments {
 		lower := strings.ToLower(comment)
-		if !strings.Contains(lower, lockPhrase) || !strings.Contains(lower, ownerRef) {
+		if !containsExactPullRefAfterPhrase(comment, lockPhrase, lockOwnerPullNumber) {
 			continue
 		}
-		if strings.Contains(lower, deletePhrase) || strings.Contains(lower, applyPhrase) {
+		if containsExactPullRefAfterPhrase(comment, deletePhrase, lockOwnerPullNumber) || strings.Contains(lower, applyPhrase) {
 			return comment, true
 		}
 	}
 	return "", false
+}
+
+func containsExactPullRefAfterPhrase(comment, phrase string, pullNumber int) bool {
+	lower := strings.ToLower(comment)
+	target := strings.ToLower(phrase) + fmt.Sprintf("#%d", pullNumber)
+	idx := 0
+	for {
+		pos := strings.Index(lower[idx:], target)
+		if pos == -1 {
+			return false
+		}
+		end := idx + pos + len(target)
+		if hasPullRefNumericBoundary(comment, end) {
+			return true
+		}
+		idx = end
+	}
+}
+
+func containsExactPullRef(comment string, pullNumber int) bool {
+	ref := fmt.Sprintf("#%d", pullNumber)
+	idx := 0
+	for {
+		pos := strings.Index(comment[idx:], ref)
+		if pos == -1 {
+			return false
+		}
+		end := idx + pos + len(ref)
+		if hasPullRefNumericBoundary(comment, end) {
+			return true
+		}
+		idx = end
+	}
+}
+
+func hasPullRefNumericBoundary(comment string, end int) bool {
+	return end == len(comment) || comment[end] < '0' || comment[end] > '9'
 }
 
 func truncateForLog(value string, maxLen int) string {

--- a/e2e/on_apply_lock.go
+++ b/e2e/on_apply_lock.go
@@ -4,12 +4,15 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
@@ -20,13 +23,6 @@ const (
 	lifecycleCommandMaxPolls = 60
 )
 
-var lockConflictCommentSubstrings = []string{
-	"currently locked",
-	"locked by",
-	"delete the lock",
-	"apply that plan",
-}
-
 type lockPreservationPR struct {
 	label      string
 	cloneDir   string
@@ -35,94 +31,124 @@ type lockPreservationPR struct {
 	pullID     int
 }
 
-func (t *E2ETester) runOnApplyLockPreservation(ctx context.Context) (*E2EResult, error) {
-	tc := t.testCase
-	result := &E2EResult{testCase: tc.Name}
-	timestamp := time.Now().UTC().Format("20060102150405")
+var e2eNonceCounter atomic.Uint64
 
-	pr1, err := t.createOnApplyLockPR(ctx, "pr1", fmt.Sprintf("e2e-lock-pr1-%s", timestamp), tc.MutateFile)
+func (t *E2ETester) runOnApplyLockPreservation(ctx context.Context) (result *E2EResult, err error) {
+	tc := t.testCase
+	result = &E2EResult{testCase: tc.Name}
+	var prs []*lockPreservationPR
+	defer func() {
+		cleanupErr := cleanUpLockPRs(ctx, t, prs...)
+		switch {
+		case err != nil && cleanupErr != nil:
+			err = fmt.Errorf("%w; cleanup failed: %v", err, cleanupErr)
+		case cleanupErr != nil:
+			err = cleanupErr
+		}
+	}()
+
+	err = t.runOnApplyLockPreservationBody(ctx, result, &prs)
+	return result, err
+}
+
+func (t *E2ETester) runOnApplyLockPreservationBody(ctx context.Context, result *E2EResult, prs *[]*lockPreservationPR) error {
+	tc := t.testCase
+	nonce := e2eRunNonce()
+
+	pr1, err := t.createOnApplyLockPR(ctx, "pr1", fmt.Sprintf("e2e-lock-pr1-%s", nonce), tc.MutateFile)
 	if err != nil {
-		return result, err
+		return err
 	}
+	*prs = append(*prs, pr1)
 	result.pullRequestURL = pr1.url
 	result.branchName = pr1.branchName
-	defer cleanUpLockPR(ctx, t, pr1)
 
 	log.Printf("[%s] PR1 branch %q pull request %s", tc.Name, pr1.branchName, pr1.url)
 	time.Sleep(initialWait)
 
 	state, err := pollAtlantisCommandStatusAfter(ctx, t.vcsClient, pr1.branchName, "plan", tc.Name, CommitStatus{})
 	if err != nil {
-		return result, err
+		return err
 	}
 	result.testResult = state
 	if !t.vcsClient.DidAtlantisSucceed(state) {
-		return result, fmt.Errorf("[%s] PR1 plan expected success but got %q", tc.Name, state)
+		return fmt.Errorf("[%s] PR1 plan expected success but got %q", tc.Name, state)
 	}
 	if err := assertProjectStatuses(ctx, t.vcsClient, pr1.branchName, tc); err != nil {
-		return result, err
+		return err
 	}
 
 	state, err = t.postAtlantisCommandAndWait(ctx, pr1.pullID, pr1.branchName, tc.Name, "apply", onApplyLockApplyCommand)
 	if err != nil {
-		return result, err
+		return err
 	}
 	result.testResult = state
 	if !t.vcsClient.DidAtlantisSucceed(state) {
-		return result, fmt.Errorf("[%s] PR1 apply expected success but got %q", tc.Name, state)
+		return fmt.Errorf("[%s] PR1 apply expected success but got %q", tc.Name, state)
 	}
 
 	planBaseline, err := t.vcsClient.GetCommitStatus(ctx, pr1.branchName, atlantisCommandStatusContext("plan"))
 	if err != nil {
-		return result, fmt.Errorf("[%s] getting PR1 plan status before cleanup trigger: %w", tc.Name, err)
+		return fmt.Errorf("[%s] getting PR1 plan status before cleanup trigger: %w", tc.Name, err)
+	}
+	projectPlanBaseline, err := t.vcsClient.GetCommitStatus(ctx, pr1.branchName, onApplyLockProjectPlanStatusContext())
+	if err != nil {
+		return fmt.Errorf("[%s] getting PR1 project plan status before cleanup trigger: %w", tc.Name, err)
 	}
 	log.Printf("[%s] posting PR1 cleanup-trigger plan command", tc.Name)
 	if err := t.vcsClient.PostPRComment(ctx, pr1.pullID, onApplyLockPlanCommand); err != nil {
-		return result, fmt.Errorf("[%s] posting PR1 plan command: %w", tc.Name, err)
+		return fmt.Errorf("[%s] posting PR1 plan command: %w", tc.Name, err)
 	}
 	state, err = pollAtlantisCommandStatusAfter(ctx, t.vcsClient, pr1.branchName, "plan", tc.Name, planBaseline)
 	if err != nil {
-		return result, err
+		return err
 	}
 	result.testResult = state
 	if !t.vcsClient.DidAtlantisSucceed(state) {
-		return result, fmt.Errorf("[%s] PR1 cleanup-trigger plan expected success but got %q", tc.Name, state)
+		return fmt.Errorf("[%s] PR1 cleanup-trigger plan expected success but got %q", tc.Name, state)
+	}
+	projectPlanState, err := pollCommitStatusAfter(ctx, t.vcsClient, pr1.branchName, onApplyLockProjectPlanStatusContext(), tc.Name, projectPlanBaseline)
+	if err != nil {
+		return err
+	}
+	if !t.vcsClient.DidAtlantisSucceed(projectPlanState) {
+		return fmt.Errorf("[%s] PR1 cleanup-trigger project plan for %s expected success but got %q", tc.Name, onApplyLockProjectName, projectPlanState)
 	}
 
-	pr2, err := t.createOnApplyLockPR(ctx, "pr2", fmt.Sprintf("e2e-lock-pr2-%s", timestamp), "e2e_pr2_trigger.tf")
+	pr2, err := t.createOnApplyLockPR(ctx, "pr2", fmt.Sprintf("e2e-lock-pr2-%s", nonce), "e2e_pr2_trigger.tf")
 	if err != nil {
-		return result, err
+		return err
 	}
-	defer cleanUpLockPR(ctx, t, pr2)
+	*prs = append(*prs, pr2)
 	log.Printf("[%s] PR2 branch %q pull request %s", tc.Name, pr2.branchName, pr2.url)
 	time.Sleep(initialWait)
 
 	state, err = pollAtlantisCommandStatusAfter(ctx, t.vcsClient, pr2.branchName, "plan", tc.Name, CommitStatus{})
 	if err != nil {
-		return result, err
+		return err
 	}
 	result.testResult = state
 	if !t.vcsClient.DidAtlantisSucceed(state) {
-		return result, fmt.Errorf("[%s] PR2 plan expected success but got %q", tc.Name, state)
+		return fmt.Errorf("[%s] PR2 plan expected success but got %q", tc.Name, state)
 	}
 	if err := assertProjectStatuses(ctx, t.vcsClient, pr2.branchName, tc); err != nil {
-		return result, err
+		return err
 	}
 
 	state, err = t.postAtlantisCommandAndWait(ctx, pr2.pullID, pr2.branchName, tc.Name, "apply", onApplyLockApplyCommand)
 	if err != nil {
-		return result, err
+		return err
 	}
 	result.testResult = state
 	if !t.vcsClient.DidAtlantisFail(state) {
-		return result, fmt.Errorf("[%s] PR2 apply expected lock-blocked failure but got %q; PR1=%s PR2=%s", tc.Name, state, pr1.url, pr2.url)
+		return fmt.Errorf("[%s] PR2 apply expected lock-blocked failure but got %q; PR1=%s PR2=%s", tc.Name, state, pr1.url, pr2.url)
 	}
-	if err := assertLockConflictComment(ctx, t.vcsClient, pr2.pullID, tc.Name); err != nil {
-		return result, err
+	if err := assertLockConflictComment(ctx, t.vcsClient, pr2.pullID, tc.Name, pr1.pullID); err != nil {
+		return err
 	}
 
 	result.testResult = "success"
-	return result, nil
+	return nil
 }
 
 func (t *E2ETester) createOnApplyLockPR(ctx context.Context, label, branchName, mutateFile string) (*lockPreservationPR, error) {
@@ -161,6 +187,9 @@ func (t *E2ETester) createOnApplyLockPR(ctx context.Context, label, branchName, 
 	title := fmt.Sprintf("[E2E] %s %s", tc.Name, label)
 	url, pullID, err := t.vcsClient.CreatePullRequest(ctx, title, branchName)
 	if err != nil {
+		if deleteErr := deleteRemoteBranch(cloneDir, branchName); deleteErr != nil {
+			return nil, fmt.Errorf("creating pull request after pushing branch %q: %w; additionally failed to delete pushed branch: %v", branchName, err, deleteErr)
+		}
 		return nil, err
 	}
 	return &lockPreservationPR{
@@ -172,13 +201,35 @@ func (t *E2ETester) createOnApplyLockPR(ctx context.Context, label, branchName, 
 	}, nil
 }
 
-func cleanUpLockPR(ctx context.Context, t *E2ETester, pr *lockPreservationPR) {
+func cleanUpLockPRs(ctx context.Context, t *E2ETester, prs ...*lockPreservationPR) error {
+	var cleanupErr error
+	for _, pr := range slices.Backward(prs) {
+		if err := cleanUpLockPR(ctx, t, pr); err != nil {
+			cleanupErr = errors.Join(cleanupErr, err)
+		}
+	}
+	return cleanupErr
+}
+
+func cleanUpLockPR(ctx context.Context, t *E2ETester, pr *lockPreservationPR) error {
 	if pr == nil {
-		return
+		return nil
 	}
-	if cleanErr := cleanUp(ctx, t, pr.pullID, pr.branchName); cleanErr != nil {
-		log.Printf("[%s] cleanup failed for %s branch %q: %v", t.testCase.Name, pr.label, pr.branchName, cleanErr)
+	var cleanupErr error
+	if err := t.vcsClient.ClosePullRequest(ctx, pr.pullID); err != nil {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("closing pull request %d: %w", pr.pullID, err))
+	} else {
+		log.Printf("closed pull request %d", pr.pullID)
 	}
+	if err := t.vcsClient.DeleteBranch(ctx, pr.branchName); err != nil {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("deleting branch %s: %w", pr.branchName, err))
+	} else {
+		log.Printf("deleted branch %s", pr.branchName)
+	}
+	if cleanupErr != nil {
+		return fmt.Errorf("[%s] cleanup failed for %s pull %d branch %q: %w", t.testCase.Name, pr.label, pr.pullID, pr.branchName, cleanupErr)
+	}
+	return nil
 }
 
 func writeFixtureMutation(cloneDir, dir, mutateFile, content string) error {
@@ -206,6 +257,26 @@ func runGit(dir string, args ...string) error {
 	return nil
 }
 
+func deleteRemoteBranch(cloneDir, branchName string) error {
+	return runGit(cloneDir, "push", "origin", "--delete", branchName)
+}
+
+func e2eRunNonce() string {
+	now := time.Now().UTC().UnixNano()
+	counter := e2eNonceCounter.Add(1)
+	if runID := os.Getenv("GITHUB_RUN_ID"); runID != "" {
+		if attempt := os.Getenv("GITHUB_RUN_ATTEMPT"); attempt != "" {
+			return fmt.Sprintf("%s-%s-%d-%d", runID, attempt, now, counter)
+		}
+		return fmt.Sprintf("%s-%d-%d", runID, now, counter)
+	}
+	return fmt.Sprintf("%d-%d-%d", now, os.Getpid(), counter)
+}
+
+func onApplyLockProjectPlanStatusContext() string {
+	return projectStatusPrefix + onApplyLockProjectName
+}
+
 func (t *E2ETester) postAtlantisCommandAndWait(ctx context.Context, pullID int, branchName, caseName, statusCommand, body string) (string, error) {
 	statusContext := atlantisCommandStatusContext(statusCommand)
 	baseline, err := t.vcsClient.GetCommitStatus(ctx, branchName, statusContext)
@@ -221,6 +292,10 @@ func (t *E2ETester) postAtlantisCommandAndWait(ctx context.Context, pullID int, 
 
 func pollAtlantisCommandStatusAfter(ctx context.Context, client VCSClient, branchName, command, caseName string, baseline CommitStatus) (string, error) {
 	statusContext := atlantisCommandStatusContext(command)
+	return pollCommitStatusAfter(ctx, client, branchName, statusContext, caseName, baseline)
+}
+
+func pollCommitStatusAfter(ctx context.Context, client VCSClient, branchName, statusContext, caseName string, baseline CommitStatus) (string, error) {
 	state := "not started"
 	var statusErr error
 	for range lifecycleCommandMaxPolls {
@@ -364,32 +439,37 @@ func isTopLevelYAMLSection(line string) bool {
 	return line != "" && !strings.HasPrefix(line, " ") && strings.HasSuffix(strings.TrimSpace(line), ":")
 }
 
-func assertLockConflictComment(ctx context.Context, client VCSClient, pullNumber int, caseName string) error {
+func assertLockConflictComment(ctx context.Context, client VCSClient, pullNumber int, caseName string, lockOwnerPullNumber int) error {
 	var comments []string
 	var commentsErr error
 	for range lifecycleCommandMaxPolls {
 		comments, commentsErr = client.GetPRComments(ctx, pullNumber)
 		if commentsErr != nil {
 			log.Printf("[%s] error polling PR comments for lock conflict: %v", caseName, commentsErr)
-		} else if comment, ok := findLockConflictComment(comments); ok {
+		} else if comment, ok := findLockConflictComment(comments, lockOwnerPullNumber); ok {
 			log.Printf("[%s] found expected lock conflict comment: %q", caseName, truncateForLog(comment, 160))
 			return nil
 		}
 		time.Sleep(pollInterval)
 	}
 	if commentsErr != nil {
-		return fmt.Errorf("[%s] expected lock conflict comment but comment polling failed: %w", caseName, commentsErr)
+		return fmt.Errorf("[%s] expected lock conflict comment for lock owner pull #%d on pull #%d but comment polling failed: %w", caseName, lockOwnerPullNumber, pullNumber, commentsErr)
 	}
-	return fmt.Errorf("[%s] expected lock conflict comment containing one of %v not found in %d comments:\n%s", caseName, lockConflictCommentSubstrings, len(comments), strings.Join(comments, "\n---\n"))
+	return fmt.Errorf("[%s] expected repo-lock conflict comment for lock owner pull #%d on pull #%d not found in %d comments:\n%s", caseName, lockOwnerPullNumber, pullNumber, len(comments), strings.Join(comments, "\n---\n"))
 }
 
-func findLockConflictComment(comments []string) (string, bool) {
+func findLockConflictComment(comments []string, lockOwnerPullNumber int) (string, bool) {
+	ownerRef := fmt.Sprintf("#%d", lockOwnerPullNumber)
+	lockPhrase := "this project is currently locked by an unapplied plan from pull"
+	deletePhrase := "delete the lock from " + ownerRef
+	applyPhrase := "apply that plan and merge the pull request"
 	for _, comment := range comments {
 		lower := strings.ToLower(comment)
-		for _, candidate := range lockConflictCommentSubstrings {
-			if strings.Contains(lower, candidate) {
-				return comment, true
-			}
+		if !strings.Contains(lower, lockPhrase) || !strings.Contains(lower, ownerRef) {
+			continue
+		}
+		if strings.Contains(lower, deletePhrase) || strings.Contains(lower, applyPhrase) {
+			return comment, true
 		}
 	}
 	return "", false

--- a/e2e/on_apply_lock.go
+++ b/e2e/on_apply_lock.go
@@ -1,0 +1,403 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	onApplyLockProjectName   = "locking-on-apply-preservation"
+	onApplyLockApplyCommand  = "atlantis apply -p " + onApplyLockProjectName
+	onApplyLockPlanCommand   = "atlantis plan"
+	lifecycleCommandMaxPolls = 60
+)
+
+var lockConflictCommentSubstrings = []string{
+	"currently locked",
+	"locked by",
+	"delete the lock",
+	"apply that plan",
+}
+
+type lockPreservationPR struct {
+	label      string
+	cloneDir   string
+	branchName string
+	url        string
+	pullID     int
+}
+
+func (t *E2ETester) runOnApplyLockPreservation(ctx context.Context) (*E2EResult, error) {
+	tc := t.testCase
+	result := &E2EResult{testCase: tc.Name}
+	timestamp := time.Now().UTC().Format("20060102150405")
+
+	pr1, err := t.createOnApplyLockPR(ctx, "pr1", fmt.Sprintf("e2e-lock-pr1-%s", timestamp), tc.MutateFile)
+	if err != nil {
+		return result, err
+	}
+	result.pullRequestURL = pr1.url
+	result.branchName = pr1.branchName
+	defer cleanUpLockPR(ctx, t, pr1)
+
+	log.Printf("[%s] PR1 branch %q pull request %s", tc.Name, pr1.branchName, pr1.url)
+	time.Sleep(initialWait)
+
+	state, err := pollAtlantisCommandStatusAfter(ctx, t.vcsClient, pr1.branchName, "plan", tc.Name, CommitStatus{})
+	if err != nil {
+		return result, err
+	}
+	result.testResult = state
+	if !t.vcsClient.DidAtlantisSucceed(state) {
+		return result, fmt.Errorf("[%s] PR1 plan expected success but got %q", tc.Name, state)
+	}
+	if err := assertProjectStatuses(ctx, t.vcsClient, pr1.branchName, tc); err != nil {
+		return result, err
+	}
+
+	state, err = t.postAtlantisCommandAndWait(ctx, pr1.pullID, pr1.branchName, tc.Name, "apply", onApplyLockApplyCommand)
+	if err != nil {
+		return result, err
+	}
+	result.testResult = state
+	if !t.vcsClient.DidAtlantisSucceed(state) {
+		return result, fmt.Errorf("[%s] PR1 apply expected success but got %q", tc.Name, state)
+	}
+
+	planBaseline, err := t.vcsClient.GetCommitStatus(ctx, pr1.branchName, atlantisCommandStatusContext("plan"))
+	if err != nil {
+		return result, fmt.Errorf("[%s] getting PR1 plan status before cleanup trigger: %w", tc.Name, err)
+	}
+	log.Printf("[%s] posting PR1 cleanup-trigger plan command", tc.Name)
+	if err := t.vcsClient.PostPRComment(ctx, pr1.pullID, onApplyLockPlanCommand); err != nil {
+		return result, fmt.Errorf("[%s] posting PR1 plan command: %w", tc.Name, err)
+	}
+	state, err = pollAtlantisCommandStatusAfter(ctx, t.vcsClient, pr1.branchName, "plan", tc.Name, planBaseline)
+	if err != nil {
+		return result, err
+	}
+	result.testResult = state
+	if !t.vcsClient.DidAtlantisSucceed(state) {
+		return result, fmt.Errorf("[%s] PR1 cleanup-trigger plan expected success but got %q", tc.Name, state)
+	}
+
+	pr2, err := t.createOnApplyLockPR(ctx, "pr2", fmt.Sprintf("e2e-lock-pr2-%s", timestamp), "e2e_pr2_trigger.tf")
+	if err != nil {
+		return result, err
+	}
+	defer cleanUpLockPR(ctx, t, pr2)
+	log.Printf("[%s] PR2 branch %q pull request %s", tc.Name, pr2.branchName, pr2.url)
+	time.Sleep(initialWait)
+
+	state, err = pollAtlantisCommandStatusAfter(ctx, t.vcsClient, pr2.branchName, "plan", tc.Name, CommitStatus{})
+	if err != nil {
+		return result, err
+	}
+	result.testResult = state
+	if !t.vcsClient.DidAtlantisSucceed(state) {
+		return result, fmt.Errorf("[%s] PR2 plan expected success but got %q", tc.Name, state)
+	}
+	if err := assertProjectStatuses(ctx, t.vcsClient, pr2.branchName, tc); err != nil {
+		return result, err
+	}
+
+	state, err = t.postAtlantisCommandAndWait(ctx, pr2.pullID, pr2.branchName, tc.Name, "apply", onApplyLockApplyCommand)
+	if err != nil {
+		return result, err
+	}
+	result.testResult = state
+	if !t.vcsClient.DidAtlantisFail(state) {
+		return result, fmt.Errorf("[%s] PR2 apply expected lock-blocked failure but got %q; PR1=%s PR2=%s", tc.Name, state, pr1.url, pr2.url)
+	}
+	if err := assertLockConflictComment(ctx, t.vcsClient, pr2.pullID, tc.Name); err != nil {
+		return result, err
+	}
+
+	result.testResult = "success"
+	return result, nil
+}
+
+func (t *E2ETester) createOnApplyLockPR(ctx context.Context, label, branchName, mutateFile string) (*lockPreservationPR, error) {
+	tc := t.testCase
+	cloneDir := filepath.Join(t.cloneDirRoot, fmt.Sprintf("%s-%s-test", tc.Name, label))
+	log.Printf("[%s] creating %s clone dir %q", tc.Name, label, cloneDir)
+	if err := os.MkdirAll(cloneDir, 0700); err != nil {
+		return nil, fmt.Errorf("creating clone dir %q: %w", cloneDir, err)
+	}
+	if err := t.vcsClient.Clone(cloneDir); err != nil {
+		return nil, err
+	}
+	if err := runGit(cloneDir, "checkout", "-b", branchName); err != nil {
+		return nil, err
+	}
+
+	if mutateFile == "" {
+		mutateFile = fmt.Sprintf("%s.tf", tc.Name)
+	}
+	if err := writeFixtureMutation(cloneDir, tc.Dir, mutateFile, tc.MutateContent); err != nil {
+		return nil, err
+	}
+	if err := enableOnApplyRepoLocksForFixture(cloneDir); err != nil {
+		return nil, err
+	}
+	if err := runGit(cloneDir, "add", filepath.Join(tc.Dir, mutateFile), "atlantis.yaml"); err != nil {
+		return nil, err
+	}
+	if err := runGit(cloneDir, "commit", "-m", fmt.Sprintf("e2e: %s %s", tc.Name, label)); err != nil {
+		return nil, err
+	}
+	if err := runGit(cloneDir, "push", "origin", branchName); err != nil {
+		return nil, err
+	}
+
+	title := fmt.Sprintf("[E2E] %s %s", tc.Name, label)
+	url, pullID, err := t.vcsClient.CreatePullRequest(ctx, title, branchName)
+	if err != nil {
+		return nil, err
+	}
+	return &lockPreservationPR{
+		label:      label,
+		cloneDir:   cloneDir,
+		branchName: branchName,
+		url:        url,
+		pullID:     pullID,
+	}, nil
+}
+
+func cleanUpLockPR(ctx context.Context, t *E2ETester, pr *lockPreservationPR) {
+	if pr == nil {
+		return
+	}
+	if cleanErr := cleanUp(ctx, t, pr.pullID, pr.branchName); cleanErr != nil {
+		log.Printf("[%s] cleanup failed for %s branch %q: %v", t.testCase.Name, pr.label, pr.branchName, cleanErr)
+	}
+}
+
+func writeFixtureMutation(cloneDir, dir, mutateFile, content string) error {
+	if content == "" {
+		content = defaultMutateContent
+	}
+	filePath := filepath.Join(cloneDir, dir, mutateFile)
+	if err := os.MkdirAll(filepath.Dir(filePath), 0700); err != nil {
+		return fmt.Errorf("creating parent dir for %q: %w", filePath, err)
+	}
+	log.Printf("writing mutation file %q", filePath)
+	if err := os.WriteFile(filePath, []byte(content), 0600); err != nil {
+		return fmt.Errorf("writing mutation file %q: %w", filePath, err)
+	}
+	return nil
+}
+
+func runGit(dir string, args ...string) error {
+	cmd := exec.Command("git", args...) //nolint:gosec // arguments are test-controlled branch/file names.
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, string(output))
+	}
+	return nil
+}
+
+func (t *E2ETester) postAtlantisCommandAndWait(ctx context.Context, pullID int, branchName, caseName, statusCommand, body string) (string, error) {
+	statusContext := atlantisCommandStatusContext(statusCommand)
+	baseline, err := t.vcsClient.GetCommitStatus(ctx, branchName, statusContext)
+	if err != nil {
+		return "", fmt.Errorf("[%s] getting baseline %s status: %w", caseName, statusContext, err)
+	}
+	log.Printf("[%s] posting command to PR %d: %s", caseName, pullID, body)
+	if err := t.vcsClient.PostPRComment(ctx, pullID, body); err != nil {
+		return "", fmt.Errorf("[%s] posting command %q: %w", caseName, body, err)
+	}
+	return pollAtlantisCommandStatusAfter(ctx, t.vcsClient, branchName, statusCommand, caseName, baseline)
+}
+
+func pollAtlantisCommandStatusAfter(ctx context.Context, client VCSClient, branchName, command, caseName string, baseline CommitStatus) (string, error) {
+	statusContext := atlantisCommandStatusContext(command)
+	state := "not started"
+	var statusErr error
+	for i := 0; i < lifecycleCommandMaxPolls; i++ {
+		time.Sleep(pollInterval)
+		status, err := client.GetCommitStatus(ctx, branchName, statusContext)
+		if err != nil {
+			statusErr = err
+			log.Printf("[%s] error polling %s status for branch %q: %v", caseName, statusContext, branchName, err)
+			continue
+		}
+		if status.State == "" {
+			log.Printf("[%s] %s has not started yet on branch %q", caseName, statusContext, branchName)
+			continue
+		}
+		state = status.State
+		if !isNewCommitStatus(status, baseline) {
+			log.Printf("[%s] %s status is still from previous run: state=%s id=%d", caseName, statusContext, status.State, status.ID)
+			continue
+		}
+		log.Printf("[%s] %s status on branch %q: %s", caseName, statusContext, branchName, state)
+		if !client.IsAtlantisInProgress(state) {
+			return state, nil
+		}
+	}
+	if statusErr != nil {
+		return state, fmt.Errorf("[%s] %s timed out after %d polls for branch %q; last state %q; last error: %w", caseName, statusContext, lifecycleCommandMaxPolls, branchName, state, statusErr)
+	}
+	return state, fmt.Errorf("[%s] %s timed out after %d polls for branch %q; last state %q", caseName, statusContext, lifecycleCommandMaxPolls, branchName, state)
+}
+
+func isNewCommitStatus(status, baseline CommitStatus) bool {
+	if status.State == "" {
+		return false
+	}
+	if baseline.ID == 0 && baseline.UpdatedAt.IsZero() {
+		return true
+	}
+	if baseline.ID != 0 && status.ID != baseline.ID {
+		return true
+	}
+	if !baseline.UpdatedAt.IsZero() && !status.UpdatedAt.IsZero() && status.UpdatedAt.After(baseline.UpdatedAt) {
+		return true
+	}
+	return false
+}
+
+func enableOnApplyRepoLocksForFixture(cloneDir string) error {
+	path := filepath.Join(cloneDir, "atlantis.yaml")
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat atlantis.yaml: %w", err)
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading atlantis.yaml: %w", err)
+	}
+	patched, err := enableOnApplyRepoLocksForFixtureContent(string(contents))
+	if err != nil {
+		return err
+	}
+	if patched == string(contents) {
+		return nil
+	}
+	if err := os.WriteFile(path, []byte(patched), info.Mode().Perm()); err != nil {
+		return fmt.Errorf("writing atlantis.yaml: %w", err)
+	}
+	return nil
+}
+
+func enableOnApplyRepoLocksForFixtureContent(contents string) (string, error) {
+	lines := strings.Split(contents, "\n")
+	start, end, err := findProjectBlock(lines, onApplyLockProjectName)
+	if err != nil {
+		return "", err
+	}
+	for i := start; i < end; i++ {
+		if strings.TrimSpace(lines[i]) != "repo_locks:" {
+			continue
+		}
+		if i+1 < end && strings.TrimSpace(lines[i+1]) == "mode: on_apply" {
+			return contents, nil
+		}
+		return "", fmt.Errorf("project %q already contains repo_locks but not mode: on_apply", onApplyLockProjectName)
+	}
+
+	insertAt := -1
+	for i := start; i < end; i++ {
+		if strings.TrimSpace(lines[i]) == "workspace: default" {
+			insertAt = i + 1
+			break
+		}
+	}
+	if insertAt == -1 {
+		return "", fmt.Errorf("project %q is missing workspace: default", onApplyLockProjectName)
+	}
+
+	insert := []string{
+		"    repo_locks:",
+		"      mode: on_apply",
+	}
+	patched := make([]string, 0, len(lines)+len(insert))
+	patched = append(patched, lines[:insertAt]...)
+	patched = append(patched, insert...)
+	patched = append(patched, lines[insertAt:]...)
+	return strings.Join(patched, "\n"), nil
+}
+
+func findProjectBlock(lines []string, projectName string) (int, int, error) {
+	start := -1
+	end := -1
+	for i := 0; i < len(lines); i++ {
+		if !strings.HasPrefix(lines[i], "  - ") {
+			continue
+		}
+		candidateEnd := len(lines)
+		for j := i + 1; j < len(lines); j++ {
+			if strings.HasPrefix(lines[j], "  - ") || isTopLevelYAMLSection(lines[j]) {
+				candidateEnd = j
+				break
+			}
+		}
+		for j := i; j < candidateEnd; j++ {
+			if strings.TrimSpace(lines[j]) != "name: "+projectName {
+				continue
+			}
+			if start != -1 {
+				return 0, 0, fmt.Errorf("found multiple project entries named %q", projectName)
+			}
+			start = i
+			end = candidateEnd
+			break
+		}
+	}
+	if start == -1 {
+		return 0, 0, fmt.Errorf("project %q not found in atlantis.yaml", projectName)
+	}
+	return start, end, nil
+}
+
+func isTopLevelYAMLSection(line string) bool {
+	return line != "" && !strings.HasPrefix(line, " ") && strings.HasSuffix(strings.TrimSpace(line), ":")
+}
+
+func assertLockConflictComment(ctx context.Context, client VCSClient, pullNumber int, caseName string) error {
+	var comments []string
+	var commentsErr error
+	for i := 0; i < lifecycleCommandMaxPolls; i++ {
+		comments, commentsErr = client.GetPRComments(ctx, pullNumber)
+		if commentsErr != nil {
+			log.Printf("[%s] error polling PR comments for lock conflict: %v", caseName, commentsErr)
+		} else if comment, ok := findLockConflictComment(comments); ok {
+			log.Printf("[%s] found expected lock conflict comment: %q", caseName, truncateForLog(comment, 160))
+			return nil
+		}
+		time.Sleep(pollInterval)
+	}
+	if commentsErr != nil {
+		return fmt.Errorf("[%s] expected lock conflict comment but comment polling failed: %w", caseName, commentsErr)
+	}
+	return fmt.Errorf("[%s] expected lock conflict comment containing one of %v not found in %d comments:\n%s", caseName, lockConflictCommentSubstrings, len(comments), strings.Join(comments, "\n---\n"))
+}
+
+func findLockConflictComment(comments []string) (string, bool) {
+	for _, comment := range comments {
+		lower := strings.ToLower(comment)
+		for _, candidate := range lockConflictCommentSubstrings {
+			if strings.Contains(lower, candidate) {
+				return comment, true
+			}
+		}
+	}
+	return "", false
+}
+
+func truncateForLog(value string, maxLen int) string {
+	if len(value) <= maxLen {
+		return value
+	}
+	return value[:maxLen] + "..."
+}

--- a/e2e/on_apply_lock_test.go
+++ b/e2e/on_apply_lock_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -181,6 +182,47 @@ func TestE2ERunNonceIncludesPerRunEntropy(t *testing.T) {
 	}
 }
 
+func TestNewLifecycleCleanupContextIgnoresParentCancellation(t *testing.T) {
+	parent, cancelParent := context.WithCancel(context.Background())
+	cancelParent()
+
+	ctx, cleanup := newLifecycleCleanupContext(parent)
+	defer cleanup()
+
+	select {
+	case <-ctx.Done():
+		t.Fatalf("cleanup context was already canceled: %v", ctx.Err())
+	default:
+	}
+}
+
+func TestContainsExactPullRef(t *testing.T) {
+	tests := []struct {
+		name       string
+		comment    string
+		pullNumber int
+		want       bool
+	}{
+		{name: "end of string", comment: "#123", pullNumber: 123, want: true},
+		{name: "period", comment: "#123.", pullNumber: 123, want: true},
+		{name: "comma", comment: "#123,", pullNumber: 123, want: true},
+		{name: "space", comment: "#123 ", pullNumber: 123, want: true},
+		{name: "newline", comment: "#123\n", pullNumber: 123, want: true},
+		{name: "superset number", comment: "#1234", pullNumber: 123, want: false},
+		{name: "embedded superset number", comment: "abc#1234", pullNumber: 123, want: false},
+		{name: "numeric boundary only permits letters", comment: "#123abc", pullNumber: 123, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := containsExactPullRef(tt.comment, tt.pullNumber)
+			if got != tt.want {
+				t.Fatalf("containsExactPullRef(%q, %d) = %v, want %v", tt.comment, tt.pullNumber, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFindLockConflictComment(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -194,6 +236,24 @@ func TestFindLockConflictComment(t *testing.T) {
 				"plan succeeded",
 				"This project is currently locked by an unapplied plan from pull #123. To continue, delete the lock from #123 or apply that plan and merge the pull request.",
 			},
+			ownerPullNumber: 123,
+			want:            true,
+		},
+		{
+			name:            "does not match owner pull prefix",
+			comments:        []string{"This project is currently locked by an unapplied plan from pull #1234. To continue, delete the lock from #1234 or apply that plan and merge the pull request."},
+			ownerPullNumber: 123,
+			want:            false,
+		},
+		{
+			name:            "does not match shorter wrong owner",
+			comments:        []string{"This project is currently locked by an unapplied plan from pull #123. To continue, delete the lock from #123 or apply that plan and merge the pull request."},
+			ownerPullNumber: 1234,
+			want:            false,
+		},
+		{
+			name:            "matches exact owner before punctuation",
+			comments:        []string{"This project is currently locked by an unapplied plan from pull #123. To continue, delete the lock from #123 or apply that plan and merge the pull request."},
 			ownerPullNumber: 123,
 			want:            true,
 		},

--- a/e2e/on_apply_lock_test.go
+++ b/e2e/on_apply_lock_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+const sampleAtlantisYAML = `version: 3
+projects:
+  - dir: standalone
+    name: standalone
+    workspace: default
+
+  # --- Locking lifecycle fixtures ---
+  - dir: locking/on-apply-lock-preservation
+    name: locking-on-apply-preservation
+    workspace: default
+    # NOTE: The future runner scenario must run this project with
+    # repo_locks.mode: on_apply.
+
+workflows:
+  default:
+    plan:
+      steps:
+        - init
+        - plan
+`
+
+func TestEnableOnApplyRepoLocksForFixtureContent(t *testing.T) {
+	got, err := enableOnApplyRepoLocksForFixtureContent(sampleAtlantisYAML)
+	if err != nil {
+		t.Fatalf("enableOnApplyRepoLocksForFixtureContent() error = %v", err)
+	}
+
+	wantBlock := `  - dir: locking/on-apply-lock-preservation
+    name: locking-on-apply-preservation
+    workspace: default
+    repo_locks:
+      mode: on_apply
+    # NOTE:`
+	if !strings.Contains(got, wantBlock) {
+		t.Fatalf("patched YAML missing repo_locks block under fixture project:\n%s", got)
+	}
+	if !strings.Contains(got, "  - dir: standalone\n    name: standalone\n    workspace: default") {
+		t.Fatalf("patched YAML changed unrelated project:\n%s", got)
+	}
+}
+
+func TestEnableOnApplyRepoLocksForFixtureContentMissingProject(t *testing.T) {
+	_, err := enableOnApplyRepoLocksForFixtureContent(`version: 3
+projects:
+  - dir: standalone
+    name: standalone
+`)
+	if err == nil {
+		t.Fatal("enableOnApplyRepoLocksForFixtureContent() error = nil, want missing project error")
+	}
+}
+
+func TestEnableOnApplyRepoLocksForFixtureContentAlreadyOnApply(t *testing.T) {
+	input := strings.Replace(sampleAtlantisYAML, "    name: locking-on-apply-preservation\n    workspace: default\n    # NOTE:", "    name: locking-on-apply-preservation\n    workspace: default\n    repo_locks:\n      mode: on_apply\n    # NOTE:", 1)
+	got, err := enableOnApplyRepoLocksForFixtureContent(input)
+	if err != nil {
+		t.Fatalf("enableOnApplyRepoLocksForFixtureContent() error = %v", err)
+	}
+	if got != input {
+		t.Fatalf("already-active repo_locks should be deterministic and unchanged\nwant:\n%s\ngot:\n%s", input, got)
+	}
+}
+
+func TestEnableOnApplyRepoLocksForFixtureContentUnexpectedRepoLocks(t *testing.T) {
+	input := strings.Replace(sampleAtlantisYAML, "    name: locking-on-apply-preservation\n    workspace: default\n    # NOTE:", "    name: locking-on-apply-preservation\n    workspace: default\n    repo_locks:\n      mode: on_plan\n    # NOTE:", 1)
+	_, err := enableOnApplyRepoLocksForFixtureContent(input)
+	if err == nil {
+		t.Fatal("enableOnApplyRepoLocksForFixtureContent() error = nil, want unexpected repo_locks error")
+	}
+}
+
+func TestFindLockConflictComment(t *testing.T) {
+	comment, ok := findLockConflictComment([]string{
+		"plan succeeded",
+		"This project is currently locked by pull request #1.",
+	})
+	if !ok {
+		t.Fatal("findLockConflictComment() ok = false, want true")
+	}
+	if !strings.Contains(comment, "currently locked") {
+		t.Fatalf("findLockConflictComment() comment = %q", comment)
+	}
+}

--- a/e2e/on_apply_lock_test.go
+++ b/e2e/on_apply_lock_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 const sampleAtlantisYAML = `version: 3
@@ -78,15 +79,162 @@ func TestEnableOnApplyRepoLocksForFixtureContentUnexpectedRepoLocks(t *testing.T
 	}
 }
 
-func TestFindLockConflictComment(t *testing.T) {
-	comment, ok := findLockConflictComment([]string{
-		"plan succeeded",
-		"This project is currently locked by pull request #1.",
-	})
-	if !ok {
-		t.Fatal("findLockConflictComment() ok = false, want true")
+func TestAtlantisStatusContexts(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{name: "plan", command: "plan", want: "atlantis/plan"},
+		{name: "apply", command: "apply", want: "atlantis/apply"},
+		{name: "unknown command keeps current permissive mapping", command: "unlock", want: "atlantis/unlock"},
 	}
-	if !strings.Contains(comment, "currently locked") {
-		t.Fatalf("findLockConflictComment() comment = %q", comment)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := atlantisCommandStatusContext(tt.command)
+			if got != tt.want {
+				t.Fatalf("atlantisCommandStatusContext(%q) = %q, want %q", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOnApplyLockProjectPlanStatusContext(t *testing.T) {
+	got := onApplyLockProjectPlanStatusContext()
+	want := "atlantis/plan: locking-on-apply-preservation"
+	if got != want {
+		t.Fatalf("onApplyLockProjectPlanStatusContext() = %q, want %q", got, want)
+	}
+}
+
+func TestIsNewCommitStatus(t *testing.T) {
+	baseTime := time.Date(2026, 6, 29, 1, 2, 3, 0, time.UTC)
+	newerTime := baseTime.Add(time.Second)
+	olderTime := baseTime.Add(-time.Second)
+
+	tests := []struct {
+		name     string
+		status   CommitStatus
+		baseline CommitStatus
+		want     bool
+	}{
+		{
+			name:     "empty status is never new",
+			status:   CommitStatus{},
+			baseline: CommitStatus{},
+			want:     false,
+		},
+		{
+			name:     "no baseline means non-empty status is new",
+			status:   CommitStatus{State: "success", ID: 1, UpdatedAt: baseTime},
+			baseline: CommitStatus{},
+			want:     true,
+		},
+		{
+			name:     "same ID and same timestamp is not new",
+			status:   CommitStatus{State: "success", ID: 1, UpdatedAt: baseTime},
+			baseline: CommitStatus{State: "success", ID: 1, UpdatedAt: baseTime},
+			want:     false,
+		},
+		{
+			name:     "different ID is new",
+			status:   CommitStatus{State: "success", ID: 2, UpdatedAt: baseTime},
+			baseline: CommitStatus{State: "success", ID: 1, UpdatedAt: baseTime},
+			want:     true,
+		},
+		{
+			name:     "same ID but newer timestamp is new",
+			status:   CommitStatus{State: "success", ID: 1, UpdatedAt: newerTime},
+			baseline: CommitStatus{State: "success", ID: 1, UpdatedAt: baseTime},
+			want:     true,
+		},
+		{
+			name:     "older timestamp is not new",
+			status:   CommitStatus{State: "success", ID: 1, UpdatedAt: olderTime},
+			baseline: CommitStatus{State: "success", ID: 1, UpdatedAt: baseTime},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isNewCommitStatus(tt.status, tt.baseline)
+			if got != tt.want {
+				t.Fatalf("isNewCommitStatus(%+v, %+v) = %v, want %v", tt.status, tt.baseline, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestE2ERunNonceIncludesPerRunEntropy(t *testing.T) {
+	t.Setenv("GITHUB_RUN_ID", "12345")
+	t.Setenv("GITHUB_RUN_ATTEMPT", "2")
+
+	first := e2eRunNonce()
+	second := e2eRunNonce()
+	if first == second {
+		t.Fatalf("e2eRunNonce() returned duplicate values: %q", first)
+	}
+	if !strings.HasPrefix(first, "12345-2-") || !strings.HasPrefix(second, "12345-2-") {
+		t.Fatalf("e2eRunNonce() did not include GitHub run metadata: first=%q second=%q", first, second)
+	}
+}
+
+func TestFindLockConflictComment(t *testing.T) {
+	tests := []struct {
+		name            string
+		comments        []string
+		ownerPullNumber int
+		want            bool
+	}{
+		{
+			name: "repo lock owned by expected PR",
+			comments: []string{
+				"plan succeeded",
+				"This project is currently locked by an unapplied plan from pull #123. To continue, delete the lock from #123 or apply that plan and merge the pull request.",
+			},
+			ownerPullNumber: 123,
+			want:            true,
+		},
+		{
+			name:            "normal plan success comment",
+			comments:        []string{"Plan succeeded for locking-on-apply-preservation."},
+			ownerPullNumber: 123,
+			want:            false,
+		},
+		{
+			name:            "normal apply failure comment",
+			comments:        []string{"Apply failed: terraform exited with status 1."},
+			ownerPullNumber: 123,
+			want:            false,
+		},
+		{
+			name:            "working dir lock comment",
+			comments:        []string{"The working directory is currently locked."},
+			ownerPullNumber: 123,
+			want:            false,
+		},
+		{
+			name:            "repo lock owned by another PR",
+			comments:        []string{"This project is currently locked by an unapplied plan from pull #999. To continue, delete the lock from #999 or apply that plan and merge the pull request."},
+			ownerPullNumber: 123,
+			want:            false,
+		},
+		{
+			name:            "generic fragments only",
+			comments:        []string{"currently locked delete the lock apply that plan"},
+			ownerPullNumber: 123,
+			want:            false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, got := findLockConflictComment(tt.comments, tt.ownerPullNumber)
+			if got != tt.want {
+				t.Fatalf("findLockConflictComment(%v, %d) = %v, want %v", tt.comments, tt.ownerPullNumber, got, tt.want)
+			}
+		})
 	}
 }

--- a/e2e/testcase.go
+++ b/e2e/testcase.go
@@ -20,6 +20,14 @@ const (
 	CaseDisabled                   // Never run, documented for future
 )
 
+// Scenario controls the runner path for complex lifecycle tests.
+type Scenario int
+
+const (
+	ScenarioPlanOnly Scenario = iota
+	ScenarioOnApplyLockPreservation
+)
+
 // TestCase defines a single E2E fixture exercise.
 type TestCase struct {
 	// Name identifies the test case in logs and results.
@@ -60,6 +68,9 @@ type TestCase struct {
 	// Reserved; apply execution is not yet implemented in the harness.
 	ApplyCommand string
 
+	// Scenario selects a specialized runner path. Zero keeps the default plan-only behavior.
+	Scenario Scenario
+
 	// VCS controls which providers run this case.
 	VCS VCSProvider
 
@@ -81,6 +92,10 @@ const defaultMutateContent = `resource "null_resource" "e2e" {
 // projectStatusPrefix is the prefix for per-project Atlantis statuses.
 // The aggregate status is "atlantis/plan" (no colon/space).
 const projectStatusPrefix = "atlantis/plan: "
+
+func atlantisCommandStatusContext(command string) string {
+	return "atlantis/" + command
+}
 
 // testCases is the fixture test matrix.
 // Cases with Status=CaseActive run in every E2E invocation.
@@ -246,5 +261,15 @@ var testCases = []TestCase{
 		MutateFile: "e2e_trigger.tf",
 		Status:     CaseOptIn,
 		SkipReason: "Validates explicit-over-autodiscovery precedence. Enable with E2E_OPT_IN=1.",
+	},
+	{
+		Name:                   "locking-on-apply-preservation",
+		Dir:                    "locking/on-apply-lock-preservation",
+		MutateFile:             "e2e_pr1_trigger.tf",
+		ExpectedStatusContexts: []string{"atlantis/plan: locking-on-apply-preservation"},
+		VCS:                    VCSGitHub,
+		Status:                 CaseOptIn,
+		SkipReason:             "Exercises apply plus two-PR repo-lock lifecycle; enable with E2E_OPT_IN=1.",
+		Scenario:               ScenarioOnApplyLockPreservation,
 	},
 }

--- a/e2e/vcs.go
+++ b/e2e/vcs.go
@@ -4,16 +4,33 @@
 
 package main
 
-import "context"
+import (
+	"context"
+	"time"
+)
+
+type CommitStatus struct {
+	State     string
+	ID        int64
+	UpdatedAt time.Time
+}
 
 type VCSClient interface {
 	Clone(cloneDir string) error
 	CreateAtlantisWebhook(ctx context.Context, hookURL string) (int64, error)
 	DeleteAtlantisHook(ctx context.Context, hookID int64) error
 	CreatePullRequest(ctx context.Context, title, branchName string) (string, int, error)
+	// PostPRComment posts a PR/MR comment that Atlantis treats as a command.
+	PostPRComment(ctx context.Context, pullNumber int, body string) error
 	// GetAtlantisStatus polls for plan completion. Returns aggregate terminal
 	// state across all matching statuses. Used for the polling loop only.
 	GetAtlantisStatus(ctx context.Context, branchName string) (string, error)
+	// GetAtlantisCommandStatus polls an aggregate Atlantis command status such
+	// as "atlantis/plan" or "atlantis/apply".
+	GetAtlantisCommandStatus(ctx context.Context, branchName string, command string) (string, error)
+	// GetCommitStatus returns a specific commit status context with metadata
+	// used to distinguish repeated command runs on the same SHA.
+	GetCommitStatus(ctx context.Context, branchName, statusContext string) (CommitStatus, error)
 	// GetProjectStatuses returns all per-project Atlantis status contexts and
 	// their states. Contexts have the form "atlantis/plan: <project>".
 	// Used for post-completion assertions. Returns nil on GitLab (unsupported).

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -40,11 +40,12 @@ if [ -n "${ATLANTIS_GH_APP_ID:-}" ]; then
   WRITE_GIT_CREDS="--write-git-creds"
 fi
 
+# repo_locks is needed for the on_apply lock-lifecycle fixture to activate from its test PR branch.
 ./atlantis server \
   --data-dir="/tmp" \
   --log-level="debug" \
   --repo-allowlist="github.com/runatlantis/atlantis-tests,gitlab.com/runatlantis/atlantis-tests" \
-  --repo-config-json='{"repos":[{"id":"/.*/", "allowed_overrides":["apply_requirements","workflow"], "allow_custom_workflows":true}]}' \
+  --repo-config-json='{"repos":[{"id":"/.*/", "allowed_overrides":["apply_requirements","workflow","repo_locks"], "allow_custom_workflows":true}]}' \
   $WRITE_GIT_CREDS \
   &> /tmp/atlantis-server.log &
 ATLANTIS_PID=$!


### PR DESCRIPTION
## What changed

Adds an opt-in GitHub E2E scenario for `repo_locks.mode: on_apply` lock preservation, using the fixture added in runatlantis/atlantis-tests#21363.

The scenario exercises the lifecycle needed for runatlantis/atlantis#6531 / #6606:

1. PR1 plans the locking fixture.
2. PR1 applies it with `repo_locks.mode: on_apply`.
3. PR1 triggers a later generic plan cleanup.
4. PR2 targets the same fixture.
5. PR2 apply is expected to be blocked by PR1's apply-created lock.

## Why

This catches regressions where later plan cleanup incorrectly deletes an apply-created repo lock.

## Notes

- The scenario is opt-in because it creates two PRs and exercises apply/lock lifecycle.
- The E2E server config now allows `repo_locks` as a repo-side override.
- The scenario activates `repo_locks.mode: on_apply` in the test PR branches so `atlantis-tests` main can remain scaffold-only and parseable under older runners.

## Validation

- `cd e2e && go test ./... -count=1`
- `gofmt -w e2e/*.go`
- `git diff --check`
- `go test ./server/core/config/... ./server/events/... -run 'RepoLocks|repo_locks|ProjectLocker|PlanCommandRunner' -count=1`

Not run: live E2E requires VCS credentials and ngrok.
