### PR TITLE
feat: Bitbucket Access Tokens; Fixes #5015

### DIFF
--- a/server/events/vcs/bitbucketcloud/client.go
+++ b/server/events/vcs/bitbucketcloud/client.go
@@ -362,8 +362,15 @@ func (b *Client) prepRequest(method string, path string, body io.Reader) (*http.
 	if err != nil {
 		return nil, err
 	}
-	// Use ApiUser for API authentication, Username is for git operations
-	req.SetBasicAuth(b.apiUser, b.password)
+
+	// Bitbucket access tokens (workspace/project/repo) begin with "ATCT".
+	if strings.HasPrefix(b.password, "ATCT") {
+		// Bitbucket Access Tokens Use Bearer Token Auth
+		req.Header.Set("Authorization", "Bearer "+b.password)
+	} else {
+		// Bitbucket API tokens and app passwords (deprecated) use basic auth.
+		req.SetBasicAuth(b.apiUser, b.password)
+	}
 	if body != nil {
 		req.Header.Add("Content-Type", "application/json")
 	}

--- a/server/events/vcs/bitbucketcloud/client_internal_test.go
+++ b/server/events/vcs/bitbucketcloud/client_internal_test.go
@@ -1,0 +1,51 @@
+package bitbucketcloud
+
+import (
+	"encoding/base64"
+	"net/http"
+	"strings"
+	"testing"
+
+	. "github.com/runatlantis/atlantis/testing"
+)
+
+func TestClient_APIUserDefault(t *testing.T) {
+	client := New(http.DefaultClient, "user", "pass", "", "runatlantis.io")
+	Equals(t, client.username, client.apiUser)
+}
+
+func TestClient_AuthHeaderAppPassword(t *testing.T) {
+	client := New(http.DefaultClient, "user", "ATBBmockapppassword", "", "runatlantis.io")
+	req, err := client.prepRequest("GET", "/mock/url", nil)
+	Ok(t, err)
+	authHeader := req.Header.Get("Authorization")
+	scheme, encoded, ok := strings.Cut(authHeader, " ")
+	Assert(t, ok, "expected Authorization header to contain scheme and credentials")
+	Equals(t, "Basic", scheme)
+	Equals(t, base64.StdEncoding.EncodeToString([]byte(client.apiUser+":"+client.password)), encoded)
+}
+
+func TestClient_AuthHeaderApiToken(t *testing.T) {
+	// apiUser is the atlassian account email address
+	client := New(http.DefaultClient, "user", "ATATmockapitoken", "user@myemail.net", "runatlantis.io")
+	req, err := client.prepRequest("GET", "/mock/url", nil)
+	Ok(t, err)
+	authHeader := req.Header.Get("Authorization")
+	scheme, encoded, ok := strings.Cut(authHeader, " ")
+	Assert(t, ok, "expected Authorization header to contain scheme and credentials")
+	Equals(t, "Basic", scheme)
+	Equals(t, base64.StdEncoding.EncodeToString([]byte(client.apiUser+":"+client.password)), encoded)
+}
+
+func TestClient_AuthHeaderAccessToken(t *testing.T) {
+	// apiUser is not required for Access Token authenticated API requests
+	// The username "x-token-auth" is used for git interactions
+	client := New(http.DefaultClient, "x-token-auth", "ATCTmockaccesstoken", "", "runatlantis.io")
+	req, err := client.prepRequest("GET", "/mock/url", nil)
+	Ok(t, err)
+	authHeader := req.Header.Get("Authorization")
+	scheme, token, ok := strings.Cut(authHeader, " ")
+	Assert(t, ok, "expected Authorization header to contain scheme and token")
+	Equals(t, "Bearer", scheme)
+	Equals(t, client.password, token)
+}


### PR DESCRIPTION
## what

Adds support for Bitbucket Cloud Access Tokens, without removing support for User API Tokens or App Passwords (app passwords are heavily deprecated by Atlassian at this time). Additional details available in #5015.

To use a Bitbucket Access Token (starts with **ATCT** by Atlassian convention), one would use these Atlantis config options:

`--bitbucket-user="x-token-auth"`, `--bitbucket-token="ATCT................"`

Note: The `--bitbucket-api-user` flag is not required when using Bitbucket Access tokens.

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->


## why

Adds support for Bitbucket Cloud Access Tokens. These are scoped-tokens that are "tied to [a] workspace, not a user, and are managed by the workspace's admins". These are not currently supported in Atlantis. Ref: https://support.atlassian.com/bitbucket-cloud/docs/using-access-tokens)

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## tests

I adding tests for private method "prepRequest" which adds the Authentication header. Tests are available in server/events/vcs/bitbucketcloud/client_auth_test.go.

I did not add the test to the existing server/events/vcs/bitbucketcloud/client_test.go file because I could not test a private func from a separate package. Please provide a recommendation if there is a better way to do this.

This has not been tested in a live bitbucket-cloud-connected deployment. Once a container image is available, this would be my next step.

<!--
- [ ] I have tested my changes by adding tests for private method "prepRequest" which adds the Authentication header. Tests are available in server/events/vcs/bitbucketcloud/client_auth_test.go.

Note: I did not add the test to the existing server/events/vcs/bitbucketcloud/client_test.go file because I could not test a private func from a separate package).
-->

## references

closes #5015

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

