### PR TITLE
fix: normalize TestExecute_Flags path assertions

### DIFF
--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -9,6 +9,7 @@ import (
 	"cmp"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"slices"
@@ -226,13 +227,53 @@ func TestExecute_Defaults(t *testing.T) {
 	}
 }
 
+func normalizePath(v any) string {
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+
+	if s == "" || s == "." {
+		return ""
+	}
+
+	if len(s) >= 2 && s[1] == ':' {
+		s = s[2:]
+	}
+
+	s = filepath.ToSlash(s)
+	s = path.Clean(s)
+
+	return s
+}
+
+var pathFlags = map[string]struct{}{
+	"data-dir":                        {},
+	"markdown-template-overrides-dir": {},
+}
+
 func TestExecute_Flags(t *testing.T) {
 	t.Log("Should use all flags that are set.")
+
 	c := setup(testFlags, t)
+
 	err := c.Execute()
 	Ok(t, err)
+
 	for flag, exp := range testFlags {
-		Equals(t, exp, configVal(t, passedConfig, flag))
+		got := configVal(t, passedConfig, flag)
+
+		expS := fmt.Sprintf("%v", exp)
+		gotS := fmt.Sprintf("%v", got)
+
+		if _, ok := pathFlags[flag]; ok {
+			expS = normalizePath(expS)
+			gotS = normalizePath(gotS)
+		}
+
+		t.Logf("flag=%s exp=%v got=%v", flag, expS, gotS)
+
+		Equals(t, expS, gotS)
 	}
 }
 

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -227,12 +227,7 @@ func TestExecute_Defaults(t *testing.T) {
 	}
 }
 
-func normalizePath(v any) string {
-	s, ok := v.(string)
-	if !ok {
-		return ""
-	}
-
+func normalizePath(s string) string {
 	if s == "" || s == "." {
 		return ""
 	}
@@ -241,15 +236,63 @@ func normalizePath(v any) string {
 		s = s[2:]
 	}
 
-	s = filepath.ToSlash(s)
+	s = strings.ReplaceAll(s, "\\", "/")
 	s = path.Clean(s)
+	if s == "." {
+		return ""
+	}
 
 	return s
 }
 
+func TestNormalizePath(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		exp  string
+	}{
+		{
+			name: "empty",
+			in:   "",
+			exp:  "",
+		},
+		{
+			name: "dot",
+			in:   ".",
+			exp:  "",
+		},
+		{
+			name: "unix path",
+			in:   "foo/bar",
+			exp:  "foo/bar",
+		},
+		{
+			name: "windows separators",
+			in:   `foo\bar`,
+			exp:  "foo/bar",
+		},
+		{
+			name: "windows drive with backslashes",
+			in:   `C:\foo\bar`,
+			exp:  "/foo/bar",
+		},
+		{
+			name: "windows drive with slashes",
+			in:   "C:/foo/bar",
+			exp:  "/foo/bar",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Equals(t, tt.exp, normalizePath(tt.in))
+		})
+	}
+}
+
 var pathFlags = map[string]struct{}{
-	"data-dir":                        {},
-	"markdown-template-overrides-dir": {},
+	DataDirFlag:                      {},
+	MarkdownTemplateOverridesDirFlag: {},
 }
 
 func TestExecute_Flags(t *testing.T) {
@@ -263,17 +306,22 @@ func TestExecute_Flags(t *testing.T) {
 	for flag, exp := range testFlags {
 		got := configVal(t, passedConfig, flag)
 
-		expS := fmt.Sprintf("%v", exp)
-		gotS := fmt.Sprintf("%v", got)
-
 		if _, ok := pathFlags[flag]; ok {
-			expS = normalizePath(expS)
-			gotS = normalizePath(gotS)
+			expPath, ok := exp.(string)
+			Equals(t, true, ok)
+			gotPath, ok := got.(string)
+			Equals(t, true, ok)
+
+			normExp := normalizePath(expPath)
+			normGot := normalizePath(gotPath)
+
+			t.Logf("flag=%s exp=%v got=%v", flag, normExp, normGot)
+			Equals(t, normExp, normGot)
+			continue
 		}
 
-		t.Logf("flag=%s exp=%v got=%v", flag, expS, gotS)
-
-		Equals(t, expS, gotS)
+		t.Logf("flag=%s exp=%v got=%v", flag, exp, got)
+		Equals(t, exp, got)
 	}
 }
 


### PR DESCRIPTION
## Problem

`TestExecute_Flags` can fail across operating systems because path-like flag values may use different path representations, such as Unix-style paths and Windows drive-letter paths.

The test should normalize only the path-like flags while preserving typed equality for every other flag.

## Fix

- normalizes only path-related flags before comparison
- replaces Windows backslashes with `/` before `path.Clean`
- strips Windows drive letters for comparison consistency
- keeps typed `Equals(t, exp, got)` assertions for non-path flags
- uses existing flag constants in the `pathFlags` set
- adds focused `normalizePath` regression coverage

## Impact

- fixes cross-platform path assertion instability in `TestExecute_Flags`
- preserves non-path flag type coverage
- changes tests only; no production behavior changes

## Testing

- `go test ./cmd -run 'TestExecute_Flags|TestNormalizePath' -count=1`
- `go test ./cmd -count=1`
