### PR TITLE
ci: add top-ranking issues automation

### DIFF
--- a/.codex/top-issues-ranking-exploration.md
+++ b/.codex/top-issues-ranking-exploration.md
@@ -1,0 +1,324 @@
+# Top Issues Ranking Automation Exploration
+
+Date: 2026-06-29
+
+## Summary Recommendation
+
+Implement with changes.
+
+Atlantis already asks users in both issue templates to vote with thumbs-up reactions and avoid "+1" comments. A maintained ranking issue would make that existing signal visible to maintainers and contributors. The current data looks useful: the top open Atlantis issues by thumbs-up reactions are mostly recognizable feature requests and bugs, not random noise.
+
+Do not copy OpenTofu's implementation verbatim. Reimplement the idea for Atlantis because OpenTofu's Go file is MPL-2.0 licensed and carries OpenTofu/HashiCorp copyright headers, while Atlantis is Apache-2.0. The Atlantis version should also explicitly exclude PRs, use Atlantis labels, exclude stale/noise labels, format titles as Markdown links, include labels/comments/updated date, and make the target issue configurable.
+
+## OpenTofu Implementation Findings
+
+References:
+
+- Tracking issue: https://github.com/opentofu/opentofu/issues/1496
+- Workflow: https://github.com/opentofu/opentofu/blob/main/.github/workflows/update-top-issues-ranking.yml
+- Script directory: https://github.com/opentofu/opentofu/tree/main/.github/scripts/update_top_issues_ranking
+
+| Area | OpenTofu behavior |
+| --- | --- |
+| Trigger model | Manual workflow_dispatch plus daily schedule at 10:00 UTC. |
+| Repository guard | Job-level guard: repository owner must be opentofu. |
+| Runner | ubuntu-latest. |
+| Permissions | contents: read and issues: write. |
+| Actions | checkout and setup-go pinned by SHA with version comments. |
+| Script invocation | cd into .github/scripts/update_top_issues_ranking, download modules, run main.go with owner, repo, and tracking issue number 1496. |
+| Script language | Standalone Go module. |
+| Dependencies | github.com/google/go-github/v61 and indirect go-querystring. |
+| Auth | Reads GITHUB_TOKEN; falls back to unauthenticated client if absent. |
+| Issue listing | Lists all open repository issues with pagination, 100 per page. |
+| PR exclusion | No explicit PR exclusion. GitHub issue APIs can return PRs through issue endpoints, so a copied implementation could include labeled PRs. |
+| Threshold | Keeps issues with at least 2 thumbs-up reactions. |
+| Sorting | Sorts descending by thumbs-up count. Ties are not explicitly stabilized. |
+| Label grouping | Hard-coded groups: enhancement and bug. |
+| Max rows | Top 20 per group. |
+| Template | Short intro plus Top Enhancements and Top Bugs sections; rows are numbered entries with bare issue URLs and reaction counts. |
+| Timestamp | None. |
+| Roadmap disclaimer | None beyond saying rankings are based on reactions. |
+| Failure modes | Missing args can panic; invalid issue number or GitHub API errors call log.Fatal; no dry-run; no retry/backoff; no target issue validation; no explicit PR filtering. |
+| License/copying | main.go is MPL-2.0 with OpenTofu and HashiCorp copyright headers. Atlantis should reimplement rather than copy. |
+
+## Atlantis Repository Conventions
+
+### Labels
+
+Relevant live labels:
+
+- feature: New functionality/enhancement.
+- bug: Something is not working.
+- rfc: Requirements for Comment.
+- needs discussion: Large change needing community/maintainer review.
+- help wanted: Good feature for contributors.
+- quick-win: Obviously worth doing and under roughly 4 hours.
+- regression: Bug introduced in a new version.
+- question: Further information is requested.
+- Exclusion candidates: Stale, duplicate, wont-do, spam, waiting-on-response.
+
+There is no live enhancement label in the label list, although .github/release.yml references enhancement in release-note categories. Atlantis issue templates use feature.
+
+### Issue Templates
+
+.github/ISSUE_TEMPLATE/bug_report.md and .github/ISSUE_TEMPLATE/feature_request.md both ask users to add a thumbs-up reaction to the original issue and not leave "+1" comments. That makes this automation aligned with current project guidance.
+
+### GitHub Actions Style
+
+- Actions are generally pinned to full SHAs with a trailing version comment.
+- Many jobs use step-security/harden-runner with egress-policy: audit.
+- Newer jobs commonly use ubuntu-24.04, although some existing scheduled/security jobs still use ubuntu-latest.
+- Permissions are explicit and scoped.
+- Scheduled workflows already exist, including stale.yml daily, scorecard.yml weekly, and codeql.yml weekly.
+
+### Go Tooling
+
+- Root module: github.com/runatlantis/atlantis.
+- Root go.mod uses go 1.26.4.
+- Root module already depends on github.com/google/go-github/v88.
+- There is no existing .github/scripts directory. A workflow-local .github/scripts/update_top_issues_ranking directory is acceptable, but it would be new.
+- Prefer a standalone Go module under .github/scripts for isolation from product dependencies. Use go 1.26.4 and go-github/v88 for consistency.
+
+## Live Atlantis Issue Signal
+
+Data sampled with GitHub GraphQL search on 2026-06-29 using open issues sorted by thumbs-up reactions.
+
+- Open issues overall: 710.
+- Open issues excluding Stale, duplicate, wont-do, and spam: 280.
+
+Top open issues overall after excluding stale/noise:
+
+| Rank | Issue | Thumbs-up | Comments | Updated | Labels |
+| --- | --- | ---: | ---: | --- | --- |
+| 1 | [#3245 Drift Detection](https://github.com/runatlantis/atlantis/issues/3245) | 243 | 31 | 2026-05-25 | feature, help wanted, needs discussion, rfc |
+| 2 | [#260 Run plan/apply for multiple projects in parallel](https://github.com/runatlantis/atlantis/issues/260) | 139 | 48 | 2024-02-21 | feature, help wanted |
+| 3 | [#2172 Feature request: allow apply on merge](https://github.com/runatlantis/atlantis/issues/2172) | 127 | 46 | 2024-12-05 | feature, help wanted |
+| 4 | [#2242 Error using shared Terraform providers with a large number of parallel project plans](https://github.com/runatlantis/atlantis/issues/2242) | 126 | 23 | 2025-04-17 | bug, work-in-progress |
+| 5 | [#4452 SAML/SSO Authentication for Atlantis Web UI and API](https://github.com/runatlantis/atlantis/issues/4452) | 111 | 6 | 2026-06-27 | feature |
+| 6 | [#4319 Metrics for PRs are never expiring](https://github.com/runatlantis/atlantis/issues/4319) | 60 | 16 | 2026-06-17 | bug, regression, never-stale |
+| 7 | [#2125 gitlab: atlantis/apply job stays pending](https://github.com/runatlantis/atlantis/issues/2125) | 52 | 34 | 2026-03-18 | bug, help wanted, provider/gitlab |
+| 8 | [#5415 Allow merge method as configurable option in atlantis.yaml](https://github.com/runatlantis/atlantis/issues/5415) | 47 | 3 | 2025-11-01 | feature |
+| 9 | [#941 Support atlantis destroy subcommand](https://github.com/runatlantis/atlantis/issues/941) | 47 | 15 | 2026-05-06 | feature |
+| 10 | [#391 Support prerequisite apply of projects for apply_requirements](https://github.com/runatlantis/atlantis/issues/391) | 44 | 13 | 2025-08-22 | feature, help wanted |
+
+Useful observations:
+
+- Ranking by thumbs-up is meaningful for Atlantis; the top list surfaces recurring user asks.
+- Excluding Stale matters. Without exclusion, several high-vote stale items appear near the top.
+- Feature ranking is strong: top feature requests have 40 to 240+ thumbs-up reactions.
+- Bug ranking is also strong: top bugs have 19 to 126+ thumbs-up reactions.
+- rfc has only 2 open issues, so combine it with needs discussion.
+- question is comparatively noisy and often stale; do not include it in v1.
+
+## Proposed Atlantis Design
+
+### Tracking Issue
+
+Maintainers should create the tracking issue manually first. The workflow/script should receive the issue number from configuration rather than hard-coding it deep in Go code.
+
+Suggested title:
+
+Top-Ranking Atlantis Issues 📊
+
+Suggested initial body:
+
+This issue is updated automatically with open Atlantis issues ranked by thumbs-up reactions.
+
+The ranking is community signal for maintainers and contributors. It is not a roadmap commitment, priority guarantee, or acceptance decision.
+
+Please vote by adding a thumbs-up reaction to the original issue instead of leaving "+1" comments.
+
+### Categories And Label Mapping
+
+| Category | Labels included | Rationale |
+| --- | --- | --- |
+| Top Feature Requests | feature | Matches the feature template and main user-demand surface. |
+| Top Bugs | bug | Captures operational pain and correctness issues. |
+| Top Regressions | regression | Small but important set; useful for triage urgency. |
+| Top RFC / Needs Discussion | rfc, needs discussion | Strategic or larger design items; combined because rfc alone is sparse. |
+| Top Contributor-Friendly Issues | help wanted, quick-win | Useful for contributors looking for high-impact work. |
+
+Recommended exclusions for all categories:
+
+- Closed issues.
+- Pull requests.
+- The tracking issue itself.
+- Stale.
+- duplicate.
+- wont-do.
+- spam.
+- waiting-on-response.
+
+Do not include question in v1 unless maintainers explicitly want a support-signal section.
+
+### Ranking Parameters
+
+| Parameter | Recommendation |
+| --- | --- |
+| Minimum thumbs-up threshold | 10. Atlantis has enough reaction volume that OpenTofu's threshold of 2 would include lower-signal entries. |
+| Max rows per category | 15. Enough to show breadth without oversized issue bodies. |
+| Sort | Thumbs-up descending, comment count descending, updated date descending, issue number ascending. |
+| Row format | Markdown table with linked issue title, thumbs-up count, comments, updated date, and labels. |
+| Generated timestamp | Include UTC timestamp. |
+| Roadmap disclaimer | Include an explicit signal-not-roadmap note. |
+| Target issue number | Workflow env var or workflow input, for example TOP_ISSUES_TRACKING_ISSUE. |
+| Dry run | Add --dry-run to print generated Markdown without editing. |
+
+### Sample Generated Markdown
+
+Based on current live data and proposed exclusions/threshold:
+
+## Top-Ranking Atlantis Issues 📊
+
+Last updated: 2026-06-29 00:00 UTC.
+
+This issue is updated automatically from open Atlantis issues ranked by thumbs-up reactions. Rankings are community signal for maintainers and contributors, not a roadmap commitment or acceptance decision.
+
+Excluded labels: Stale, duplicate, wont-do, spam, waiting-on-response.
+
+### Top Feature Requests
+
+| Rank | Issue | Thumbs-up | Comments | Updated | Labels |
+| --- | --- | ---: | ---: | --- | --- |
+| 1 | [#3245 Drift Detection](https://github.com/runatlantis/atlantis/issues/3245) | 243 | 31 | 2026-05-25 | feature, help wanted, needs discussion, rfc |
+| 2 | [#260 Run plan/apply for multiple projects in parallel](https://github.com/runatlantis/atlantis/issues/260) | 139 | 48 | 2024-02-21 | feature, help wanted |
+| 3 | [#2172 Feature request: allow apply on merge](https://github.com/runatlantis/atlantis/issues/2172) | 127 | 46 | 2024-12-05 | feature, help wanted |
+| 4 | [#4452 SAML/SSO Authentication for Atlantis Web UI and API](https://github.com/runatlantis/atlantis/issues/4452) | 111 | 6 | 2026-06-27 | feature |
+| 5 | [#5415 Allow merge method as configurable option in atlantis.yaml](https://github.com/runatlantis/atlantis/issues/5415) | 47 | 3 | 2025-11-01 | feature |
+
+### Top Bugs
+
+| Rank | Issue | Thumbs-up | Comments | Updated | Labels |
+| --- | --- | ---: | ---: | --- | --- |
+| 1 | [#2242 Error using shared Terraform providers with a large number of parallel project plans](https://github.com/runatlantis/atlantis/issues/2242) | 126 | 23 | 2025-04-17 | bug, work-in-progress |
+| 2 | [#4319 Metrics for PRs are never expiring](https://github.com/runatlantis/atlantis/issues/4319) | 60 | 16 | 2026-06-17 | bug, regression, never-stale |
+| 3 | [#2125 gitlab: atlantis/apply job stays pending](https://github.com/runatlantis/atlantis/issues/2125) | 52 | 34 | 2026-03-18 | bug, help wanted, provider/gitlab |
+| 4 | [#2412 Transient errors during parallel plan from .terraform.lock: plugins are not consistent](https://github.com/runatlantis/atlantis/issues/2412) | 41 | 27 | 2026-04-20 | bug, help wanted |
+| 5 | [#2129 Invalid Key when attempting to stream logs over websocket](https://github.com/runatlantis/atlantis/issues/2129) | 41 | 18 | 2025-03-10 | bug, help wanted, streaming-logs |
+
+### Top Regressions
+
+| Rank | Issue | Thumbs-up | Comments | Updated | Labels |
+| --- | --- | ---: | ---: | --- | --- |
+| 1 | [#4319 Metrics for PRs are never expiring](https://github.com/runatlantis/atlantis/issues/4319) | 60 | 16 | 2026-06-17 | bug, regression, never-stale |
+| 2 | [#5048 Unclearable locks with mergeability requirements after upgrade](https://github.com/runatlantis/atlantis/issues/5048) | 12 | 14 | 2025-03-13 | bug, regression |
+| 3 | [#3031 post_workflow_hook errors after apply when using --automerge](https://github.com/runatlantis/atlantis/issues/3031) | 11 | 19 | 2024-09-19 | bug, regression, hook, collab, never-stale |
+| 4 | [#4636 Gitlab Formatting and reaction issues in v0.28](https://github.com/runatlantis/atlantis/issues/4636) | 11 | 14 | 2024-09-06 | bug, regression |
+
+### Top RFC / Needs Discussion
+
+| Rank | Issue | Thumbs-up | Comments | Updated | Labels |
+| --- | --- | ---: | ---: | --- | --- |
+| 1 | [#3245 Drift Detection](https://github.com/runatlantis/atlantis/issues/3245) | 243 | 31 | 2026-05-25 | feature, help wanted, needs discussion, rfc |
+| 2 | [#671 Run terraform workflows from local CLI command without a VCS](https://github.com/runatlantis/atlantis/issues/671) | 17 | 8 | 2023-01-17 | feature, help wanted, needs discussion |
+| 3 | [#3202 More maintainers, reviewers, early adopters, and doc writers](https://github.com/runatlantis/atlantis/issues/3202) | 17 | 3 | 2025-03-30 | help wanted, needs discussion, never-stale |
+| 4 | [#6158 WebUI Refactor](https://github.com/runatlantis/atlantis/issues/6158) | 11 | 19 | 2026-03-22 | feature, refactoring, needs discussion, website, breaking-change |
+
+## Security And Permissions
+
+Recommended workflow shape:
+
+- Triggers: workflow_dispatch and daily schedule, for example 15 10 * * *.
+- Guard: github.repository == runatlantis/atlantis.
+- Top-level permissions: contents: read.
+- Job permissions: issues: write.
+- Token: GITHUB_TOKEN is sufficient for listing issues and editing one issue in the same repository.
+- Fork safety: no pull_request trigger; repository guard prevents accidental writes from copied repos.
+- Include step-security/harden-runner in audit mode to match Atlantis conventions.
+- Pin checkout/setup-go actions by SHA with version comments.
+
+The script should validate the target issue number and only edit that configured issue. It should not create issues, add labels, close issues, comment, or edit any other issue.
+
+## Maintenance Cost
+
+### Go Script Approach
+
+Recommended.
+
+Pros:
+
+- Easy to unit test filtering, grouping, sorting, and rendering.
+- Fits Atlantis' Go-heavy tooling.
+- go-github is already familiar and present in the root module.
+- Pagination and reaction counts are straightforward.
+- Safer than complex shell/JQ once categories and exclusions grow.
+
+Cons:
+
+- Adds a small separate module and go.sum.
+- Needs occasional dependency updates.
+- Must avoid copying OpenTofu MPL-2.0 code directly.
+
+Recommended structure:
+
+- .github/workflows/update-top-issues-ranking.yml
+- .github/scripts/update_top_issues_ranking/go.mod
+- .github/scripts/update_top_issues_ranking/go.sum
+- .github/scripts/update_top_issues_ranking/main.go
+- .github/scripts/update_top_issues_ranking/ranking.tmpl
+- .github/scripts/update_top_issues_ranking/main_test.go
+
+### Root Module Reuse
+
+Not recommended for v1. The root module is large and product-focused. A workflow utility should not add churn to product dependencies or root test surfaces.
+
+### Shell / gh / API Script
+
+Possible but not preferred. It avoids a Go module, but it is harder to unit test, more fragile around pagination/quoting, and less clear for deterministic sorting and Markdown escaping.
+
+## Implementation Notes
+
+Recommended script behavior:
+
+1. Parse flags: owner, repo, issue-number, min-thumbs-up, max-per-category, dry-run.
+2. Read GITHUB_TOKEN and require it in non-dry-run mode.
+3. List open issues with pagination.
+4. Explicitly skip pull requests.
+5. Skip issues with excluded labels.
+6. Skip the tracking issue itself.
+7. Skip issues below threshold.
+8. Group by category label mappings.
+9. Sort deterministically by thumbs-up, comments, updated date, and issue number.
+10. Render Markdown using text/template.
+11. In dry-run mode, print to stdout.
+12. In write mode, edit only the configured tracking issue.
+
+## Exact Files Likely Added Or Changed
+
+Likely added:
+
+- .github/workflows/update-top-issues-ranking.yml
+- .github/scripts/update_top_issues_ranking/go.mod
+- .github/scripts/update_top_issues_ranking/go.sum
+- .github/scripts/update_top_issues_ranking/main.go
+- .github/scripts/update_top_issues_ranking/ranking.tmpl
+- .github/scripts/update_top_issues_ranking/main_test.go
+
+Optional later changes:
+
+- .github/ISSUE_TEMPLATE/bug_report.md
+- .github/ISSUE_TEMPLATE/feature_request.md
+
+The optional template change would link to the ranking issue after maintainers create it. Do not include that in the initial implementation unless maintainers explicitly want it.
+
+## Implementation Risks
+
+- Reaction count is community signal, not severity. High-vote features can dominate urgent lower-vote bugs.
+- Stale issues can still have high historical support. Excluding them makes rankings more actionable but may hide dormant demand.
+- Label hygiene matters.
+- Multi-label issues can appear in multiple categories. That is acceptable if framed as multiple views, but it may feel repetitive.
+- The ranking issue itself can become a target for reactions/comments; the script should exclude it from rankings.
+- GitHub issue endpoints can include PRs; the script must explicitly skip PRs.
+- Copying OpenTofu code would introduce MPL-2.0 license considerations.
+- Scheduled workflow permissions must remain limited to the one job that edits the configured issue.
+
+## Validation Plan
+
+1. Create or identify the tracking issue manually.
+2. Add unit tests for PR exclusion, excluded labels, threshold filtering, deterministic sort ties, category grouping, tracking issue self-exclusion, and Markdown escaping.
+3. Run script tests: cd .github/scripts/update_top_issues_ranking && go test ./...
+4. Run dry-run locally against live data with GITHUB_TOKEN from gh auth token.
+5. Run gofmt over the script directory.
+6. Validate workflow syntax with actionlint if available.
+7. Review generated Markdown manually for links, tables, excluded labels, and absence of PRs.
+8. After merge, run workflow_dispatch on runatlantis/atlantis and verify only the configured tracking issue body changes.

--- a/.codex/top-issues-ranking-implementation.md
+++ b/.codex/top-issues-ranking-implementation.md
@@ -1,0 +1,112 @@
+# Top Issues Ranking Implementation Prototype
+
+Date: 2026-06-29
+
+## Design Summary
+
+This prototype adds an Atlantis-native scheduled/manual GitHub Actions workflow and a standalone Go utility that updates one configured tracking issue with open Atlantis issues ranked by thumbs-up reactions.
+
+The implementation is a fresh Atlantis Apache-2.0 implementation, not a copy of OpenTofu's MPL-2.0 Go source.
+
+The script:
+
+- lists all open issues with pagination
+- explicitly excludes pull requests
+- excludes the tracking issue itself
+- excludes closed issues and configured noise labels
+- filters by minimum thumbs-up threshold
+- groups issues into Atlantis-specific categories
+- sorts deterministically
+- renders Markdown tables
+- prints the generated Markdown in dry-run mode
+- edits only the configured tracking issue in write mode
+
+## Label / Category Mapping
+
+| Category | Labels |
+| --- | --- |
+| Top Feature Requests | feature |
+| Top Bugs | bug |
+| Top Regressions | regression |
+| Top RFC / Needs Discussion | rfc, needs discussion |
+| Top Contributor-Friendly Issues | help wanted, quick-win |
+
+Excluded labels:
+
+- Stale
+- duplicate
+- wont-do
+- spam
+- waiting-on-response
+
+Defaults:
+
+- Minimum thumbs-up threshold: 10
+- Max rows per category: 15
+
+## Tracking Issue Setup Steps
+
+Tracking issue:
+
+- URL: <https://github.com/runatlantis/atlantis/issues/6608>
+- Issue number: 6608
+
+Repository variable:
+
+- TOP_ISSUES_TRACKING_ISSUE is set to 6608.
+- Recreate or repair it with:
+
+      gh variable set TOP_ISSUES_TRACKING_ISSUE --repo runatlantis/atlantis --body 6608
+
+Manual verification after the workflow is merged:
+
+1. Open the "Update top issues ranking" workflow in GitHub Actions.
+2. Run workflow_dispatch with issue_number left blank to use TOP_ISSUES_TRACKING_ISSUE, or set issue_number to 6608 for an explicit override.
+3. Confirm the workflow updates <https://github.com/runatlantis/atlantis/issues/6608> and no other issue.
+
+The workflow intentionally fails with a clear error if no tracking issue number is configured.
+
+## Dry-Run Command
+
+From the script directory:
+
+    GITHUB_TOKEN=$(gh auth token) go run . --owner runatlantis --repo atlantis --issue-number 6608 --dry-run
+
+The dry-run does not edit GitHub and prints the generated Markdown to stdout.
+
+## Production Workflow Command / Path
+
+Workflow:
+
+    .github/workflows/update-top-issues-ranking.yml
+
+Production command run by the workflow:
+
+    cd .github/scripts/update_top_issues_ranking
+    go run . --owner runatlantis --repo atlantis --issue-number "$issue_number"
+
+## Security / Permission Notes
+
+- The workflow has no pull_request trigger.
+- The job is guarded with github.repository == 'runatlantis/atlantis'.
+- Top-level permissions are contents: read.
+- The update job adds issues: write because it edits the configured tracking issue.
+- The script requires GITHUB_TOKEN in write mode.
+- The script only calls Issues.Edit for the configured issue number.
+- step-security/harden-runner runs in audit mode.
+- Actions are pinned by full SHA with version comments.
+
+## Limitations
+
+- Reaction count is community signal, not severity or maintainer priority.
+- Stale issues can still have meaningful historical demand, but are excluded by default for actionability.
+- Issues with multiple labels can appear in multiple categories.
+- Label hygiene affects category accuracy.
+- The workflow will fail if TOP_ISSUES_TRACKING_ISSUE is removed or set to an invalid issue number.
+
+## Follow-Up Options
+
+- Link the tracking issue from bug and feature issue templates after maintainers create it.
+- Add a separate "Recently updated high-signal issues" section.
+- Make categories and excluded labels configurable through a YAML file.
+- Add a workflow_dispatch dry-run mode that uploads generated Markdown as an artifact.

--- a/.github/scripts/update_top_issues_ranking/go.mod
+++ b/.github/scripts/update_top_issues_ranking/go.mod
@@ -1,0 +1,7 @@
+module github.com/runatlantis/atlantis/.github/scripts/update_top_issues_ranking
+
+go 1.26.4
+
+require github.com/google/go-github/v88 v88.0.0
+
+require github.com/google/go-querystring v1.2.0 // indirect

--- a/.github/scripts/update_top_issues_ranking/go.sum
+++ b/.github/scripts/update_top_issues_ranking/go.sum
@@ -1,0 +1,7 @@
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/go-github/v88 v88.0.0 h1:dZA9IKkPK1eXZj4ypngnpRj5FwdpTv4whix2PrQMP7M=
+github.com/google/go-github/v88 v88.0.0/go.mod h1:rufTDgn2N45wjhukLTyxmvc9nilSp3mr3Rgtt6b1MPw=
+github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
+github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=

--- a/.github/scripts/update_top_issues_ranking/main.go
+++ b/.github/scripts/update_top_issues_ranking/main.go
@@ -1,0 +1,382 @@
+// Copyright 2026 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"slices"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/google/go-github/v88/github"
+)
+
+//go:embed ranking.tmpl
+var rankingTemplate string
+
+const (
+	defaultMinThumbsUp    = 10
+	defaultMaxPerCategory = 15
+	markdownBacktick      = "\x60"
+)
+
+var (
+	defaultCategories = []categoryConfig{
+		{Name: "Top Feature Requests", Labels: []string{"feature"}},
+		{Name: "Top Bugs", Labels: []string{"bug"}},
+		{Name: "Top Regressions", Labels: []string{"regression"}},
+		{Name: "Top RFC / Needs Discussion", Labels: []string{"rfc", "needs discussion"}},
+		{Name: "Top Contributor-Friendly Issues", Labels: []string{"help wanted", "quick-win"}},
+	}
+
+	defaultExcludedLabels = []string{
+		"Stale",
+		"duplicate",
+		"wont-do",
+		"spam",
+		"waiting-on-response",
+	}
+)
+
+type options struct {
+	Owner          string
+	Repo           string
+	IssueNumber    int
+	MinThumbsUp    int
+	MaxPerCategory int
+	DryRun         bool
+}
+
+type categoryConfig struct {
+	Name   string
+	Labels []string
+}
+
+type rankedIssue struct {
+	Number        int
+	Title         string
+	URL           string
+	Labels        []string
+	ThumbsUp      int
+	Comments      int
+	UpdatedAt     time.Time
+	State         string
+	IsPullRequest bool
+}
+
+type rankingConfig struct {
+	Categories          []categoryConfig
+	ExcludedLabels      []string
+	TrackingIssueNumber int
+	MinThumbsUp         int
+	MaxPerCategory      int
+	GeneratedAt         time.Time
+}
+
+type rankingData struct {
+	GeneratedAt    string
+	MinThumbsUp    int
+	ExcludedLabels string
+	Categories     []categoryData
+}
+
+type categoryData struct {
+	Name   string
+	Issues []issueRow
+}
+
+type issueRow struct {
+	Rank     int
+	Issue    string
+	ThumbsUp int
+	Comments int
+	Updated  string
+	Labels   string
+}
+
+func main() {
+	opts, err := parseOptions(os.Args[1:])
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := run(context.Background(), opts, os.Getenv("GITHUB_TOKEN"), os.Stdout); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func parseOptions(args []string) (options, error) {
+	var opts options
+	fs := flag.NewFlagSet("update-top-issues-ranking", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.StringVar(&opts.Owner, "owner", "", "GitHub repository owner")
+	fs.StringVar(&opts.Repo, "repo", "", "GitHub repository name")
+	fs.IntVar(&opts.IssueNumber, "issue-number", 0, "tracking issue number to update")
+	fs.IntVar(&opts.MinThumbsUp, "min-thumbs-up", defaultMinThumbsUp, "minimum thumbs-up reactions required")
+	fs.IntVar(&opts.MaxPerCategory, "max-per-category", defaultMaxPerCategory, "maximum issues to render per category")
+	fs.BoolVar(&opts.DryRun, "dry-run", false, "print generated Markdown instead of updating GitHub")
+
+	if err := fs.Parse(args); err != nil {
+		return options{}, err
+	}
+	if opts.Owner == "" {
+		return options{}, errors.New("--owner is required")
+	}
+	if opts.Repo == "" {
+		return options{}, errors.New("--repo is required")
+	}
+	if opts.MinThumbsUp < 0 {
+		return options{}, errors.New("--min-thumbs-up must be greater than or equal to 0")
+	}
+	if opts.MaxPerCategory <= 0 {
+		return options{}, errors.New("--max-per-category must be greater than 0")
+	}
+	if !opts.DryRun && opts.IssueNumber <= 0 {
+		return options{}, errors.New("--issue-number must be set to the tracking issue number in write mode")
+	}
+	return opts, nil
+}
+
+func run(ctx context.Context, opts options, token string, out io.Writer) error {
+	if !opts.DryRun && token == "" {
+		return errors.New("GITHUB_TOKEN is required in write mode")
+	}
+
+	clientOptions := []github.ClientOptionsFunc{}
+	if token != "" {
+		clientOptions = append(clientOptions, github.WithAuthToken(token))
+	}
+	client, err := github.NewClient(clientOptions...)
+	if err != nil {
+		return fmt.Errorf("creating GitHub client: %w", err)
+	}
+
+	issues, err := listOpenIssues(ctx, client, opts.Owner, opts.Repo)
+	if err != nil {
+		return err
+	}
+
+	data := buildRankingData(issues, rankingConfig{
+		Categories:          defaultCategories,
+		ExcludedLabels:      defaultExcludedLabels,
+		TrackingIssueNumber: opts.IssueNumber,
+		MinThumbsUp:         opts.MinThumbsUp,
+		MaxPerCategory:      opts.MaxPerCategory,
+		GeneratedAt:         time.Now().UTC(),
+	})
+
+	body, err := renderRanking(data)
+	if err != nil {
+		return err
+	}
+
+	if opts.DryRun {
+		_, err := fmt.Fprint(out, body)
+		return err
+	}
+
+	_, _, err = client.Issues.Edit(ctx, opts.Owner, opts.Repo, opts.IssueNumber, &github.IssueRequest{
+		Body: github.Ptr(body),
+	})
+	if err != nil {
+		return fmt.Errorf("updating issue #%d: %w", opts.IssueNumber, err)
+	}
+	return nil
+}
+
+func listOpenIssues(ctx context.Context, client *github.Client, owner string, repo string) ([]rankedIssue, error) {
+	opts := &github.IssueListByRepoOptions{
+		State: "open",
+		ListOptions: github.ListOptions{
+			PerPage: 100,
+		},
+	}
+
+	var issues []rankedIssue
+	for {
+		page, resp, err := client.Issues.ListByRepo(ctx, owner, repo, opts)
+		if err != nil {
+			return nil, fmt.Errorf("listing open issues: %w", err)
+		}
+		for _, issue := range page {
+			issues = append(issues, issueFromGitHub(issue))
+		}
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		opts.ListOptions.Page = resp.NextPage
+	}
+
+	return issues, nil
+}
+
+func issueFromGitHub(issue *github.Issue) rankedIssue {
+	labels := make([]string, 0, len(issue.Labels))
+	for _, label := range issue.Labels {
+		labels = append(labels, label.GetName())
+	}
+	slices.SortFunc(labels, func(a string, b string) int {
+		return strings.Compare(strings.ToLower(a), strings.ToLower(b))
+	})
+
+	return rankedIssue{
+		Number:        issue.GetNumber(),
+		Title:         issue.GetTitle(),
+		URL:           issue.GetHTMLURL(),
+		Labels:        labels,
+		ThumbsUp:      issue.GetReactions().GetPlusOne(),
+		Comments:      issue.GetComments(),
+		UpdatedAt:     issue.GetUpdatedAt().Time,
+		State:         issue.GetState(),
+		IsPullRequest: issue.IsPullRequest(),
+	}
+}
+
+func buildRankingData(issues []rankedIssue, cfg rankingConfig) rankingData {
+	filtered := make([]rankedIssue, 0, len(issues))
+	for _, issue := range issues {
+		if includeIssue(issue, cfg) {
+			filtered = append(filtered, issue)
+		}
+	}
+
+	data := rankingData{
+		GeneratedAt:    cfg.GeneratedAt.UTC().Format("2006-01-02 15:04:05 UTC"),
+		MinThumbsUp:    cfg.MinThumbsUp,
+		ExcludedLabels: formatInlineCodeList(cfg.ExcludedLabels),
+		Categories:     make([]categoryData, 0, len(cfg.Categories)),
+	}
+
+	for _, category := range cfg.Categories {
+		categoryIssues := make([]rankedIssue, 0, len(filtered))
+		for _, issue := range filtered {
+			if hasAnyLabel(issue, category.Labels) {
+				categoryIssues = append(categoryIssues, issue)
+			}
+		}
+		sortIssues(categoryIssues)
+		if len(categoryIssues) > cfg.MaxPerCategory {
+			categoryIssues = categoryIssues[:cfg.MaxPerCategory]
+		}
+
+		categoryData := categoryData{Name: category.Name}
+		for i, issue := range categoryIssues {
+			categoryData.Issues = append(categoryData.Issues, issueRow{
+				Rank:     i + 1,
+				Issue:    issueMarkdownLink(issue),
+				ThumbsUp: issue.ThumbsUp,
+				Comments: issue.Comments,
+				Updated:  issue.UpdatedAt.UTC().Format("2006-01-02"),
+				Labels:   formatLabelList(issue.Labels),
+			})
+		}
+		data.Categories = append(data.Categories, categoryData)
+	}
+
+	return data
+}
+
+func includeIssue(issue rankedIssue, cfg rankingConfig) bool {
+	if issue.IsPullRequest {
+		return false
+	}
+	if !strings.EqualFold(issue.State, "open") {
+		return false
+	}
+	if cfg.TrackingIssueNumber > 0 && issue.Number == cfg.TrackingIssueNumber {
+		return false
+	}
+	if issue.ThumbsUp < cfg.MinThumbsUp {
+		return false
+	}
+	return !hasAnyLabel(issue, cfg.ExcludedLabels)
+}
+
+func sortIssues(issues []rankedIssue) {
+	slices.SortFunc(issues, func(a rankedIssue, b rankedIssue) int {
+		if a.ThumbsUp != b.ThumbsUp {
+			return b.ThumbsUp - a.ThumbsUp
+		}
+		if a.Comments != b.Comments {
+			return b.Comments - a.Comments
+		}
+		if !a.UpdatedAt.Equal(b.UpdatedAt) {
+			if a.UpdatedAt.After(b.UpdatedAt) {
+				return -1
+			}
+			return 1
+		}
+		return a.Number - b.Number
+	})
+}
+
+func renderRanking(data rankingData) (string, error) {
+	tmpl, err := template.New("ranking").Parse(rankingTemplate)
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func hasAnyLabel(issue rankedIssue, labels []string) bool {
+	issueLabels := make(map[string]struct{}, len(issue.Labels))
+	for _, label := range issue.Labels {
+		issueLabels[strings.ToLower(label)] = struct{}{}
+	}
+	for _, label := range labels {
+		if _, ok := issueLabels[strings.ToLower(label)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func issueMarkdownLink(issue rankedIssue) string {
+	return fmt.Sprintf("[#%d %s](%s)", issue.Number, escapeMarkdownTableText(issue.Title), issue.URL)
+}
+
+func formatLabelList(labels []string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	escaped := make([]string, 0, len(labels))
+	for _, label := range labels {
+		escaped = append(escaped, markdownBacktick+escapeMarkdownTableText(label)+markdownBacktick)
+	}
+	return strings.Join(escaped, ", ")
+}
+
+func formatInlineCodeList(values []string) string {
+	escaped := make([]string, 0, len(values))
+	for _, value := range values {
+		escaped = append(escaped, markdownBacktick+escapeMarkdownTableText(value)+markdownBacktick)
+	}
+	return strings.Join(escaped, ", ")
+}
+
+func escapeMarkdownTableText(s string) string {
+	replacer := strings.NewReplacer(
+		"\\", "\\\\",
+		"|", "\\|",
+		"\r", " ",
+		"\n", " ",
+		"[", "\\[",
+		"]", "\\]",
+	)
+	return strings.Join(strings.Fields(replacer.Replace(s)), " ")
+}

--- a/.github/scripts/update_top_issues_ranking/main_test.go
+++ b/.github/scripts/update_top_issues_ranking/main_test.go
@@ -1,0 +1,223 @@
+// Copyright 2026 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildRankingDataFiltersIssues(t *testing.T) {
+	base := testIssue(1, "feature", 20, labels("feature"))
+	category := []categoryConfig{{Name: "Features", Labels: []string{"feature"}}}
+
+	tests := []struct {
+		name                string
+		issue               rankedIssue
+		trackingIssueNumber int
+		wantIncluded        bool
+	}{
+		{
+			name:         "includes matching issue",
+			issue:        base,
+			wantIncluded: true,
+		},
+		{
+			name: "excludes pull requests",
+			issue: testIssue(2, "pull request", 100, labels("feature"), func(issue *rankedIssue) {
+				issue.IsPullRequest = true
+			}),
+		},
+		{
+			name:  "excludes configured labels case insensitively",
+			issue: testIssue(3, "stale", 100, labels("feature", "stale")),
+		},
+		{
+			name:  "excludes issues below threshold",
+			issue: testIssue(4, "below threshold", 9, labels("feature")),
+		},
+		{
+			name:                "excludes tracking issue",
+			issue:               testIssue(5, "tracking issue", 100, labels("feature")),
+			trackingIssueNumber: 5,
+		},
+		{
+			name: "excludes closed issues",
+			issue: testIssue(6, "closed", 100, labels("feature"), func(issue *rankedIssue) {
+				issue.State = "closed"
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := buildRankingData([]rankedIssue{tt.issue}, testConfig(category, tt.trackingIssueNumber))
+			got := data.Categories[0].Issues
+			if tt.wantIncluded {
+				if len(got) != 1 {
+					t.Fatalf("expected issue to be included, got %#v", got)
+				}
+				if !strings.Contains(got[0].Issue, "#"+strconv.Itoa(tt.issue.Number)+" ") {
+					t.Fatalf("expected issue #%d, got %q", tt.issue.Number, got[0].Issue)
+				}
+				return
+			}
+			if len(got) != 0 {
+				t.Fatalf("expected issue to be excluded, got %#v", got)
+			}
+		})
+	}
+}
+
+func TestBuildRankingDataGroupsByCategory(t *testing.T) {
+	issues := []rankedIssue{
+		testIssue(1, "feature", 20, labels("feature")),
+		testIssue(2, "bug regression", 20, labels("bug", "regression")),
+		testIssue(3, "discussion", 20, labels("needs discussion")),
+		testIssue(4, "contributor", 20, labels("quick-win")),
+	}
+
+	data := buildRankingData(issues, testConfig(defaultCategories, 0))
+
+	assertCategoryIssues(t, data, "Top Feature Requests", []int{1})
+	assertCategoryIssues(t, data, "Top Bugs", []int{2})
+	assertCategoryIssues(t, data, "Top Regressions", []int{2})
+	assertCategoryIssues(t, data, "Top RFC / Needs Discussion", []int{3})
+	assertCategoryIssues(t, data, "Top Contributor-Friendly Issues", []int{4})
+}
+
+func TestSortIssuesDeterministicTies(t *testing.T) {
+	issues := []rankedIssue{
+		testIssue(4, "lower comments", 10, labels("feature"), withComments(1), withUpdated("2024-01-01")),
+		testIssue(3, "older", 10, labels("feature"), withComments(2), withUpdated("2023-01-01")),
+		testIssue(2, "higher number", 10, labels("feature"), withComments(2), withUpdated("2024-01-01")),
+		testIssue(1, "lowest number", 10, labels("feature"), withComments(2), withUpdated("2024-01-01")),
+		testIssue(5, "most thumbs up", 11, labels("feature"), withComments(0), withUpdated("2020-01-01")),
+	}
+
+	data := buildRankingData(issues, testConfig([]categoryConfig{{Name: "Features", Labels: []string{"feature"}}}, 0))
+
+	assertCategoryIssues(t, data, "Features", []int{5, 1, 2, 3, 4})
+}
+
+func TestBuildRankingDataLimitsRowsPerCategory(t *testing.T) {
+	issues := []rankedIssue{
+		testIssue(1, "one", 30, labels("feature")),
+		testIssue(2, "two", 20, labels("feature")),
+		testIssue(3, "three", 10, labels("feature")),
+	}
+
+	cfg := testConfig([]categoryConfig{{Name: "Features", Labels: []string{"feature"}}}, 0)
+	cfg.MaxPerCategory = 2
+	data := buildRankingData(issues, cfg)
+
+	assertCategoryIssues(t, data, "Features", []int{1, 2})
+}
+
+func TestRenderRankingMarkdownTableAndEscaping(t *testing.T) {
+	issue := testIssue(42, "Pipe | [brackets]\nnext", 12, labels("feature", "provider/github"), withComments(3), withUpdated("2026-06-29"))
+	data := buildRankingData([]rankedIssue{issue}, testConfig([]categoryConfig{{Name: "Features", Labels: []string{"feature"}}}, 0))
+
+	got, err := renderRanking(data)
+	if err != nil {
+		t.Fatalf("render ranking: %v", err)
+	}
+
+	expected := []string{
+		"# Top-Ranking Atlantis Issues 📊",
+		"_Last updated: 2026-06-29 12:00:00 UTC._",
+		"| Rank | Issue | 👍 | Comments | Updated | Labels |",
+		"| 1 | [#42 Pipe \\| \\[brackets\\] next](https://github.com/runatlantis/atlantis/issues/42) | 12 | 3 | 2026-06-29 | " + markdownBacktick + "feature" + markdownBacktick + ", " + markdownBacktick + "provider/github" + markdownBacktick + " |",
+		"ranked by 👍 reactions on the original issue",
+		"not a roadmap commitment, priority guarantee, or acceptance decision",
+	}
+	for _, want := range expected {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected rendered markdown to contain %q\n\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderRankingEmptyCategory(t *testing.T) {
+	data := buildRankingData(nil, testConfig([]categoryConfig{{Name: "Features", Labels: []string{"feature"}}}, 0))
+
+	got, err := renderRanking(data)
+	if err != nil {
+		t.Fatalf("render ranking: %v", err)
+	}
+	if !strings.Contains(got, "## Features") {
+		t.Fatalf("expected category heading, got:\n%s", got)
+	}
+	if !strings.Contains(got, "No matching issues above threshold.") {
+		t.Fatalf("expected empty category message, got:\n%s", got)
+	}
+}
+
+func testConfig(categories []categoryConfig, trackingIssueNumber int) rankingConfig {
+	return rankingConfig{
+		Categories:          categories,
+		ExcludedLabels:      defaultExcludedLabels,
+		TrackingIssueNumber: trackingIssueNumber,
+		MinThumbsUp:         defaultMinThumbsUp,
+		MaxPerCategory:      defaultMaxPerCategory,
+		GeneratedAt:         time.Date(2026, 6, 29, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+func testIssue(number int, title string, thumbsUp int, issueLabels []string, opts ...func(*rankedIssue)) rankedIssue {
+	issue := rankedIssue{
+		Number:    number,
+		Title:     title,
+		URL:       "https://github.com/runatlantis/atlantis/issues/" + strconv.Itoa(number),
+		Labels:    issueLabels,
+		ThumbsUp:  thumbsUp,
+		UpdatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		State:     "open",
+	}
+	for _, opt := range opts {
+		opt(&issue)
+	}
+	return issue
+}
+
+func labels(values ...string) []string {
+	return values
+}
+
+func withComments(comments int) func(*rankedIssue) {
+	return func(issue *rankedIssue) {
+		issue.Comments = comments
+	}
+}
+
+func withUpdated(date string) func(*rankedIssue) {
+	return func(issue *rankedIssue) {
+		parsed, err := time.Parse("2006-01-02", date)
+		if err != nil {
+			panic(err)
+		}
+		issue.UpdatedAt = parsed
+	}
+}
+
+func assertCategoryIssues(t *testing.T, data rankingData, categoryName string, want []int) {
+	t.Helper()
+	for _, category := range data.Categories {
+		if category.Name != categoryName {
+			continue
+		}
+		if len(category.Issues) != len(want) {
+			t.Fatalf("%s: expected %d issues, got %d: %#v", categoryName, len(want), len(category.Issues), category.Issues)
+		}
+		for i, row := range category.Issues {
+			if !strings.Contains(row.Issue, "#"+strconv.Itoa(want[i])+" ") {
+				t.Fatalf("%s: row %d expected issue #%d, got %q", categoryName, i, want[i], row.Issue)
+			}
+		}
+		return
+	}
+	t.Fatalf("category %q not found", categoryName)
+}

--- a/.github/scripts/update_top_issues_ranking/ranking.tmpl
+++ b/.github/scripts/update_top_issues_ranking/ranking.tmpl
@@ -1,0 +1,19 @@
+# Top-Ranking Atlantis Issues 📊
+
+_Last updated: {{ .GeneratedAt }}._
+
+This issue is updated automatically from open Atlantis issues ranked by 👍 reactions on the original issue. Rankings are community signal for maintainers and contributors, not a roadmap commitment, priority guarantee, or acceptance decision.
+
+Minimum 👍 threshold: {{ .MinThumbsUp }}.
+
+Excluded labels: {{ .ExcludedLabels }}.
+{{ range .Categories }}
+## {{ .Name }}
+{{ if .Issues }}
+| Rank | Issue | 👍 | Comments | Updated | Labels |
+| --- | --- | ---: | ---: | --- | --- |
+{{ range .Issues }}| {{ .Rank }} | {{ .Issue }} | {{ .ThumbsUp }} | {{ .Comments }} | {{ .Updated }} | {{ .Labels }} |
+{{ end }}{{ else }}
+No matching issues above threshold.
+{{ end }}
+{{ end }}

--- a/.github/workflows/update-top-issues-ranking.yml
+++ b/.github/workflows/update-top-issues-ranking.yml
@@ -1,0 +1,53 @@
+name: Update top issues ranking
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Tracking issue number to update. Overrides TOP_ISSUES_TRACKING_ISSUE when set.
+        required: false
+        type: string
+  schedule:
+    - cron: '15 10 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  update:
+    if: github.repository == 'runatlantis/atlantis'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TOP_ISSUES_TRACKING_ISSUE: ${{ vars.TOP_ISSUES_TRACKING_ISSUE }}
+      TOP_ISSUES_TRACKING_ISSUE_INPUT: ${{ github.event.inputs.issue_number }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: .github/scripts/update_top_issues_ranking/go.mod
+          cache-dependency-path: .github/scripts/update_top_issues_ranking/go.sum
+
+      - name: Update top issues ranking
+        run: |
+          issue_number="${TOP_ISSUES_TRACKING_ISSUE_INPUT:-${TOP_ISSUES_TRACKING_ISSUE:-}}"
+          if [ -z "$issue_number" ] || [ "$issue_number" = "0" ]; then
+            echo "::error::Create the tracking issue, then set the TOP_ISSUES_TRACKING_ISSUE repository variable or pass issue_number when running workflow_dispatch."
+            exit 1
+          fi
+
+          cd .github/scripts/update_top_issues_ranking
+          go run . \
+            --owner runatlantis \
+            --repo atlantis \
+            --issue-number "$issue_number"


### PR DESCRIPTION
## Summary

Adds a scheduled/manual workflow that updates a tracking issue with top open Atlantis issues ranked by 👍 reactions.

Tracking issue:

- https://github.com/runatlantis/atlantis/issues/6608

Repository variable:

- `TOP_ISSUES_TRACKING_ISSUE=6608`

## Why

Atlantis issue templates already ask users to vote with 👍 reactions instead of leaving `+1` comments. This makes that existing community signal easier for maintainers and contributors to inspect.

This ranking is intentionally framed as signal only. It is not a roadmap commitment, priority guarantee, or acceptance decision.

## Implementation

Adds:

- `.github/workflows/update-top-issues-ranking.yml`
- `.github/scripts/update_top_issues_ranking`
- `.codex/top-issues-ranking-exploration.md`
- `.codex/top-issues-ranking-implementation.md`

The script:

- lists all open issues with pagination
- excludes pull requests
- excludes the tracking issue itself
- excludes stale/noise labels
- filters by minimum 👍 threshold, default `10`
- groups issues by Atlantis labels:
  - `feature`
  - `bug`
  - `regression`
  - `rfc` / `needs discussion`
  - `help wanted` / `quick-win`
- sorts deterministically by:
  - 👍 descending
  - comment count descending
  - updated date descending
  - issue number ascending
- renders Markdown tables
- supports `--dry-run`
- only edits the configured issue in write mode

## Security / workflow behavior

- Uses `contents: read`
- Uses `issues: write` only for the update job
- Guards the job with `github.repository == 'runatlantis/atlantis'`
- Uses `GITHUB_TOKEN`
- Keeps the tracking issue number configurable through `TOP_ISSUES_TRACKING_ISSUE`
- Supports manual dispatch override for trusted maintainers

## Validation

Passed:

```bash
cd .github/scripts/update_top_issues_ranking && go test ./... -count=1
GITHUB_TOKEN=$(gh auth token) go run . --owner runatlantis --repo atlantis --issue-number 6608 --dry-run
GITHUB_TOKEN=$(gh auth token) go run . --owner runatlantis --repo atlantis --issue-number 6608
actionlint .github/workflows/update-top-issues-ranking.yml
```

## Notes

This is a fresh Atlantis-specific implementation. It does not copy OpenTofu’s MPL-2.0 Go source.
