### PR TITLE
feat: keep plans on partial failure, add 'atlantis plan --failed'

### DIFF
--- a/runatlantis.io/docs/api-endpoints.md
+++ b/runatlantis.io/docs/api-endpoints.md
@@ -178,6 +178,10 @@ curl --request POST 'https://<ATLANTIS_HOST_NAME>/api/plan' \
 }
 ```
 
+::: tip NOTE
+`PlansDeleted` is deprecated and always `false`: plans are no longer deleted when a project errors. It is kept in the response for backwards compatibility.
+:::
+
 #### Sample Response (Error)
 
 When a request/auth/setup error occurs, the legacy endpoint returns a top-level error body:

--- a/runatlantis.io/docs/automerging.md
+++ b/runatlantis.io/docs/automerging.md
@@ -74,10 +74,17 @@ atlantis apply -d dir1
 ```
 
 Even though that plan succeeded, because **all** plans must succeed for **any** plans
-to be saved.
+to be applied.
 
-Once I fix the issue in `dir2`, I can push a new commit which will trigger an
-autoplan. Then I will be able to apply both plans.
+Atlantis keeps the successful plan for `dir1/`, but blocks apply while `dir2/`
+is still failed. Once I fix the issue in `dir2`, I can push a new commit which
+will trigger an autoplan, or I can re-run only failed plans:
+
+```shell
+atlantis plan --failed
+```
+
+Then I will be able to apply both plans.
 
 ### All Plans must be applied
 

--- a/runatlantis.io/docs/automerging.md
+++ b/runatlantis.io/docs/automerging.md
@@ -59,7 +59,7 @@ This is currently only implemented for the GitHub VCS.
 ### All Plans Must Succeed
 
 When automerge is enabled, **all plans** in a pull request **must succeed** before
-**any** plans can be applied.
+the pull request is merged, and before `atlantis apply` will apply everything.
 
 For example, imagine this scenario:
 
@@ -67,17 +67,32 @@ For example, imagine this scenario:
    and `dir2/`.
 1. The plan for `dir2/` fails because my Terraform syntax is wrong.
 
-In this scenario, I can't run
+Atlantis keeps the successful plan for `dir1/`, but blocks
+
+```shell
+atlantis apply
+```
+
+while `dir2/` is still failed, because **all** plans must succeed before **all**
+plans can be applied.
+
+I can still apply an individual project that planned successfully:
 
 ```shell
 atlantis apply -d dir1
 ```
 
-Even though that plan succeeded, because **all** plans must succeed for **any** plans
-to be saved.
+This is allowed because applying `dir1/` may be exactly what makes `dir2/` plan
+successfully, for example when `dir2/` depends on a resource that `dir1/` creates.
 
 Once I fix the issue in `dir2`, I can push a new commit which will trigger an
-autoplan. Then I will be able to apply both plans.
+autoplan, or I can re-run only failed plans:
+
+```shell
+atlantis plan --failed
+```
+
+Then I will be able to apply both plans.
 
 ### All Plans must be applied
 

--- a/runatlantis.io/docs/using-atlantis.md
+++ b/runatlantis.io/docs/using-atlantis.md
@@ -75,6 +75,7 @@ atlantis plan -w staging
 
 * `-d directory` Which directory to run plan in relative to root of repo. Use `.` for root.
   * Ex. `atlantis plan -d child/dir`
+* `--failed` Run plan only for projects whose previous plan failed. This is useful after a multi-project plan where some projects succeeded and one or more projects failed.
 * `-p project` Which project to run plan for. Refers to the name of the project configured in the repo's [`atlantis.yaml` file](repo-level-atlantis-yaml.md). Cannot be used at same time as `-d` or `-w` because the project defines this already.
 * `-w workspace` Switch to this [Terraform workspace](https://developer.hashicorp.com/terraform/language/state/workspaces) before planning. Defaults to `default`. Ignore this if Terraform workspaces are unused.
 * `--verbose` Append Atlantis log to comment.

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -195,6 +195,15 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 		return
 	}
 
+	if failedProjects := ctx.ErroredPlanProjects(); len(failedProjects) > 0 {
+		ctx.Log.Info("blocking apply because %d plan(s) failed", len(failedProjects))
+		if statusErr := a.commitStatusUpdater.UpdateCombined(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, command.Apply); statusErr != nil {
+			ctx.Log.Warn("unable to update commit status: %s", statusErr)
+		}
+		a.pullUpdater.updatePull(ctx, cmd, command.Result{Failure: failedPlansApplyBlockFailure(failedProjects)})
+		return
+	}
+
 	// If there are no projects to apply, don't respond to the PR and ignore
 	if len(projectCmds) == 0 && a.SilenceNoProjects {
 		ctx.Log.Info("determined there was no project to run plan in")

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -195,6 +195,18 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 		return
 	}
 
+	// Only a generic apply is blocked: a targeted apply of a project that
+	// planned successfully is still allowed, since applying it may be what
+	// unblocks the projects that failed.
+	if failedProjects := ctx.ErroredPlanProjects(); len(failedProjects) > 0 && !cmd.IsForSpecificProject() {
+		ctx.Log.Info("blocking apply of all projects because %d plan(s) failed", len(failedProjects))
+		if statusErr := a.commitStatusUpdater.UpdateCombined(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, command.Apply); statusErr != nil {
+			ctx.Log.Warn("unable to update commit status: %s", statusErr)
+		}
+		a.pullUpdater.updatePull(ctx, cmd, command.Result{Failure: failedPlansApplyBlockFailure(failedProjects)})
+		return
+	}
+
 	// If there are no projects to apply, don't respond to the PR and ignore
 	if len(projectCmds) == 0 && a.SilenceNoProjects {
 		ctx.Log.Info("determined there was no project to run plan in")

--- a/server/events/command/context.go
+++ b/server/events/command/context.go
@@ -109,3 +109,11 @@ type Context struct {
 	// pre-workflow hooks may have generated or updated atlantis.yaml.
 	PreferLocalRepoCfgForTargetedIgnore bool
 }
+
+// ErroredPlanProjects returns projects whose latest plan errored.
+func (c Context) ErroredPlanProjects() []models.ProjectStatus {
+	if c.PullStatus == nil {
+		return nil
+	}
+	return c.PullStatus.ErroredPlanProjects()
+}

--- a/server/events/command/context_test.go
+++ b/server/events/command/context_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package command_test
+
+import (
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/events/models"
+	. "github.com/runatlantis/atlantis/testing"
+)
+
+func TestContext_ErroredPlanProjects(t *testing.T) {
+	ctx := command.Context{
+		PullStatus: &models.PullStatus{
+			Projects: []models.ProjectStatus{
+				{
+					Workspace:  "default",
+					RepoRelDir: ".",
+					Status:     models.PlannedPlanStatus,
+				},
+				{
+					Workspace:   "default",
+					RepoRelDir:  "staging",
+					ProjectName: "staging",
+					Status:      models.ErroredPlanStatus,
+				},
+			},
+		},
+	}
+
+	failedProjects := ctx.ErroredPlanProjects()
+
+	Equals(t, 1, len(failedProjects))
+	Equals(t, "staging", failedProjects[0].RepoRelDir)
+}
+
+func TestContext_ErroredPlanProjects_NilPullStatus(t *testing.T) {
+	ctx := command.Context{}
+
+	Equals(t, 0, len(ctx.ErroredPlanProjects()))
+}

--- a/server/events/command/result.go
+++ b/server/events/command/result.go
@@ -8,9 +8,12 @@ type Result struct {
 	Error          error
 	Failure        string
 	ProjectResults []ProjectResult
-	// PlansDeleted is true if all plans created during this command were
-	// deleted. This happens if automerging is enabled and one project has an
-	// error since automerging requires all plans to succeed.
+	// PlansDeleted used to be true if all plans created during this command
+	// were deleted, which happened when automerging was enabled and a project
+	// errored. Plans are now kept on partial failure, so it is always false.
+	//
+	// Deprecated: kept only so the API response shape stays stable; do not
+	// read or set it.
 	PlansDeleted bool
 }
 

--- a/server/events/command/result_test.go
+++ b/server/events/command/result_test.go
@@ -138,12 +138,10 @@ func TestResult_MarshalJSON(t *testing.T) {
 			result: command.Result{
 				Failure:        "",
 				ProjectResults: []command.ProjectResult{},
-				PlansDeleted:   false,
 			},
 			checkFields: map[string]any{
-				"Error":        nil,
-				"Failure":      "",
-				"PlansDeleted": false,
+				"Error":   nil,
+				"Failure": "",
 			},
 		},
 		"error preserves legacy empty object shape": {
@@ -151,12 +149,10 @@ func TestResult_MarshalJSON(t *testing.T) {
 				Error:          errors.New("something went wrong"),
 				Failure:        "deployment failed",
 				ProjectResults: []command.ProjectResult{},
-				PlansDeleted:   true,
 			},
 			checkFields: map[string]any{
-				"Error":        map[string]any{},
-				"Failure":      "deployment failed",
-				"PlansDeleted": true,
+				"Error":   map[string]any{},
+				"Failure": "deployment failed",
 			},
 		},
 		"nested project errors serialize correctly": {

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -666,6 +666,41 @@ func TestRunCommentCommandPlan_NoProjectsEmptyPullStatusWriteFailureIsUserVisibl
 	Assert(t, strings.Contains(comment, "writing empty plan status"), "got: %s", comment)
 }
 
+func TestRunCommentCommandPlanFailedOnly_NoFailedProjects(t *testing.T) {
+	t.Log("if a plan --failed command is run and there are no failed projects Atlantis comments by default")
+	vcsClient := setup(t)
+	var pull github.PullRequest
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState}
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(&pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(&pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+
+	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan, FailedPlansOnly: true})
+	vcsClient.VerifyWasCalledOnce().CreateComment(
+		Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull.Num), Eq("No failed plans to re-run."), Eq("plan"))
+}
+
+func TestRunCommentCommandPlanFailedOnly_NoFailedProjectsSilenceEnabled(t *testing.T) {
+	t.Log("if a plan --failed command is run and there are no failed projects SilenceNoProjects suppresses the comment")
+	vcsClient := setup(t)
+	planCommandRunner.SilenceNoProjects = true
+	var pull github.PullRequest
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState}
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(&pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(&pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+
+	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan, FailedPlansOnly: true})
+	vcsClient.VerifyWasCalled(Never()).CreateComment(
+		Any[logging.SimpleLogging](), Any[models.Repo](), Any[int](), Any[string](), Any[string]())
+	commitUpdater.VerifyWasCalledOnce().UpdateCombinedCount(
+		Any[logging.SimpleLogging](),
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Eq[models.CommitStatus](models.SuccessCommitStatus),
+		Eq[command.Name](command.Plan),
+		Eq(models.ProjectCounts{}),
+	)
+}
+
 func TestRunCommentCommandPlan_NoProjectsTarget_SilenceEnabled(t *testing.T) {
 	// TODO
 	t.Log("if a plan command is run against a project and SilenceNoProjects is enabled, we are silencing all comments if the project is not in the repo config")
@@ -2508,8 +2543,8 @@ func TestRunSpecificPlanCommandDoesnt_DeletePlans(t *testing.T) {
 }
 
 // Test that if one plan fails and we are using automerge, that
-// we delete the plans.
-func TestRunAutoplanCommandWithError_DeletePlans(t *testing.T) {
+// we keep the successful plans generated during the run.
+func TestRunAutoplanCommandWithError_KeepsPlans(t *testing.T) {
 	vcsClient := setup(t)
 
 	tmp := t.TempDir()
@@ -2556,8 +2591,9 @@ func TestRunAutoplanCommandWithError_DeletePlans(t *testing.T) {
 		ThenReturn(tmp, nil)
 	testdata.Pull.BaseRepo = testdata.GithubRepo
 	ch.RunAutoplanCommand(testdata.GithubRepo, testdata.GithubRepo, testdata.Pull, testdata.User)
-	// gets called twice: the first time before the plan starts, the second time after the plan errors
-	pendingPlanFinder.VerifyWasCalled(Times(2)).Find(tmp)
+	// gets called once before the plan starts to clear any stale plans;
+	// the plans from this run are kept even though one project errored
+	pendingPlanFinder.VerifyWasCalledOnce().Find(tmp)
 
 	vcsClient.VerifyWasCalled(Times(0)).DiscardReviews(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest]())
 }
@@ -2650,6 +2686,60 @@ func TestApplyMergeablityWhenPolicyCheckFails(t *testing.T) {
 
 	When(workingDir.GetPullDir(testdata.GithubRepo, modelPull)).ThenReturn(tmp, nil)
 	ch.RunCommentCommand(testdata.GithubRepo, &testdata.GithubRepo, &modelPull, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Apply})
+}
+
+func TestRunApply_BlockedWhenPullHasFailedPlan(t *testing.T) {
+	t.Log("if \"atlantis apply\" is run with automerge and at least one plan failed then apply is not performed")
+	tmp := t.TempDir()
+	boltDB, err := boltdb.New(tmp)
+	t.Cleanup(func() {
+		boltDB.Close()
+	})
+	Ok(t, err)
+	vcsClient := setup(t, func(testConfig *TestConfig) {
+		testConfig.database = boltDB
+	})
+
+	pull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num}
+	_, err = boltDB.UpdatePullWithResults(pull, []command.ProjectResult{
+		{
+			Command:    command.Plan,
+			RepoRelDir: "ok",
+			Workspace:  "default",
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PlanSuccess: &models.PlanSuccess{},
+			},
+		},
+		{
+			Command:    command.Plan,
+			RepoRelDir: "failed",
+			Workspace:  "default",
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				Error: errors.New("plan failed"),
+			},
+		},
+	})
+	Ok(t, err)
+
+	ghPull := &github.PullRequest{State: github.Ptr("open")}
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(ghPull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(ghPull))).ThenReturn(pull, pull.BaseRepo, testdata.GithubRepo, nil)
+	When(projectCommandBuilder.BuildApplyCommands(Any[*command.Context](), Any[*events.CommentCommand]())).
+		ThenReturn([]command.ProjectContext{
+			{
+				CommandName: command.Apply,
+				RepoRelDir:  "ok",
+				Workspace:   "default",
+			},
+		}, nil)
+
+	ch.RunCommentCommand(testdata.GithubRepo, &testdata.GithubRepo, &pull, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Apply})
+
+	projectCommandRunner.VerifyWasCalled(Never()).Apply(Any[command.ProjectContext]())
+	_, _, _, comment, _ := vcsClient.VerifyWasCalledOnce().CreateComment(
+		Any[logging.SimpleLogging](), Any[models.Repo](), Any[int](), Any[string](), Eq("apply")).GetCapturedArguments()
+	Assert(t, strings.Contains(comment, "Apply is blocked because 1 plan(s) failed"), "expected apply blocked comment, got %q", comment)
+	Assert(t, strings.Contains(comment, "atlantis plan --failed"), "expected plan --failed hint, got %q", comment)
 }
 
 func TestApplyWithAutoMerge_VSCMerge(t *testing.T) {

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -666,6 +666,41 @@ func TestRunCommentCommandPlan_NoProjectsEmptyPullStatusWriteFailureIsUserVisibl
 	Assert(t, strings.Contains(comment, "writing empty plan status"), "got: %s", comment)
 }
 
+func TestRunCommentCommandPlanFailedOnly_NoFailedProjects(t *testing.T) {
+	t.Log("if a plan --failed command is run and there are no failed projects Atlantis comments by default")
+	vcsClient := setup(t)
+	var pull github.PullRequest
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState}
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(&pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(&pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+
+	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan, FailedPlansOnly: true})
+	vcsClient.VerifyWasCalledOnce().CreateComment(
+		Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull.Num), Eq("No failed plans to re-run."), Eq("plan"))
+}
+
+func TestRunCommentCommandPlanFailedOnly_NoFailedProjectsSilenceEnabled(t *testing.T) {
+	t.Log("if a plan --failed command is run and there are no failed projects SilenceNoProjects suppresses the comment")
+	vcsClient := setup(t)
+	planCommandRunner.SilenceNoProjects = true
+	var pull github.PullRequest
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState}
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(&pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(&pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+
+	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan, FailedPlansOnly: true})
+	vcsClient.VerifyWasCalled(Never()).CreateComment(
+		Any[logging.SimpleLogging](), Any[models.Repo](), Any[int](), Any[string](), Any[string]())
+	commitUpdater.VerifyWasCalledOnce().UpdateCombinedCount(
+		Any[logging.SimpleLogging](),
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Eq[models.CommitStatus](models.SuccessCommitStatus),
+		Eq[command.Name](command.Plan),
+		Eq(models.ProjectCounts{}),
+	)
+}
+
 func TestRunCommentCommandPlan_NoProjectsTarget_SilenceEnabled(t *testing.T) {
 	// TODO
 	t.Log("if a plan command is run against a project and SilenceNoProjects is enabled, we are silencing all comments if the project is not in the repo config")
@@ -2508,8 +2543,8 @@ func TestRunSpecificPlanCommandDoesnt_DeletePlans(t *testing.T) {
 }
 
 // Test that if one plan fails and we are using automerge, that
-// we delete the plans.
-func TestRunAutoplanCommandWithError_DeletePlans(t *testing.T) {
+// we keep the successful plans generated during the run.
+func TestRunAutoplanCommandWithError_KeepsPlans(t *testing.T) {
 	vcsClient := setup(t)
 
 	tmp := t.TempDir()
@@ -2556,8 +2591,9 @@ func TestRunAutoplanCommandWithError_DeletePlans(t *testing.T) {
 		ThenReturn(tmp, nil)
 	testdata.Pull.BaseRepo = testdata.GithubRepo
 	ch.RunAutoplanCommand(testdata.GithubRepo, testdata.GithubRepo, testdata.Pull, testdata.User)
-	// gets called twice: the first time before the plan starts, the second time after the plan errors
-	pendingPlanFinder.VerifyWasCalled(Times(2)).Find(tmp)
+	// gets called once before the plan starts to clear any stale plans;
+	// the plans from this run are kept even though one project errored
+	pendingPlanFinder.VerifyWasCalledOnce().Find(tmp)
 
 	vcsClient.VerifyWasCalled(Times(0)).DiscardReviews(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest]())
 }
@@ -2650,6 +2686,112 @@ func TestApplyMergeablityWhenPolicyCheckFails(t *testing.T) {
 
 	When(workingDir.GetPullDir(testdata.GithubRepo, modelPull)).ThenReturn(tmp, nil)
 	ch.RunCommentCommand(testdata.GithubRepo, &testdata.GithubRepo, &modelPull, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Apply})
+}
+
+func TestRunApply_BlockedWhenPullHasFailedPlan(t *testing.T) {
+	t.Log("if \"atlantis apply\" is run with automerge and at least one plan failed then apply is not performed")
+	tmp := t.TempDir()
+	boltDB, err := boltdb.New(tmp)
+	t.Cleanup(func() {
+		boltDB.Close()
+	})
+	Ok(t, err)
+	vcsClient := setup(t, func(testConfig *TestConfig) {
+		testConfig.database = boltDB
+	})
+
+	pull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num}
+	_, err = boltDB.UpdatePullWithResults(pull, []command.ProjectResult{
+		{
+			Command:    command.Plan,
+			RepoRelDir: "ok",
+			Workspace:  "default",
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PlanSuccess: &models.PlanSuccess{},
+			},
+		},
+		{
+			Command:    command.Plan,
+			RepoRelDir: "failed",
+			Workspace:  "default",
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				Error: errors.New("plan failed"),
+			},
+		},
+	})
+	Ok(t, err)
+
+	ghPull := &github.PullRequest{State: github.Ptr("open")}
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(ghPull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(ghPull))).ThenReturn(pull, pull.BaseRepo, testdata.GithubRepo, nil)
+	When(projectCommandBuilder.BuildApplyCommands(Any[*command.Context](), Any[*events.CommentCommand]())).
+		ThenReturn([]command.ProjectContext{
+			{
+				CommandName: command.Apply,
+				RepoRelDir:  "ok",
+				Workspace:   "default",
+			},
+		}, nil)
+
+	ch.RunCommentCommand(testdata.GithubRepo, &testdata.GithubRepo, &pull, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Apply})
+
+	projectCommandRunner.VerifyWasCalled(Never()).Apply(Any[command.ProjectContext]())
+	_, _, _, comment, _ := vcsClient.VerifyWasCalledOnce().CreateComment(
+		Any[logging.SimpleLogging](), Any[models.Repo](), Any[int](), Any[string](), Eq("apply")).GetCapturedArguments()
+	Assert(t, strings.Contains(comment, "Applying all projects is blocked because 1 plan(s) failed"), "expected apply blocked comment, got %q", comment)
+	Assert(t, strings.Contains(comment, "atlantis plan --failed"), "expected plan --failed hint, got %q", comment)
+}
+
+func TestRunApply_TargetedApplyAllowedWhenOtherPlanFailed(t *testing.T) {
+	t.Log("if \"atlantis apply\" is run for a specific project then a failed plan in" +
+		" another project does not block it, since applying it may unblock the failure")
+	tmp := t.TempDir()
+	boltDB, err := boltdb.New(tmp)
+	t.Cleanup(func() {
+		boltDB.Close()
+	})
+	Ok(t, err)
+	setup(t, func(testConfig *TestConfig) {
+		testConfig.database = boltDB
+	})
+
+	pull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num}
+	_, err = boltDB.UpdatePullWithResults(pull, []command.ProjectResult{
+		{
+			Command:    command.Plan,
+			RepoRelDir: "ok",
+			Workspace:  "default",
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PlanSuccess: &models.PlanSuccess{},
+			},
+		},
+		{
+			Command:    command.Plan,
+			RepoRelDir: "failed",
+			Workspace:  "default",
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				Error: errors.New("plan failed"),
+			},
+		},
+	})
+	Ok(t, err)
+
+	ghPull := &github.PullRequest{State: github.Ptr("open")}
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(ghPull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(ghPull))).ThenReturn(pull, pull.BaseRepo, testdata.GithubRepo, nil)
+	When(projectCommandBuilder.BuildApplyCommands(Any[*command.Context](), Any[*events.CommentCommand]())).
+		ThenReturn([]command.ProjectContext{
+			{
+				CommandName: command.Apply,
+				RepoRelDir:  "ok",
+				Workspace:   "default",
+			},
+		}, nil)
+
+	ch.RunCommentCommand(testdata.GithubRepo, &testdata.GithubRepo, &pull, testdata.User, testdata.Pull.Num,
+		&events.CommentCommand{Name: command.Apply, RepoRelDir: "ok", Workspace: "default"})
+
+	projectCommandRunner.VerifyWasCalledOnce().Apply(Any[command.ProjectContext]())
 }
 
 func TestApplyWithAutoMerge_VSCMerge(t *testing.T) {

--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -30,6 +30,8 @@ const (
 	dirFlagShort                 = "d"
 	projectFlagLong              = "project"
 	projectFlagShort             = "p"
+	failedFlagLong               = "failed"
+	failedFlagShort              = ""
 	policySetFlagLong            = "policy-set"
 	policySetFlagShort           = ""
 	autoMergeDisabledFlagLong    = "auto-merge-disabled"
@@ -242,6 +244,7 @@ func (e *CommentParser) Parse(rawComment string, vcsHost models.VCSHostType) Com
 	var verbose bool
 	var autoMergeDisabled bool
 	var autoMergeMethod string
+	var failedPlansOnly bool
 	var flagSet *pflag.FlagSet
 	var name command.Name
 
@@ -254,6 +257,7 @@ func (e *CommentParser) Parse(rawComment string, vcsHost models.VCSHostType) Com
 		flagSet.StringVarP(&workspace, workspaceFlagLong, workspaceFlagShort, "", "Switch to this Terraform workspace before planning.")
 		flagSet.StringVarP(&dir, dirFlagLong, dirFlagShort, "", "Which directory to run plan in relative to root of repo, ex. 'child/dir'.")
 		flagSet.StringVarP(&project, projectFlagLong, projectFlagShort, "", "Which project to run plan for. Refers to the name of the project configured in a repo config file. Cannot be used at same time as workspace or dir flags.")
+		flagSet.BoolVarP(&failedPlansOnly, failedFlagLong, failedFlagShort, false, "Run plan only for projects with failed plans.")
 		flagSet.BoolVarP(&verbose, verboseFlagLong, verboseFlagShort, false, "Append Atlantis log to comment.")
 	case command.Apply.String():
 		name = command.Apply
@@ -341,6 +345,11 @@ func (e *CommentParser) Parse(rawComment string, vcsHost models.VCSHostType) Com
 		return CommentParseResult{CommentResponse: e.errMarkdown(err, cmd, flagSet)}
 	}
 
+	if failedPlansOnly && (workspace != "" || dir != "" || project != "") {
+		err := fmt.Sprintf("cannot use --%s at same time as -%s/--%s, -%s/--%s or -%s/--%s", failedFlagLong, projectFlagShort, projectFlagLong, dirFlagShort, dirFlagLong, workspaceFlagShort, workspaceFlagLong)
+		return CommentParseResult{CommentResponse: e.errMarkdown(err, cmd, flagSet)}
+	}
+
 	if autoMergeMethod != "" {
 		if autoMergeDisabled {
 			err := fmt.Sprintf("cannot use --%s at the same time as --%s", autoMergeMethodFlagLong, autoMergeDisabledFlagLong)
@@ -353,9 +362,9 @@ func (e *CommentParser) Parse(rawComment string, vcsHost models.VCSHostType) Com
 		}
 	}
 
-	return CommentParseResult{
-		Command: NewCommentCommand(dir, extraArgs, name, subName, verbose, autoMergeDisabled, autoMergeMethod, workspace, project, policySet, clearPolicyApproval),
-	}
+	commentCommand := NewCommentCommand(dir, extraArgs, name, subName, verbose, autoMergeDisabled, autoMergeMethod, workspace, project, policySet, clearPolicyApproval)
+	commentCommand.FailedPlansOnly = failedPlansOnly
+	return CommentParseResult{Command: commentCommand}
 }
 
 func (e *CommentParser) parseArgs(name command.Name, args []string, flagSet *pflag.FlagSet) (string, []string, string) {

--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -646,6 +646,30 @@ func TestParse_UsingProjectAtSameTimeAsWorkspaceOrDir(t *testing.T) {
 	}
 }
 
+func TestParse_PlanFailed(t *testing.T) {
+	r := commentParser.Parse("atlantis plan --failed", models.Github)
+	Equals(t, "", r.CommentResponse)
+	Equals(t, &events.CommentCommand{
+		Name:            command.Plan,
+		FailedPlansOnly: true,
+	}, r.Command)
+}
+
+func TestParse_PlanFailedCannotUseProjectSelectors(t *testing.T) {
+	comments := []string{
+		"atlantis plan --failed -d dir",
+		"atlantis plan --failed -w workspace",
+		"atlantis plan --failed -p project",
+	}
+	for _, comment := range comments {
+		t.Run(comment, func(t *testing.T) {
+			r := commentParser.Parse(comment, models.Github)
+			Assert(t, strings.Contains(r.CommentResponse, "Error: cannot use --failed at same time as"),
+				"For comment %q expected CommentResponse %q to contain --failed validation error", comment, r.CommentResponse)
+		})
+	}
+}
+
 func TestParse_Parsing(t *testing.T) {
 	cases := []struct {
 		flags        string
@@ -1211,6 +1235,7 @@ func TestParse_VCSUsername(t *testing.T) {
 var PlanUsage = `Usage of plan:
   -d, --dir string         Which directory to run plan in relative to root of repo,
                            ex. 'child/dir'.
+      --failed             Run plan only for projects with failed plans.
   -p, --project string     Which project to run plan for. Refers to the name of the
                            project configured in a repo config file. Cannot be used
                            at same time as workspace or dir flags.

--- a/server/events/event_parser.go
+++ b/server/events/event_parser.go
@@ -138,13 +138,15 @@ type CommentCommand struct {
 	PolicySet string
 	// ClearPolicyApproval is true if approvals should be cleared out for specified policies.
 	ClearPolicyApproval bool
+	// FailedPlansOnly is true if plan should re-run only projects with failed plans.
+	FailedPlansOnly bool
 }
 
 // IsForSpecificProject returns true if the command is for a specific dir, workspace
 // or project name. Otherwise it's a command like "atlantis plan" or "atlantis
 // apply".
 func (c CommentCommand) IsForSpecificProject() bool {
-	return c.RepoRelDir != "" || c.Workspace != "" || c.ProjectName != ""
+	return c.RepoRelDir != "" || c.Workspace != "" || c.ProjectName != "" || c.FailedPlansOnly
 }
 
 // Dir returns the dir of this command.
@@ -174,7 +176,7 @@ func (c CommentCommand) IsAutoplan() bool {
 
 // String returns a string representation of the command.
 func (c CommentCommand) String() string {
-	return fmt.Sprintf("command=%q, verbose=%t, dir=%q, workspace=%q, project=%q, policyset=%q, auto-merge-disabled=%t, auto-merge-method=%s, clear-policy-approval=%t, flags=%q", c.Name.String(), c.Verbose, c.RepoRelDir, c.Workspace, c.ProjectName, c.PolicySet, c.AutoMergeDisabled, c.AutoMergeMethod, c.ClearPolicyApproval, strings.Join(c.Flags, ","))
+	return fmt.Sprintf("command=%q, verbose=%t, dir=%q, workspace=%q, project=%q, policyset=%q, auto-merge-disabled=%t, auto-merge-method=%s, clear-policy-approval=%t, failed=%t, flags=%q", c.Name.String(), c.Verbose, c.RepoRelDir, c.Workspace, c.ProjectName, c.PolicySet, c.AutoMergeDisabled, c.AutoMergeMethod, c.ClearPolicyApproval, c.FailedPlansOnly, strings.Join(c.Flags, ","))
 }
 
 // NewCommentCommand constructs a CommentCommand, setting all missing fields to defaults.

--- a/server/events/event_parser_test.go
+++ b/server/events/event_parser_test.go
@@ -816,7 +816,7 @@ func TestCommentCommand_IsAutoplan(t *testing.T) {
 }
 
 func TestCommentCommand_String(t *testing.T) {
-	exp := `command="plan", verbose=true, dir="mydir", workspace="myworkspace", project="myproject", policyset="", auto-merge-disabled=false, auto-merge-method=, clear-policy-approval=false, flags="flag1,flag2"`
+	exp := `command="plan", verbose=true, dir="mydir", workspace="myworkspace", project="myproject", policyset="", auto-merge-disabled=false, auto-merge-method=, clear-policy-approval=false, failed=false, flags="flag1,flag2"`
 	Equals(t, exp, (events.CommentCommand{
 		RepoRelDir:  "mydir",
 		Flags:       []string{"flag1", "flag2"},

--- a/server/events/failed_plan_status.go
+++ b/server/events/failed_plan_status.go
@@ -1,0 +1,32 @@
+// Copyright 2026 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package events
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/runatlantis/atlantis/server/events/models"
+)
+
+func failedPlansApplyBlockFailure(failedProjects []models.ProjectStatus) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Apply is blocked because %d plan(s) failed. Re-run failed plans with `atlantis plan --failed`.", len(failedProjects))
+	for _, project := range failedProjects {
+		b.WriteString("\n")
+		b.WriteString(formatProjectStatus(project))
+	}
+	return b.String()
+}
+
+func formatProjectStatus(project models.ProjectStatus) string {
+	parts := []string{
+		fmt.Sprintf("dir: `%s`", project.RepoRelDir),
+		fmt.Sprintf("workspace: `%s`", project.Workspace),
+	}
+	if project.ProjectName != "" {
+		parts = append(parts, fmt.Sprintf("project: `%s`", project.ProjectName))
+	}
+	return "- " + strings.Join(parts, " ")
+}

--- a/server/events/failed_plan_status.go
+++ b/server/events/failed_plan_status.go
@@ -1,0 +1,32 @@
+// Copyright 2026 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package events
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/runatlantis/atlantis/server/events/models"
+)
+
+func failedPlansApplyBlockFailure(failedProjects []models.ProjectStatus) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Applying all projects is blocked because %d plan(s) failed. Re-run failed plans with `atlantis plan --failed`, or apply a project that planned successfully with `atlantis apply -p <project>`.", len(failedProjects))
+	for _, project := range failedProjects {
+		b.WriteString("\n")
+		b.WriteString(formatProjectStatus(project))
+	}
+	return b.String()
+}
+
+func formatProjectStatus(project models.ProjectStatus) string {
+	parts := []string{
+		fmt.Sprintf("dir: `%s`", project.RepoRelDir),
+		fmt.Sprintf("workspace: `%s`", project.Workspace),
+	}
+	if project.ProjectName != "" {
+		parts = append(parts, fmt.Sprintf("project: `%s`", project.ProjectName))
+	}
+	return "- " + strings.Join(parts, " ")
+}

--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -54,11 +54,13 @@ type MarkdownRenderer struct {
 
 // commonData is data that all responses have.
 type commonData struct {
-	Command                   string
-	CommandName               string
-	SubCommand                string
-	Verbose                   bool
-	Log                       string
+	Command      string
+	CommandName  string
+	SubCommand   string
+	Verbose      bool
+	Log          string
+	ApplyBlocked bool
+	// Deprecated: use ApplyBlocked instead.
 	PlansDeleted              bool
 	DisableApplyAll           bool
 	DisableApply              bool
@@ -92,9 +94,10 @@ type resultData struct {
 type planResultData struct {
 	Results []projectResultTmplData
 	commonData
-	NumPlansWithChanges   int
-	NumPlansWithNoChanges int
-	NumPlanFailures       int
+	NumPlansWithChanges      int
+	NumPlansWithNoChanges    int
+	NumPlanFailures          int
+	SuggestFailedPlanCommand bool
 }
 
 type applyResultData struct {
@@ -107,7 +110,9 @@ type applyResultData struct {
 
 type planSuccessData struct {
 	models.PlanSuccess
-	PlanSummary              string
+	PlanSummary  string
+	ApplyBlocked bool
+	// Deprecated: use ApplyBlocked instead.
 	PlanWasDeleted           bool
 	DisableApply             bool
 	DisableRepoLocking       bool
@@ -208,7 +213,6 @@ func (m *MarkdownRenderer) Render(ctx *command.Context, res command.Result, cmd 
 		SubCommand:                cmd.SubCommandName(),
 		Verbose:                   cmd.IsVerbose(),
 		Log:                       ctx.Log.GetHistory(),
-		PlansDeleted:              res.PlansDeleted,
 		DisableApplyAll:           m.disableApplyAll || m.disableApply,
 		DisableApply:              m.disableApply,
 		DisableRepoLocking:        m.disableRepoLocking,
@@ -232,6 +236,7 @@ func (m *MarkdownRenderer) Render(ctx *command.Context, res command.Result, cmd 
 
 func (m *MarkdownRenderer) renderProjectResults(ctx *command.Context, results []command.ProjectResult, common commonData) string {
 	vcsHost := ctx.Pull.BaseRepo.VCSHost.Type
+	common.ApplyBlocked = applyBlockedByPlanResults(results, common)
 
 	var resultsTmplData []projectResultTmplData
 	numPlanSuccesses := 0
@@ -257,7 +262,7 @@ func (m *MarkdownRenderer) renderProjectResults(ctx *command.Context, results []
 			result.PlanSuccess.TerraformOutput = strings.TrimSpace(result.PlanSuccess.TerraformOutput)
 			data := planSuccessData{
 				PlanSuccess:              *result.PlanSuccess,
-				PlanWasDeleted:           common.PlansDeleted,
+				ApplyBlocked:             common.ApplyBlocked,
 				DisableApply:             common.DisableApply,
 				DisableRepoLocking:       common.DisableRepoLocking,
 				EnableDiffMarkdownFormat: common.EnableDiffMarkdownFormat,
@@ -423,11 +428,31 @@ func (m *MarkdownRenderer) renderProjectResults(ctx *command.Context, results []
 	switch common.CommandName {
 	case planCommandTitle:
 		numPlanFailures := len(results) - numPlanSuccesses
-		return m.renderTemplateTrimSpace(tmpl, planResultData{resultsTmplData, common, numPlansWithChanges, numPlansWithNoChanges, numPlanFailures})
+		suggestFailedPlanCommand := numPlanFailures > 0 && numPlanSuccesses > 0
+		return m.renderTemplateTrimSpace(tmpl, planResultData{
+			Results:                  resultsTmplData,
+			commonData:               common,
+			NumPlansWithChanges:      numPlansWithChanges,
+			NumPlansWithNoChanges:    numPlansWithNoChanges,
+			NumPlanFailures:          numPlanFailures,
+			SuggestFailedPlanCommand: suggestFailedPlanCommand,
+		})
 	case applyCommandTitle:
 		return m.renderTemplateTrimSpace(tmpl, applyResultData{resultsTmplData, common, numApplySuccesses, numApplyFailures, numApplyErrors})
 	}
 	return m.renderTemplateTrimSpace(tmpl, resultData{resultsTmplData, common})
+}
+
+func applyBlockedByPlanResults(results []command.ProjectResult, common commonData) bool {
+	if common.CommandName != planCommandTitle {
+		return false
+	}
+	for _, result := range results {
+		if result.Error != nil || result.Failure != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // shouldUseWrappedTmpl returns true if we should use the wrapped markdown

--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -1249,6 +1249,50 @@ Ran Plan for dir: $path$ workspace: $workspace$
 `,
 		},
 		{
+			"multiple failed plans",
+			command.Plan,
+			"",
+			[]command.ProjectResult{
+				{
+					RepoRelDir: "path",
+					Workspace:  "workspace",
+					ProjectCommandOutput: command.ProjectCommandOutput{
+						Failure: "failure",
+					},
+				},
+				{
+					RepoRelDir: "path2",
+					Workspace:  "workspace",
+					ProjectCommandOutput: command.ProjectCommandOutput{
+						Error: errors.New("error"),
+					},
+				},
+			},
+			models.Github,
+			`
+Ran Plan for 2 projects:
+
+1. dir: $path$ workspace: $workspace$
+1. dir: $path2$ workspace: $workspace$
+---
+
+### 1. dir: $path$ workspace: $workspace$
+**Plan Failed**: failure
+
+---
+### 2. dir: $path2$ workspace: $workspace$
+**Plan Error**
+$$$
+error
+$$$
+
+---
+### Plan Summary
+
+2 projects, 0 with changes, 0 with no changes, 2 failed
+`,
+		},
+		{
 			"successful, failed, and errored plan",
 			command.Plan,
 			"",
@@ -1295,10 +1339,7 @@ $$$diff
 terraform-output
 $$$
 
-* :arrow_forward: To **apply** this plan, comment:
-  $$$shell
-  atlantis apply -d path -w workspace
-  $$$
+This plan was saved, but apply is blocked until all plans succeed.
 * :put_litter_in_its_place: To **delete** this plan and lock, click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
   $$$shell
@@ -1321,13 +1362,9 @@ $$$
 
 3 projects, 1 with changes, 0 with no changes, 2 failed
 
-* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
+* :repeat: To **re-run failed plans**, comment:
   $$$shell
-  atlantis apply
-  $$$
-* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
-  $$$shell
-  atlantis unlock
+  atlantis plan --failed
   $$$
 `,
 		},
@@ -3368,98 +3405,31 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 	Equals(t, normalize(exp), normalize(rendered))
 }
 
-// Test rendering when there was an error in one of the plans and we deleted
-// all the plans as a result.
-func TestRenderProjectResults_PlansDeleted(t *testing.T) {
-	cases := map[string]struct {
-		res command.Result
-		exp string
-	}{
-		"one failure": {
-			res: command.Result{
-				ProjectResults: []command.ProjectResult{
-					{
-						RepoRelDir: ".",
-						Workspace:  "staging",
-						ProjectCommandOutput: command.ProjectCommandOutput{
-							Failure: "failure",
-						},
+func TestRenderProjectResults_FailedPlanBlocksApply(t *testing.T) {
+	res := command.Result{
+		ProjectResults: []command.ProjectResult{
+			{
+				RepoRelDir: ".",
+				Workspace:  "staging",
+				ProjectCommandOutput: command.ProjectCommandOutput{
+					Failure: "failure",
+				},
+			},
+			{
+				RepoRelDir: ".",
+				Workspace:  "production",
+				ProjectCommandOutput: command.ProjectCommandOutput{
+					PlanSuccess: &models.PlanSuccess{
+						TerraformOutput: "tf out",
+						LockURL:         "lock-url",
+						RePlanCmd:       "re-plan cmd",
+						ApplyCmd:        "apply cmd",
 					},
 				},
-				PlansDeleted: true,
 			},
-			exp: `
-Ran Plan for dir: $.$ workspace: $staging$
-
-**Plan Failed**: failure
-`,
 		},
-		"two failures": {
-			res: command.Result{
-				ProjectResults: []command.ProjectResult{
-					{
-						RepoRelDir: ".",
-						Workspace:  "staging",
-						ProjectCommandOutput: command.ProjectCommandOutput{
-							Failure: "failure",
-						},
-					},
-					{
-						RepoRelDir: ".",
-						Workspace:  "production",
-						ProjectCommandOutput: command.ProjectCommandOutput{
-							Failure: "failure",
-						},
-					},
-				},
-				PlansDeleted: true,
-			},
-			exp: `
-Ran Plan for 2 projects:
-
-1. dir: $.$ workspace: $staging$
-1. dir: $.$ workspace: $production$
----
-
-### 1. dir: $.$ workspace: $staging$
-**Plan Failed**: failure
-
----
-### 2. dir: $.$ workspace: $production$
-**Plan Failed**: failure
-
----
-### Plan Summary
-
-2 projects, 0 with changes, 0 with no changes, 2 failed
-`,
-		},
-		"one failure, one success": {
-			res: command.Result{
-				ProjectResults: []command.ProjectResult{
-					{
-						RepoRelDir: ".",
-						Workspace:  "staging",
-						ProjectCommandOutput: command.ProjectCommandOutput{
-							Failure: "failure",
-						},
-					},
-					{
-						RepoRelDir: ".",
-						Workspace:  "production",
-						ProjectCommandOutput: command.ProjectCommandOutput{
-							PlanSuccess: &models.PlanSuccess{
-								TerraformOutput: "tf out",
-								LockURL:         "lock-url",
-								RePlanCmd:       "re-plan cmd",
-								ApplyCmd:        "apply cmd",
-							},
-						},
-					},
-				},
-				PlansDeleted: true,
-			},
-			exp: `
+	}
+	exp := `
 Ran Plan for 2 projects:
 
 1. dir: $.$ workspace: $staging$
@@ -3475,51 +3445,126 @@ $$$diff
 tf out
 $$$
 
-This plan was not saved because one or more projects failed and automerge requires all plans pass.
+This plan was saved, but apply is blocked until all plans succeed.
+* :put_litter_in_its_place: To **delete** this plan and lock, click [here](lock-url)
+* :repeat: To **plan** this project again, comment:
+  $$$shell
+  re-plan cmd
+  $$$
 
 ---
 ### Plan Summary
 
 2 projects, 1 with changes, 0 with no changes, 1 failed
-`,
+
+* :repeat: To **re-run failed plans**, comment:
+  $$$shell
+  atlantis plan --failed
+  $$$
+`
+
+	mr := events.NewMarkdownRenderer(
+		false,      // gitlabSupportsCommonMark
+		false,      // disableApplyAll
+		false,      // disableApply
+		false,      // disableMarkdownFolding
+		false,      // disableRepoLocking
+		false,      // enableDiffMarkdownFormat
+		"",         // markdownTemplateOverridesDir
+		"atlantis", // executableName
+		false,      // hideUnchangedPlanComments
+		false,      // quietPolicyChecks
+	)
+	logger := logging.NewNoopLogger(t).WithHistory()
+	ctx := &command.Context{
+		Log: logger,
+		Pull: models.PullRequest{
+			BaseRepo: models.Repo{
+				VCSHost: models.VCSHost{
+					Type: models.Github,
+				},
+			},
+		},
+	}
+	cmd := &events.CommentCommand{Name: command.Plan}
+	rendered := mr.Render(ctx, res, cmd)
+	Equals(t, normalize(exp), normalize(rendered))
+}
+
+// Custom template overrides that reference the deprecated PlanWasDeleted and
+// PlansDeleted fields must keep rendering: the fields are retained (always
+// false) even though the built-in templates no longer use them.
+func TestRenderProjectResults_DeprecatedPlanDeletionFieldsStillRender(t *testing.T) {
+	overridesDir := t.TempDir()
+	err := os.WriteFile(filepath.Join(overridesDir, "plan_success_unwrapped.tmpl"), []byte(`
+{{ define "planSuccessUnwrapped" -}}
+{{ if .PlanWasDeleted }}legacy-plan-deleted{{ else }}legacy-compat-apply: {{ .ApplyCmd }}{{ end }}
+{{ end -}}
+`), 0o600)
+	Ok(t, err)
+	err = os.WriteFile(filepath.Join(overridesDir, "multi_project_plan_footer.tmpl"), []byte(`
+{{ define "multiProjectPlanFooter" -}}
+{{ if not .PlansDeleted }}legacy-compat-footer{{ end }}
+{{ end -}}
+`), 0o600)
+	Ok(t, err)
+
+	mr := events.NewMarkdownRenderer(
+		false,        // gitlabSupportsCommonMark
+		false,        // disableApplyAll
+		false,        // disableApply
+		false,        // disableMarkdownFolding
+		false,        // disableRepoLocking
+		false,        // enableDiffMarkdownFormat
+		overridesDir, // markdownTemplateOverridesDir
+		"atlantis",   // executableName
+		false,        // hideUnchangedPlanComments
+		false,        // quietPolicyChecks
+	)
+	ctx := &command.Context{
+		Log: logging.NewNoopLogger(t).WithHistory(),
+		Pull: models.PullRequest{
+			BaseRepo: models.Repo{
+				VCSHost: models.VCSHost{
+					Type: models.Github,
+				},
+			},
+		},
+	}
+	res := command.Result{
+		ProjectResults: []command.ProjectResult{
+			{
+				RepoRelDir: ".",
+				Workspace:  "staging",
+				ProjectCommandOutput: command.ProjectCommandOutput{
+					PlanSuccess: &models.PlanSuccess{
+						TerraformOutput: "tf out",
+						LockURL:         "lock-url",
+						RePlanCmd:       "re-plan cmd",
+						ApplyCmd:        "apply cmd",
+					},
+				},
+			},
+			{
+				RepoRelDir: ".",
+				Workspace:  "production",
+				ProjectCommandOutput: command.ProjectCommandOutput{
+					PlanSuccess: &models.PlanSuccess{
+						TerraformOutput: "tf out",
+						LockURL:         "lock-url",
+						RePlanCmd:       "re-plan cmd",
+						ApplyCmd:        "apply cmd",
+					},
+				},
+			},
 		},
 	}
 
-	for name, c := range cases {
-		t.Run(name, func(t *testing.T) {
-			mr := events.NewMarkdownRenderer(
-				false,      // gitlabSupportsCommonMark
-				false,      // disableApplyAll
-				false,      // disableApply
-				false,      // disableMarkdownFolding
-				false,      // disableRepoLocking
-				false,      // enableDiffMarkdownFormat
-				"",         // markdownTemplateOverridesDir
-				"atlantis", // executableName
-				false,      // hideUnchangedPlanComments
-				false,      // quietPolicyChecks
-			)
-			logger := logging.NewNoopLogger(t).WithHistory()
-			logText := "log"
-			logger.Info("%s", logText)
-			ctx := &command.Context{
-				Log: logger,
-				Pull: models.PullRequest{
-					BaseRepo: models.Repo{
-						VCSHost: models.VCSHost{
-							Type: models.Github,
-						},
-					},
-				},
-			}
-			cmd := &events.CommentCommand{
-				Name:    command.Plan,
-				Verbose: false,
-			}
-			rendered := mr.Render(ctx, c.res, cmd)
-			Equals(t, normalize(c.exp), normalize(rendered))
-		})
-	}
+	rendered := mr.Render(ctx, res, &events.CommentCommand{Name: command.Plan})
+	Assert(t, !strings.Contains(rendered, "Failed to render template"), "expected no template error, got %q", rendered)
+	Assert(t, strings.Contains(rendered, "legacy-compat-apply: apply cmd"), "expected legacy PlanWasDeleted override to render its else branch, got %q", rendered)
+	Assert(t, !strings.Contains(rendered, "legacy-plan-deleted"), "expected PlanWasDeleted to be false, got %q", rendered)
+	Assert(t, strings.Contains(rendered, "legacy-compat-footer"), "expected legacy PlansDeleted override to render, got %q", rendered)
 }
 
 // test that id repo locking is disabled the link to unlock the project is not rendered
@@ -3933,10 +3978,7 @@ $$$diff
 terraform-output
 $$$
 
-* :arrow_forward: To **apply** this plan, comment:
-  $$$shell
-  atlantis apply -d path -w workspace
-  $$$
+This plan was saved, but apply is blocked until all plans succeed.
 * :repeat: To **plan** this project again, comment:
   $$$shell
   atlantis plan -d path -w workspace
@@ -3958,13 +4000,9 @@ $$$
 
 3 projects, 1 with changes, 0 with no changes, 2 failed
 
-* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
+* :repeat: To **re-run failed plans**, comment:
   $$$shell
-  atlantis apply
-  $$$
-* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
-  $$$shell
-  atlantis unlock
+  atlantis plan --failed
   $$$
 `,
 		},

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -816,6 +816,17 @@ func (p PullStatus) StatusCount(status ProjectPlanStatus) int {
 	return c
 }
 
+// ErroredPlanProjects returns the projects whose latest plan errored.
+func (p PullStatus) ErroredPlanProjects() []ProjectStatus {
+	var errored []ProjectStatus
+	for _, project := range p.Projects {
+		if project.Status == ErroredPlanStatus {
+			errored = append(errored, project)
+		}
+	}
+	return errored
+}
+
 // ProjectCounts holds the success/failure counts for a set of project operations.
 // For command.Apply: Errored counts projects with apply errors. NoChanges is a
 // subset of Success (projects that were already up to date count as successful).

--- a/server/events/models/models_test.go
+++ b/server/events/models/models_test.go
@@ -1292,6 +1292,35 @@ func TestPullStatus_StatusCount(t *testing.T) {
 	Equals(t, 1, ps.StatusCount(models.PassedPolicyCheckStatus))
 }
 
+func TestPullStatus_ErroredPlanProjects(t *testing.T) {
+	ps := models.PullStatus{
+		Projects: []models.ProjectStatus{
+			{
+				RepoRelDir: "planned",
+				Status:     models.PlannedPlanStatus,
+			},
+			{
+				RepoRelDir: "failed-a",
+				Status:     models.ErroredPlanStatus,
+			},
+			{
+				RepoRelDir: "failed-b",
+				Status:     models.ErroredPlanStatus,
+			},
+			{
+				RepoRelDir: "applied",
+				Status:     models.AppliedPlanStatus,
+			},
+		},
+	}
+
+	errored := ps.ErroredPlanProjects()
+
+	Equals(t, 2, len(errored))
+	Equals(t, "failed-a", errored[0].RepoRelDir)
+	Equals(t, "failed-b", errored[1].RepoRelDir)
+}
+
 func TestPlanSuccessStats(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -179,14 +179,6 @@ func (p *PlanCommandRunner) runAutoplan(ctx *command.Context) {
 
 	result := runProjectCmdsWithCancellationTracker(ctx, projectCmds, p.cancellationTracker, p.parallelPoolSize, p.isParallelEnabled(projectCmds), p.prjCmdRunner.Plan)
 
-	if p.autoMerger.automergeEnabled(projectCmds) && result.HasErrors() {
-		ctx.Log.Info("deleting plans because there were errors and automerge requires all plans succeed")
-		if err := p.deletePlansAndPlanLocks(ctx, projectCmds); err != nil {
-			ctx.Log.Err("deleting pending plans: %s", err)
-		}
-		result.PlansDeleted = true
-	}
-
 	p.pullUpdater.updatePull(ctx, AutoplanCommand{}, result)
 
 	pullStatus, err := p.dbUpdater.updateDB(ctx, ctx.Pull, result.ProjectResults)
@@ -197,9 +189,8 @@ func (p *PlanCommandRunner) runAutoplan(ctx *command.Context) {
 	p.updateCommitStatus(ctx, pullStatus, command.Plan)
 	p.updateCommitStatus(ctx, pullStatus, command.Apply)
 
-	// Check if there are any planned projects and if there are any errors or if plans are being deleted
-	if len(policyCheckCmds) > 0 &&
-		(!result.HasErrors() && !result.PlansDeleted) {
+	// Check if there are any planned projects and if there are any errors.
+	if len(policyCheckCmds) > 0 && !result.HasErrors() {
 		// Run policy_check command
 		ctx.Log.Info("Running policy_checks for all plans")
 
@@ -305,6 +296,14 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 		}
 		return
 	}
+
+	if cmd.FailedPlansOnly && len(projectCmds) == 0 {
+		if err := p.vcsClient.CreateComment(ctx.Log, baseRepo, pull.Num, noFailedPlansComment, command.Plan.String()); err != nil {
+			ctx.Log.Err("unable to comment: %s", err)
+		}
+		return
+	}
+
 	projectCmds, policyCheckCmds := p.partitionProjectCmds(ctx, projectCmds)
 	if len(projectCmds) > 0 {
 		p.updatePendingCommitStatus(ctx, command.Plan)
@@ -325,14 +324,6 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 
 	result := runProjectCmdsWithCancellationTracker(ctx, projectCmds, p.cancellationTracker, p.parallelPoolSize, p.isParallelEnabled(projectCmds), p.prjCmdRunner.Plan)
 	ctx.CommandHasErrors = result.HasErrors()
-
-	if p.autoMerger.automergeEnabled(projectCmds) && result.HasErrors() {
-		ctx.Log.Info("deleting plans because there were errors and automerge requires all plans succeed")
-		if err := p.deletePlansAndPlanLocks(ctx, projectCmds); err != nil {
-			ctx.Log.Err("deleting pending plans: %s", err)
-		}
-		result.PlansDeleted = true
-	}
 
 	p.pullUpdater.updatePull(
 		ctx,
@@ -357,8 +348,7 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 
 	// Runs policy checks step after all plans are successful.
 	// This step does not approve any policies that require approval.
-	if len(result.ProjectResults) > 0 &&
-		(!result.HasErrors() && !result.PlansDeleted) {
+	if len(result.ProjectResults) > 0 && !result.HasErrors() {
 		ctx.Log.Info("Running policy check for '%s'", cmd.CommandName())
 		p.policyCheckCommandRunner.Run(ctx, policyCheckCmds)
 	} else if len(projectCmds) == 0 && !cmd.IsForSpecificProject() {
@@ -580,6 +570,8 @@ func (p *PlanCommandRunner) unlockPlanLockIfOwnedByPull(ctx *command.Context, pr
 	}
 	return nil
 }
+
+const noFailedPlansComment = "No failed plans to re-run."
 
 func (p *PlanCommandRunner) partitionProjectCmds(
 	ctx *command.Context,

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -319,6 +319,10 @@ func (p *DefaultProjectCommandBuilder) BuildAutoplanCommands(ctx *command.Contex
 
 // See ProjectCommandBuilder.BuildPlanCommands.
 func (p *DefaultProjectCommandBuilder) BuildPlanCommands(ctx *command.Context, cmd *CommentCommand) ([]command.ProjectContext, error) {
+	if cmd.FailedPlansOnly {
+		ctx.Log.Debug("Building plan command for failed projects")
+		return p.buildFailedProjectPlanCommands(ctx, cmd)
+	}
 	if cmd.DiscoverAllProjects {
 		ctx.Log.Debug("Building plan command for all configured and auto-discovered projects")
 		return p.buildAllProjectsByCfg(ctx, cmd.CommandName(), cmd.SubName, cmd.Flags, cmd.Verbose)
@@ -330,6 +334,52 @@ func (p *DefaultProjectCommandBuilder) BuildPlanCommands(ctx *command.Context, c
 	ctx.Log.Debug("Building plan command for specific project with directory: '%v', workspace: '%v', project: '%v'",
 		cmd.RepoRelDir, cmd.Workspace, cmd.ProjectName)
 	return p.buildProjectPlanCommand(ctx, cmd)
+}
+
+func (p *DefaultProjectCommandBuilder) buildFailedProjectPlanCommands(ctx *command.Context, cmd *CommentCommand) ([]command.ProjectContext, error) {
+	failedProjects := ctx.ErroredPlanProjects()
+	if len(failedProjects) == 0 {
+		ctx.Log.Info("no failed plans found")
+		return []command.ProjectContext{}, nil
+	}
+
+	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, DefaultWorkspace, DefaultRepoRelDir, "", cmd.Name)
+	if err != nil {
+		return nil, err
+	}
+	defer unlockFn()
+
+	defaultRepoDir, err := p.WorkingDir.Clone(ctx.Log, ctx.HeadRepo, ctx.Pull, DefaultWorkspace)
+	if err != nil {
+		return nil, err
+	}
+
+	var cmds []command.ProjectContext
+	for _, project := range failedProjects {
+		projectCmds, err := p.buildProjectCommandCtx(
+			ctx,
+			command.Plan,
+			cmd.SubName,
+			project.ProjectName,
+			cmd.Flags,
+			defaultRepoDir,
+			project.RepoRelDir,
+			project.Workspace,
+			false,
+			false,
+			cmd.Verbose,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("building command for failed plan at dir %q workspace %q: %w", project.RepoRelDir, project.Workspace, err)
+		}
+		cmds = append(cmds, projectCmds...)
+	}
+
+	sort.Slice(cmds, func(i, j int) bool {
+		return cmds[i].ExecutionOrderGroup < cmds[j].ExecutionOrderGroup
+	})
+
+	return cmds, nil
 }
 
 // See ProjectCommandBuilder.BuildApplyCommands.

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/mocks"
 	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/events/models/testdata"
 	vcsmocks "github.com/runatlantis/atlantis/server/events/vcs/mocks"
 	"github.com/runatlantis/atlantis/server/logging"
 	. "github.com/runatlantis/atlantis/testing"
@@ -4037,6 +4038,95 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply_IgnoreStaleNamedPlanInIgno
 	Equals(t, 1, len(ctxs))
 	Equals(t, "app", ctxs[0].RepoRelDir)
 	Equals(t, "app", ctxs[0].ProjectName)
+	Equals(t, "default", ctxs[0].Workspace)
+}
+
+func TestDefaultProjectCommandBuilder_BuildPlanFailedOnly(t *testing.T) {
+	RegisterMockTestingT(t)
+
+	atlantisYAML := "version: 3\nprojects:\n- name: failed\n  dir: failed\n- name: ok\n  dir: ok\n"
+	tmpDir := DirStructure(t, map[string]any{
+		"default": map[string]any{
+			"atlantis.yaml": atlantisYAML,
+			"failed": map[string]any{
+				"main.tf": nil,
+			},
+			"ok": map[string]any{
+				"main.tf": nil,
+			},
+		},
+	})
+
+	workingDir := mocks.NewMockWorkingDir()
+	When(workingDir.Clone(
+		Any[logging.SimpleLogging](),
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Eq(events.DefaultWorkspace))).
+		ThenReturn(filepath.Join(tmpDir, "default"), nil)
+
+	logger := logging.NewNoopLogger(t)
+	userConfig := defaultUserConfig
+	globalCfg := valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{AllowAllRepoSettings: true})
+	scope := metricstest.NewLoggingScope(t, logger, "atlantis")
+
+	builder := events.NewProjectCommandBuilder(
+		false,
+		&config.ParserValidator{},
+		&events.DefaultProjectFinder{},
+		nil,
+		workingDir,
+		events.NewDefaultWorkingDirLocker(),
+		globalCfg,
+		&events.DefaultPendingPlanFinder{},
+		&events.CommentParser{ExecutableName: "atlantis"},
+		userConfig.SkipCloneNoChanges,
+		userConfig.EnableRegExpCmd,
+		userConfig.EnableAutoMerge,
+		userConfig.EnableParallelPlan,
+		userConfig.EnableParallelApply,
+		userConfig.AutoDetectModuleFiles,
+		userConfig.AutoplanFileList,
+		userConfig.RestrictFileList,
+		userConfig.DefaultTFDistribution,
+		userConfig.SilenceNoProjects,
+		userConfig.IncludeGitUntrackedFiles,
+		userConfig.AutoDiscoverMode,
+		scope,
+		tfclientmocks.NewMockClient(),
+	)
+
+	ctxs, err := builder.BuildPlanCommands(
+		&command.Context{
+			Log:      logger,
+			Scope:    scope,
+			Pull:     testdata.Pull,
+			HeadRepo: testdata.GithubRepo,
+			PullStatus: &models.PullStatus{
+				Projects: []models.ProjectStatus{
+					{
+						Workspace:   "default",
+						RepoRelDir:  "failed",
+						ProjectName: "failed",
+						Status:      models.ErroredPlanStatus,
+					},
+					{
+						Workspace:   "default",
+						RepoRelDir:  "ok",
+						ProjectName: "ok",
+						Status:      models.PlannedPlanStatus,
+					},
+				},
+			},
+		},
+		&events.CommentCommand{
+			Name:            command.Plan,
+			FailedPlansOnly: true,
+		})
+	Ok(t, err)
+	Equals(t, 1, len(ctxs))
+	Equals(t, "failed", ctxs[0].RepoRelDir)
+	Equals(t, "failed", ctxs[0].ProjectName)
 	Equals(t, "default", ctxs[0].Workspace)
 }
 

--- a/server/events/templates/i18n/es/multi_project_plan_footer.tmpl
+++ b/server/events/templates/i18n/es/multi_project_plan_footer.tmpl
@@ -3,7 +3,12 @@
 ### Resumen del plan
 
 {{ len .Results }} proyectos, {{ .NumPlansWithChanges }} con cambios, {{ .NumPlansWithNoChanges }} sin cambios, {{ .NumPlanFailures }} fallidos
-{{ if and (not .PlansDeleted) (ne .DisableApplyAll true) }}
+{{ if .SuggestFailedPlanCommand }}
+* :repeat: Para **volver a ejecutar los planes fallidos**, comenta:
+  ```shell
+  {{ .ExecutableName }} plan --failed
+  ```
+{{ else if and (not .ApplyBlocked) (ne .DisableApplyAll true) }}
 * :fast_forward: Para **aplicar** todos los planes pendientes de esta {{ .VcsRequestType }}, comenta:
   ```shell
   {{ .ExecutableName }} apply

--- a/server/events/templates/i18n/es/multi_project_policy.tmpl
+++ b/server/events/templates/i18n/es/multi_project_policy.tmpl
@@ -14,7 +14,7 @@
 {{ end -}}
 {{ end -}}
 {{ if ne .DisableApplyAll true -}}
-{{ if and (gt (len .Results) 0) (not .PlansDeleted) -}}
+{{ if gt (len .Results) 0 -}}
 * :fast_forward: Para **aplicar** todos los planes pendientes de esta {{ .VcsRequestType }}, comenta:
   ```shell
   {{ .ExecutableName }} apply

--- a/server/events/templates/i18n/es/multi_project_policy_unsuccessful.tmpl
+++ b/server/events/templates/i18n/es/multi_project_policy_unsuccessful.tmpl
@@ -12,7 +12,7 @@
 {{ end -}}
 {{ end -}}
 {{ if ne .DisableApplyAll true -}}
-{{ if and (gt (len .Results) 0) (not .PlansDeleted) -}}
+{{ if gt (len .Results) 0 -}}
 * :heavy_check_mark: Para **aprobar** todos los planes pendientes de esta {{ .VcsRequestType }}, comenta:
   ```shell
   {{ .ExecutableName }} approve_policies

--- a/server/events/templates/i18n/es/plan_success_unwrapped.tmpl
+++ b/server/events/templates/i18n/es/plan_success_unwrapped.tmpl
@@ -3,14 +3,15 @@
 {{ if .EnableDiffMarkdownFormat }}{{ .DiffMarkdownFormattedTerraformOutput }}{{ else }}{{ .TerraformOutput }}{{ end }}
 ```
 
-{{ if .PlanWasDeleted -}}
-Este plan no se guardó porque uno o más proyectos fallaron y automerge requiere que todos los planes pasen.
+{{ if .ApplyBlocked -}}
+Este plan se guardó, pero la aplicación está bloqueada hasta que todos los planes tengan éxito.
 {{ else -}}
 {{ if not .DisableApply -}}
 * :arrow_forward: Para **aplicar** este plan, comenta:
   ```shell
   {{ .ApplyCmd }}
   ```
+{{ end -}}
 {{ end -}}
 {{ if not .DisableRepoLocking -}}
 * :put_litter_in_its_place: Para **eliminar** este plan y bloqueo, haz clic [aquí]({{ .LockURL }})
@@ -19,6 +20,5 @@ Este plan no se guardó porque uno o más proyectos fallaron y automerge requier
   ```shell
   {{ .RePlanCmd }}
   ```
-{{ end -}}
 {{ template "mergedAgain" . -}}
 {{ end -}}

--- a/server/events/templates/i18n/es/plan_success_wrapped.tmpl
+++ b/server/events/templates/i18n/es/plan_success_wrapped.tmpl
@@ -6,14 +6,15 @@
 ```
 </details>
 
-{{ if .PlanWasDeleted -}}
-Este plan no se guardó porque uno o más proyectos fallaron y automerge requiere que todos los planes pasen.
+{{ if .ApplyBlocked -}}
+Este plan se guardó, pero la aplicación está bloqueada hasta que todos los planes tengan éxito.
 {{ else -}}
 {{ if not .DisableApply -}}
 * :arrow_forward: Para **aplicar** este plan, comenta:
   ```shell
   {{ .ApplyCmd }}
   ```
+{{ end -}}
 {{ end -}}
 {{ if not .DisableRepoLocking -}}
 * :put_litter_in_its_place: Para **eliminar** este plan y bloqueo, haz clic [aquí]({{ .LockURL }})
@@ -22,7 +23,6 @@ Este plan no se guardó porque uno o más proyectos fallaron y automerge requier
   ```shell
   {{ .RePlanCmd }}
   ```
-{{ end -}}
 {{ .PlanSummary }}
 {{ template "mergedAgain" . -}}
 {{ end -}}

--- a/server/events/templates/multi_project_plan_footer.tmpl
+++ b/server/events/templates/multi_project_plan_footer.tmpl
@@ -3,7 +3,12 @@
 ### Plan Summary
 
 {{ len .Results }} projects, {{ .NumPlansWithChanges }} with changes, {{ .NumPlansWithNoChanges }} with no changes, {{ .NumPlanFailures }} failed
-{{ if and (not .PlansDeleted) (ne .DisableApplyAll true) }}
+{{ if .SuggestFailedPlanCommand }}
+* :repeat: To **re-run failed plans**, comment:
+  ```shell
+  {{ .ExecutableName }} plan --failed
+  ```
+{{ else if and (not .ApplyBlocked) (ne .DisableApplyAll true) }}
 * :fast_forward: To **apply** all unapplied plans from this {{ .VcsRequestType }}, comment:
   ```shell
   {{ .ExecutableName }} apply

--- a/server/events/templates/multi_project_policy.tmpl
+++ b/server/events/templates/multi_project_policy.tmpl
@@ -14,7 +14,7 @@
 {{ end -}}
 {{ end -}}
 {{ if ne .DisableApplyAll true -}}
-{{ if and (gt (len .Results) 0) (not .PlansDeleted) -}}
+{{ if gt (len .Results) 0 -}}
 * :fast_forward: To **apply** all unapplied plans from this {{ .VcsRequestType }}, comment:
   ```shell
   {{ .ExecutableName }} apply

--- a/server/events/templates/multi_project_policy_unsuccessful.tmpl
+++ b/server/events/templates/multi_project_policy_unsuccessful.tmpl
@@ -12,7 +12,7 @@
 {{ end -}}
 {{ end -}}
 {{ if ne .DisableApplyAll true -}}
-{{ if and (gt (len .Results) 0) (not .PlansDeleted) -}}
+{{ if gt (len .Results) 0 -}}
 * :heavy_check_mark: To **approve** all unapplied plans from this {{ .VcsRequestType }}, comment:
   ```shell
   {{ .ExecutableName }} approve_policies

--- a/server/events/templates/plan_success_unwrapped.tmpl
+++ b/server/events/templates/plan_success_unwrapped.tmpl
@@ -3,14 +3,15 @@
 {{ if .EnableDiffMarkdownFormat }}{{ .DiffMarkdownFormattedTerraformOutput }}{{ else }}{{ .TerraformOutput }}{{ end }}
 ```
 
-{{ if .PlanWasDeleted -}}
-This plan was not saved because one or more projects failed and automerge requires all plans pass.
+{{ if .ApplyBlocked -}}
+This plan was saved, but apply is blocked until all plans succeed.
 {{ else -}}
 {{ if not .DisableApply -}}
 * :arrow_forward: To **apply** this plan, comment:
   ```shell
   {{ .ApplyCmd }}
   ```
+{{ end -}}
 {{ end -}}
 {{ if not .DisableRepoLocking -}}
 * :put_litter_in_its_place: To **delete** this plan and lock, click [here]({{ .LockURL }})
@@ -19,6 +20,5 @@ This plan was not saved because one or more projects failed and automerge requir
   ```shell
   {{ .RePlanCmd }}
   ```
-{{ end -}}
 {{ template "mergedAgain" . -}}
 {{ end -}}

--- a/server/events/templates/plan_success_wrapped.tmpl
+++ b/server/events/templates/plan_success_wrapped.tmpl
@@ -6,14 +6,15 @@
 ```
 </details>
 
-{{ if .PlanWasDeleted -}}
-This plan was not saved because one or more projects failed and automerge requires all plans pass.
+{{ if .ApplyBlocked -}}
+This plan was saved, but apply is blocked until all plans succeed.
 {{ else -}}
 {{ if not .DisableApply -}}
 * :arrow_forward: To **apply** this plan, comment:
   ```shell
   {{ .ApplyCmd }}
   ```
+{{ end -}}
 {{ end -}}
 {{ if not .DisableRepoLocking -}}
 * :put_litter_in_its_place: To **delete** this plan and lock, click [here]({{ .LockURL }})
@@ -22,7 +23,6 @@ This plan was not saved because one or more projects failed and automerge requir
   ```shell
   {{ .RePlanCmd }}
   ```
-{{ end -}}
 {{ .PlanSummary }}
 {{ template "mergedAgain" . -}}
 {{ end -}}


### PR DESCRIPTION
## what

- Stop deleting **all** plans in a batch when a single project's plan fails under automerge — successful plans are now kept.
- Block `apply` while any project's plan is still failed: a `failed` combined commit status is set and Atlantis comments which projects are blocking.
- Add `atlantis plan --failed` to re-plan only the projects whose plans errored (instead of re-planning everything). The flag is mutually exclusive with `-d`/`-p`/`-w`.
- Plan comments now suggest `plan --failed` when a multi-project plan has both successes and failures, and a saved-but-blocked plan says so explicitly.
- Deprecate the `Result.PlansDeleted` field. Keeping for API backwards compatibility, suggest removing it if it's okay
- Likewise, the `PlanWasDeleted` and `PlansDeleted` markdown template fields are deprecated but kept (always `false`), so custom template overrides don't break. The built-in templates no longer use them.

Example workflow that is now possible:

1. plan 20 projects, 2 fail due to a network issue or a race condition
2. atlantis suggests running `atlantis plan --failed`, user checks that the errors are indeed transient
3. `atlantis plan --failed` plans the 2 failed plans successfully
4. `atlantis apply` now applies everything - the 18 successful plans aren't touched again

## why

- With automerge enabled, even one failed plan previously wiped every plan in the batch, including the ones that succeeded. In some cases plan failures are transient, fixable externally or fixable with atlantis commands like `import` and `state rm`. Replanning successful plans here is just a waste of time.
- Keeping the good plans and offering a targeted re-run makes recovery from a partial failure cheap.

## tests

- [x] Added unit tests: `--failed` flag parsing/validation, building plan commands for failed projects only, apply-blocking when a pull has a failed plan, the "no failed plans to re-run" path (with and without `--silence-no-projects`), and the updated plan-comment rendering.
- [x] Updated existing renderer/runner tests to expect kept plans + blocked apply instead of deleted plans.
- [x] Added a test that a custom template override referencing the deprecated `PlanWasDeleted`/`PlansDeleted` fields still renders.
- [x] `go build ./server/...`, `go vet`, and the affected `server/events`, `server/events/command`, and `server/events/models` tests pass locally.

## references

- closes #3002
