### PR TITLE
fix: avoid duplicating streamed output on job page failures

### DIFF
--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -286,7 +286,8 @@ func (p *ProjectOutputWrapper) streamFailureToJob(ctx command.ProjectContext, re
 
 func streamJobFailureLines(p *ProjectOutputWrapper, ctx command.ProjectContext, label string, message string) {
 	p.JobMessageSender.Send(ctx, label+":", false)
-	for _, line := range strings.Split(strings.ReplaceAll(strings.ReplaceAll(message, "\r\n", "\n"), "\r", "\n"), "\n") {
+	normalized := strings.ReplaceAll(strings.ReplaceAll(message, "\r\n", "\n"), "\r", "\n")
+	for line := range strings.SplitSeq(normalized, "\n") {
 		p.JobMessageSender.Send(ctx, line, false)
 	}
 }

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -266,6 +266,10 @@ func deferredApplyProjectContext(projectCmds []command.ProjectContext, result co
 // Each line is sent separately so the websocket writer's per-line \r prefix
 // renders correctly in the xterm-based job page.
 func (p *ProjectOutputWrapper) streamFailureToJob(ctx command.ProjectContext, result command.ProjectCommandOutput) {
+	if ctx.SuppressJobOutput {
+		return
+	}
+
 	errorMessage := ""
 	if result.Error != nil {
 		errorMessage = strings.TrimSpace(jobErrorMessage(result.Error))

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -263,36 +263,46 @@ func deferredApplyProjectContext(projectCmds []command.ProjectContext, result co
 // output stream so the per-project job page linked from the VCS commit status
 // has a visible final status when plan or apply fails before producing any
 // terraform output (e.g. lock contention, depends_on, requirement checks).
-// Uses \r\n so the xterm-based job page renders the banner on its own lines.
+// Each line is sent separately so the websocket writer's per-line \r prefix
+// renders correctly in the xterm-based job page.
 func (p *ProjectOutputWrapper) streamFailureToJob(ctx command.ProjectContext, result command.ProjectCommandOutput) {
+	errorMessage := ""
 	if result.Error != nil {
-		p.JobMessageSender.Send(ctx, jobFailureBanner("Error", jobErrorMessage(result.Error)), false)
+		errorMessage = strings.TrimSpace(jobErrorMessage(result.Error))
 	}
-	if result.Failure != "" {
-		p.JobMessageSender.Send(ctx, jobFailureBanner("Failure", result.Failure), false)
+	failureMessage := strings.TrimSpace(result.Failure)
+	if errorMessage == "" && failureMessage == "" {
+		return
+	}
+
+	p.JobMessageSender.Send(ctx, "", false)
+	if errorMessage != "" {
+		streamJobFailureLines(p, ctx, "Error", errorMessage)
+	}
+	if failureMessage != "" {
+		streamJobFailureLines(p, ctx, "Failure", failureMessage)
 	}
 }
 
-func jobFailureBanner(label string, message string) string {
-	return fmt.Sprintf("\r\n%s:\r\n%s\r\n", label, normalizeJobLineEndings(message))
-}
-
-func normalizeJobLineEndings(message string) string {
-	message = strings.ReplaceAll(message, "\r\n", "\n")
-	message = strings.ReplaceAll(message, "\r", "\n")
-	return strings.ReplaceAll(message, "\n", "\r\n")
+func streamJobFailureLines(p *ProjectOutputWrapper, ctx command.ProjectContext, label string, message string) {
+	p.JobMessageSender.Send(ctx, label+":", false)
+	for _, line := range strings.Split(strings.ReplaceAll(strings.ReplaceAll(message, "\r\n", "\n"), "\r", "\n"), "\n") {
+		p.JobMessageSender.Send(ctx, line, false)
+	}
 }
 
 func jobErrorMessage(err error) string {
-	if errWithOutput, ok := err.(interface{ JobMessage() string }); ok {
-		return errWithOutput.JobMessage()
+	var withJobMessage interface{ JobMessage() string }
+	if errors.As(err, &withJobMessage) {
+		return withJobMessage.JobMessage()
 	}
 	return err.Error()
 }
 
 type errWithStepOutput struct {
-	err    error
-	output string
+	err      error
+	output   string
+	streamed bool
 }
 
 func (e errWithStepOutput) Error() string {
@@ -307,13 +317,17 @@ func (e errWithStepOutput) Unwrap() error {
 }
 
 func (e errWithStepOutput) JobMessage() string {
-	return jobErrorMessage(e.err)
+	if e.streamed || e.output == "" {
+		return jobErrorMessage(e.err)
+	}
+	return e.Error()
 }
 
-func errorWithStepOutput(err error, outputs []string) error {
+func errorWithStepOutput(err error, outputs []string, streamed bool) error {
 	return errWithStepOutput{
-		err:    err,
-		output: strings.Join(outputs, "\n"),
+		err:      err,
+		output:   strings.Join(outputs, "\n"),
+		streamed: streamed,
 	}
 }
 
@@ -852,7 +866,7 @@ func (p *DefaultProjectCommandRunner) doPlan(ctx command.ProjectContext) (*model
 		if unlockErr := lockAttempt.UnlockFn(); unlockErr != nil {
 			ctx.Log.Err("error unlocking state after plan error: %v", unlockErr)
 		}
-		return nil, "", errorWithStepOutput(err, outputs)
+		return nil, "", errorWithStepOutput(err, outputs, !ctx.SuppressJobOutput)
 	}
 
 	return &models.PlanSuccess{
@@ -969,7 +983,7 @@ func (p *DefaultProjectCommandRunner) doApply(ctx command.ProjectContext) (apply
 	}
 
 	if err != nil {
-		return "", remoteApplyRunURL, "", errorWithStepOutput(err, outputs)
+		return "", remoteApplyRunURL, "", errorWithStepOutput(err, outputs, !ctx.SuppressJobOutput)
 	}
 
 	return strings.Join(outputs, "\n"), remoteApplyRunURL, "", nil
@@ -1000,7 +1014,7 @@ func (p *DefaultProjectCommandRunner) doVersion(ctx command.ProjectContext) (ver
 
 	outputs, err := p.runSteps(ctx.Steps, ctx, absPath)
 	if err != nil {
-		return "", "", fmt.Errorf("%s\n%s", err, strings.Join(outputs, "\n"))
+		return "", "", errorWithStepOutput(err, outputs, !ctx.SuppressJobOutput)
 	}
 
 	return strings.Join(outputs, "\n"), "", nil
@@ -1044,7 +1058,7 @@ func (p *DefaultProjectCommandRunner) doImport(ctx command.ProjectContext) (out 
 
 	outputs, err := p.runSteps(ctx.Steps, ctx, projAbsPath)
 	if err != nil {
-		return nil, "", fmt.Errorf("%s\n%s", err, strings.Join(outputs, "\n"))
+		return nil, "", errorWithStepOutput(err, outputs, !ctx.SuppressJobOutput)
 	}
 
 	// after import, re-plan command is required without import args
@@ -1088,7 +1102,7 @@ func (p *DefaultProjectCommandRunner) doStateRm(ctx command.ProjectContext) (out
 
 	outputs, err := p.runSteps(ctx.Steps, ctx, projAbsPath)
 	if err != nil {
-		return nil, "", fmt.Errorf("%s\n%s", err, strings.Join(outputs, "\n"))
+		return nil, "", errorWithStepOutput(err, outputs, !ctx.SuppressJobOutput)
 	}
 
 	// after state rm, re-plan command is required without state rm args

--- a/server/events/project_command_runner_job_output_internal_test.go
+++ b/server/events/project_command_runner_job_output_internal_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package events
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	. "github.com/runatlantis/atlantis/testing"
+)
+
+func TestJobErrorMessageUsesJobMessageForWrappedStepOutput(t *testing.T) {
+	inner := errors.New("running terraform in path: exit status 1")
+	output := strings.Repeat("      + latest_version = (known after apply)\n", 5)
+	stepErr := errorWithStepOutput(inner, []string{output}, true)
+	wrapped := fmt.Errorf("plan failed: %w", stepErr)
+
+	Assert(t, !strings.Contains(jobErrorMessage(wrapped), "+ latest_version"),
+		"expected wrapped step output error not to replay terraform output in job message, got %q", jobErrorMessage(wrapped))
+	Equals(t, "running terraform in path: exit status 1", jobErrorMessage(wrapped))
+}
+
+func TestErrWithStepOutputJobMessageIncludesOutputWhenNotStreamed(t *testing.T) {
+	inner := errors.New("step failed")
+	stepErr := errorWithStepOutput(inner, []string{"not streamed output"}, false).(errWithStepOutput)
+
+	Equals(t, stepErr.Error(), stepErr.JobMessage())
+	Assert(t, strings.Contains(stepErr.JobMessage(), "not streamed output"),
+		"expected non-streamed output in job message, got %q", stepErr.JobMessage())
+}
+
+func TestErrWithStepOutputJobMessageOmitsOutputWhenStreamed(t *testing.T) {
+	inner := errors.New("step failed")
+	stepErr := errorWithStepOutput(inner, []string{"already streamed output"}, true).(errWithStepOutput)
+
+	Equals(t, "step failed", stepErr.JobMessage())
+	Assert(t, !strings.Contains(stepErr.JobMessage(), "already streamed output"),
+		"expected streamed output to be omitted from job message, got %q", stepErr.JobMessage())
+}

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -426,6 +426,34 @@ func TestProjectOutputWrapperSuppressesJobOutput(t *testing.T) {
 	mockJobMessageSender.VerifyWasCalled(Never()).Send(Any[command.ProjectContext](), Any[string](), Any[bool]())
 }
 
+func TestProjectOutputWrapperSuppressesFailureJobOutput(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockProjectCommandRunner := mocks.NewMockProjectCommandRunner()
+	mockJobURLSetter := mocks.NewMockJobURLSetter()
+	mockJobMessageSender := mocks.NewMockJobMessageSender()
+	ctx := command.ProjectContext{
+		Log:               logging.NewNoopLogger(t),
+		SuppressJobOutput: true,
+	}
+	expected := command.ProjectCommandOutput{
+		Error: errors.New("plan failed"),
+	}
+	When(mockProjectCommandRunner.Plan(ctx)).ThenReturn(expected)
+
+	runner := &events.ProjectOutputWrapper{
+		ProjectCommandRunner: mockProjectCommandRunner,
+		JobURLSetter:         mockJobURLSetter,
+		JobMessageSender:     mockJobMessageSender,
+	}
+	result := runner.Plan(ctx)
+
+	Equals(t, expected, result)
+	mockProjectCommandRunner.VerifyWasCalledOnce().Plan(ctx)
+	mockJobURLSetter.VerifyWasCalled(Once()).SetJobURLWithStatus(ctx, command.Plan, models.PendingCommitStatus, nil)
+	mockJobURLSetter.VerifyWasCalled(Once()).SetJobURLWithStatus(ctx, command.Plan, models.FailedCommitStatus, &expected)
+	mockJobMessageSender.VerifyWasCalled(Never()).Send(Any[command.ProjectContext](), Any[string](), Any[bool]())
+}
+
 func TestProjectOutputWrapperDoesNotReplayStreamedStepOutput(t *testing.T) {
 	RegisterMockTestingT(t)
 

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -46,7 +46,8 @@ func expectJobFailureBanner(
 	sends := 0
 	mockJobMessageSender.VerifyWasCalledInOrder(Once(), inOrder).Send(ctx, label+":", false)
 	sends++
-	for _, line := range strings.Split(strings.ReplaceAll(strings.ReplaceAll(message, "\r\n", "\n"), "\r", "\n"), "\n") {
+	normalized := strings.ReplaceAll(strings.ReplaceAll(message, "\r\n", "\n"), "\r", "\n")
+	for line := range strings.SplitSeq(normalized, "\n") {
 		mockJobMessageSender.VerifyWasCalledInOrder(Once(), inOrder).Send(ctx, line, false)
 		sends++
 	}

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -36,6 +36,23 @@ import (
 	. "github.com/runatlantis/atlantis/testing"
 )
 
+func expectJobFailureBanner(
+	inOrder *InOrderContext,
+	mockJobMessageSender *mocks.MockJobMessageSender,
+	ctx command.ProjectContext,
+	label string,
+	message string,
+) int {
+	sends := 0
+	mockJobMessageSender.VerifyWasCalledInOrder(Once(), inOrder).Send(ctx, label+":", false)
+	sends++
+	for _, line := range strings.Split(strings.ReplaceAll(strings.ReplaceAll(message, "\r\n", "\n"), "\r", "\n"), "\n") {
+		mockJobMessageSender.VerifyWasCalledInOrder(Once(), inOrder).Send(ctx, line, false)
+		sends++
+	}
+	return sends
+}
+
 // Test that it runs the expected plan steps.
 func TestDefaultProjectCommandRunner_Plan(t *testing.T) {
 	RegisterMockTestingT(t)
@@ -177,22 +194,22 @@ func TestProjectOutputWrapper(t *testing.T) {
 	}
 
 	const (
-		expErrorBanner          = "\r\nError:\r\nerror\r\n"
-		expMultilineErrorBanner = "\r\nError:\r\nerror\r\nmore detail\r\n"
-		expFailureBanner        = "\r\nFailure:\r\nfailure\r\n"
-		expMultilineFailure     = "\r\nFailure:\r\nfailure\r\nmore detail\r\n"
+		expErrorMessage          = "error"
+		expMultilineErrorMessage = "error\nmore detail"
+		expFailureMessage        = "failure"
+		expMultilineFailure      = "failure\nmore detail"
 	)
 
 	cases := []struct {
-		Description      string
-		Failure          bool
-		Error            bool
-		Success          bool
-		CommandName      command.Name
-		ErrorMessage     string
-		FailureMessage   string
-		ExpErrorBanner   string
-		ExpFailureBanner string
+		Description       string
+		Failure           bool
+		Error             bool
+		Success           bool
+		CommandName       command.Name
+		ErrorMessage      string
+		FailureMessage    string
+		ExpErrorMessage   string
+		ExpFailureMessage string
 	}{
 		{
 			Description: "plan success",
@@ -205,11 +222,11 @@ func TestProjectOutputWrapper(t *testing.T) {
 			CommandName: command.Plan,
 		},
 		{
-			Description:      "plan multiline failure",
-			Failure:          true,
-			CommandName:      command.Plan,
-			FailureMessage:   "failure\nmore detail",
-			ExpFailureBanner: expMultilineFailure,
+			Description:       "plan multiline failure",
+			Failure:           true,
+			CommandName:       command.Plan,
+			FailureMessage:    "failure\nmore detail",
+			ExpFailureMessage: expMultilineFailure,
 		},
 		{
 			Description: "plan error",
@@ -217,11 +234,11 @@ func TestProjectOutputWrapper(t *testing.T) {
 			CommandName: command.Plan,
 		},
 		{
-			Description:    "plan multiline error",
-			Error:          true,
-			CommandName:    command.Plan,
-			ErrorMessage:   "error\nmore detail",
-			ExpErrorBanner: expMultilineErrorBanner,
+			Description:     "plan multiline error",
+			Error:           true,
+			CommandName:     command.Plan,
+			ErrorMessage:    "error\nmore detail",
+			ExpErrorMessage: expMultilineErrorMessage,
 		},
 		{
 			Description: "plan error and failure",
@@ -320,21 +337,23 @@ func TestProjectOutputWrapper(t *testing.T) {
 			// so the xterm-based job page renders the final status.
 			inOrder := new(InOrderContext)
 			expectedSends := 0
-			if c.Error {
-				expectedBanner := c.ExpErrorBanner
-				if expectedBanner == "" {
-					expectedBanner = expErrorBanner
-				}
-				mockJobMessageSender.VerifyWasCalledInOrder(Once(), inOrder).Send(ctx, expectedBanner, false)
+			if c.Error || c.Failure {
+				mockJobMessageSender.VerifyWasCalledInOrder(Once(), inOrder).Send(ctx, "", false)
 				expectedSends++
 			}
-			if c.Failure {
-				expectedBanner := c.ExpFailureBanner
-				if expectedBanner == "" {
-					expectedBanner = expFailureBanner
+			if c.Error {
+				expectedMessage := c.ExpErrorMessage
+				if expectedMessage == "" {
+					expectedMessage = expErrorMessage
 				}
-				mockJobMessageSender.VerifyWasCalledInOrder(Once(), inOrder).Send(ctx, expectedBanner, false)
-				expectedSends++
+				expectedSends += expectJobFailureBanner(inOrder, mockJobMessageSender, ctx, "Error", expectedMessage)
+			}
+			if c.Failure {
+				expectedMessage := c.ExpFailureMessage
+				if expectedMessage == "" {
+					expectedMessage = expFailureMessage
+				}
+				expectedSends += expectJobFailureBanner(inOrder, mockJobMessageSender, ctx, "Failure", expectedMessage)
 			}
 			mockJobMessageSender.VerifyWasCalledInOrder(Once(), inOrder).Send(ctx, "", true)
 			expectedSends++
@@ -451,9 +470,10 @@ func TestProjectOutputWrapperDoesNotReplayStreamedStepOutput(t *testing.T) {
 
 	ErrEquals(t, "error\nmore detail\nalready streamed output", result.Error)
 	inOrder := new(InOrderContext)
-	mockJobMessageSender.VerifyWasCalledInOrder(Once(), inOrder).Send(ctx, "\r\nError:\r\nerror\r\nmore detail\r\n", false)
+	mockJobMessageSender.VerifyWasCalledInOrder(Once(), inOrder).Send(ctx, "", false)
+	expectJobFailureBanner(inOrder, mockJobMessageSender, ctx, "Error", "error\nmore detail")
 	mockJobMessageSender.VerifyWasCalledInOrder(Once(), inOrder).Send(ctx, "", true)
-	mockJobMessageSender.VerifyWasCalled(Times(2)).Send(Any[command.ProjectContext](), Any[string](), Any[bool]())
+	mockJobMessageSender.VerifyWasCalled(Times(5)).Send(Any[command.ProjectContext](), Any[string](), Any[bool]())
 }
 
 func TestProjectOutputWrapperDoesNotReplayCustomRunStepOutput(t *testing.T) {
@@ -516,13 +536,17 @@ func TestProjectOutputWrapperDoesNotReplayCustomRunStepOutput(t *testing.T) {
 	result := runner.Plan(ctx)
 
 	ErrContains(t, "already streamed output", result.Error)
-	_, messages, operationComplete := mockJobMessageSender.VerifyWasCalled(Times(2)).
+	_, messages, operationComplete := mockJobMessageSender.VerifyWasCalled(Times(4)).
 		Send(Any[command.ProjectContext](), Any[string](), Any[bool]()).GetAllCapturedArguments()
-	Assert(t, strings.Contains(messages[0], "\r\nError:\r\nrunning 'sh -c' 'cat output.txt; exit 1'"), fmt.Sprintf("expected error summary banner, got %q", messages[0]))
-	Assert(t, !strings.Contains(messages[0], "already streamed output"), fmt.Sprintf("expected banner not to replay run output, got %q", messages[0]))
-	Equals(t, "", messages[1])
+	Assert(t, messages[0] == "", fmt.Sprintf("expected leading blank line, got %q", messages[0]))
+	Assert(t, messages[1] == "Error:", fmt.Sprintf("expected error label, got %q", messages[1]))
+	Assert(t, strings.Contains(messages[2], "running 'sh -c' 'cat output.txt; exit 1'"), fmt.Sprintf("expected error summary banner, got %q", messages[2]))
+	for _, message := range messages[:3] {
+		Assert(t, !strings.Contains(message, "already streamed output"), fmt.Sprintf("expected banner not to replay run output, got %q", message))
+	}
+	Equals(t, "", messages[3])
 	Equals(t, false, operationComplete[0])
-	Equals(t, true, operationComplete[1])
+	Equals(t, true, operationComplete[3])
 }
 
 func TestProjectOutputWrapperPreservesNonStreamedEnvStepOutput(t *testing.T) {
@@ -590,13 +614,15 @@ func TestProjectOutputWrapperPreservesNonStreamedEnvStepOutput(t *testing.T) {
 	result := runner.Plan(ctx)
 
 	ErrContains(t, "not streamed output", result.Error)
-	_, messages, operationComplete := mockJobMessageSender.VerifyWasCalled(Times(2)).
+	_, messages, operationComplete := mockJobMessageSender.VerifyWasCalled(Times(5)).
 		Send(Any[command.ProjectContext](), Any[string](), Any[bool]()).GetAllCapturedArguments()
-	Assert(t, strings.Contains(messages[0], "\r\nError:\r\n"), fmt.Sprintf("expected error banner, got %q", messages[0]))
-	Assert(t, strings.Contains(messages[0], "\r\nnot streamed output\r\n"), fmt.Sprintf("expected banner to include non-streamed output, got %q", messages[0]))
-	Equals(t, "", messages[1])
+	Assert(t, messages[0] == "", fmt.Sprintf("expected leading blank line, got %q", messages[0]))
+	Assert(t, messages[1] == "Error:", fmt.Sprintf("expected error label, got %q", messages[1]))
+	Assert(t, strings.Contains(messages[2], "running 'sh -c' 'cat output.txt; exit 1'"), fmt.Sprintf("expected error summary banner, got %q", messages[2]))
+	Assert(t, messages[3] == "not streamed output", fmt.Sprintf("expected banner to include non-streamed output, got %q", messages[3]))
+	Equals(t, "", messages[4])
 	Equals(t, false, operationComplete[0])
-	Equals(t, true, operationComplete[1])
+	Equals(t, true, operationComplete[4])
 }
 
 // Test what happens if there's no working dir. This signals that the project


### PR DESCRIPTION
:wave: 

I had a couple problems with my fix in #6414 - mainly that failed runs would repeat errors, and the repeated error would have its line formatting all messed up, so I'm aiming to fix that here.

I'll run my local build of this for a while too to test, but just wanted to get this filed regardless.

## Summary

- Follow-up fix to #6414: job page failure banners no longer replay terraform/step output that was already streamed live during plan/apply
- Use `errors.As` for `JobMessage()` lookup so wrapped `errWithStepOutput` errors do not fall back to `err.Error()` and dump the full plan output again
- Track whether step output was already streamed (`errWithStepOutput.streamed`) and send failure banners line-by-line so the websocket `\r` prefix renders correctly in xterm (avoids garbled duplicate output)
- Migrate remaining `fmt.Errorf("%s\n%s", ...)` step error paths (version/import/state_rm) to `errWithStepOutput`

## why

When a terraform plan failed after streaming output, #6414 could re-send the entire plan output as a single multi-line job message. Combined with embedded `\r\n` and the websocket writer's leading `\r`, this produced duplicated, garbled output on the job page.

## tests

- [x] `go test ./server/events/ -run 'TestProjectOutputWrapper|TestJobErrorMessage|TestErrWithStepOutput'`
- [x] `make check-fmt`

## references

- Follow-up to #6414
- Refs #4386