### PR TITLE
fix: inherit apply_requirements across matching server-side repo blocks

### DIFF
--- a/server/core/config/parser_validator_test.go
+++ b/server/core/config/parser_validator_test.go
@@ -2336,9 +2336,10 @@ projects:
 	}
 }
 
-// A later matching repo block that does not set apply_requirements must not
-// override the requirements inherited from an earlier block, even when policy
-// checks inject policies_passed into every block.
+// A later matching repo block that omits apply_requirements must inherit the
+// requirements from an earlier block rather than override them, even with
+// policy checks enabled (which would otherwise inject a policies_passed-only
+// slice into the omitted requirement).
 func TestParseGlobalCfg_InheritReqsAcrossMatchingRepos(t *testing.T) {
 	input := `repos:
 - id: /.*/
@@ -2357,4 +2358,27 @@ func TestParseGlobalCfg_InheritReqsAcrossMatchingRepos(t *testing.T) {
 	merged := global.MergeProjectCfg(logging.NewNoopLogger(t), "github.com/owner/repo",
 		valid.Project{Dir: ".", Workspace: "default"}, valid.RepoCfg{})
 	Equals(t, []string{"approved", "mergeable", "policies_passed"}, merged.ApplyRequirements)
+}
+
+// A later matching repo block that explicitly sets an empty apply_requirements
+// must override (clear) inherited requirements rather than inherit them. The
+// non-nil empty list must be preserved (not collapsed to nil) for this to work.
+func TestParseGlobalCfg_ExplicitEmptyReqsOverride(t *testing.T) {
+	input := `repos:
+- id: /.*/
+  apply_requirements: [approved, mergeable]
+- id: github.com/owner/repo
+  apply_requirements: []
+`
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "conf.yaml")
+	Ok(t, os.WriteFile(path, []byte(input), 0600))
+
+	global, err := (&config.ParserValidator{}).ParseGlobalCfg(path,
+		valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{PolicyCheckEnabled: false}))
+	Ok(t, err)
+
+	merged := global.MergeProjectCfg(logging.NewNoopLogger(t), "github.com/owner/repo",
+		valid.Project{Dir: ".", Workspace: "default"}, valid.RepoCfg{})
+	Equals(t, []string{}, merged.ApplyRequirements)
 }

--- a/server/core/config/parser_validator_test.go
+++ b/server/core/config/parser_validator_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config"
 	"github.com/runatlantis/atlantis/server/core/config/raw"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/logging"
 	. "github.com/runatlantis/atlantis/testing"
 )
 
@@ -2333,4 +2334,27 @@ projects:
 	for _, p := range cfg.Projects {
 		Assert(t, p.Name == nil, "expanded projects should not have names")
 	}
+}
+
+// A later matching repo block that does not set apply_requirements must not
+// override the requirements inherited from an earlier block, even when policy
+// checks inject policies_passed into every block.
+func TestParseGlobalCfg_InheritReqsAcrossMatchingRepos(t *testing.T) {
+	input := `repos:
+- id: /.*/
+  apply_requirements: [approved, mergeable]
+- id: github.com/owner/repo
+  allow_custom_workflows: true
+`
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "conf.yaml")
+	Ok(t, os.WriteFile(path, []byte(input), 0600))
+
+	global, err := (&config.ParserValidator{}).ParseGlobalCfg(path,
+		valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{PolicyCheckEnabled: true}))
+	Ok(t, err)
+
+	merged := global.MergeProjectCfg(logging.NewNoopLogger(t), "github.com/owner/repo",
+		valid.Project{Dir: ".", Workspace: "default"}, valid.RepoCfg{})
+	Equals(t, []string{"approved", "mergeable", "policies_passed"}, merged.ApplyRequirements)
 }

--- a/server/core/config/raw/global_cfg.go
+++ b/server/core/config/raw/global_cfg.go
@@ -315,16 +315,27 @@ func (r Repo) ToValid(workflows map[string]valid.Workflow, globalPlanReqs []stri
 		}
 	}
 
+	// Keep omitted (nil) requirements nil so getMatchingCfg inherits them
+	// instead of a policies_passed-only slice overriding an earlier block.
 	var mergedPlanReqs []string
-	mergedPlanReqs = append(mergedPlanReqs, r.PlanRequirements...)
+	if r.PlanRequirements != nil {
+		mergedPlanReqs = append(mergedPlanReqs, r.PlanRequirements...)
+	}
 	var mergedApplyReqs []string
-	mergedApplyReqs = append(mergedApplyReqs, r.ApplyRequirements...)
+	if r.ApplyRequirements != nil {
+		mergedApplyReqs = append(mergedApplyReqs, r.ApplyRequirements...)
+	}
 	var mergedImportReqs []string
-	mergedImportReqs = append(mergedImportReqs, r.ImportRequirements...)
+	if r.ImportRequirements != nil {
+		mergedImportReqs = append(mergedImportReqs, r.ImportRequirements...)
+	}
 
 	// only add global reqs if they don't exist already.
 OuterGlobalPlanReqs:
 	for _, globalReq := range globalPlanReqs {
+		if r.PlanRequirements == nil {
+			break
+		}
 		for _, currReq := range r.PlanRequirements {
 			if globalReq == currReq {
 				continue OuterGlobalPlanReqs
@@ -339,6 +350,9 @@ OuterGlobalPlanReqs:
 	}
 OuterGlobalApplyReqs:
 	for _, globalReq := range globalApplyReqs {
+		if r.ApplyRequirements == nil {
+			break
+		}
 		for _, currReq := range r.ApplyRequirements {
 			if globalReq == currReq {
 				continue OuterGlobalApplyReqs
@@ -353,6 +367,9 @@ OuterGlobalApplyReqs:
 	}
 OuterGlobalImportReqs:
 	for _, globalReq := range globalImportReqs {
+		if r.ImportRequirements == nil {
+			break
+		}
 		for _, currReq := range r.ImportRequirements {
 			if globalReq == currReq {
 				continue OuterGlobalImportReqs

--- a/server/core/config/raw/global_cfg.go
+++ b/server/core/config/raw/global_cfg.go
@@ -315,22 +315,16 @@ func (r Repo) ToValid(workflows map[string]valid.Workflow, globalPlanReqs []stri
 		}
 	}
 
-	// Keep omitted (nil) requirements nil so getMatchingCfg inherits them
-	// instead of a policies_passed-only slice overriding an earlier block.
 	var mergedPlanReqs []string
-	if r.PlanRequirements != nil {
-		mergedPlanReqs = append(mergedPlanReqs, r.PlanRequirements...)
-	}
+	mergedPlanReqs = append(mergedPlanReqs, r.PlanRequirements...)
 	var mergedApplyReqs []string
-	if r.ApplyRequirements != nil {
-		mergedApplyReqs = append(mergedApplyReqs, r.ApplyRequirements...)
-	}
+	mergedApplyReqs = append(mergedApplyReqs, r.ApplyRequirements...)
 	var mergedImportReqs []string
-	if r.ImportRequirements != nil {
-		mergedImportReqs = append(mergedImportReqs, r.ImportRequirements...)
-	}
+	mergedImportReqs = append(mergedImportReqs, r.ImportRequirements...)
 
-	// only add global reqs if they don't exist already.
+	// Only add global reqs if the block set this requirement; keep an omitted
+	// (nil) requirement nil so getMatchingCfg inherits it from an earlier block
+	// instead of a policies_passed-only slice overriding it.
 OuterGlobalPlanReqs:
 	for _, globalReq := range globalPlanReqs {
 		if r.PlanRequirements == nil {

--- a/server/core/config/raw/global_cfg.go
+++ b/server/core/config/raw/global_cfg.go
@@ -315,12 +315,11 @@ func (r Repo) ToValid(workflows map[string]valid.Workflow, globalPlanReqs []stri
 		}
 	}
 
-	var mergedPlanReqs []string
-	mergedPlanReqs = append(mergedPlanReqs, r.PlanRequirements...)
-	var mergedApplyReqs []string
-	mergedApplyReqs = append(mergedApplyReqs, r.ApplyRequirements...)
-	var mergedImportReqs []string
-	mergedImportReqs = append(mergedImportReqs, r.ImportRequirements...)
+	// Clone (not append into nil) so nil stays nil and an explicit empty list
+	// stays non-nil empty; getMatchingCfg relies on that distinction.
+	mergedPlanReqs := slices.Clone(r.PlanRequirements)
+	mergedApplyReqs := slices.Clone(r.ApplyRequirements)
+	mergedImportReqs := slices.Clone(r.ImportRequirements)
 
 	// Only add global reqs if the block set this requirement; keep an omitted
 	// (nil) requirement nil so getMatchingCfg inherits it from an earlier block


### PR DESCRIPTION
## what

- When a repo matches multiple server-side `repos` blocks, a later block that does not set `apply_requirements` no longer overrides the requirements inherited from an earlier block.
- Omitted (`nil`) plan/apply/import requirements are kept `nil` so `getMatchingCfg` inherits them; the injected non-overridable reqs (`policies_passed`) are only added to requirements a block actually set.

## why

- With `--enable-policy-checks`, `Repo.ToValid` appended `policies_passed` to every block, turning an omitted (`nil`) requirement into a non-nil `[policies_passed]` slice.
- `getMatchingCfg` resolves requirements by last-match-wins, so a later matching block that never set `apply_requirements` silently replaced the `approved`/`mergeable` reqs from an earlier `/.*/` block with just `[policies_passed]`.
- Result: `atlantis apply` could run with **zero approvals** on any repo that also matched a narrower block for unrelated settings (e.g. `allow_custom_workflows`). Effective reqs observed in the wild: `apply_requirements: [policies_passed]`.
- Distinct from #3908 / #3960, which fixed the repo-level `atlantis.yaml` override path in `MergeProjectCfg`, not this server-side `getMatchingCfg` path.

## tests

- [x] Added `TestParseGlobalCfg_InheritReqsAcrossMatchingRepos`: parses a two-block global config with policy checks enabled and asserts the effective `apply_requirements` is `[approved, mergeable, policies_passed]`. Verified it fails without the fix (`[policies_passed]`) and passes with it.
- [x] `go test ./server/core/config/...` (529 passed), `go vet`, `gofmt` clean.

## references

- closes #6623