### PR TITLE
fix: Add prune to remove stale branch info during git update/fetch

### DIFF
--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -290,13 +290,13 @@ func (w *FileWorkspace) recheckDiverged(logger logging.SimpleLogging, p models.P
 	if w.usesPRSourceRemote(headRepo, p) {
 		cmds = append(cmds,
 			[]string{"git", "remote", "set-url", prSourceRemote, headRepo.CloneURL},
-			[]string{"git", "remote", "update"},
+			[]string{"git", "remote", "update", "--prune"},
 		)
 	} else {
 		// On the GitHub App path the source (fork) remote isn't used to fetch the
 		// PR head, so only refresh origin. This avoids fetching a possibly
 		// inaccessible fork, which would fail and make us assume divergence.
-		cmds = append(cmds, []string{"git", "remote", "update", "origin"})
+		cmds = append(cmds, []string{"git", "remote", "update", "origin", "--prune"})
 	}
 
 	for _, args := range cmds {
@@ -389,7 +389,7 @@ func (w *FileWorkspace) GetDivergedFilesFromPullHead(logger logging.SimpleLoggin
 // gitRefLock(cloneDir) and gitReadLock(cloneDir) (or the write lock).
 func (w *FileWorkspace) hasDiverged(logger logging.SimpleLogging, cloneDir string) bool {
 	logger.Debug("HasDiverged: running git fetch in %s", cloneDir)
-	cmd := exec.Command("git", "fetch")
+	cmd := exec.Command("git", "fetch", "--prune")
 	cmd.Dir = cloneDir
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -506,7 +506,7 @@ func (w *FileWorkspace) getDivergedFilesFromPullHead(logger logging.SimpleLoggin
 
 func (w *FileWorkspace) getDivergedFilesFromRef(logger logging.SimpleLogging, cloneDir string, pullRequest models.PullRequest, startRef string) ([]string, error) {
 	logger.Debug("GetDivergedFiles: running git fetch")
-	fetchCmd := exec.Command("git", "fetch")
+	fetchCmd := exec.Command("git", "fetch", "--prune")
 	fetchCmd.Dir = cloneDir
 	outputFetch, err := fetchCmd.CombinedOutput()
 	if err != nil {
@@ -571,9 +571,9 @@ func (w *FileWorkspace) updateToRef(logger logging.SimpleLogging, c wrappedGitCo
 	// On the GitHub App path the source (fork) remote isn't used to fetch the PR
 	// head (mergeToBaseBranch fetches pull/<n>/head from origin), so only update
 	// origin and avoid fetching a possibly inaccessible fork.
-	fetchArgs := []string{"fetch", "--all"}
+	fetchArgs := []string{"fetch", "--all", "--prune"}
 	if !w.usesPRSourceRemote(c.head, c.pr) {
-		fetchArgs = []string{"fetch", "origin"}
+		fetchArgs = []string{"fetch", "origin", "--prune"}
 	}
 	if err := w.wrappedGit(logger, c, fetchArgs...); err != nil {
 		return err
@@ -845,7 +845,7 @@ func (w *FileWorkspace) mergeToBaseBranch(logger logging.SimpleLogging, c wrappe
 	if err := w.wrappedGit(logger, c, "merge-base", c.pr.BaseBranch, "FETCH_HEAD"); err != nil {
 		// git merge-base returning error means that we did not receive enough commits in shallow clone.
 		// Fall back to retrieving full repo history.
-		if err := w.wrappedGit(logger, c, "fetch", "--unshallow"); err != nil {
+		if err := w.wrappedGit(logger, c, "fetch", "--unshallow", "--prune"); err != nil {
 			return err
 		}
 

--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -1021,6 +1021,72 @@ func TestClone_ResetOnWrongCommitWithMergeStrategy(t *testing.T) {
 	Equals(t, expCommit, actCommit)
 }
 
+// TestMergeAgain_PrunesConflictingRefNames verifies that git remote update uses --prune.
+// Without --prune, if origin once had "feature/foo" (leaving refs/remotes/origin/feature/
+// as a directory on disk) and the remote then deletes that branch and creates "feature",
+// git remote update fails with "cannot lock ref 'refs/remotes/origin/feature': ... exists;
+// cannot create 'refs/remotes/origin/feature'". With --prune, the stale ref is removed
+// first and the update succeeds.
+func TestMergeAgain_PrunesConflictingRefNames(t *testing.T) {
+	repoDir := initRepo(t)
+
+	// Create feature/foo on remote so that cloning it will create
+	// refs/remotes/origin/feature/foo (i.e. the "feature/" directory on disk).
+	runCmd(t, repoDir, "git", "checkout", "-b", "feature/foo")
+	runCmd(t, repoDir, "touch", "foo.tf")
+	runCmd(t, repoDir, "git", "add", "foo.tf")
+	runCmd(t, repoDir, "git", "commit", "-m", "add feature/foo")
+	runCmd(t, repoDir, "git", "checkout", "main")
+
+	// Clone without --single-branch so all remote branches are fetched,
+	// which creates refs/remotes/origin/feature/foo in the workspace.
+	atlantisDir := repoDir + "/repos/0/default"
+	runCmd(t, repoDir, "mkdir", "-p", "repos/0/default")
+	runCmd(t, atlantisDir, "git", "clone", repoDir, ".")
+	runCmd(t, atlantisDir, "git", "remote", "add", "source", repoDir)
+	runCmd(t, atlantisDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
+	runCmd(t, atlantisDir, "git", "config", "--local", "user.name", "atlantisbot")
+	runCmd(t, atlantisDir, "git", "config", "--local", "commit.gpgsign", "false")
+
+	// Confirm the conflicting ref exists in the workspace.
+	remoteBranches := runCmd(t, atlantisDir, "git", "branch", "-r")
+	assert.Contains(t, remoteBranches, "origin/feature/foo")
+
+	// Delete feature/foo from remote and replace it with a flat "feature" branch.
+	// refs/remotes/origin/feature can't be a file while refs/remotes/origin/feature/
+	// is a directory, so git remote update (without --prune) would fail here.
+	runCmd(t, repoDir, "git", "branch", "-D", "feature/foo")
+	runCmd(t, repoDir, "git", "checkout", "-b", "feature")
+	runCmd(t, repoDir, "touch", "feature.tf")
+	runCmd(t, repoDir, "git", "add", "feature.tf")
+	runCmd(t, repoDir, "git", "commit", "-m", "add feature")
+	runCmd(t, repoDir, "git", "checkout", "main")
+
+	logger := logging.NewNoopLogger(t)
+	wd := &events.FileWorkspace{
+		DataDir:             repoDir,
+		CheckoutMerge:       true,
+		CheckoutDepth:       50,
+		GpgNoSigningEnabled: true,
+	}
+
+	// MergeAgain calls recheckDiverged which runs git remote update --prune.
+	// --prune removes refs/remotes/origin/feature/foo before fetching
+	// refs/remotes/origin/feature, avoiding the "cannot lock ref" failure.
+	_, err := wd.MergeAgain(logger, models.Repo{CloneURL: repoDir}, models.PullRequest{
+		BaseRepo:   models.Repo{CloneURL: repoDir},
+		HeadBranch: "main",
+		BaseBranch: "main",
+	}, "default")
+	Ok(t, err)
+
+	// Without --prune, the conflicting refs/remotes/origin/feature/foo ref
+	// blocks "git remote update" from ever creating refs/remotes/origin/feature.
+	remoteBranches = runCmd(t, atlantisDir, "git", "branch", "-r")
+	assert.NotContains(t, remoteBranches, "origin/feature/foo")
+	assert.Contains(t, remoteBranches, "origin/feature")
+}
+
 // Test that if the branch we're merging into has diverged and we're using
 // checkout-strategy=merge, we actually merge the branch.
 // Also check that we do not merge if we are not using the merge strategy.


### PR DESCRIPTION
## what

Adds --prune to the git commands that FileWorkspace uses to refresh remote-tracking refs during the merge-checkout-strategy flow.


## why

Without --prune, a renamed/deleted remote branch can leave a stale remote-tracking ref (e.g. refs/remotes/origin/feature/foo) in the workspace clone. If a new branch is later pushed whose name collides at the ref-path level (e.g. feature), git remote update/git fetch fails with cannot lock ref / exists; cannot create, since git can't have both a file and a directory at the same path under refs/remotes/origin/.

recheckDiverged treats that fetch failure as "assume divergence" and swallows the error, so the failure was silent. Atlantis would still attempt a merge, but the workspace's remote-tracking refs would be left stale/out of sync until manually cleaned up. --prune removes refs that no longer exist on the remote before fetching, so the conflicting stale ref never blocks the update.

## tests

- [x] Added TestMergeAgain_PrunesConflictingRefNames, which reproduces a remote branch rename that creates a ref-name conflict (origin/feature/foo → origin/feature) and asserts that after MergeAgain runs, the stale origin/feature/foo ref is gone and origin/feature exists.
- [x] We verified that this works by running this change in our local installation.


