### PR TITLE
fix: close temp file before rename in cmd tests

### DIFF
--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -1370,10 +1370,18 @@ func setupWithDefaults(flags map[string]any, t *testing.T) *cobra.Command {
 func tempFile(t *testing.T, contents string) string {
 	f, err := os.CreateTemp("", "")
 	Ok(t, err)
+
+	err = f.Close()
+	Ok(t, err)
+
 	newName := f.Name() + ".yaml"
+
 	err = os.Rename(f.Name(), newName)
 	Ok(t, err)
-	os.WriteFile(newName, []byte(contents), 0600) // nolint: errcheck
+
+	err = os.WriteFile(newName, []byte(contents), 0600)
+	Ok(t, err)
+
 	return newName
 }
 


### PR DESCRIPTION
## What

Update the `tempFile()` test helper in `cmd/server_test.go` to close the temporary file before renaming it and check the result of `os.WriteFile`.

## Why

On Windows, renaming an open file can fail with an error similar to:

```text
The process cannot access the file because it is being used by another process.