### PR TITLE
feat: add --enable-local-stores to decouple plan file storage from data-dir

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -80,6 +80,7 @@ const (
 	DiscardApprovalOnPlanFlag        = "discard-approval-on-plan"
 	EmojiReaction                    = "emoji-reaction"
 	EnableDiffMarkdownFormat         = "enable-diff-markdown-format"
+	EnableLocalStoresFlag            = "enable-local-stores"
 	EnablePolicyChecksFlag           = "enable-policy-checks"
 	EnableRegExpCmdFlag              = "enable-regexp-cmd"
 	EnableProfilingAPI               = "enable-profiling-api"
@@ -319,6 +320,10 @@ var stringFlags = map[string]stringFlag{
 	EmojiReaction: {
 		description:  "Emoji Reaction to use to react to comments.",
 		defaultValue: DefaultEmojiReaction,
+	},
+	EnableLocalStoresFlag: {
+		description:  "Path to directory to store local Terraform plan files. If unset, defaults to --" + DataDirFlag + ".",
+		defaultValue: "",
 	},
 	ExecutableName: {
 		description:  "Comment command executable name.",
@@ -932,6 +937,9 @@ func (s *ServerCmd) run() error {
 	if err := s.setDataDir(&userConfig); err != nil {
 		return err
 	}
+	if err := s.setEnableLocalStoresDir(&userConfig); err != nil {
+		return err
+	}
 	if err := s.setMarkdownTemplateOverridesDir(&userConfig); err != nil {
 		return err
 	}
@@ -1237,6 +1245,31 @@ func (s *ServerCmd) setDataDir(userConfig *server.UserConfig) error {
 		return fmt.Errorf("making data-dir absolute: %w", err)
 	}
 	userConfig.DataDir = finalPath
+	return nil
+}
+
+// setEnableLocalStoresDir checks if ~ was used in enable-local-stores and converts it to the actual
+// home directory. If unset, it defaults to the resolved data-dir. It also converts relative paths to absolute.
+func (s *ServerCmd) setEnableLocalStoresDir(userConfig *server.UserConfig) error {
+	if userConfig.EnableLocalStores == "" {
+		userConfig.EnableLocalStores = userConfig.DataDir
+		return nil
+	}
+
+	finalPath := userConfig.EnableLocalStores
+	if strings.HasPrefix(finalPath, "~/") {
+		var err error
+		finalPath, err = homedir.Expand(finalPath)
+		if err != nil {
+			return fmt.Errorf("determining home directory: %w", err)
+		}
+	}
+
+	finalPath, err := filepath.Abs(finalPath)
+	if err != nil {
+		return fmt.Errorf("making enable-local-stores absolute: %w", err)
+	}
+	userConfig.EnableLocalStores = finalPath
 	return nil
 }
 

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -80,6 +80,7 @@ var testFlags = map[string]any{
 	DisableGlobalApplyLockFlag:       false,
 	DiscardApprovalOnPlanFlag:        true,
 	EmojiReaction:                    "eyes",
+	EnableLocalStoresFlag:            "/plans",
 	ExecutableName:                   "atlantis",
 	FailOnPreWorkflowHookError:       false,
 	GHAllowMergeableBypassApply:      false,
@@ -199,6 +200,7 @@ func TestExecute_Defaults(t *testing.T) {
 		GHTokenFlag:                      "token",
 		GiteaBaseURLFlag:                 "http://localhost",
 		DataDirFlag:                      dataDir,
+		EnableLocalStoresFlag:            dataDir,
 		MarkdownTemplateOverridesDirFlag: markdownTemplateOverridesDir,
 		AtlantisURLFlag:                  "http://" + hostname + ":4141",
 		RepoAllowlistFlag:                "*",
@@ -292,6 +294,7 @@ func TestNormalizePath(t *testing.T) {
 
 var pathFlags = map[string]struct{}{
 	DataDirFlag:                      {},
+	EnableLocalStoresFlag:            {},
 	MarkdownTemplateOverridesDirFlag: {},
 }
 
@@ -448,6 +451,36 @@ func TestAllFlagsDocumented(t *testing.T) {
 		}
 	}
 
+}
+
+func TestExecute_ExpandHomeInEnableLocalStores(t *testing.T) {
+	t.Log("If ~ is used as an enable-local-stores path, should expand to absolute home path")
+	c := setup(map[string]any{
+		GHUserFlag:            "user",
+		GHTokenFlag:           "token",
+		RepoAllowlistFlag:     "*",
+		EnableLocalStoresFlag: "~/this/is/a/path",
+	}, t)
+	err := c.Execute()
+	Ok(t, err)
+
+	home, err := homedir.Dir()
+	Ok(t, err)
+	Equals(t, home+"/this/is/a/path", passedConfig.EnableLocalStores)
+}
+
+func TestExecute_RelativeEnableLocalStores(t *testing.T) {
+	t.Log("Should convert relative enable-local-stores dir to absolute.")
+	c := setupWithDefaults(map[string]any{
+		EnableLocalStoresFlag: "../",
+	}, t)
+
+	expectedAbsolutePath, err := filepath.Abs("../")
+	Ok(t, err)
+
+	err = c.Execute()
+	Ok(t, err)
+	Equals(t, expectedAbsolutePath, passedConfig.EnableLocalStores)
 }
 
 func TestExecute_ConfigFile(t *testing.T) {

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -452,7 +452,7 @@ ATLANTIS_DATA_DIR="path/to/data/dir"
 ```
 
 Directory where Atlantis will store its data. Will be created if it doesn't exist.
-Defaults to `~/.atlantis`. Atlantis will store its database, checked out repos, Terraform plans and downloaded
+Defaults to `~/.atlantis`. Atlantis will store its database, checked out repos, Terraform plans by default, and downloaded
 Terraform binaries here. If Atlantis loses this directory, [locks](locking.md)
 will be lost and unapplied plans will be lost.
 
@@ -642,6 +642,16 @@ This flag requires `--enable-drift-detection`; without it, `action: "apply"` req
 rejected while read-only drift detection remains available. This flag does not bypass
 repository `apply_requirements`; requirements that need pull request state fail closed for
 non-PR remediation requests. Defaults to `false`.
+
+### `--enable-local-stores`
+
+```bash
+atlantis server --enable-local-stores="path/to/local/plan/dir"
+# or
+ATLANTIS_ENABLE_LOCAL_STORES="path/to/local/plan/dir"
+```
+
+Directory where Atlantis will store local Terraform plan files. If unset, this defaults to the resolved `--data-dir` value so existing installations keep the same on-disk layout. When set to a different directory, checked out repositories remain under `--data-dir` and generated `.tfplan` files use the same repo, pull request, workspace, and project path layout under `--enable-local-stores`.
 
 ### `--enable-policy-checks` <Badge text="v0.17.0" type="info"/>
 

--- a/server/core/runtime/apply_step_runner.go
+++ b/server/core/runtime/apply_step_runner.go
@@ -33,7 +33,7 @@ func (a *ApplyStepRunner) Run(ctx command.ProjectContext, extraArgs []string, pa
 		return "", errors.New("cannot run apply with -target because we are applying an already generated plan. Instead, run -target with atlantis plan")
 	}
 
-	planPath := filepath.Join(path, GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	planPath := GetPlanFilePath(ctx, path)
 	contents, err := os.ReadFile(planPath)
 	if os.IsNotExist(err) {
 		return "", fmt.Errorf("no plan found at path %q and workspace %q–did you run plan?", ctx.RepoRelDir, ctx.Workspace)

--- a/server/core/runtime/apply_step_runner_test.go
+++ b/server/core/runtime/apply_step_runner_test.go
@@ -82,6 +82,47 @@ func TestRun_Success(t *testing.T) {
 	Assert(t, os.IsNotExist(err), "planfile should be deleted")
 }
 
+func TestRun_UsesLocalPlanStoreDir(t *testing.T) {
+	projectPath := t.TempDir()
+	planStoreDir := t.TempDir()
+	planPath := filepath.Join(planStoreDir, "repos", "owner", "repo", "2", "workspace", "env", "workspace.tfplan")
+	Ok(t, os.MkdirAll(filepath.Dir(planPath), 0700))
+	Ok(t, os.WriteFile(planPath, nil, 0600))
+
+	logger := logging.NewNoopLogger(t)
+	ctx := command.ProjectContext{
+		BaseRepo: models.Repo{
+			FullName: "owner/repo",
+		},
+		EscapedCommentArgs: []string{"comment", "args"},
+		LocalPlanStoreDir:  planStoreDir,
+		Log:                logger,
+		Pull: models.PullRequest{
+			Num: 2,
+		},
+		RepoRelDir: "env",
+		Workspace:  "workspace",
+	}
+
+	RegisterMockTestingT(t)
+	terraform := tfclientmocks.NewMockClient()
+	mockDownloader := mocks.NewMockDownloader()
+	tfDistribution := tf.NewDistributionTerraformWithDownloader(mockDownloader)
+	o := runtime.ApplyStepRunner{
+		TerraformExecutor:     terraform,
+		DefaultTFDistribution: tfDistribution,
+	}
+	When(terraform.RunCommandWithVersion(Any[command.ProjectContext](), Any[string](), Any[[]string](), Any[map[string]string](), Any[tf.Distribution](), Any[*version.Version](), Any[string]())).
+		ThenReturn("output", nil)
+
+	output, err := o.Run(ctx, []string{"extra", "args"}, projectPath, map[string]string(nil))
+	Ok(t, err)
+	Equals(t, "output", output)
+	terraform.VerifyWasCalledOnce().RunCommandWithVersion(ctx, projectPath, []string{"apply", "-input=false", "extra", "args", "comment", "args", fmt.Sprintf("%q", planPath)}, map[string]string(nil), tfDistribution, nil, "workspace")
+	_, err = os.Stat(planPath)
+	Assert(t, os.IsNotExist(err), "planfile should be deleted")
+}
+
 func TestRun_AppliesCorrectProjectPlan(t *testing.T) {
 	// When running for a project, the planfile has a different name.
 	tmpDir := t.TempDir()

--- a/server/core/runtime/import_step_runner.go
+++ b/server/core/runtime/import_step_runner.go
@@ -44,7 +44,7 @@ func (p *importStepRunner) Run(ctx command.ProjectContext, extraArgs []string, p
 	out, err := p.terraformExecutor.RunCommandWithVersion(ctx, filepath.Clean(path), importCmd, envs, tfDistribution, tfVersion, ctx.Workspace)
 
 	// If the import was successful and a plan file exists, delete the plan.
-	planPath := filepath.Join(path, GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	planPath := GetPlanFilePath(ctx, path)
 	if err == nil {
 		if _, planPathErr := os.Stat(planPath); !os.IsNotExist(planPathErr) {
 			ctx.Log.Info("import successful, deleting planfile")

--- a/server/core/runtime/plan_step_runner.go
+++ b/server/core/runtime/plan_step_runner.go
@@ -57,7 +57,12 @@ func (p *planStepRunner) Run(ctx command.ProjectContext, extraArgs []string, pat
 		tfVersion = ctx.TerraformVersion
 	}
 
-	planFile := filepath.Join(path, GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	planFile := GetPlanFilePath(ctx, path)
+	if ctx.LocalPlanStoreDir != "" {
+		if err := os.MkdirAll(filepath.Dir(planFile), 0700); err != nil {
+			return "", fmt.Errorf("creating plan file directory: %w", err)
+		}
+	}
 	planCmd := p.buildPlanCmd(ctx, extraArgs, path, tfVersion, planFile)
 	output, err := p.TerraformExecutor.RunCommandWithVersion(ctx, filepath.Clean(path), planCmd, envs, tfDistribution, tfVersion, ctx.Workspace)
 	if p.isRemoteOpsErr(output, err) {

--- a/server/core/runtime/plan_type_step_runner_delegate.go
+++ b/server/core/runtime/plan_type_step_runner_delegate.go
@@ -6,7 +6,6 @@ package runtime
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/runatlantis/atlantis/server/events/command"
 )
@@ -35,7 +34,7 @@ func (p *planTypeStepRunnerDelegate) isRemotePlan(planFile string) (bool, error)
 }
 
 func (p *planTypeStepRunnerDelegate) Run(ctx command.ProjectContext, extraArgs []string, path string, envs map[string]string) (string, error) {
-	planFile := filepath.Join(path, GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	planFile := GetPlanFilePath(ctx, path)
 	remotePlan, err := p.isRemotePlan(planFile)
 
 	if err != nil {

--- a/server/core/runtime/run_step_runner.go
+++ b/server/core/runtime/run_step_runner.go
@@ -69,7 +69,7 @@ func (r *RunStepRunner) Run(
 		"HEAD_REPO_NAME":                  ctx.HeadRepo.Name,
 		"HEAD_REPO_OWNER":                 ctx.HeadRepo.Owner,
 		"PATH":                            fmt.Sprintf("%s:%s", os.Getenv("PATH"), r.TerraformBinDir),
-		"PLANFILE":                        filepath.Join(path, GetPlanFilename(ctx.Workspace, ctx.ProjectName)),
+		"PLANFILE":                        GetPlanFilePath(ctx, path),
 		"SHOWFILE":                        filepath.Join(path, ctx.GetShowResultFileName()),
 		"POLICYCHECKFILE":                 filepath.Join(path, ctx.GetPolicyCheckResultFileName()),
 		"PROJECT_NAME":                    ctx.ProjectName,

--- a/server/core/runtime/runtime.go
+++ b/server/core/runtime/runtime.go
@@ -8,7 +8,9 @@ package runtime
 import (
 	"bytes"
 	"fmt"
+	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	version "github.com/hashicorp/go-version"
@@ -24,6 +26,7 @@ const (
 	// a link to the run url will be output.
 	lineBeforeRunURL     = "To view this run in a browser, visit:"
 	planfileSlashReplace = "::"
+	planStoreReposDir    = "repos"
 )
 
 // TerraformExec brings the interface from TerraformClient into this package
@@ -97,6 +100,24 @@ func GetPlanFilename(workspace string, projName string) string {
 	}
 	projName = strings.ReplaceAll(projName, "/", planfileSlashReplace)
 	return fmt.Sprintf("%s-%s.tfplan", projName, workspace)
+}
+
+// GetPlanFileDir returns the directory where Atlantis stores the plan file for ctx.
+func GetPlanFileDir(ctx command.ProjectContext, projectPath string) string {
+	if ctx.LocalPlanStoreDir == "" {
+		return projectPath
+	}
+	return filepath.Join(ctx.LocalPlanStoreDir, planStoreReposDir, ctx.BaseRepo.FullName, strconv.Itoa(ctx.Pull.Num), ctx.Workspace, ctx.RepoRelDir)
+}
+
+// GetPlanFilePath returns the full path to the generated Terraform plan file.
+func GetPlanFilePath(ctx command.ProjectContext, projectPath string) string {
+	return filepath.Join(GetPlanFileDir(ctx, projectPath), GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+}
+
+// GetPlanPullDir returns the root directory for all plan files for a pull request.
+func GetPlanPullDir(localPlanStoreDir string, r models.Repo, p models.PullRequest) string {
+	return filepath.Join(localPlanStoreDir, planStoreReposDir, r.FullName, strconv.Itoa(p.Num))
 }
 
 // isRemotePlan returns true if planContents are from a plan that was generated

--- a/server/core/runtime/runtime_test.go
+++ b/server/core/runtime/runtime_test.go
@@ -5,9 +5,12 @@ package runtime_test
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/runatlantis/atlantis/server/core/runtime"
+	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/events/models"
 	. "github.com/runatlantis/atlantis/testing"
 )
 
@@ -58,6 +61,27 @@ func TestGetPlanFilename(t *testing.T) {
 			Equals(t, c.exp, runtime.GetPlanFilename(c.workspace, c.projectName))
 		})
 	}
+}
+
+func TestGetPlanFilePath(t *testing.T) {
+	projectPath := filepath.Join("data", "repos", "owner", "repo", "2", "default", "modules", "app")
+	ctx := command.ProjectContext{
+		BaseRepo: models.Repo{
+			FullName: "owner/repo",
+		},
+		LocalPlanStoreDir: filepath.Join("plans"),
+		ProjectName:       "project/name",
+		Pull: models.PullRequest{
+			Num: 2,
+		},
+		RepoRelDir: "modules/app",
+		Workspace:  "default",
+	}
+
+	Equals(t, filepath.Join("plans", "repos", "owner", "repo", "2", "default", "modules", "app", "project::name-default.tfplan"), runtime.GetPlanFilePath(ctx, projectPath))
+
+	ctx.LocalPlanStoreDir = ""
+	Equals(t, filepath.Join(projectPath, "project::name-default.tfplan"), runtime.GetPlanFilePath(ctx, projectPath))
 }
 
 func TestProjectNameFromPlanfile(t *testing.T) {

--- a/server/core/runtime/show_step_runner.go
+++ b/server/core/runtime/show_step_runner.go
@@ -43,7 +43,7 @@ func (p *showStepRunner) Run(ctx command.ProjectContext, _ []string, path string
 		tfVersion = ctx.TerraformVersion
 	}
 
-	planFile := filepath.Join(path, GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	planFile := GetPlanFilePath(ctx, path)
 	showResultFile := filepath.Join(path, ctx.GetShowResultFileName())
 
 	output, err := p.terraformExecutor.RunCommandWithVersion(

--- a/server/core/runtime/state_rm_step_runner.go
+++ b/server/core/runtime/state_rm_step_runner.go
@@ -44,7 +44,7 @@ func (p *stateRmStepRunner) Run(ctx command.ProjectContext, extraArgs []string, 
 	out, err := p.terraformExecutor.RunCommandWithVersion(ctx, filepath.Clean(path), stateRmCmd, envs, tfDistribution, tfVersion, ctx.Workspace)
 
 	// If the state rm was successful and a plan file exists, delete the plan.
-	planPath := filepath.Join(path, GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	planPath := GetPlanFilePath(ctx, path)
 	if err == nil {
 		if _, planPathErr := os.Stat(planPath); !os.IsNotExist(planPathErr) {
 			ctx.Log.Info("state rm successful, deleting planfile")

--- a/server/events/apply_plan_validator.go
+++ b/server/events/apply_plan_validator.go
@@ -117,7 +117,7 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 	}
 
 	if ctx.ExpectedPlanHash != "" {
-		actualHash, err := hashFile(absPath, planPath)
+		actualHash, err := hashFile(runtime.GetPlanFileDir(ctx, absPath), planPath)
 		if err != nil {
 			return fmt.Errorf("hashing plan file for dir %q workspace %q project %q: %w", ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName, err)
 		}
@@ -196,19 +196,19 @@ func statusAllowedForApplyExecution(status models.ProjectPlanStatus) bool {
 }
 
 func planFilePath(ctx command.ProjectContext, absPath string) string {
-	return filepath.Join(absPath, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	return runtime.GetPlanFilePath(ctx, absPath)
 }
 
 func safePlanFilePath(ctx command.ProjectContext, absPath string) (string, error) {
 	planPath := planFilePath(ctx, absPath)
-	if _, err := containedPlanRelPath(absPath, planPath); err != nil {
+	if _, err := containedPlanRelPath(runtime.GetPlanFileDir(ctx, absPath), planPath); err != nil {
 		return "", err
 	}
 	return planPath, nil
 }
 
 func pendingPlanFilePath(plan PendingPlan) (string, error) {
-	absPath := filepath.Join(plan.RepoDir, plan.RepoRelDir)
+	absPath := filepath.Join(plan.planRepoDir(), plan.RepoRelDir)
 	planPath := filepath.Join(absPath, runtime.GetPlanFilename(plan.Workspace, plan.ProjectName))
 	if _, err := containedPlanRelPath(absPath, planPath); err != nil {
 		return "", err

--- a/server/events/command/project_context.go
+++ b/server/events/command/project_context.go
@@ -94,6 +94,9 @@ type ProjectContext struct {
 	// ProjectName is the name of the project set in atlantis.yaml. If there was
 	// no name this will be an empty string.
 	ProjectName string
+	// LocalPlanStoreDir is the root directory for local Terraform plan files.
+	// If empty, plan files are stored in the project working directory.
+	LocalPlanStoreDir string
 	// RepoConfigVersion is the version of the repo's atlantis.yaml file. If
 	// there was no file, this will be 0.
 	RepoConfigVersion int

--- a/server/events/pending_plan_finder.go
+++ b/server/events/pending_plan_finder.go
@@ -22,19 +22,32 @@ type PendingPlanFinder interface {
 }
 
 // DefaultPendingPlanFinder finds unapplied plans.
-type DefaultPendingPlanFinder struct{}
+type DefaultPendingPlanFinder struct {
+	DataDir           string
+	LocalPlanStoreDir string
+}
 
 // PendingPlan is a plan that has not been applied.
 type PendingPlan struct {
 	// RepoDir is the absolute path to the root of the repo that holds this
-	// plan.
+	// plan's workspace clone.
 	RepoDir string
+	// PlanDir is the absolute path to the root of the workspace plan store.
+	// If empty, RepoDir is used for backward compatibility.
+	PlanDir string
 	// RepoRelDir is the relative path from the repo to the project that
 	// the plan is for.
 	RepoRelDir string
 	// Workspace is the workspace this plan should execute in.
 	Workspace   string
 	ProjectName string
+}
+
+func (p PendingPlan) planRepoDir() string {
+	if p.PlanDir != "" {
+		return p.PlanDir
+	}
+	return p.RepoDir
 }
 
 // Find finds all pending plans in pullDir. pullDir should be the working
@@ -46,6 +59,36 @@ func (p *DefaultPendingPlanFinder) Find(pullDir string) ([]PendingPlan, error) {
 }
 
 func (p *DefaultPendingPlanFinder) findWithAbsPaths(pullDir string) ([]PendingPlan, []string, error) {
+	planPullDir, separatePlanDir, err := p.planPullDir(pullDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	if separatePlanDir {
+		return p.findInPlanStore(pullDir, planPullDir)
+	}
+	return p.findInGitWorkspaces(pullDir)
+}
+
+func (p *DefaultPendingPlanFinder) planPullDir(pullDir string) (string, bool, error) {
+	if p.DataDir == "" || p.LocalPlanStoreDir == "" {
+		return pullDir, false, nil
+	}
+
+	cloneRoot := filepath.Clean(filepath.Join(p.DataDir, workingDirPrefix))
+	cleanPullDir := filepath.Clean(pullDir)
+	relPullDir, err := filepath.Rel(cloneRoot, cleanPullDir)
+	if err != nil {
+		return "", false, fmt.Errorf("checking pull directory %q: %w", pullDir, err)
+	}
+	if relPullDir == ".." || filepath.IsAbs(relPullDir) || strings.HasPrefix(relPullDir, ".."+string(filepath.Separator)) {
+		return "", false, fmt.Errorf("pull directory %q escapes clone root %q", pullDir, cloneRoot)
+	}
+
+	planPullDir := filepath.Join(p.LocalPlanStoreDir, workingDirPrefix, relPullDir)
+	return planPullDir, filepath.Clean(planPullDir) != cleanPullDir, nil
+}
+
+func (p *DefaultPendingPlanFinder) findInGitWorkspaces(pullDir string) ([]PendingPlan, []string, error) {
 	workspaceDirs, err := os.ReadDir(pullDir)
 	if err != nil {
 		return nil, nil, err
@@ -106,6 +149,79 @@ func (p *DefaultPendingPlanFinder) findWithAbsPaths(pullDir string) ([]PendingPl
 				})
 				absPaths = append(absPaths, filepath.Join(repoDir, file))
 			}
+		}
+	}
+	return plans, absPaths, nil
+}
+
+func (p *DefaultPendingPlanFinder) findInPlanStore(clonePullDir string, planPullDir string) ([]PendingPlan, []string, error) {
+	workspaceDirs, err := os.ReadDir(planPullDir)
+	if os.IsNotExist(err) {
+		return nil, nil, nil
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	absClonePullDir, err := filepath.Abs(clonePullDir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting absolute clone pull directory: %w", err)
+	}
+	absPlanPullDir, err := filepath.Abs(planPullDir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting absolute plan pull directory: %w", err)
+	}
+
+	var plans []PendingPlan
+	var absPaths []string
+	for _, workspaceDir := range workspaceDirs {
+		if !workspaceDir.IsDir() {
+			continue
+		}
+
+		workspace := workspaceDir.Name()
+		cloneRepoDir, err := workspaceRepoDir(absClonePullDir, workspace)
+		if err != nil {
+			return nil, nil, err
+		}
+		planRepoDir, err := workspaceRepoDir(absPlanPullDir, workspace)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if err := filepath.WalkDir(planRepoDir, func(path string, entry os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() {
+				if entry.Name() == ".terragrunt-cache" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if filepath.Ext(path) != ".tfplan" {
+				return nil
+			}
+
+			relFile, err := filepath.Rel(planRepoDir, path)
+			if err != nil {
+				return fmt.Errorf("checking plan path %q: %w", path, err)
+			}
+			projectName, err := runtime.ProjectNameFromPlanfile(workspace, filepath.Base(relFile))
+			if err != nil {
+				return err
+			}
+			plans = append(plans, PendingPlan{
+				RepoDir:     cloneRepoDir,
+				PlanDir:     planRepoDir,
+				RepoRelDir:  filepath.Dir(relFile),
+				Workspace:   workspace,
+				ProjectName: projectName,
+			})
+			absPaths = append(absPaths, path)
+			return nil
+		}); err != nil {
+			return nil, nil, err
 		}
 	}
 	return plans, absPaths, nil

--- a/server/events/pending_plan_finder_test.go
+++ b/server/events/pending_plan_finder_test.go
@@ -280,6 +280,35 @@ func TestPendingPlanFinder_Find(t *testing.T) {
 	}
 }
 
+func TestPendingPlanFinder_FindSeparateLocalPlanStore(t *testing.T) {
+	dataDir := t.TempDir()
+	planStoreDir := t.TempDir()
+	clonePullDir := filepath.Join(dataDir, "repos", "owner", "repo", "7")
+	cloneWorkspaceDir := filepath.Join(clonePullDir, "default")
+	Ok(t, os.MkdirAll(cloneWorkspaceDir, 0700))
+	runCmd(t, cloneWorkspaceDir, "git", "init")
+
+	planWorkspaceDir := filepath.Join(planStoreDir, "repos", "owner", "repo", "7", "default")
+	planPath := filepath.Join(planWorkspaceDir, "project", "default.tfplan")
+	Ok(t, os.MkdirAll(filepath.Dir(planPath), 0700))
+	Ok(t, os.WriteFile(planPath, []byte("plan"), 0600))
+
+	pf := &events.DefaultPendingPlanFinder{
+		DataDir:           dataDir,
+		LocalPlanStoreDir: planStoreDir,
+	}
+	plans, err := pf.Find(clonePullDir)
+	Ok(t, err)
+	Equals(t, []events.PendingPlan{
+		{
+			RepoDir:    cloneWorkspaceDir,
+			PlanDir:    planWorkspaceDir,
+			RepoRelDir: "project",
+			Workspace:  "default",
+		},
+	}, plans)
+}
+
 // If a planfile is checked in to git, we shouldn't use it.
 func TestPendingPlanFinder_FindPlanCheckedIn(t *testing.T) {
 	tmpDir := DirStructure(t, map[string]any{

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -517,7 +517,7 @@ func (p *PlanCommandRunner) deletePlansWithPostDelete(ctx *command.Context, post
 	}
 
 	for _, plan := range plans {
-		planPath := filepath.Join(plan.RepoDir, plan.RepoRelDir, runtime.GetPlanFilename(plan.Workspace, plan.ProjectName))
+		planPath := filepath.Join(plan.planRepoDir(), plan.RepoRelDir, runtime.GetPlanFilename(plan.Workspace, plan.ProjectName))
 		if err := utils.RemoveIgnoreNonExistent(planPath); err != nil {
 			return nil, fmt.Errorf("deleting plan at %s: %w", planPath, err)
 		}

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/runatlantis/atlantis/server/core/config/raw"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/core/runtime"
 	"github.com/runatlantis/atlantis/server/core/terraform/tfclient"
 	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/metrics"
@@ -93,6 +94,7 @@ func NewInstrumentedProjectCommandBuilder(
 	AutoDiscoverMode string,
 	scope tally.Scope,
 	terraformClient tfclient.Client,
+	localPlanStoreDir string,
 ) *InstrumentedProjectCommandBuilder {
 	scope = scope.SubScope("builder")
 
@@ -100,34 +102,37 @@ func NewInstrumentedProjectCommandBuilder(
 		metrics.InitCounter(scope, m)
 	}
 
+	builder := NewProjectCommandBuilder(
+		policyChecksSupported,
+		parserValidator,
+		projectFinder,
+		vcsClient,
+		workingDir,
+		workingDirLocker,
+		globalCfg,
+		pendingPlanFinder,
+		commentBuilder,
+		skipCloneNoChanges,
+		EnableRegExpCmd,
+		EnableAutoMerge,
+		EnableParallelPlan,
+		EnableParallelApply,
+		AutoDetectModuleFiles,
+		AutoplanFileList,
+		RestrictFileList,
+		DefaultTFDistribution,
+		SilenceNoProjects,
+		IncludeGitUntrackedFiles,
+		AutoDiscoverMode,
+		scope,
+		terraformClient,
+	)
+	builder.LocalPlanStoreDir = localPlanStoreDir
+
 	return &InstrumentedProjectCommandBuilder{
-		ProjectCommandBuilder: NewProjectCommandBuilder(
-			policyChecksSupported,
-			parserValidator,
-			projectFinder,
-			vcsClient,
-			workingDir,
-			workingDirLocker,
-			globalCfg,
-			pendingPlanFinder,
-			commentBuilder,
-			skipCloneNoChanges,
-			EnableRegExpCmd,
-			EnableAutoMerge,
-			EnableParallelPlan,
-			EnableParallelApply,
-			AutoDetectModuleFiles,
-			AutoplanFileList,
-			RestrictFileList,
-			DefaultTFDistribution,
-			SilenceNoProjects,
-			IncludeGitUntrackedFiles,
-			AutoDiscoverMode,
-			scope,
-			terraformClient,
-		),
-		Logger: logger,
-		scope:  scope,
+		ProjectCommandBuilder: builder,
+		Logger:                logger,
+		scope:                 scope,
 	}
 }
 
@@ -298,6 +303,15 @@ type DefaultProjectCommandBuilder struct {
 	AutoDiscoverMode string
 	// Handles the actual running of Terraform commands.
 	TerraformExecutor tfclient.Client
+	// Root directory for local Terraform plan files.
+	LocalPlanStoreDir string
+}
+
+func (p *DefaultProjectCommandBuilder) withLocalPlanStoreDir(projCtxs []command.ProjectContext) []command.ProjectContext {
+	for i := range projCtxs {
+		projCtxs[i].LocalPlanStoreDir = p.LocalPlanStoreDir
+	}
+	return projCtxs
 }
 
 // See ProjectCommandBuilder.BuildAutoplanCommands.
@@ -837,7 +851,7 @@ func (p *DefaultProjectCommandBuilder) buildAllProjectsByCfg(ctx *command.Contex
 		return projCtxs[i].ExecutionOrderGroup < projCtxs[j].ExecutionOrderGroup
 	})
 
-	return filterProjectContextsByTeamAllowlist(projCtxs, repoDir, ctx.FailOnTeamAllowlistDenied)
+	return filterProjectContextsByTeamAllowlist(p.withLocalPlanStoreDir(projCtxs), repoDir, ctx.FailOnTeamAllowlistDenied)
 }
 
 // buildAllCommandsByCfg builds init contexts for all projects we determine were
@@ -939,7 +953,7 @@ func (p *DefaultProjectCommandBuilder) buildAllCommandsByCfg(ctx *command.Contex
 	})
 
 	// Filter projects to only include ones the user is authorized for
-	return filterProjectContextsByTeamAllowlist(projCtxs, repoDir, ctx.FailOnTeamAllowlistDenied)
+	return filterProjectContextsByTeamAllowlist(p.withLocalPlanStoreDir(projCtxs), repoDir, ctx.FailOnTeamAllowlistDenied)
 }
 
 // buildProjectPlanCommand builds a plan context for a single project.
@@ -1266,7 +1280,7 @@ func (p *DefaultProjectCommandBuilder) buildAllProjectCommandsByPlan(ctx *comman
 			return nil, fmt.Errorf("building command for dir '%s': %w", plan.RepoRelDir, err)
 		}
 		if commentCmd.Name == command.Apply {
-			planBasePath := filepath.Join(plan.RepoDir, plan.RepoRelDir)
+			planBasePath := filepath.Join(plan.planRepoDir(), plan.RepoRelDir)
 			planPath, err := pendingPlanFilePath(plan)
 			if err != nil {
 				return nil, fmt.Errorf("validating plan path for dir %q: %w", plan.RepoRelDir, err)
@@ -1562,7 +1576,7 @@ func (p *DefaultProjectCommandBuilder) setExpectedPlanHashes(ctx *command.Contex
 		if err != nil {
 			return fmt.Errorf("validating plan path for dir %q: %w", projCtxs[i].RepoRelDir, err)
 		}
-		planHash, err := hashFile(absPath, planPath)
+		planHash, err := hashFile(runtime.GetPlanFileDir(projCtxs[i], absPath), planPath)
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue
@@ -1680,7 +1694,7 @@ func (p *DefaultProjectCommandBuilder) buildProjectCommandCtxWithCfg(ctx *comman
 	}
 
 	// Filter projects to only include ones the user is authorized for
-	return filterProjectContextsByTeamAllowlist(projCtxs, repoDir, ctx.FailOnTeamAllowlistDenied)
+	return filterProjectContextsByTeamAllowlist(p.withLocalPlanStoreDir(projCtxs), repoDir, ctx.FailOnTeamAllowlistDenied)
 }
 
 func filterProjectContextsByTeamAllowlist(projCtxs []command.ProjectContext, repoDir string, failOnDenied bool) ([]command.ProjectContext, error) {

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -924,7 +924,7 @@ func (p *DefaultProjectCommandRunner) doApply(ctx command.ProjectContext) (apply
 		if err != nil {
 			return "", "", "", err
 		}
-		planHash, err := hashFile(absPath, planPath)
+		planHash, err := hashFile(runtime.GetPlanFileDir(ctx, absPath), planPath)
 		if err != nil {
 			return "", "", "", fmt.Errorf("hashing plan file for dir %q workspace %q project %q: %w", ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName, err)
 		}

--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -87,6 +87,9 @@ type WorkingDir interface {
 // FileWorkspace implements WorkingDir with the file system.
 type FileWorkspace struct {
 	DataDir string
+	// LocalPlanStoreDir is the root directory for local Terraform plan files.
+	// If empty, DataDir is used for backward compatibility.
+	LocalPlanStoreDir string
 	// CheckoutMerge is true if we should check out the branch that corresponds
 	// to what the base branch will look like *after* the pull request is merged.
 	// If this is false, then we will check out the head branch from the pull
@@ -613,6 +616,18 @@ func (w *FileWorkspace) updateToRef(logger logging.SimpleLogging, c wrappedGitCo
 }
 
 func (w *FileWorkspace) cleanStalePlanFiles(logger logging.SimpleLogging, c wrappedGitContext) error {
+	if filepath.Clean(w.localPlanStoreDir()) != filepath.Clean(w.DataDir) {
+		workspace, err := w.workspaceFromCloneDir(c.pr.BaseRepo, c.pr, c.dir)
+		if err != nil {
+			return err
+		}
+		planWorkspaceDir, err := w.planWorkspaceDir(c.pr.BaseRepo, c.pr, workspace)
+		if err != nil {
+			return err
+		}
+		return removeTfPlanFiles(planWorkspaceDir)
+	}
+
 	// Plan files are untracked, so git reset --hard does not remove them.
 	// Use -x because Terraform plan files are commonly ignored by repos.
 	return w.wrappedGit(logger, c, "clean", "-f", "-x", "-e", ".terragrunt-cache", "--", ":(glob)**/*.tfplan")
@@ -660,6 +675,9 @@ func (w *FileWorkspace) forceClone(logger logging.SimpleLogging, c wrappedGitCon
 	err := os.RemoveAll(c.dir)
 	if err != nil {
 		return fmt.Errorf("deleting dir '%s' before cloning: %w", c.dir, err)
+	}
+	if err := w.deletePlanWorkspaceIfSeparate(c.pr.BaseRepo, c.pr, c.dir); err != nil {
+		return err
 	}
 
 	// Create the directory and parents if necessary.
@@ -897,7 +915,21 @@ func (w *FileWorkspace) Delete(logger logging.SimpleLogging, r models.Repo, p mo
 		return err
 	}
 	logger.Info("Deleting repo pull directory: %s", repoPullDir)
-	return removeAllSubPath(filepath.Join(w.DataDir, workingDirPrefix), repoPullDir)
+	cloneErr := removeAllSubPath(filepath.Join(w.DataDir, workingDirPrefix), repoPullDir)
+
+	planPullDir, err := w.planPullDir(r, p)
+	if err != nil {
+		return err
+	}
+	if filepath.Clean(planPullDir) == filepath.Clean(repoPullDir) {
+		return cloneErr
+	}
+	logger.Info("Deleting plan pull directory: %s", planPullDir)
+	planErr := removeAllSubPath(filepath.Join(w.localPlanStoreDir(), workingDirPrefix), planPullDir)
+	if cloneErr != nil {
+		return cloneErr
+	}
+	return planErr
 }
 
 // DeleteForWorkspace deletes the working dir for this workspace.
@@ -911,7 +943,25 @@ func (w *FileWorkspace) DeleteForWorkspace(logger logging.SimpleLogging, r model
 	if err != nil {
 		return err
 	}
-	return removeAllSubPath(pullDir, workspaceDir)
+	cloneErr := removeAllSubPath(pullDir, workspaceDir)
+
+	planWorkspaceDir, err := w.planWorkspaceDir(r, p, workspace)
+	if err != nil {
+		return err
+	}
+	if filepath.Clean(planWorkspaceDir) == filepath.Clean(workspaceDir) {
+		return cloneErr
+	}
+	planPullDir, err := w.planPullDir(r, p)
+	if err != nil {
+		return err
+	}
+	logger.Info("Deleting plan workspace directory: %s", planWorkspaceDir)
+	planErr := removeAllSubPath(planPullDir, planWorkspaceDir)
+	if cloneErr != nil {
+		return cloneErr
+	}
+	return planErr
 }
 
 func removeAllSubPath(baseDir, targetDir string) error {
@@ -944,6 +994,100 @@ func (w *FileWorkspace) repoPullDir(r models.Repo, p models.PullRequest) (string
 		return "", fmt.Errorf("repo path traversal detected: %w", err)
 	}
 	return dir, nil
+}
+
+func (w *FileWorkspace) localPlanStoreDir() string {
+	if w.LocalPlanStoreDir == "" {
+		return w.DataDir
+	}
+	return w.LocalPlanStoreDir
+}
+
+func (w *FileWorkspace) planPullDir(r models.Repo, p models.PullRequest) (string, error) {
+	dir := runtime.GetPlanPullDir(w.localPlanStoreDir(), r, p)
+	if err := utils.EnsureSubPath(filepath.Join(w.localPlanStoreDir(), workingDirPrefix), dir); err != nil {
+		return "", fmt.Errorf("plan path traversal detected: %w", err)
+	}
+	return dir, nil
+}
+
+func (w *FileWorkspace) planWorkspaceDir(r models.Repo, p models.PullRequest, workspace string) (string, error) {
+	pullDir, err := w.planPullDir(r, p)
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(pullDir, workspace)
+	if err := utils.EnsureSubPath(pullDir, dir); err != nil {
+		return "", fmt.Errorf("plan workspace path traversal detected: %w", err)
+	}
+	return dir, nil
+}
+
+func (w *FileWorkspace) planProjectDir(r models.Repo, p models.PullRequest, workspace string, projectPath string) (string, error) {
+	workspaceDir, err := w.planWorkspaceDir(r, p, workspace)
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(workspaceDir, projectPath)
+	if err := utils.EnsureSubPath(workspaceDir, dir); err != nil {
+		return "", fmt.Errorf("plan project path traversal detected: %w", err)
+	}
+	return dir, nil
+}
+
+func (w *FileWorkspace) workspaceFromCloneDir(r models.Repo, p models.PullRequest, cloneDir string) (string, error) {
+	pullDir, err := w.repoPullDir(r, p)
+	if err != nil {
+		return "", err
+	}
+	workspace, err := filepath.Rel(pullDir, cloneDir)
+	if err != nil {
+		return "", fmt.Errorf("checking clone directory %q: %w", cloneDir, err)
+	}
+	if workspace == "." || workspace == ".." || filepath.IsAbs(workspace) || strings.HasPrefix(workspace, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("clone directory %q escapes pull directory %q", cloneDir, pullDir)
+	}
+	return workspace, nil
+}
+
+func (w *FileWorkspace) deletePlanWorkspaceIfSeparate(r models.Repo, p models.PullRequest, cloneDir string) error {
+	if filepath.Clean(w.localPlanStoreDir()) == filepath.Clean(w.DataDir) {
+		return nil
+	}
+	workspace, err := w.workspaceFromCloneDir(r, p, cloneDir)
+	if err != nil {
+		return err
+	}
+	planWorkspaceDir, err := w.planWorkspaceDir(r, p, workspace)
+	if err != nil {
+		return err
+	}
+	planPullDir, err := w.planPullDir(r, p)
+	if err != nil {
+		return err
+	}
+	return removeAllSubPath(planPullDir, planWorkspaceDir)
+}
+
+func removeTfPlanFiles(root string) error {
+	return filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			if path == root && os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if entry.IsDir() {
+			if entry.Name() == ".terragrunt-cache" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".tfplan" {
+			return nil
+		}
+		return utils.RemoveIgnoreNonExistent(path)
+	})
 }
 
 func (w *FileWorkspace) cloneDir(r models.Repo, p models.PullRequest, workspace string) (string, error) {
@@ -988,12 +1132,12 @@ func (w *FileWorkspace) SetCheckForUpstreamChanges() {
 }
 
 func (w *FileWorkspace) DeletePlan(logger logging.SimpleLogging, r models.Repo, p models.PullRequest, workspace string, projectPath string, projectName string) error {
-	cloneDir, err := w.cloneDir(r, p, workspace)
+	planDir, err := w.planProjectDir(r, p, workspace, projectPath)
 	if err != nil {
 		return err
 	}
-	planPath := filepath.Join(cloneDir, projectPath, runtime.GetPlanFilename(workspace, projectName))
-	if err := utils.EnsureSubPath(cloneDir, planPath); err != nil {
+	planPath := filepath.Join(planDir, runtime.GetPlanFilename(workspace, projectName))
+	if err := utils.EnsureSubPath(planDir, planPath); err != nil {
 		return fmt.Errorf("plan path traversal detected: %w", err)
 	}
 	logger.Info("Deleting plan: %s", planPath)

--- a/server/server.go
+++ b/server/server.go
@@ -545,10 +545,11 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	workingDirLocker := events.NewDefaultWorkingDirLocker()
 
 	var workingDir events.WorkingDir = &events.FileWorkspace{
-		DataDir:          userConfig.DataDir,
-		CheckoutMerge:    userConfig.CheckoutStrategy == "merge",
-		CheckoutDepth:    userConfig.CheckoutDepth,
-		GithubAppEnabled: githubAppEnabled,
+		DataDir:           userConfig.DataDir,
+		LocalPlanStoreDir: userConfig.EnableLocalStores,
+		CheckoutMerge:     userConfig.CheckoutStrategy == "merge",
+		CheckoutDepth:     userConfig.CheckoutDepth,
+		GithubAppEnabled:  githubAppEnabled,
 	}
 
 	scheduledExecutorService := scheduled.NewExecutorService(
@@ -647,7 +648,10 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	)
 	defaultTfDistribution := terraformClient.DefaultDistribution()
 	defaultTfVersion := terraformClient.DefaultVersion()
-	pendingPlanFinder := &events.DefaultPendingPlanFinder{}
+	pendingPlanFinder := &events.DefaultPendingPlanFinder{
+		DataDir:           userConfig.DataDir,
+		LocalPlanStoreDir: userConfig.EnableLocalStores,
+	}
 	runStepRunner := &runtime.RunStepRunner{
 		TerraformExecutor:       terraformClient,
 		DefaultTFDistribution:   defaultTfDistribution,
@@ -709,6 +713,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		userConfig.AutoDiscoverModeFlag,
 		statsScope,
 		terraformClient,
+		userConfig.EnableLocalStores,
 	)
 
 	showStepRunner, err := runtime.NewShowStepRunner(terraformClient, defaultTfDistribution, defaultTfVersion)

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -40,6 +40,7 @@ type UserConfig struct {
 	CheckoutDepth               int    `mapstructure:"checkout-depth"`
 	CheckoutStrategy            string `mapstructure:"checkout-strategy"`
 	DataDir                     string `mapstructure:"data-dir"`
+	EnableLocalStores           string `mapstructure:"enable-local-stores"`
 	DisableApplyAll             bool   `mapstructure:"disable-apply-all"`
 	DisableAutoplan             bool   `mapstructure:"disable-autoplan"`
 	DisableAutoplanLabel        string `mapstructure:"disable-autoplan-label"`


### PR DESCRIPTION
## what

Adds a new `--enable-local-stores` server flag (env: `ATLANTIS_ENABLE_LOCAL_STORES`) that lets operators store Terraform plan files (`.tfplan`) in a dedicated directory separate from `--data-dir`.

When set, plan files follow the layout:
```
<enable-local-stores>/repos/<owner>/<repo>/<pr-num>/<workspace>/<project-path>/<workspace>.tfplan
```
Git workspace clones continue to live under `--data-dir`. When unset, behaviour is identical to today (plan files co-located with the workspace clone).

## why

In some deployments the Atlantis data directory lives on ephemeral or network-mounted storage. Decoupling plan file storage allows operators to direct `.tfplan` files to a faster, more durable, or independently-managed volume without moving the full git workspace clone. It also makes it easier to audit or archive generated plan artifacts independently of source checkouts.

## tests

- `TestExecute_ExpandHomeInEnableLocalStores` – verifies `~/…` paths are expanded to absolute home paths
- `TestExecute_RelativeEnableLocalStores` – verifies relative paths are resolved to absolute
- `TestGetPlanFilePath` – unit-tests the new `GetPlanFilePath` helper with and without a separate plan store
- `TestRun_UsesLocalPlanStoreDir` – verifies the apply step runner reads plans from the plan store directory
- `TestPendingPlanFinder_FindSeparateLocalPlanStore` – verifies pending plan discovery works when plans live in a separate directory

## references

- Superseded by #6636 (renamed flag to `--plan-store-dir`)
- Proposal: #6637
- `--enable-local-stores` flag documented in `runatlantis.io/docs/server-configuration.md` (on this branch)
