### PR TITLE
fix: Propagate errors in divergence checks to abort plan

### DIFF
--- a/server/events/command_requirement_handler.go
+++ b/server/events/command_requirement_handler.go
@@ -111,7 +111,9 @@ func (a *DefaultCommandRequirementHandler) validateCommandRequirement(repoDir st
 			diverged, err := a.hasUndivergedImpact(repoDir, ctx, cmd)
 			if err != nil {
 				ctx.Log.Warn("evaluating undiverged requirement has failed, falling back to full divergence check: %s", err)
-				diverged = a.hasDiverged(repoDir, ctx, cmd, nil)
+				// Here it doesn't matter if diverged check has errored. If `true` is returned,
+				// diverged path will be followed which will ask the user to rebase
+				diverged, _ = a.hasDiverged(repoDir, ctx, cmd, nil)
 			}
 			if diverged {
 				return fmt.Sprintf("Default branch must be rebased onto pull request before running %s.", cmd), nil
@@ -179,7 +181,7 @@ func isAtlantisProjectPlanStatus(statusName, vcsStatusName string) bool {
 
 func (a *DefaultCommandRequirementHandler) hasUndivergedImpact(repoDir string, ctx command.ProjectContext, cmd command.Name) (bool, error) {
 	if a.ProjectImpactResolver == nil {
-		return a.hasDiverged(repoDir, ctx, cmd, ctx.AutoplanWhenModified), nil
+		return a.hasDiverged(repoDir, ctx, cmd, ctx.AutoplanWhenModified)
 	}
 
 	var handled bool
@@ -194,12 +196,12 @@ func (a *DefaultCommandRequirementHandler) hasUndivergedImpact(repoDir string, c
 		return false, err
 	}
 	if !handled {
-		return a.hasDiverged(repoDir, ctx, cmd, ctx.AutoplanWhenModified), nil
+		return a.hasDiverged(repoDir, ctx, cmd, ctx.AutoplanWhenModified)
 	}
 	return impacted, nil
 }
 
-func (a *DefaultCommandRequirementHandler) hasDiverged(repoDir string, ctx command.ProjectContext, cmd command.Name, autoplanWhenModified []string) bool {
+func (a *DefaultCommandRequirementHandler) hasDiverged(repoDir string, ctx command.ProjectContext, cmd command.Name, autoplanWhenModified []string) (bool, error) {
 	if cmd == command.Plan {
 		return a.WorkingDir.HasDivergedFromPullHead(ctx.Log, repoDir, ctx.RepoRelDir, autoplanWhenModified, ctx.Pull)
 	}

--- a/server/events/command_requirement_handler_test.go
+++ b/server/events/command_requirement_handler_test.go
@@ -53,7 +53,7 @@ func TestAggregateApplyRequirements_ValidatePlanProject(t *testing.T) {
 				ProjectPlanStatus: models.PassedPolicyCheckStatus,
 			},
 			setup: func(workingDir *mocks.MockWorkingDir) {
-				When(workingDir.HasDivergedFromPullHead(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(false)
+				When(workingDir.HasDivergedFromPullHead(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(false, nil)
 			},
 			wantErr: assert.NoError,
 		},
@@ -99,7 +99,7 @@ func TestAggregateApplyRequirements_ValidatePlanProject(t *testing.T) {
 				PlanRequirements: []string{raw.UnDivergedRequirement},
 			},
 			setup: func(workingDir *mocks.MockWorkingDir) {
-				When(workingDir.HasDivergedFromPullHead(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(true)
+				When(workingDir.HasDivergedFromPullHead(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(true, nil)
 			},
 			wantFailure: "Default branch must be rebased onto pull request before running plan.",
 			wantErr:     assert.NoError,
@@ -227,7 +227,7 @@ func TestAggregateApplyRequirements_ValidateApplyProject(t *testing.T) {
 					Any[string](),
 					Any[[]string](),
 					Any[models.PullRequest](),
-				)).ThenReturn(true)
+				)).ThenReturn(true, nil)
 			},
 			wantFailure: "Default branch must be rebased onto pull request before running apply.",
 			wantErr:     assert.NoError,
@@ -305,7 +305,7 @@ func TestAggregateApplyRequirements_ValidateApplyProject(t *testing.T) {
 				ProjectPlanStatus: models.PassedPolicyCheckStatus,
 			},
 			setup: func(workingDir *mocks.MockWorkingDir) {
-				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(false)
+				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(false, nil)
 			},
 			wantErr: assert.NoError,
 		},
@@ -361,7 +361,7 @@ func TestAggregateApplyRequirements_ValidateApplyProject(t *testing.T) {
 				ApplyRequirements: []string{raw.UnDivergedRequirement},
 			},
 			setup: func(workingDir *mocks.MockWorkingDir) {
-				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(true)
+				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(true, nil)
 			},
 			wantFailure: "Default branch must be rebased onto pull request before running apply.",
 			wantErr:     assert.NoError,
@@ -845,7 +845,7 @@ func TestAggregateApplyRequirements_ValidateImportProject(t *testing.T) {
 				ProjectPlanStatus: models.PassedPolicyCheckStatus,
 			},
 			setup: func(workingDir *mocks.MockWorkingDir) {
-				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(false)
+				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(false, nil)
 			},
 			wantErr: assert.NoError,
 		},
@@ -877,7 +877,7 @@ func TestAggregateApplyRequirements_ValidateImportProject(t *testing.T) {
 				ImportRequirements: []string{raw.UnDivergedRequirement},
 			},
 			setup: func(workingDir *mocks.MockWorkingDir) {
-				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(true)
+				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(true, nil)
 			},
 			wantFailure: "Default branch must be rebased onto pull request before running import.",
 			wantErr:     assert.NoError,

--- a/server/events/command_requirement_handler_test.go
+++ b/server/events/command_requirement_handler_test.go
@@ -104,6 +104,21 @@ func TestAggregateApplyRequirements_ValidatePlanProject(t *testing.T) {
 			wantFailure: "Default branch must be rebased onto pull request before running plan.",
 			wantErr:     assert.NoError,
 		},
+		{
+			// HasDivergedFromPullHead errors (e.g. remote update/fetch fails) but still
+			// reports diverged=true as its fail-safe. The handler must not surface that
+			// error to the caller — it should still require a rebase, not silently pass.
+			name: "fail by diverged when divergence check errors",
+			ctx: command.ProjectContext{
+				Log:              logging.NewNoopLogger(t),
+				PlanRequirements: []string{raw.UnDivergedRequirement},
+			},
+			setup: func(workingDir *mocks.MockWorkingDir) {
+				When(workingDir.HasDivergedFromPullHead(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(true, fmt.Errorf("simulated remote update failure"))
+			},
+			wantFailure: "Default branch must be rebased onto pull request before running plan.",
+			wantErr:     assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -362,6 +377,21 @@ func TestAggregateApplyRequirements_ValidateApplyProject(t *testing.T) {
 			},
 			setup: func(workingDir *mocks.MockWorkingDir) {
 				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(true, nil)
+			},
+			wantFailure: "Default branch must be rebased onto pull request before running apply.",
+			wantErr:     assert.NoError,
+		},
+		{
+			// HasDiverged errors (e.g. remote update/fetch fails) but still reports
+			// diverged=true as its fail-safe. The handler must not surface that error
+			// to the caller — it should still require a rebase, not silently pass.
+			name: "fail by diverged when divergence check errors",
+			ctx: command.ProjectContext{
+				Log:               logging.NewNoopLogger(t),
+				ApplyRequirements: []string{raw.UnDivergedRequirement},
+			},
+			setup: func(workingDir *mocks.MockWorkingDir) {
+				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(true, fmt.Errorf("simulated remote update failure"))
 			},
 			wantFailure: "Default branch must be rebased onto pull request before running apply.",
 			wantErr:     assert.NoError,
@@ -878,6 +908,21 @@ func TestAggregateApplyRequirements_ValidateImportProject(t *testing.T) {
 			},
 			setup: func(workingDir *mocks.MockWorkingDir) {
 				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(true, nil)
+			},
+			wantFailure: "Default branch must be rebased onto pull request before running import.",
+			wantErr:     assert.NoError,
+		},
+		{
+			// HasDiverged errors (e.g. remote update/fetch fails) but still reports
+			// diverged=true as its fail-safe. The handler must not surface that error
+			// to the caller — it should still require a rebase, not silently pass.
+			name: "fail by diverged when divergence check errors",
+			ctx: command.ProjectContext{
+				Log:                logging.NewNoopLogger(t),
+				ImportRequirements: []string{raw.UnDivergedRequirement},
+			},
+			setup: func(workingDir *mocks.MockWorkingDir) {
+				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(true, fmt.Errorf("simulated remote update failure"))
 			},
 			wantFailure: "Default branch must be rebased onto pull request before running import.",
 			wantErr:     assert.NoError,

--- a/server/events/mock_workingdir_test.go
+++ b/server/events/mock_workingdir_test.go
@@ -200,34 +200,42 @@ func (mock *MockWorkingDir) GitReadLock(r models.Repo, p models.PullRequest, wor
 	return _ret0
 }
 
-func (mock *MockWorkingDir) HasDiverged(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) bool {
+func (mock *MockWorkingDir) HasDiverged(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) (bool, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockWorkingDir().")
 	}
 	_params := []pegomock.Param{logger, cloneDir, projectPath, autoplanWhenModified, pullRequest}
-	_result := pegomock.GetGenericMockFrom(mock).Invoke("HasDiverged", _params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem()})
+	_result := pegomock.GetGenericMockFrom(mock).Invoke("HasDiverged", _params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
 	var _ret0 bool
+	var _ret1 error
 	if len(_result) != 0 {
 		if _result[0] != nil {
 			_ret0 = _result[0].(bool)
 		}
+		if _result[1] != nil {
+			_ret1 = _result[1].(error)
+		}
 	}
-	return _ret0
+	return _ret0, _ret1
 }
 
-func (mock *MockWorkingDir) HasDivergedFromPullHead(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) bool {
+func (mock *MockWorkingDir) HasDivergedFromPullHead(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) (bool, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockWorkingDir().")
 	}
 	_params := []pegomock.Param{logger, cloneDir, projectPath, autoplanWhenModified, pullRequest}
-	_result := pegomock.GetGenericMockFrom(mock).Invoke("HasDivergedFromPullHead", _params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem()})
+	_result := pegomock.GetGenericMockFrom(mock).Invoke("HasDivergedFromPullHead", _params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
 	var _ret0 bool
+	var _ret1 error
 	if len(_result) != 0 {
 		if _result[0] != nil {
 			_ret0 = _result[0].(bool)
 		}
+		if _result[1] != nil {
+			_ret1 = _result[1].(error)
+		}
 	}
-	return _ret0
+	return _ret0, _ret1
 }
 
 func (mock *MockWorkingDir) MergeAgain(logger logging.SimpleLogging, headRepo models.Repo, p models.PullRequest, workspace string) (bool, error) {

--- a/server/events/mocks/mock_working_dir.go
+++ b/server/events/mocks/mock_working_dir.go
@@ -200,34 +200,42 @@ func (mock *MockWorkingDir) GitReadLock(r models.Repo, p models.PullRequest, wor
 	return _ret0
 }
 
-func (mock *MockWorkingDir) HasDiverged(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) bool {
+func (mock *MockWorkingDir) HasDiverged(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) (bool, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockWorkingDir().")
 	}
 	_params := []pegomock.Param{logger, cloneDir, projectPath, autoplanWhenModified, pullRequest}
-	_result := pegomock.GetGenericMockFrom(mock).Invoke("HasDiverged", _params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem()})
+	_result := pegomock.GetGenericMockFrom(mock).Invoke("HasDiverged", _params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
 	var _ret0 bool
+	var _ret1 error
 	if len(_result) != 0 {
 		if _result[0] != nil {
 			_ret0 = _result[0].(bool)
 		}
+		if _result[1] != nil {
+			_ret1 = _result[1].(error)
+		}
 	}
-	return _ret0
+	return _ret0, _ret1
 }
 
-func (mock *MockWorkingDir) HasDivergedFromPullHead(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) bool {
+func (mock *MockWorkingDir) HasDivergedFromPullHead(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) (bool, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockWorkingDir().")
 	}
 	_params := []pegomock.Param{logger, cloneDir, projectPath, autoplanWhenModified, pullRequest}
-	_result := pegomock.GetGenericMockFrom(mock).Invoke("HasDivergedFromPullHead", _params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem()})
+	_result := pegomock.GetGenericMockFrom(mock).Invoke("HasDivergedFromPullHead", _params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
 	var _ret0 bool
+	var _ret1 error
 	if len(_result) != 0 {
 		if _result[0] != nil {
 			_ret0 = _result[0].(bool)
 		}
+		if _result[1] != nil {
+			_ret1 = _result[1].(error)
+		}
 	}
-	return _ret0
+	return _ret0, _ret1
 }
 
 func (mock *MockWorkingDir) MergeAgain(logger logging.SimpleLogging, headRepo models.Repo, p models.PullRequest, workspace string) (bool, error) {

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -687,7 +687,7 @@ func TestDefaultProjectCommandRunner_PlanUndivergedBlocksAfterMergeAgain(t *test
 	When(mockWorkingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](),
 		Any[string]())).ThenReturn(repoDir, nil)
 	When(mockWorkingDir.HasDivergedFromPullHead(Any[logging.SimpleLogging](), Any[string](), Any[string](),
-		Any[[]string](), Any[models.PullRequest]())).ThenReturn(true)
+		Any[[]string](), Any[models.PullRequest]())).ThenReturn(true, nil)
 
 	res := runner.Plan(ctx)
 
@@ -770,7 +770,7 @@ func TestDefaultProjectCommandRunner_PlanValidationFailureKeepsLockWhenDeletePla
 	When(mockWorkingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](),
 		Any[string]())).ThenReturn(repoDir, nil)
 	When(mockWorkingDir.HasDivergedFromPullHead(Any[logging.SimpleLogging](), Any[string](), Any[string](),
-		Any[[]string](), Any[models.PullRequest]())).ThenReturn(true)
+		Any[[]string](), Any[models.PullRequest]())).ThenReturn(true, nil)
 	When(mockWorkingDir.DeletePlan(Any[logging.SimpleLogging](), Eq(ctx.Pull.BaseRepo), Eq(ctx.Pull),
 		Eq(ctx.Workspace), Eq(ctx.RepoRelDir), Eq(ctx.ProjectName))).ThenReturn(errors.New("delete failed"))
 
@@ -805,12 +805,12 @@ func (m *mergeCreatesProjectWorkingDir) GetWorkingDir(models.Repo, models.PullRe
 	return m.repoDir, nil
 }
 
-func (m *mergeCreatesProjectWorkingDir) HasDiverged(logging.SimpleLogging, string, string, []string, models.PullRequest) bool {
-	return false
+func (m *mergeCreatesProjectWorkingDir) HasDiverged(logging.SimpleLogging, string, string, []string, models.PullRequest) (bool, error) {
+	return false, nil
 }
 
-func (m *mergeCreatesProjectWorkingDir) HasDivergedFromPullHead(logging.SimpleLogging, string, string, []string, models.PullRequest) bool {
-	return false
+func (m *mergeCreatesProjectWorkingDir) HasDivergedFromPullHead(logging.SimpleLogging, string, string, []string, models.PullRequest) (bool, error) {
+	return false, nil
 }
 
 func (m *mergeCreatesProjectWorkingDir) GetDivergedFiles(logging.SimpleLogging, string, models.PullRequest) ([]string, error) {
@@ -863,7 +863,7 @@ func TestDefaultProjectCommandRunner_ApplyDiverged(t *testing.T) {
 	}
 	tmp := t.TempDir()
 	When(mockWorkingDir.GetWorkingDir(ctx.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(tmp, nil)
-	When(mockWorkingDir.HasDiverged(ctx.Log, tmp, ctx.RepoRelDir, ctx.AutoplanWhenModified, ctx.Pull)).ThenReturn(true)
+	When(mockWorkingDir.HasDiverged(ctx.Log, tmp, ctx.RepoRelDir, ctx.AutoplanWhenModified, ctx.Pull)).ThenReturn(true, nil)
 
 	res := runner.Apply(ctx)
 	Equals(t, "Default branch must be rebased onto pull request before running apply.", res.Failure)

--- a/server/events/undiverged_project_impact_test.go
+++ b/server/events/undiverged_project_impact_test.go
@@ -212,7 +212,7 @@ func TestDefaultCommandRequirementHandler_TargetedUndivergedFallsBackWhenGenerat
 	repoDir := autoDiscoveredRepo(t)
 	resolver := newTestUndivergedProjectImpactResolver("**/*.tf", defaultAutoplanFileList, "auto")
 	workingDir := NewMockWorkingDir()
-	When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Eq(repoDir), Eq("project1"), Eq([]string{"generated-only/**"}), Any[models.PullRequest]())).ThenReturn(true)
+	When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Eq(repoDir), Eq("project1"), Eq([]string{"generated-only/**"}), Any[models.PullRequest]())).ThenReturn(true, nil)
 
 	handler := &DefaultCommandRequirementHandler{
 		WorkingDir:            workingDir,
@@ -236,7 +236,7 @@ func TestDefaultCommandRequirementHandler_TargetedUndivergedFallsBackForEmptyCon
 	repoDir := configuredProjectRepoWithEmptyWhenModified(t)
 	resolver := newTestUndivergedProjectImpactResolver("**/*.tf", defaultAutoplanFileList, "auto")
 	workingDir := NewMockWorkingDir()
-	When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Eq(repoDir), Eq("project1"), Eq([]string{}), Any[models.PullRequest]())).ThenReturn(true)
+	When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Eq(repoDir), Eq("project1"), Eq([]string{}), Any[models.PullRequest]())).ThenReturn(true, nil)
 
 	handler := &DefaultCommandRequirementHandler{
 		WorkingDir:            workingDir,
@@ -258,8 +258,8 @@ func TestDefaultCommandRequirementHandler_TargetedUndivergedFallsBackToFullCheck
 
 	repoDir := configuredProjectRepo(t)
 	workingDir := NewMockWorkingDir()
-	When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Eq(repoDir), Eq("project1"), Eq([]string{"modules/database/**"}), Any[models.PullRequest]())).ThenReturn(true)
-	When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Eq(repoDir), Eq("project1"), Eq([]string(nil)), Any[models.PullRequest]())).ThenReturn(false)
+	When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Eq(repoDir), Eq("project1"), Eq([]string{"modules/database/**"}), Any[models.PullRequest]())).ThenReturn(true, nil)
+	When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Eq(repoDir), Eq("project1"), Eq([]string(nil)), Any[models.PullRequest]())).ThenReturn(false, nil)
 
 	handler := &DefaultCommandRequirementHandler{
 		WorkingDir:            workingDir,

--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -61,10 +61,10 @@ type WorkingDir interface {
 	// When autoplanWhenModified patterns are provided, only divergence affecting
 	// files matching those patterns is considered. When patterns are empty,
 	// any divergence is reported.
-	HasDiverged(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) bool
+	HasDiverged(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) (bool, error)
 	// HasDivergedFromPullHead checks if the pull request head has diverged from
 	// the base branch.
-	HasDivergedFromPullHead(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) bool
+	HasDivergedFromPullHead(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) (bool, error)
 	// GetDivergedFiles returns the files changed on the base branch since the
 	// current checkout. When merge checkout is disabled there is no divergence
 	// check, so this returns no files and no error.
@@ -219,7 +219,11 @@ func (w *FileWorkspace) MergeAgain(
 	}
 	c := wrappedGitContext{cloneDir, headRepo, p}
 
-	if !w.recheckDiverged(logger, p, headRepo, cloneDir) {
+	diverged, err := w.recheckDiverged(logger, p, headRepo, cloneDir)
+	if err != nil {
+		return true, err
+	}
+	if !diverged {
 		return false, nil
 	}
 
@@ -255,17 +259,17 @@ func (w *FileWorkspace) MergeAgain(
 // This matters in the case of the merge checkout strategy because after
 // cloning the repo and doing the merge, it's possible main was updated
 // and we have to perform a new merge.
-// If there are any errors we return true since we prefer to assume divergence
-// for safety.
+// If there are any errors we return (true, err) since we prefer to assume divergence
+// for safety and don't want plan against stale code. Plan will fail.
 // Acquires gitRefLock and gitReadLock internally to serialize git metadata operations.
 // Does NOT require the caller to hold the repo read or write lock.
-func (w *FileWorkspace) recheckDiverged(logger logging.SimpleLogging, p models.PullRequest, headRepo models.Repo, cloneDir string) bool {
+func (w *FileWorkspace) recheckDiverged(logger logging.SimpleLogging, p models.PullRequest, headRepo models.Repo, cloneDir string) (bool, error) {
 	if !w.CheckoutMerge {
 		// It only makes sense to warn that main has diverged if we're using
 		// the checkout merge strategy. If we're just checking out the branch,
 		// then it doesn't matter what's going on with main because we've
 		// decided to always run off the branch.
-		return false
+		return false, nil
 	}
 
 	// Hold the read and ref locks for the entire sequence: URL updates write .git/config,
@@ -305,19 +309,20 @@ func (w *FileWorkspace) recheckDiverged(logger logging.SimpleLogging, p models.P
 
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			logger.Warn("getting remote update failed: %s", string(output))
-			return true
+			cmdErr := fmt.Errorf("getting remote update failed: %w: %s", err, strings.TrimSpace(string(output)))
+			logger.Err("%s", cmdErr.Error())
+			return true, cmdErr
 		}
 	}
 
 	return w.hasDiverged(logger, cloneDir)
 }
 
-func (w *FileWorkspace) HasDiverged(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) bool {
+func (w *FileWorkspace) HasDiverged(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) (bool, error) {
 	logger.Debug("HasDiverged: starting divergence check in %s", cloneDir)
 	if !w.CheckoutMerge {
 		logger.Debug("HasDiverged: CheckoutMerge is false, skipping divergence check")
-		return false
+		return false, nil
 	}
 
 	// Hold repo read lock and ref lock for the full duration (fetch + status) so we don't race with
@@ -329,16 +334,16 @@ func (w *FileWorkspace) HasDiverged(logger logging.SimpleLogging, cloneDir strin
 	defer unlockGitRefLock()
 
 	if len(autoplanWhenModified) > 0 {
-		return w.hasDivergedForPatterns(logger, cloneDir, projectPath, autoplanWhenModified, pullRequest, w.getDivergedFiles)
+		return w.hasDivergedForPatterns(logger, cloneDir, projectPath, autoplanWhenModified, pullRequest, w.getDivergedFiles), nil
 	}
 	return w.hasDiverged(logger, cloneDir)
 }
 
-func (w *FileWorkspace) HasDivergedFromPullHead(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) bool {
+func (w *FileWorkspace) HasDivergedFromPullHead(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) (bool, error) {
 	logger.Debug("HasDivergedFromPullHead: starting divergence check in %s", cloneDir)
 	if !w.CheckoutMerge {
 		logger.Debug("HasDivergedFromPullHead: CheckoutMerge is false, skipping divergence check")
-		return false
+		return false, nil
 	}
 
 	unlockGitReadLock := w.gitReadLock(cloneDir)
@@ -348,7 +353,7 @@ func (w *FileWorkspace) HasDivergedFromPullHead(logger logging.SimpleLogging, cl
 	defer unlockGitRefLock()
 
 	if len(autoplanWhenModified) > 0 {
-		return w.hasDivergedForPatterns(logger, cloneDir, projectPath, autoplanWhenModified, pullRequest, w.getDivergedFilesFromPullHead)
+		return w.hasDivergedForPatterns(logger, cloneDir, projectPath, autoplanWhenModified, pullRequest, w.getDivergedFilesFromPullHead), nil
 	}
 	return w.hasDivergedFromPullHead(logger, cloneDir, pullRequest)
 }
@@ -387,14 +392,15 @@ func (w *FileWorkspace) GetDivergedFilesFromPullHead(logger logging.SimpleLoggin
 
 // hasDiverged runs fetch and git status to detect divergence. Caller must hold
 // gitRefLock(cloneDir) and gitReadLock(cloneDir) (or the write lock).
-func (w *FileWorkspace) hasDiverged(logger logging.SimpleLogging, cloneDir string) bool {
+func (w *FileWorkspace) hasDiverged(logger logging.SimpleLogging, cloneDir string) (bool, error) {
 	logger.Debug("HasDiverged: running git fetch in %s", cloneDir)
 	cmd := exec.Command("git", "fetch")
 	cmd.Dir = cloneDir
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		logger.Warn("HasDiverged: fetching repo has failed: %s", string(output))
-		return true
+		fetchErr := fmt.Errorf("running git fetch: %w (output: %s)", err, strings.TrimSpace(string(output)))
+		logger.Err("%s", fetchErr.Error())
+		return true, fetchErr
 	}
 	logger.Debug("HasDiverged: git fetch completed successfully")
 
@@ -404,15 +410,15 @@ func (w *FileWorkspace) hasDiverged(logger logging.SimpleLogging, cloneDir strin
 	outputStatusUno, err := statusUnoCmd.CombinedOutput()
 	if err != nil {
 		logger.Warn("getting repo status has failed: %s", string(outputStatusUno))
-		return true
+		return true, nil
 	}
 	logger.Debug("HasDiverged: git status output: %s", string(outputStatusUno))
 	hasDiverged := strings.Contains(string(outputStatusUno), "have diverged")
 	logger.Debug("HasDiverged: result=%t", hasDiverged)
-	return hasDiverged
+	return hasDiverged, nil
 }
 
-func (w *FileWorkspace) hasDivergedFromPullHead(logger logging.SimpleLogging, cloneDir string, pullRequest models.PullRequest) bool {
+func (w *FileWorkspace) hasDivergedFromPullHead(logger logging.SimpleLogging, cloneDir string, pullRequest models.PullRequest) (bool, error) {
 	if pullRequest.BaseBranch == "" {
 		logger.Debug("HasDiverged: pull request base branch is empty, using git status divergence check")
 		return w.hasDiverged(logger, cloneDir)
@@ -421,12 +427,12 @@ func (w *FileWorkspace) hasDivergedFromPullHead(logger logging.SimpleLogging, cl
 	divergedFiles, err := w.getDivergedFilesFromPullHead(logger, cloneDir, pullRequest)
 	if err != nil {
 		logger.Warn("HasDiverged: getting changed files has failed: %s", err)
-		return true
+		return true, err
 	}
 
 	hasDiverged := len(divergedFiles) > 0
 	logger.Debug("HasDiverged: result=%t", hasDiverged)
-	return hasDiverged
+	return hasDiverged, nil
 }
 
 // hasDivergedForPatterns checks if the base branch has new commits that affect files

--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -334,7 +334,7 @@ func (w *FileWorkspace) HasDiverged(logger logging.SimpleLogging, cloneDir strin
 	defer unlockGitRefLock()
 
 	if len(autoplanWhenModified) > 0 {
-		return w.hasDivergedForPatterns(logger, cloneDir, projectPath, autoplanWhenModified, pullRequest, w.getDivergedFiles), nil
+		return w.hasDivergedForPatterns(logger, cloneDir, projectPath, autoplanWhenModified, pullRequest, w.getDivergedFiles)
 	}
 	return w.hasDiverged(logger, cloneDir)
 }
@@ -353,7 +353,7 @@ func (w *FileWorkspace) HasDivergedFromPullHead(logger logging.SimpleLogging, cl
 	defer unlockGitRefLock()
 
 	if len(autoplanWhenModified) > 0 {
-		return w.hasDivergedForPatterns(logger, cloneDir, projectPath, autoplanWhenModified, pullRequest, w.getDivergedFilesFromPullHead), nil
+		return w.hasDivergedForPatterns(logger, cloneDir, projectPath, autoplanWhenModified, pullRequest, w.getDivergedFilesFromPullHead)
 	}
 	return w.hasDivergedFromPullHead(logger, cloneDir, pullRequest)
 }
@@ -437,19 +437,22 @@ func (w *FileWorkspace) hasDivergedFromPullHead(logger logging.SimpleLogging, cl
 
 // hasDivergedForPatterns checks if the base branch has new commits that affect files
 // matching the given when_modified patterns. Caller must hold gitRefLock and gitReadLock.
-func (w *FileWorkspace) hasDivergedForPatterns(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest, getDivergedFiles func(logging.SimpleLogging, string, models.PullRequest) ([]string, error)) bool {
+// If there are any errors we return (true, err) since we prefer to assume divergence
+// for safety and don't want to plan against stale code, but the caller can still
+// distinguish a confirmed divergence from a failed check.
+func (w *FileWorkspace) hasDivergedForPatterns(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest, getDivergedFiles func(logging.SimpleLogging, string, models.PullRequest) ([]string, error)) (bool, error) {
 	logger.Debug("HasDiverged: running targeted divergence check for project %s with %d patterns",
 		projectPath, len(autoplanWhenModified))
 
 	nonEmptyChangedFiles, err := getDivergedFiles(logger, cloneDir, pullRequest)
 	if err != nil {
 		logger.Warn("HasDiverged: getting changed files has failed: %s", err)
-		return true
+		return true, err
 	}
 
 	if len(nonEmptyChangedFiles) == 0 {
 		logger.Debug("HasDiverged: no changed files found in divergent commits")
-		return false
+		return false, nil
 	}
 
 	logger.Debug("HasDiverged: found %d changed files in divergent commits", len(nonEmptyChangedFiles))
@@ -474,7 +477,7 @@ func (w *FileWorkspace) hasDivergedForPatterns(logger logging.SimpleLogging, clo
 	pm, err := patternmatcher.New(whenModifiedRelToRepoRoot)
 	if err != nil {
 		logger.Warn("HasDiverged: creating pattern matcher has failed: %s", err)
-		return true
+		return true, err
 	}
 
 	for _, file := range nonEmptyChangedFiles {
@@ -485,12 +488,12 @@ func (w *FileWorkspace) hasDivergedForPatterns(logger logging.SimpleLogging, clo
 		}
 		if match {
 			logger.Debug("HasDiverged: file %q matched patterns - branch has diverged", file)
-			return true
+			return true, nil
 		}
 	}
 
 	logger.Debug("HasDiverged: no changed files matched the patterns - no divergence")
-	return false
+	return false, nil
 }
 
 func divergedFilesCommandError(action string, err error, output []byte) error {

--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -309,13 +309,19 @@ func (w *FileWorkspace) recheckDiverged(logger logging.SimpleLogging, p models.P
 
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			cmdErr := fmt.Errorf("getting remote update failed: %w: %s", err, strings.TrimSpace(string(output)))
-			logger.Err("%s", cmdErr.Error())
+			sanitizedOutput := w.sanitizeGitCredentials(string(output), p.BaseRepo, headRepo)
+			sanitizedErr := w.sanitizeGitCredentials(err.Error(), p.BaseRepo, headRepo)
+			cmdErr := fmt.Errorf("getting remote update failed: %s: %s", sanitizedErr, strings.TrimSpace(sanitizedOutput))
+			logger.Err("%s", cmdErr)
 			return true, cmdErr
 		}
 	}
 
-	return w.hasDiverged(logger, cloneDir)
+	diverged, err := w.hasDiverged(logger, cloneDir)
+	if err != nil {
+		return diverged, fmt.Errorf("%s", w.sanitizeGitCredentials(err.Error(), p.BaseRepo, headRepo))
+	}
+	return diverged, nil
 }
 
 func (w *FileWorkspace) HasDiverged(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) (bool, error) {
@@ -336,7 +342,11 @@ func (w *FileWorkspace) HasDiverged(logger logging.SimpleLogging, cloneDir strin
 	if len(autoplanWhenModified) > 0 {
 		return w.hasDivergedForPatterns(logger, cloneDir, projectPath, autoplanWhenModified, pullRequest, w.getDivergedFiles)
 	}
-	return w.hasDiverged(logger, cloneDir)
+	diverged, err := w.hasDiverged(logger, cloneDir)
+	if err != nil {
+		return diverged, fmt.Errorf("%s", w.sanitizeGitCredentials(err.Error(), pullRequest.BaseRepo, models.Repo{}))
+	}
+	return diverged, nil
 }
 
 func (w *FileWorkspace) HasDivergedFromPullHead(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) (bool, error) {
@@ -421,7 +431,11 @@ func (w *FileWorkspace) hasDiverged(logger logging.SimpleLogging, cloneDir strin
 func (w *FileWorkspace) hasDivergedFromPullHead(logger logging.SimpleLogging, cloneDir string, pullRequest models.PullRequest) (bool, error) {
 	if pullRequest.BaseBranch == "" {
 		logger.Debug("HasDiverged: pull request base branch is empty, using git status divergence check")
-		return w.hasDiverged(logger, cloneDir)
+		diverged, err := w.hasDiverged(logger, cloneDir)
+		if err != nil {
+			return diverged, fmt.Errorf("%s", w.sanitizeGitCredentials(err.Error(), pullRequest.BaseRepo, models.Repo{}))
+		}
+		return diverged, nil
 	}
 
 	divergedFiles, err := w.getDivergedFilesFromPullHead(logger, cloneDir, pullRequest)

--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -1209,6 +1209,54 @@ func TestMergeAgain_ConcurrentDiverged(t *testing.T) {
 	assert.FileExists(t, filepath.Join(workspaceDir, "pr-file.txt"))
 }
 
+// TestMergeAgain_RemoteUpdateFails verifies that when recheckDiverged's "git
+// remote update" fails (e.g. the base repo's clone URL is no longer reachable),
+// MergeAgain propagates that error instead of swallowing it, so the caller
+// aborts the plan rather than running against a working tree it couldn't
+// confirm was up to date.
+func TestMergeAgain_RemoteUpdateFails(t *testing.T) {
+	repoDir := initRepo(t)
+
+	// Create a PR branch with a PR-specific commit.
+	runCmd(t, repoDir, "git", "checkout", "-b", "pr-branch")
+	runCmd(t, repoDir, "touch", "pr-file.txt")
+	runCmd(t, repoDir, "git", "add", "pr-file.txt")
+	runCmd(t, repoDir, "git", "commit", "-m", "PR change")
+	runCmd(t, repoDir, "git", "checkout", "main")
+
+	// Build the Atlantis merge-checkout workspace: clone main, fetch the PR
+	// branch, and merge — exactly what Atlantis does on first clone.
+	workspaceDir := filepath.Join(repoDir, "repos", "0", "default")
+	runCmd(t, repoDir, "mkdir", "-p", filepath.Join("repos", "0", "default"))
+	runCmd(t, workspaceDir, "git", "clone", "--branch", "main", "--single-branch", repoDir, ".")
+	runCmd(t, workspaceDir, "git", "remote", "add", "source", repoDir)
+	runCmd(t, workspaceDir, "git", "fetch", "source", "+refs/heads/pr-branch")
+	runCmd(t, workspaceDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
+	runCmd(t, workspaceDir, "git", "config", "--local", "user.name", "atlantisbot")
+	runCmd(t, workspaceDir, "git", "config", "--local", "commit.gpgsign", "false")
+	runCmd(t, workspaceDir, "git", "merge", "-q", "--no-ff", "-m", "atlantis-merge", "FETCH_HEAD")
+
+	wd := &events.FileWorkspace{
+		DataDir:             repoDir,
+		CheckoutMerge:       true,
+		CheckoutDepth:       50,
+		GpgNoSigningEnabled: true,
+	}
+
+	// Point the base repo's clone URL at a path that isn't a git remote at all,
+	// so recheckDiverged's "git remote update" fails when it tries to fetch.
+	bogusCloneURL := filepath.Join(t.TempDir(), "does-not-exist")
+	pullRequest := models.PullRequest{
+		BaseRepo:   models.Repo{CloneURL: bogusCloneURL},
+		HeadBranch: "pr-branch",
+		BaseBranch: "main",
+	}
+
+	merged, err := wd.MergeAgain(logging.NewNoopLogger(t), models.Repo{CloneURL: repoDir}, pullRequest, "default")
+	ErrContains(t, "getting remote update failed", err)
+	Assert(t, merged == true, "MergeAgain should report merged=true when the divergence check fails so callers treat the working tree as stale")
+}
+
 func TestHasDiverged_MasterHasDiverged(t *testing.T) {
 	// Initialize the git repo.
 	repoDir := initRepo(t)

--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -1268,13 +1268,15 @@ func TestHasDiverged_MasterHasDiverged(t *testing.T) {
 		CheckoutDepth:       50,
 		GpgNoSigningEnabled: true,
 	}
-	hasDiverged := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", nil, models.PullRequest{})
+	hasDiverged, err := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", nil, models.PullRequest{})
+	assert.NoError(t, err)
 	Equals(t, hasDiverged, true)
 
 	// Run it again but without the checkout merge strategy. It should return
 	// false.
 	wd.CheckoutMerge = false
-	hasDiverged = wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", nil, models.PullRequest{})
+	hasDiverged, err = wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", nil, models.PullRequest{})
+	assert.NoError(t, err)
 	Equals(t, hasDiverged, false)
 }
 
@@ -1373,7 +1375,8 @@ func TestHasDiverged_WithPatterns_CheckoutMergeDisabled(t *testing.T) {
 	}
 
 	// Should return false when CheckoutMerge is disabled.
-	hasDiverged := wd.HasDiverged(logger, firstPRDir, ".", []string{"project1/**"}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, firstPRDir, ".", []string{"project1/**"}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, false, hasDiverged)
 }
 
@@ -1460,7 +1463,8 @@ func TestHasDiverged_WithEmptyPatterns(t *testing.T) {
 	}
 
 	// With empty patterns, should fall back to regular HasDiverged which should return true.
-	hasDiverged := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, true, hasDiverged)
 }
 
@@ -1508,20 +1512,25 @@ func TestHasDivergedFromPullHead_FreshMergeCheckoutUsesPullHead(t *testing.T) {
 		HeadCommit: headCommit,
 	}
 
-	hasDiverged := wd.HasDiverged(logger, prDir, ".", []string{}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, prDir, ".", []string{}, pullRequest)
 	Equals(t, false, hasDiverged)
+	assert.NoError(t, err)
 
-	hasDiverged = wd.HasDiverged(logger, prDir, ".", []string{"project1/**"}, pullRequest)
+	hasDiverged, err = wd.HasDiverged(logger, prDir, ".", []string{"project1/**"}, pullRequest)
 	Equals(t, false, hasDiverged)
+	assert.NoError(t, err)
 
-	hasDiverged = wd.HasDivergedFromPullHead(logger, prDir, ".", []string{}, pullRequest)
+	hasDiverged, err = wd.HasDivergedFromPullHead(logger, prDir, ".", []string{}, pullRequest)
 	Equals(t, true, hasDiverged)
+	assert.NoError(t, err)
 
-	hasDiverged = wd.HasDivergedFromPullHead(logger, prDir, ".", []string{"project1/**"}, pullRequest)
+	hasDiverged, err = wd.HasDivergedFromPullHead(logger, prDir, ".", []string{"project1/**"}, pullRequest)
 	Equals(t, true, hasDiverged)
+	assert.NoError(t, err)
 
-	hasDiverged = wd.HasDivergedFromPullHead(logger, prDir, ".", []string{"project2/**"}, pullRequest)
+	hasDiverged, err = wd.HasDivergedFromPullHead(logger, prDir, ".", []string{"project2/**"}, pullRequest)
 	Equals(t, false, hasDiverged)
+	assert.NoError(t, err)
 }
 
 func TestHasDiverged_PatternHasDiverged(t *testing.T) {
@@ -1593,7 +1602,8 @@ func TestHasDiverged_PatternHasDiverged(t *testing.T) {
 	}
 
 	// Pattern matches files that have diverged (project1 was modified in first-pr and merged to main).
-	hasDiverged := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project1/**"}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project1/**"}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, true, hasDiverged)
 }
 
@@ -1654,7 +1664,8 @@ func TestHasDiverged_PatternHasNotDiverged(t *testing.T) {
 
 	// Pattern matches project1 files. Main's last commit for project1 is in second-pr's history (since it branched from main).
 	// So it has not diverged.
-	hasDiverged := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project1/**"}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project1/**"}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, false, hasDiverged)
 }
 
@@ -1715,7 +1726,8 @@ func TestHasDiverged_MultiplePatterns(t *testing.T) {
 
 	// Both patterns match files. Main's commits for these patterns are in feature-pr's history.
 	// So neither has diverged.
-	hasDiverged := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project2/**", "project3/**"}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project2/**", "project3/**"}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, false, hasDiverged)
 }
 
@@ -1759,7 +1771,8 @@ func TestHasDiverged_PatternMatchesNothing(t *testing.T) {
 	}
 
 	// Pattern matches no files (project2 doesn't exist), should not be considered diverged.
-	hasDiverged := wd.HasDiverged(logger, firstPRDir, ".", []string{"project2/**"}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, firstPRDir, ".", []string{"project2/**"}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, false, hasDiverged)
 }
 
@@ -1807,7 +1820,8 @@ func TestHasDiverged_BrandNewFiles(t *testing.T) {
 
 	// Pattern matches brand new files that main has never touched.
 	// Main hasn't "diverged" - we're just adding new content.
-	hasDiverged := wd.HasDiverged(logger, prDir, ".", []string{"project1/**"}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, prDir, ".", []string{"project1/**"}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, false, hasDiverged)
 }
 
@@ -1870,7 +1884,8 @@ func TestHasDiverged_FilesDeletedFromMain(t *testing.T) {
 
 	// Pattern matches project1 which has been deleted from main.
 	// This IS divergence - main has moved forward by deleting the files.
-	hasDiverged := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project1/**"}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project1/**"}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, true, hasDiverged)
 }
 
@@ -1940,11 +1955,13 @@ func TestHasDiverged_MixedPatternsOneDiverged(t *testing.T) {
 
 	// Check with both patterns: project1 (diverged) and project2 (not diverged).
 	// Should return true because at least one pattern has diverged.
-	hasDiverged := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project1/**", "project2/**"}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project1/**", "project2/**"}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, true, hasDiverged)
 
 	// Check with only project2 pattern (not diverged).
-	hasDiverged = wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project2/**"}, pullRequest)
+	hasDiverged, err = wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project2/**"}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, false, hasDiverged)
 }
 
@@ -2015,7 +2032,8 @@ func TestHasDiverged_PRDidNotTouchPattern(t *testing.T) {
 	// first-pr never touched project1, but main has moved forward on it.
 	// This IS considered diverged - the pattern is in autoplanWhenModified,
 	// and we want to ensure plans stay current with main's changes.
-	hasDiverged := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project1/**"}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project1/**"}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, true, hasDiverged)
 }
 
@@ -2092,12 +2110,14 @@ func TestHasDiverged_WithStaleOriginMain(t *testing.T) {
 	// Test 1: Pattern matching project1 should detect divergence.
 	// Even though HEAD has a merge commit, origin/main has a new commit touching project1/**
 	// that isn't in HEAD. The fetch should pick this up.
-	hasDiverged := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project1/**"}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project1/**"}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, true, hasDiverged)
 
 	// Test 2: Pattern matching project2 should NOT detect divergence.
 	// Main has no new commits touching project2/**, so it hasn't diverged for this pattern.
-	hasDiverged = wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project2/**"}, pullRequest)
+	hasDiverged, err = wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project2/**"}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, false, hasDiverged)
 }
 
@@ -2179,17 +2199,20 @@ func TestHasDiverged_ProjectInSubdirectory(t *testing.T) {
 	// When adjusted, it should become "modules/**/*.tf" relative to repo root.
 	projectPath := "deployments/staging/app"
 	pattern := "../../../modules/**/*.tf" // 3 levels up from deployments/staging/app
-	hasDiverged := wd.HasDiverged(logger, repoDir+"/repos/0/default", projectPath, []string{pattern}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, repoDir+"/repos/0/default", projectPath, []string{pattern}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, true, hasDiverged) // Should detect that modules/database/main.tf changed
 
 	// Test 2: Pattern that matches files within the project directory itself
 	projectPattern := "*.tf"
-	hasDiverged = wd.HasDiverged(logger, repoDir+"/repos/0/default", projectPath, []string{projectPattern}, pullRequest)
+	hasDiverged, err = wd.HasDiverged(logger, repoDir+"/repos/0/default", projectPath, []string{projectPattern}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, false, hasDiverged) // No .tf files changed in the project directory in divergent commits
 
 	// Test 3: Pattern at repo root should also work
 	absolutePattern := "modules/**/*.tf"
-	hasDiverged = wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{absolutePattern}, pullRequest)
+	hasDiverged, err = wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{absolutePattern}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, true, hasDiverged)
 }
 
@@ -2266,7 +2289,8 @@ func TestHasDiverged_DeepProjectPath(t *testing.T) {
 	projectPath := deepPath
 
 	whenModifiedPattern := "../../../../../../../config/**"
-	hasDiverged := wd.HasDiverged(logger, repoDir+"/repos/0/default", projectPath, []string{whenModifiedPattern}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, repoDir+"/repos/0/default", projectPath, []string{whenModifiedPattern}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, true, hasDiverged) // Should detect that config/settings.yaml changed
 }
 
@@ -2387,7 +2411,8 @@ func TestHasDiverged_PatternMatching(t *testing.T) {
 				HeadCommit: prHeadCommit,
 			}
 
-			hasDiverged := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", tt.patterns, pullRequest)
+			hasDiverged, err := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", tt.patterns, pullRequest)
+			assert.NoError(t, err)
 			if hasDiverged != tt.expectDivergence {
 				t.Errorf("expected divergence=%v, got=%v for patterns=%v and changedFiles=%v",
 					tt.expectDivergence, hasDiverged, tt.patterns, tt.changedFiles)

--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -1257,6 +1257,114 @@ func TestMergeAgain_RemoteUpdateFails(t *testing.T) {
 	Assert(t, merged == true, "MergeAgain should report merged=true when the divergence check fails so callers treat the working tree as stale")
 }
 
+// buildMergeCheckoutWorkspace sets up a merge-checkout workspace the way Atlantis
+// does on first clone: clone main, fetch the PR branch from "source", and merge.
+// Returns the workspace dir. Used by the credential-sanitization tests below.
+func buildMergeCheckoutWorkspace(t *testing.T, repoDir string) string {
+	t.Helper()
+
+	runCmd(t, repoDir, "git", "checkout", "-b", "pr-branch")
+	runCmd(t, repoDir, "touch", "pr-file.txt")
+	runCmd(t, repoDir, "git", "add", "pr-file.txt")
+	runCmd(t, repoDir, "git", "commit", "-m", "PR change")
+	runCmd(t, repoDir, "git", "checkout", "main")
+
+	workspaceDir := filepath.Join(repoDir, "repos", "0", "default")
+	runCmd(t, repoDir, "mkdir", "-p", filepath.Join("repos", "0", "default"))
+	runCmd(t, workspaceDir, "git", "clone", "--branch", "main", "--single-branch", repoDir, ".")
+	runCmd(t, workspaceDir, "git", "remote", "add", "source", repoDir)
+	runCmd(t, workspaceDir, "git", "fetch", "source", "+refs/heads/pr-branch")
+	runCmd(t, workspaceDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
+	runCmd(t, workspaceDir, "git", "config", "--local", "user.name", "atlantisbot")
+	runCmd(t, workspaceDir, "git", "config", "--local", "commit.gpgsign", "false")
+	runCmd(t, workspaceDir, "git", "merge", "-q", "--no-ff", "-m", "atlantis-merge", "FETCH_HEAD")
+
+	return workspaceDir
+}
+
+// TestMergeAgain_RemoteUpdateFailureSanitizesCredentials verifies that when
+// recheckDiverged's "git remote update" fails, the raw command output — which git
+// echoes the failing remote's URL into (e.g. "fatal: '<url>' does not appear to be
+// a git repository") - is sanitized before it's embedded in the returned error.
+// That error is surfaced all the way to the PR's job output, so a credentialed
+// clone URL (base or head/fork) must never appear in it verbatim.
+func TestMergeAgain_RemoteUpdateFailureSanitizesCredentials(t *testing.T) {
+	repoDir := initRepo(t)
+	buildMergeCheckoutWorkspace(t, repoDir)
+
+	wd := &events.FileWorkspace{
+		DataDir:             repoDir,
+		CheckoutMerge:       true,
+		CheckoutDepth:       50,
+		GpgNoSigningEnabled: true,
+	}
+
+	// Bogus clone URLs standing in for credentialed URLs. Each embeds a unique
+	// marker so we can assert it's stripped from the returned error, regardless
+	// of which remote(s) git's fatal output happens to mention.
+	secretBaseURL := filepath.Join(t.TempDir(), "base-secret-token-AKIABASE")
+	secretHeadURL := filepath.Join(t.TempDir(), "head-secret-token-AKIAHEAD")
+	pullRequest := models.PullRequest{
+		BaseRepo:   models.Repo{CloneURL: secretBaseURL, SanitizedCloneURL: "***base-sanitized***"},
+		HeadBranch: "pr-branch",
+		BaseBranch: "main",
+	}
+	headRepo := models.Repo{CloneURL: secretHeadURL, SanitizedCloneURL: "***head-sanitized***"}
+
+	_, err := wd.MergeAgain(logging.NewNoopLogger(t), headRepo, pullRequest, "default")
+	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), secretBaseURL, "returned error must not leak the base repo's credentialed clone URL")
+	assert.NotContains(t, err.Error(), secretHeadURL, "returned error must not leak the head repo's credentialed clone URL")
+}
+
+// TestHasDiverged_FetchFailureSanitizesCredentials verifies that a "git fetch"
+// failure against the "origin" remote, hit via the plain (non-pattern) path in
+// both HasDiverged and HasDivergedFromPullHead, never leaks the base repo's
+// credentialed clone URL into the returned error — git echoes the failing
+// remote's URL verbatim into its fatal output, so hasDiverged's returned error
+// must be sanitized by its callers before it escapes this package.
+func TestHasDiverged_FetchFailureSanitizesCredentials(t *testing.T) {
+	repoDir := initRepo(t)
+	workspaceDir := buildMergeCheckoutWorkspace(t, repoDir)
+
+	// The "origin" remote must actually be set to the same value reported as
+	// BaseRepo.CloneURL below, since that's what recheckDiverged/production code
+	// would have configured — otherwise there'd be nothing for sanitization to match.
+	secretBaseURL := filepath.Join(t.TempDir(), "base-secret-token-AKIABASE")
+	runCmd(t, workspaceDir, "git", "remote", "set-url", "origin", secretBaseURL)
+
+	wd := &events.FileWorkspace{
+		DataDir:             repoDir,
+		CheckoutMerge:       true,
+		CheckoutDepth:       50,
+		GpgNoSigningEnabled: true,
+	}
+	logger := logging.NewNoopLogger(t)
+
+	t.Run("HasDiverged, no patterns", func(t *testing.T) {
+		pullRequest := models.PullRequest{
+			BaseRepo:   models.Repo{CloneURL: secretBaseURL, SanitizedCloneURL: "***base-sanitized***"},
+			HeadBranch: "pr-branch",
+			BaseBranch: "main",
+		}
+		_, err := wd.HasDiverged(logger, workspaceDir, ".", nil, pullRequest)
+		assert.Error(t, err)
+		assert.NotContains(t, err.Error(), secretBaseURL, "HasDiverged error must not leak the base repo's credentialed clone URL")
+	})
+
+	t.Run("HasDivergedFromPullHead, no patterns, empty BaseBranch", func(t *testing.T) {
+		// An empty BaseBranch routes HasDivergedFromPullHead into hasDiverged's
+		// plain git-status fallback instead of the getDivergedFilesFromPullHead path.
+		pullRequest := models.PullRequest{
+			BaseRepo:   models.Repo{CloneURL: secretBaseURL, SanitizedCloneURL: "***base-sanitized***"},
+			HeadBranch: "pr-branch",
+		}
+		_, err := wd.HasDivergedFromPullHead(logger, workspaceDir, ".", nil, pullRequest)
+		assert.Error(t, err)
+		assert.NotContains(t, err.Error(), secretBaseURL, "HasDivergedFromPullHead error must not leak the base repo's credentialed clone URL")
+	})
+}
+
 func TestHasDiverged_MasterHasDiverged(t *testing.T) {
 	// Initialize the git repo.
 	repoDir := initRepo(t)

--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -2469,6 +2469,59 @@ func TestHasDiverged_PatternMatching(t *testing.T) {
 	}
 }
 
+// TestHasDiverged_WithPatterns_FetchFails verifies that when autoplanWhenModified
+// patterns are set, a "git fetch" failure inside the targeted divergence check
+// (hasDivergedForPatterns) is propagated as a real error instead of being silently
+// converted into an indistinguishable diverged=true result.
+func TestHasDiverged_WithPatterns_FetchFails(t *testing.T) {
+	repoDir := initRepo(t)
+
+	// Create a PR branch with a PR-specific commit.
+	runCmd(t, repoDir, "git", "checkout", "-b", "pr-branch")
+	runCmd(t, repoDir, "touch", "pr-file.txt")
+	runCmd(t, repoDir, "git", "add", "pr-file.txt")
+	runCmd(t, repoDir, "git", "commit", "-m", "PR change")
+	runCmd(t, repoDir, "git", "checkout", "main")
+
+	// Build the Atlantis merge-checkout workspace: clone main, fetch the PR
+	// branch, and merge — exactly what Atlantis does on first clone.
+	workspaceDir := filepath.Join(repoDir, "repos", "0", "default")
+	runCmd(t, repoDir, "mkdir", "-p", filepath.Join("repos", "0", "default"))
+	runCmd(t, workspaceDir, "git", "clone", "--branch", "main", "--single-branch", repoDir, ".")
+	runCmd(t, workspaceDir, "git", "remote", "add", "source", repoDir)
+	runCmd(t, workspaceDir, "git", "fetch", "source", "+refs/heads/pr-branch")
+	runCmd(t, workspaceDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
+	runCmd(t, workspaceDir, "git", "config", "--local", "user.name", "atlantisbot")
+	runCmd(t, workspaceDir, "git", "config", "--local", "commit.gpgsign", "false")
+	runCmd(t, workspaceDir, "git", "merge", "-q", "--no-ff", "-m", "atlantis-merge", "FETCH_HEAD")
+
+	// Break the origin remote so the "git fetch" inside getDivergedFiles fails.
+	bogusRemote := filepath.Join(t.TempDir(), "does-not-exist")
+	runCmd(t, workspaceDir, "git", "remote", "set-url", "origin", bogusRemote)
+
+	wd := &events.FileWorkspace{
+		DataDir:             repoDir,
+		CheckoutMerge:       true,
+		CheckoutDepth:       50,
+		GpgNoSigningEnabled: true,
+	}
+	pullRequest := models.PullRequest{
+		BaseRepo:   models.Repo{CloneURL: repoDir},
+		HeadBranch: "pr-branch",
+		BaseBranch: "main",
+	}
+	logger := logging.NewNoopLogger(t)
+	patterns := []string{"*.tf"}
+
+	hasDiverged, err := wd.HasDiverged(logger, workspaceDir, ".", patterns, pullRequest)
+	ErrContains(t, "fetching repo", err)
+	Assert(t, hasDiverged == true, "HasDiverged should assume divergence when the underlying fetch fails")
+
+	hasDivergedFromPullHead, err := wd.HasDivergedFromPullHead(logger, workspaceDir, ".", patterns, pullRequest)
+	ErrContains(t, "fetching repo", err)
+	Assert(t, hasDivergedFromPullHead == true, "HasDivergedFromPullHead should assume divergence when the underlying fetch fails")
+}
+
 func initRepo(t *testing.T) string {
 	repoDir := t.TempDir()
 	runCmd(t, repoDir, "git", "init", "--initial-branch=main")

--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -1561,24 +1561,24 @@ func TestHasDivergedFromPullHead_FreshMergeCheckoutUsesPullHead(t *testing.T) {
 	}
 
 	hasDiverged, err := wd.HasDiverged(logger, prDir, ".", []string{}, pullRequest)
-	Equals(t, false, hasDiverged)
 	assert.NoError(t, err)
+	Equals(t, false, hasDiverged)
 
 	hasDiverged, err = wd.HasDiverged(logger, prDir, ".", []string{"project1/**"}, pullRequest)
-	Equals(t, false, hasDiverged)
 	assert.NoError(t, err)
+	Equals(t, false, hasDiverged)
 
 	hasDiverged, err = wd.HasDivergedFromPullHead(logger, prDir, ".", []string{}, pullRequest)
-	Equals(t, true, hasDiverged)
 	assert.NoError(t, err)
+	Equals(t, true, hasDiverged)
 
 	hasDiverged, err = wd.HasDivergedFromPullHead(logger, prDir, ".", []string{"project1/**"}, pullRequest)
-	Equals(t, true, hasDiverged)
 	assert.NoError(t, err)
+	Equals(t, true, hasDiverged)
 
 	hasDiverged, err = wd.HasDivergedFromPullHead(logger, prDir, ".", []string{"project2/**"}, pullRequest)
-	Equals(t, false, hasDiverged)
 	assert.NoError(t, err)
+	Equals(t, false, hasDiverged)
 }
 
 func TestHasDiverged_PatternHasDiverged(t *testing.T) {


### PR DESCRIPTION
## what

Propagate errors from hasDiverged and recheckDiverged so that if they fail, the plan is also marked as failed.


## why

Currently if there are errors while checking divergence or updating remote branch, divergence is assumed. The error itself is not returned and hence hidden. In such scenarios, fixing divergence updates local repo with outdated remote and that causes stale plan which goes unnoticed.

With this change if the checks fail, the plan is also failed to ensure the user is aware.

## tests

- [x] I have tested my changes by running our local instance with these changes
- [x] Added test cases covering these scenarios

