### PR TITLE
docs: Promote Terraform distribution agnosticism in Terragrunt example

### DIFF
--- a/runatlantis.io/docs/custom-workflows.md
+++ b/runatlantis.io/docs/custom-workflows.md
@@ -296,7 +296,7 @@ workflows:
       steps:
       - env:
           name: TG_TF_PATH
-          command: 'echo "terraform${ATLANTIS_TERRAFORM_VERSION}"'
+          command: 'echo "${ATLANTIS_TERRAFORM_DISTRIBUTION}${ATLANTIS_TERRAFORM_VERSION}"'
       - env:
           # Reduce Terraform suggestion output
           name: TF_IN_AUTOMATION
@@ -311,7 +311,7 @@ workflows:
       steps:
       - env:
           name: TG_TF_PATH
-          command: 'echo "terraform${ATLANTIS_TERRAFORM_VERSION}"'
+          command: 'echo "${ATLANTIS_TERRAFORM_DISTRIBUTION}${ATLANTIS_TERRAFORM_VERSION}"'
       - env:
           # Reduce Terraform suggestion output
           name: TF_IN_AUTOMATION
@@ -321,7 +321,7 @@ workflows:
       steps:
       - env:
           name: TG_TF_PATH
-          command: 'echo "terraform${DEFAULT_TERRAFORM_VERSION}"'
+          command: 'echo "${ATLANTIS_TERRAFORM_DISTRIBUTION}"'
       - env:
           name: TF_VAR_author
           command: 'git show -s --format="%ae" $HEAD_COMMIT'
@@ -331,7 +331,7 @@ workflows:
       steps:
       - env:
           name: TG_TF_PATH
-          command: 'echo "terraform${DEFAULT_TERRAFORM_VERSION}"'
+          command: 'echo "${ATLANTIS_TERRAFORM_DISTRIBUTION}'
       # Allow for state removals as not supported for Terraform wrappers by default
       - run: terragrunt state rm $(printf '%s' $COMMENT_ARGS | sed 's/,/ /' | tr -d '\\')
 ```
@@ -351,7 +351,7 @@ workflows:
       steps:
       - env:
           name: TG_TF_PATH
-          command: 'echo "terraform${ATLANTIS_TERRAFORM_VERSION}"'
+          command: 'echo "${ATLANTIS_TERRAFORM_DISTRIBUTION}${ATLANTIS_TERRAFORM_VERSION}"'
       - env:
           # Reduce Terraform suggestion output
           name: TF_IN_AUTOMATION
@@ -363,7 +363,7 @@ workflows:
       steps:
       - env:
           name: TG_TF_PATH
-          command: 'echo "terraform${ATLANTIS_TERRAFORM_VERSION}"'
+          command: 'echo "${ATLANTIS_TERRAFORM_DISTRIBUTION}${ATLANTIS_TERRAFORM_VERSION}"'
       - env:
           # Reduce Terraform suggestion output
           name: TF_IN_AUTOMATION

--- a/runatlantis.io/docs/custom-workflows.md
+++ b/runatlantis.io/docs/custom-workflows.md
@@ -331,7 +331,7 @@ workflows:
       steps:
       - env:
           name: TG_TF_PATH
-          command: 'echo "${ATLANTIS_TERRAFORM_DISTRIBUTION}'
+          command: 'echo "${ATLANTIS_TERRAFORM_DISTRIBUTION}"'
       # Allow for state removals as not supported for Terraform wrappers by default
       - run: terragrunt state rm $(printf '%s' $COMMENT_ARGS | sed 's/,/ /' | tr -d '\\')
 ```

--- a/runatlantis.io/docs/custom-workflows.md
+++ b/runatlantis.io/docs/custom-workflows.md
@@ -270,6 +270,11 @@ commands. We can use this functionality to enable
 
 You can either use your repo's `atlantis.yaml` file or the Atlantis server's `repos.yaml` file.
 
+Atlantis selects each project's Terraform distribution and version. In the workflows below,
+`ATLANTIS_TERRAFORM_DISTRIBUTION` expands to the executable prefix (`terraform` or `tofu`), and combining it with
+`ATLANTIS_TERRAFORM_VERSION` points Terragrunt at the same versioned binary. This also supports repositories containing
+both Terraform and OpenTofu projects.
+
 Given a directory structure:
 
 ```plain
@@ -285,7 +290,6 @@ If using the server `repos.yaml` file, you would use the following config:
 
 ```yaml
 # repos.yaml
-# Specify TG_TF_PATH environment variable to accommodate setting --default-tf-version
 # Generate json plan via terragrunt for policy checks
 repos:
 - id: "/.*/"
@@ -321,7 +325,7 @@ workflows:
       steps:
       - env:
           name: TG_TF_PATH
-          command: 'echo "${ATLANTIS_TERRAFORM_DISTRIBUTION}"'
+          command: 'echo "${ATLANTIS_TERRAFORM_DISTRIBUTION}${ATLANTIS_TERRAFORM_VERSION}"'
       - env:
           name: TF_VAR_author
           command: 'git show -s --format="%ae" $HEAD_COMMIT'
@@ -331,7 +335,7 @@ workflows:
       steps:
       - env:
           name: TG_TF_PATH
-          command: 'echo "${ATLANTIS_TERRAFORM_DISTRIBUTION}"'
+          command: 'echo "${ATLANTIS_TERRAFORM_DISTRIBUTION}${ATLANTIS_TERRAFORM_VERSION}"'
       # Allow for state removals as not supported for Terraform wrappers by default
       - run: terragrunt state rm $(printf '%s' $COMMENT_ARGS | sed 's/,/ /' | tr -d '\\')
 ```


### PR DESCRIPTION
## what

Updates the terragrunt example documentation to be terraform distribution agnostic.
(i.e. no longer hardcode `terraform` or `tofu`).

## why

This allows for Atlantis + terragrunt to manage repositories where there are both terraform and tofu projects present, e.g. an atlantis.yaml similar to:
```yaml
projects:
  - dir: projects/a
    autoplan:
      when_modified: ["**/*.hcl", "**/*.tf"]
    terraform_distribution: terraform

  - dir: projects/b
    autoplan:
      when_modified: ["**/*.hcl", "**/*.tofu"]
    terraform_distribution: opentofu
```

## tests

We're using this approach successfully in our own repositories.

## references

Environment variables set here:
https://github.com/runatlantis/atlantis/blob/ac39085b350fdfbafb7def905c2f24607fb89b8f/server/core/runtime/run_step_runner.go#L59-L61

Resolves to either `tofu` or `terraform`, confirmed by tests:
https://github.com/runatlantis/atlantis/blob/ac39085b350fdfbafb7def905c2f24607fb89b8f/server/core/terraform/distribution_test.go#L14-L17

https://github.com/runatlantis/atlantis/blob/ac39085b350fdfbafb7def905c2f24607fb89b8f/server/core/terraform/distribution_test.go#L26-L29

`DEFAULT_TERRAFORM_VERSION` removed as it refers to terraform specifically, the tofu equivalent is `DEFAULT_OPENTOFU_VERSION`:
https://github.com/runatlantis/atlantis/blob/ac39085b350fdfbafb7def905c2f24607fb89b8f/Dockerfile#L9-L11

which is not required as both `tofu` and `terraform`'s default versions are symlinked:
https://github.com/runatlantis/atlantis/blob/ac39085b350fdfbafb7def905c2f24607fb89b8f/scripts/download-release.sh#L33

`ATLANTIS_TERRAFORM_VERSION` can either be specified by projects/pins or derived if not present:
https://github.com/runatlantis/atlantis/blob/ac39085b350fdfbafb7def905c2f24607fb89b8f/cmd/server.go#L490-L493