### PR TITLE
fix: register all standard net/http/pprof endpoints when --enable-pofiling-api is set

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1170,15 +1170,7 @@ func (s *Server) SetupRoutes() {
 	}
 
 	if s.EnableProfilingAPI {
-		for p, h := range map[string]http.HandlerFunc{
-			"/":        pprof.Index,
-			"/cmdline": pprof.Cmdline,
-			"/profile": pprof.Profile,
-			"/symbol":  pprof.Symbol,
-			"/trace":   pprof.Trace,
-		} {
-			s.Router.HandleFunc("/debug/pprof"+p, h).Methods("GET")
-		}
+		s.Router.PathPrefix("/debug/pprof/").HandlerFunc(pprof.Index).Methods("GET")
 	}
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -490,3 +490,4 @@ func TestSetupRoutes_ProfilingRoutesDisabled(t *testing.T) {
 				"route %s %s should NOT be registered when EnableProfilingAPI=false", c.method, c.path)
 		})
 	}
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -395,3 +395,78 @@ func TestSetupRoutes_APIRoutesRegistered(t *testing.T) {
 		})
 	}
 }
+
+func TestSetupRoutes_ProfilingRoutesRegistered(t *testing.T) {
+	t.Log("All pprof profile routes should be reachable when EnableProfilingAPI is true")
+
+	s := server.Server{
+		Router:              mux.NewRouter(),
+		APIController:       &controllers.APIController{},
+		StatusController:    &controllers.StatusController{},
+		LocksController:     &controllers.LocksController{},
+		GithubAppController: &controllers.GithubAppController{},
+		JobsController:      &controllers.JobsController{},
+		VCSEventsController: &events_controllers.VCSEventsController{},
+		Logger:              logging.NewNoopLogger(t),
+		EnableProfilingAPI:  true,
+	}
+
+	s.SetupRoutes()
+
+	// All 10 standard net/http/pprof profiles must be reachable when the
+	// profiling API is enabled. Previously only 5 were registered (index,
+	// cmdline, profile, symbol, trace) while the pprof.Index HTML page
+	// linked to all 10 -- see issue #6626.
+	cases := []struct {
+		method string
+		path   string
+	}{
+		{"GET", "/debug/pprof/"},
+		{"GET", "/debug/pprof/cmdline"},
+		{"GET", "/debug/pprof/profile"},
+		{"GET", "/debug/pprof/symbol"},
+		{"GET", "/debug/pprof/trace"},
+		{"GET", "/debug/pprof/goroutine"},
+		{"GET", "/debug/pprof/heap"},
+		{"GET", "/debug/pprof/allocs"},
+		{"GET", "/debug/pprof/block"},
+		{"GET", "/debug/pprof/mutex"},
+		{"GET", "/debug/pprof/threadcreate"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.method+" "+c.path, func(t *testing.T) {
+			req, err := http.NewRequest(c.method, c.path, nil)
+			Ok(t, err)
+
+			var match mux.RouteMatch
+			Assert(t, s.Router.Match(req, &match),
+				"route %s %s should be registered but was not found", c.method, c.path)
+		})
+	}
+}
+
+func TestSetupRoutes_ProfilingRoutesDisabled(t *testing.T) {
+	t.Log("pprof routes should NOT be reachable when EnableProfilingAPI is false")
+
+	s := server.Server{
+		Router:              mux.NewRouter(),
+		APIController:       &controllers.APIController{},
+		StatusController:    &controllers.StatusController{},
+		LocksController:     &controllers.LocksController{},
+		GithubAppController: &controllers.GithubAppController{},
+		JobsController:      &controllers.JobsController{},
+		VCSEventsController: &events_controllers.VCSEventsController{},
+		Logger:              logging.NewNoopLogger(t),
+		EnableProfilingAPI:  false,
+	}
+
+	s.SetupRoutes()
+
+	req, err := http.NewRequest("GET", "/debug/pprof/goroutine", nil)
+	Ok(t, err)
+
+	var match mux.RouteMatch
+	Assert(t, !s.Router.Match(req, &match),
+		"route GET /debug/pprof/goroutine should NOT be registered when EnableProfilingAPI=false")
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -463,10 +463,30 @@ func TestSetupRoutes_ProfilingRoutesDisabled(t *testing.T) {
 
 	s.SetupRoutes()
 
-	req, err := http.NewRequest("GET", "/debug/pprof/goroutine", nil)
-	Ok(t, err)
+	cases := []struct {
+		method string
+		path   string
+	}{
+		{"GET", "/debug/pprof/"},
+		{"GET", "/debug/pprof/cmdline"},
+		{"GET", "/debug/pprof/profile"},
+		{"GET", "/debug/pprof/symbol"},
+		{"GET", "/debug/pprof/trace"},
+		{"GET", "/debug/pprof/goroutine"},
+		{"GET", "/debug/pprof/heap"},
+		{"GET", "/debug/pprof/allocs"},
+		{"GET", "/debug/pprof/block"},
+		{"GET", "/debug/pprof/mutex"},
+		{"GET", "/debug/pprof/threadcreate"},
+	}
 
-	var match mux.RouteMatch
-	Assert(t, !s.Router.Match(req, &match),
-		"route GET /debug/pprof/goroutine should NOT be registered when EnableProfilingAPI=false")
-}
+	for _, c := range cases {
+		t.Run(c.method+" "+c.path, func(t *testing.T) {
+			req, err := http.NewRequest(c.method, c.path, nil)
+			Ok(t, err)
+
+			var match mux.RouteMatch
+			Assert(t, !s.Router.Match(req, &match),
+				"route %s %s should NOT be registered when EnableProfilingAPI=false", c.method, c.path)
+		})
+	}


### PR DESCRIPTION
## what

- Fixes a bug in `server/server.go` where `--enable-profiling-api=true` only wired up 5 of the 10 standard `net/http/pprof` routes on the atlantis router. The pprof index page has been advertising all 10 endpoints (with hyperlinks), but 6 of them — including the most useful one for debugging stalls, `/debug/pprof/goroutine` — returned 404.
- Replaces the explicit 5-route map with a single `PathPrefix("/debug/pprof/")` handler pointing at `pprof.Index`. The stdlib's `pprof.Index` dispatches internally based on the trailing path segment, so this one registration covers all 10 endpoints and matches what the index page has been claiming all along.
- Adds two tests in `server/server_test.go`, following the existing `TestSetupRoutes_APIRoutesRegistered` pattern:
  - `TestSetupRoutes_ProfilingRoutesRegistered` — asserts all 11 pprof paths (index + 10 profiles) resolve when `EnableProfilingAPI=true`.
  - `TestSetupRoutes_ProfilingRoutesDisabled` — asserts pprof paths don't resolve when the flag is off (guards against a future regression that would inadvertently expose pprof).

## why

- The `--enable-profiling-api` flag is documented as enabling `net/http/pprof` "for continuous profiling of resources used by the server" — reasonable operators read that as full pprof access.
- The single most valuable profile for diagnosing an atlantis worker-pool stall is `/debug/pprof/goroutine?debug=2` (a full stack trace of every running goroutine). We hit a ~52-minute wedge where that dump would have been the primary diagnostic; discovering only during the incident that the endpoint 404s despite the flag being enabled was a poor experience.
- Per @inkel's response in the linked issue ("It was definitely not deliberate but rather a mistake in my part... just by adding a `*` at the end of the paths does the trick"), this is the `gorilla/mux` equivalent of that suggestion — a prefix match delegated to `pprof.Index` for internal dispatch.
- The fix is minimal (one code line changed in `server.go`) and matches what the index page's HTML has been claiming since the feature landed in #5363.

## tests

- [x] I have tested my changes by running `go test ./server -run TestSetupRoutes -v` — all three tests pass, including the existing `TestSetupRoutes_APIRoutesRegistered`.
- [x] I have verified the tests catch the bug they document — temporarily reverting the fix in `server.go` causes exactly the 6 previously-missing routes to fail (`goroutine`, `heap`, `allocs`, `block`, `mutex`, `threadcreate`), while the 5 that were already working continue to pass.
- [x] I ran the full server-package tests locally with the fix in place — no regressions.

## references

- closes #6626
- Original feature PR that introduced the partial registration: [#5363](https://github.com/runatlantis/atlantis/pull/5363)