### PR TITLE
feat(#303): include commit SHA in working directory lock errors

### DIFF
--- a/server/controllers/api_controller.go
+++ b/server/controllers/api_controller.go
@@ -521,7 +521,7 @@ func (a *APIController) apiSetup(ctx *command.Context, cmdName command.Name) (er
 	baseRepo := ctx.Pull.BaseRepo
 	headRepo := ctx.HeadRepo
 
-	unlockFn, err := a.WorkingDirLocker.TryLock(baseRepo.FullName, pull.Num, events.DefaultWorkspace, events.DefaultRepoRelDir, "", cmdName)
+	unlockFn, err := a.WorkingDirLocker.TryLock(baseRepo.FullName, pull.Num, events.DefaultWorkspace, events.DefaultRepoRelDir, "", cmdName, events.WorkingDirLockMetadataForPull(pull))
 	if err != nil {
 		return err
 	}

--- a/server/controllers/api_controller_test.go
+++ b/server/controllers/api_controller_test.go
@@ -2246,7 +2246,7 @@ func setup(t *testing.T, options ...func(*apiControllerTestConfig)) (*controller
 		})
 
 	workingDirLocker := NewMockWorkingDirLocker()
-	When(workingDirLocker.TryLock(Any[string](), Any[int](), Eq(events.DefaultWorkspace), Eq(events.DefaultRepoRelDir), Eq(""), Any[command.Name]())).
+	When(workingDirLocker.TryLock(Any[string](), Any[int](), Eq(events.DefaultWorkspace), Eq(events.DefaultRepoRelDir), Eq(""), Any[command.Name](), Any[events.WorkingDirLockMetadata]())).
 		ThenReturn(func() {}, nil)
 
 	projectCommandBuilder := NewMockProjectCommandBuilder()

--- a/server/controllers/api_remediation_executor_internal_test.go
+++ b/server/controllers/api_remediation_executor_internal_test.go
@@ -273,7 +273,7 @@ func TestAPIRemediationExecutor_ExecuteApplyAbortsWhenPreApplyPlanHasErrors(t *t
 	applyLockChecker.EXPECT().CheckApplyLock().Return(locking.ApplyCommandLock{}, nil)
 
 	workingDirLocker := NewMockWorkingDirLocker()
-	When(workingDirLocker.TryLock(Any[string](), Any[int](), Any[string](), Any[string](), Any[string](), Any[command.Name]())).
+	When(workingDirLocker.TryLock(Any[string](), Any[int](), Any[string](), Any[string](), Any[string](), Any[command.Name](), Any[events.WorkingDirLockMetadata]())).
 		ThenReturn(func() {}, nil)
 	workingDir := NewMockWorkingDir()
 	When(workingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Any[string]())).
@@ -348,7 +348,7 @@ func TestAPIRemediationExecutor_ExecuteApplyProjectsSeedsPullStatusForDependenci
 	applyLockChecker.EXPECT().CheckApplyLock().Return(locking.ApplyCommandLock{}, nil)
 
 	workingDirLocker := NewMockWorkingDirLocker()
-	When(workingDirLocker.TryLock(Any[string](), Any[int](), Any[string](), Any[string](), Any[string](), Any[command.Name]())).
+	When(workingDirLocker.TryLock(Any[string](), Any[int](), Any[string](), Any[string](), Any[string](), Any[command.Name](), Any[events.WorkingDirLockMetadata]())).
 		ThenReturn(func() {}, nil)
 	workingDir := NewMockWorkingDir()
 	When(workingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Any[string]())).
@@ -491,7 +491,7 @@ func TestAPIRemediationExecutor_ExecuteApplyProjectsFailsOnOmittedDependency(t *
 	applyLockChecker := NewMockApplyLocker(gmockCtrl)
 	applyLockChecker.EXPECT().CheckApplyLock().Return(locking.ApplyCommandLock{}, nil)
 	workingDirLocker := NewMockWorkingDirLocker()
-	When(workingDirLocker.TryLock(Any[string](), Any[int](), Any[string](), Any[string](), Any[string](), Any[command.Name]())).
+	When(workingDirLocker.TryLock(Any[string](), Any[int](), Any[string](), Any[string](), Any[string](), Any[command.Name](), Any[events.WorkingDirLockMetadata]())).
 		ThenReturn(func() {}, nil)
 	workingDir := NewMockWorkingDir()
 	When(workingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Any[string]())).
@@ -593,7 +593,7 @@ func TestAPIRemediationExecutor_ExecuteApplyProjectsAbortsLaterExecutionGroups(t
 	applyLockChecker.EXPECT().CheckApplyLock().Return(locking.ApplyCommandLock{}, nil)
 
 	workingDirLocker := NewMockWorkingDirLocker()
-	When(workingDirLocker.TryLock(Any[string](), Any[int](), Any[string](), Any[string](), Any[string](), Any[command.Name]())).
+	When(workingDirLocker.TryLock(Any[string](), Any[int](), Any[string](), Any[string](), Any[string](), Any[command.Name](), Any[events.WorkingDirLockMetadata]())).
 		ThenReturn(func() {}, nil)
 	workingDir := NewMockWorkingDir()
 	When(workingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Any[string]())).
@@ -716,7 +716,7 @@ func TestAPIRemediationExecutor_ExecuteApplyProjectsSkipsPRRequirements(t *testi
 	applyLockChecker.EXPECT().CheckApplyLock().Return(locking.ApplyCommandLock{}, nil)
 
 	workingDirLocker := NewMockWorkingDirLocker()
-	When(workingDirLocker.TryLock(Any[string](), Any[int](), Any[string](), Any[string](), Any[string](), Any[command.Name]())).
+	When(workingDirLocker.TryLock(Any[string](), Any[int](), Any[string](), Any[string](), Any[string](), Any[command.Name](), Any[events.WorkingDirLockMetadata]())).
 		ThenReturn(func() {}, nil)
 	workingDir := NewMockWorkingDir()
 	When(workingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Any[string]())).
@@ -879,7 +879,7 @@ func TestAPIRemediationExecutor_ExecuteApplyProjectsRejectsStaleCachedDrift(t *t
 	applyLockChecker.EXPECT().CheckApplyLock().Return(locking.ApplyCommandLock{}, nil)
 
 	workingDirLocker := NewMockWorkingDirLocker()
-	When(workingDirLocker.TryLock(Any[string](), Any[int](), Any[string](), Any[string](), Any[string](), Any[command.Name]())).
+	When(workingDirLocker.TryLock(Any[string](), Any[int](), Any[string](), Any[string](), Any[string](), Any[command.Name](), Any[events.WorkingDirLockMetadata]())).
 		ThenReturn(func() {}, nil)
 	workingDir := NewMockWorkingDir()
 	repoDir, checkedOutCommit := initRemediationGitRepo(t)
@@ -945,7 +945,7 @@ func TestDriftApply_NonPRMutableRefChangedDuringApplyFailsClosed(t *testing.T) {
 	applyLockChecker.EXPECT().CheckApplyLock().Return(locking.ApplyCommandLock{}, nil)
 
 	workingDirLocker := NewMockWorkingDirLocker()
-	When(workingDirLocker.TryLock(Any[string](), Any[int](), Any[string](), Any[string](), Any[string](), Any[command.Name]())).
+	When(workingDirLocker.TryLock(Any[string](), Any[int](), Any[string](), Any[string](), Any[string](), Any[command.Name](), Any[events.WorkingDirLockMetadata]())).
 		ThenReturn(func() {}, nil)
 	workingDir := NewMockWorkingDir()
 	repoDir, mainCommit, _, _ := initReachabilityGitRepo(t)
@@ -1047,7 +1047,7 @@ func TestDriftApply_NonPRReleaseBranchChangedNoProjectsFailsClosed(t *testing.T)
 	applyLockChecker := NewMockApplyLocker(gmockCtrl)
 	applyLockChecker.EXPECT().CheckApplyLock().Return(locking.ApplyCommandLock{}, nil)
 	workingDirLocker := NewMockWorkingDirLocker()
-	When(workingDirLocker.TryLock(Any[string](), Any[int](), Any[string](), Any[string](), Any[string](), Any[command.Name]())).
+	When(workingDirLocker.TryLock(Any[string](), Any[int](), Any[string](), Any[string](), Any[string](), Any[command.Name](), Any[events.WorkingDirLockMetadata]())).
 		ThenReturn(func() {}, nil)
 	workingDir := NewMockWorkingDir()
 	repoDir, _, _, _ := initReachabilityGitRepo(t)
@@ -1125,7 +1125,7 @@ func TestAPIRemediationExecutor_ExecuteApplyProjectsPolicyFailureSkipsApply(t *t
 	applyLockChecker := NewMockApplyLocker(gmockCtrl)
 	applyLockChecker.EXPECT().CheckApplyLock().Return(locking.ApplyCommandLock{}, nil)
 	workingDirLocker := NewMockWorkingDirLocker()
-	When(workingDirLocker.TryLock(Any[string](), Any[int](), Any[string](), Any[string](), Any[string](), Any[command.Name]())).
+	When(workingDirLocker.TryLock(Any[string](), Any[int](), Any[string](), Any[string](), Any[string](), Any[command.Name](), Any[events.WorkingDirLockMetadata]())).
 		ThenReturn(func() {}, nil)
 	workingDir := NewMockWorkingDir()
 	When(workingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Any[string]())).
@@ -1306,7 +1306,7 @@ func TestAPIRemediationExecutor_ExecutePlanPreservesNamedTargetWorkspace(t *test
 	locker.EXPECT().UnlockByPull(baseRepo.FullName, gomock.Any()).Return(nil, nil).AnyTimes()
 
 	workingDirLocker := NewMockWorkingDirLocker()
-	When(workingDirLocker.TryLock(Any[string](), Any[int](), Any[string](), Any[string](), Any[string](), Any[command.Name]())).
+	When(workingDirLocker.TryLock(Any[string](), Any[int](), Any[string](), Any[string](), Any[string](), Any[command.Name](), Any[events.WorkingDirLockMetadata]())).
 		ThenReturn(func() {}, nil)
 	workingDir := NewMockWorkingDir()
 	When(workingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Any[string]())).

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -131,7 +131,7 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 
 	var unlockPullApply func()
 	if a.workingDirLocker != nil {
-		unlockPullApply, err = a.workingDirLocker.TryLockPull(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, command.Apply)
+		unlockPullApply, err = a.workingDirLocker.TryLockPull(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, command.Apply, WorkingDirLockMetadataForPull(ctx.Pull))
 		if err != nil {
 			ctx.CommandHasErrors = true
 			if statusErr := a.commitStatusUpdater.UpdateCombined(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, cmd.CommandName()); statusErr != nil {

--- a/server/events/apply_command_runner_test.go
+++ b/server/events/apply_command_runner_test.go
@@ -299,7 +299,7 @@ func TestApplyCommandRunner_IgnoredTargetedDirSkipsBeforeApplyLock(t *testing.T)
 func TestApplyCommandRunner_IgnoredTargetedDirSkipsWhenPlanInFlight(t *testing.T) {
 	locker := events.NewDefaultWorkingDirLocker()
 	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
-	unlockPlan, err := locker.TryLockPull(modelPull.BaseRepo.FullName, modelPull.Num, command.Plan)
+	unlockPlan, err := locker.TryLockPull(modelPull.BaseRepo.FullName, modelPull.Num, command.Plan, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 	defer unlockPlan()
 
@@ -323,7 +323,7 @@ func TestApplyCommandRunner_MergeCheckoutIgnoredTargetSkipsBeforeApplyLock(t *te
 func TestApplyCommandRunner_LocalConfigIgnoredTargetSkipsWhenPlanInFlight(t *testing.T) {
 	locker := events.NewDefaultWorkingDirLocker()
 	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
-	unlockPlan, err := locker.TryLockPull(modelPull.BaseRepo.FullName, modelPull.Num, command.Plan)
+	unlockPlan, err := locker.TryLockPull(modelPull.BaseRepo.FullName, modelPull.Num, command.Plan, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 	defer unlockPlan()
 
@@ -432,7 +432,7 @@ func testApplyCommandRunnerTargetedApplyBlocksWhenPlanInFlight(t *testing.T, cmd
 		tc.workingDirLocker = locker
 	})
 	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
-	unlockPlan, err := locker.TryLockPull(modelPull.BaseRepo.FullName, modelPull.Num, command.Plan)
+	unlockPlan, err := locker.TryLockPull(modelPull.BaseRepo.FullName, modelPull.Num, command.Plan, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 	defer unlockPlan()
 

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -779,7 +779,7 @@ func TestRunApply_DoesNotReturnZeroProjectsWhilePlanInFlight(t *testing.T) {
 		tc.SilenceNoProjects = true
 		tc.workingDirLocker = locker
 	})
-	unlock, err := locker.TryLockPull(testdata.GithubRepo.FullName, testdata.Pull.Num, command.Plan)
+	unlock, err := locker.TryLockPull(testdata.GithubRepo.FullName, testdata.Pull.Num, command.Plan, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 	defer unlock()
 

--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -7,6 +7,7 @@ package events
 import (
 	"bytes"
 	"embed"
+	"errors"
 	"fmt"
 	"io/fs"
 	"strings"
@@ -74,6 +75,10 @@ type commonData struct {
 type errData struct {
 	Error           string
 	RenderedContext string
+	HeadCommit      string
+	CommitURL       string
+	JobURL          string
+	MultipleJobs    bool
 	commonData
 }
 
@@ -222,7 +227,7 @@ func (m *MarkdownRenderer) Render(ctx *command.Context, res command.Result, cmd 
 	templates := m.markdownTemplates
 
 	if res.Error != nil {
-		return m.renderTemplateTrimSpace(templates.Lookup("unwrappedErrWithLog"), errData{res.Error.Error(), "", common})
+		return m.renderTemplateTrimSpace(templates.Lookup("unwrappedErrWithLog"), newErrData(res.Error, "", common))
 	}
 	if res.Failure != "" {
 		return m.renderTemplateTrimSpace(templates.Lookup("failureWithLog"), failureData{res.Failure, "", common})
@@ -351,7 +356,7 @@ func (m *MarkdownRenderer) renderProjectResults(ctx *command.Context, results []
 			if m.shouldUseWrappedTmpl(vcsHost, result.Error.Error()) {
 				tmpl = templates.Lookup("wrappedErr")
 			}
-			resultData.Rendered = m.renderTemplateTrimSpace(tmpl, errData{result.Error.Error(), resultData.Rendered, common})
+			resultData.Rendered = m.renderTemplateTrimSpace(tmpl, newErrData(result.Error, resultData.Rendered, common))
 			if common.CommandName == applyCommandTitle {
 				numApplyErrors++
 			}
@@ -428,6 +433,18 @@ func (m *MarkdownRenderer) renderProjectResults(ctx *command.Context, results []
 		return m.renderTemplateTrimSpace(tmpl, applyResultData{resultsTmplData, common, numApplySuccesses, numApplyFailures, numApplyErrors})
 	}
 	return m.renderTemplateTrimSpace(tmpl, resultData{resultsTmplData, common})
+}
+
+func newErrData(err error, renderedContext string, common commonData) errData {
+	data := errData{Error: err.Error(), RenderedContext: renderedContext, commonData: common}
+	var lockErr *workingDirLockError
+	if errors.As(err, &lockErr) {
+		data.HeadCommit = lockErr.metadata.HeadCommit
+		data.CommitURL = lockErr.metadata.CommitURL
+		data.JobURL = lockErr.metadata.JobURL
+		data.MultipleJobs = lockErr.multipleJobs
+	}
+	return data
 }
 
 // shouldUseWrappedTmpl returns true if we should use the wrapped markdown

--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -101,6 +101,132 @@ func TestRenderErr(t *testing.T) {
 	}
 }
 
+func TestRenderWorkingDirLockMetadata(t *testing.T) {
+	const sha = "0123456789abcdef0123456789abcdef01234567"
+	const commitURL = "https://github.com/owner/repo/commit/" + sha
+	const jobURL = "https://atlantis.example.com/jobs/job-id"
+	metadata := events.WorkingDirLockMetadata{HeadCommit: sha, CommitURL: commitURL, JobURL: jobURL}
+	newLockError := func(ownerMetadata events.WorkingDirLockMetadata) error {
+		locker := events.NewDefaultWorkingDirLocker()
+		_, err := locker.TryLock("owner/repo", 1, "default", ".", "project", command.Plan, ownerMetadata)
+		Ok(t, err)
+		_, err = locker.TryLock("owner/repo", 1, "default", ".", "project", command.Apply, events.WorkingDirLockMetadata{})
+		return err
+	}
+	newMultipleJobsLockError := func() error {
+		locker := events.NewDefaultWorkingDirLocker()
+		_, err := locker.TryLockPull("owner/repo", 1, command.Plan, metadata)
+		Ok(t, err)
+		for i, url := range []string{jobURL + "-1", jobURL + "-2"} {
+			_, err = locker.TryLock("owner/repo", 1, "default", ".", fmt.Sprintf("project-%d", i), command.Plan, events.WorkingDirLockMetadata{JobURL: url})
+			Ok(t, err)
+		}
+		_, err = locker.TryLockPull("owner/repo", 1, command.Apply, events.WorkingDirLockMetadata{})
+		return err
+	}
+	newRenderer := func(language string) *events.MarkdownRenderer {
+		return events.NewMarkdownRenderer(false, false, false, false, false, false, "", "atlantis", false, false, i18n.TranslatorConfig{LanguageCode: language})
+	}
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t).WithHistory(),
+		Pull: models.PullRequest{BaseRepo: models.Repo{VCSHost: models.VCSHost{Type: models.Github}}},
+	}
+	ctx.Log.Info("log output")
+
+	t.Run("command error renders links before log", func(t *testing.T) {
+		rendered := newRenderer("en").Render(ctx, command.Result{Error: newLockError(metadata)}, &events.CommentCommand{Name: command.Plan, Verbose: true})
+		commitLink := "- Commit: [" + sha + "](" + commitURL + ")"
+		jobLink := "- Blocking job: [View Atlantis execution](" + jobURL + ")"
+		for _, text := range []string{"```\ncannot run", commitLink + "\n" + jobLink, "<details><summary>Log</summary>"} {
+			if !strings.Contains(rendered, text) {
+				t.Fatalf("expected %q in:\n%s", text, rendered)
+			}
+		}
+		if !(strings.Index(rendered, "```") < strings.Index(rendered, commitLink) && strings.Index(rendered, commitLink) < strings.Index(rendered, jobLink) && strings.Index(rendered, jobLink) < strings.Index(rendered, "<details><summary>Log</summary>")) {
+			t.Fatalf("unexpected command error ordering:\n%s", rendered)
+		}
+	})
+
+	t.Run("link fallbacks are independent", func(t *testing.T) {
+		shaOnly := newRenderer("en").Render(ctx, command.Result{Error: newLockError(events.WorkingDirLockMetadata{HeadCommit: sha})}, &events.CommentCommand{Name: command.Plan})
+		if !strings.Contains(shaOnly, "for commit "+sha) || strings.Contains(shaOnly, "- Commit:") || strings.Contains(shaOnly, "- Blocking job:") {
+			t.Fatalf("unexpected SHA-only fallback:\n%s", shaOnly)
+		}
+		jobOnly := newRenderer("en").Render(ctx, command.Result{Error: newLockError(events.WorkingDirLockMetadata{JobURL: jobURL})}, &events.CommentCommand{Name: command.Plan})
+		if strings.Contains(jobOnly, "- Commit:") || !strings.Contains(jobOnly, "- Blocking job: [View Atlantis execution]("+jobURL+")") {
+			t.Fatalf("unexpected job-only fallback:\n%s", jobOnly)
+		}
+	})
+
+	t.Run("project error renders links before context", func(t *testing.T) {
+		result := command.ProjectResult{
+			RepoRelDir: ".",
+			Workspace:  "default",
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				Error: newLockError(metadata),
+				PlanSuccess: &models.PlanSuccess{
+					TerraformOutput: "rendered context",
+				},
+			},
+		}
+		rendered := newRenderer("en").Render(ctx, command.Result{ProjectResults: []command.ProjectResult{result}}, &events.CommentCommand{Name: command.Plan})
+		if !(strings.Index(rendered, "```\ncannot run") >= 0 && strings.Index(rendered, "- Commit:") > strings.Index(rendered, "```\ncannot run") && strings.Index(rendered, "rendered context") > strings.Index(rendered, "- Blocking job:")) {
+			t.Fatalf("unexpected unwrapped error ordering:\n%s", rendered)
+		}
+	})
+
+	t.Run("wrapped project error keeps context in details and links after", func(t *testing.T) {
+		result := command.ProjectResult{
+			RepoRelDir: ".",
+			Workspace:  "default",
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				Error: fmt.Errorf("%s%w", strings.Repeat("line\n", 13), newLockError(metadata)),
+				PlanSuccess: &models.PlanSuccess{
+					TerraformOutput: "rendered context",
+				},
+			},
+		}
+		rendered := newRenderer("en").Render(ctx, command.Result{ProjectResults: []command.ProjectResult{result}}, &events.CommentCommand{Name: command.Plan})
+		closeDetails := strings.Index(rendered, "</details>")
+		if !(strings.Index(rendered, "rendered context") < closeDetails && closeDetails < strings.Index(rendered, "- Commit:") && strings.Index(rendered, "- Commit:") < strings.Index(rendered, "- Blocking job:")) {
+			t.Fatalf("unexpected wrapped error ordering:\n%s", rendered)
+		}
+	})
+
+	t.Run("Spanish template has the same link structure", func(t *testing.T) {
+		rendered := newRenderer("es").Render(ctx, command.Result{Error: newLockError(metadata)}, &events.CommentCommand{Name: command.Plan})
+		if !strings.Contains(rendered, "- Commit: ["+sha+"]("+commitURL+")") || !strings.Contains(rendered, "- Trabajo bloqueante: [Ver ejecución de Atlantis]("+jobURL+")") {
+			t.Fatalf("expected localized links in:\n%s", rendered)
+		}
+	})
+
+	t.Run("multiple jobs notice is localized and outside error details", func(t *testing.T) {
+		for _, tt := range []struct {
+			language string
+			notice   string
+		}{
+			{language: "en", notice: "- Multiple Atlantis jobs are currently running for this commit."},
+			{language: "es", notice: "- Actualmente se están ejecutando varios trabajos de Atlantis para este commit."},
+		} {
+			t.Run(tt.language, func(t *testing.T) {
+				err := newMultipleJobsLockError()
+				unwrapped := newRenderer(tt.language).Render(ctx, command.Result{Error: err}, &events.CommentCommand{Name: command.Apply})
+				fence := strings.Index(unwrapped, "\n```\n- Commit:")
+				if notice := strings.Index(unwrapped, tt.notice); fence < 0 || notice < fence {
+					t.Fatalf("expected notice below fenced error:\n%s", unwrapped)
+				}
+
+				result := command.ProjectResult{ProjectCommandOutput: command.ProjectCommandOutput{Error: fmt.Errorf("%s%w", strings.Repeat("line\n", 13), err)}}
+				wrapped := newRenderer(tt.language).Render(ctx, command.Result{ProjectResults: []command.ProjectResult{result}}, &events.CommentCommand{Name: command.Apply})
+				details := strings.Index(wrapped, "</details>")
+				if notice := strings.Index(wrapped, tt.notice); details < 0 || notice < details {
+					t.Fatalf("expected notice below wrapped error details:\n%s", wrapped)
+				}
+			})
+		}
+	})
+}
+
 func TestRenderFailure(t *testing.T) {
 	cases := []struct {
 		Description string

--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -118,7 +118,7 @@ func TestRenderWorkingDirLockMetadata(t *testing.T) {
 		_, err := locker.TryLockPull("owner/repo", 1, command.Plan, metadata)
 		Ok(t, err)
 		for i, url := range []string{jobURL + "-1", jobURL + "-2"} {
-			_, err = locker.TryLock("owner/repo", 1, "default", ".", fmt.Sprintf("project-%d", i), command.Plan, events.WorkingDirLockMetadata{JobURL: url})
+			_, err = locker.TryLock("owner/repo", 1, "default", ".", fmt.Sprintf("project-%d", i), command.Plan, events.WorkingDirLockMetadata{HeadCommit: sha, JobURL: url})
 			Ok(t, err)
 		}
 		_, err = locker.TryLockPull("owner/repo", 1, command.Apply, events.WorkingDirLockMetadata{})
@@ -149,7 +149,7 @@ func TestRenderWorkingDirLockMetadata(t *testing.T) {
 
 	t.Run("link fallbacks are independent", func(t *testing.T) {
 		shaOnly := newRenderer("en").Render(ctx, command.Result{Error: newLockError(events.WorkingDirLockMetadata{HeadCommit: sha})}, &events.CommentCommand{Name: command.Plan})
-		if !strings.Contains(shaOnly, "for commit "+sha) || strings.Contains(shaOnly, "- Commit:") || strings.Contains(shaOnly, "- Blocking job:") {
+		if !strings.Contains(shaOnly, "for commit 0123456") || strings.Contains(shaOnly, "for commit "+sha) || strings.Contains(shaOnly, "- Commit:") || strings.Contains(shaOnly, "- Blocking job:") {
 			t.Fatalf("unexpected SHA-only fallback:\n%s", shaOnly)
 		}
 		jobOnly := newRenderer("en").Render(ctx, command.Result{Error: newLockError(events.WorkingDirLockMetadata{JobURL: jobURL})}, &events.CommentCommand{Name: command.Plan})

--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -142,7 +142,7 @@ func TestRenderWorkingDirLockMetadata(t *testing.T) {
 				t.Fatalf("expected %q in:\n%s", text, rendered)
 			}
 		}
-		if !(strings.Index(rendered, "```") < strings.Index(rendered, commitLink) && strings.Index(rendered, commitLink) < strings.Index(rendered, jobLink) && strings.Index(rendered, jobLink) < strings.Index(rendered, "<details><summary>Log</summary>")) {
+		if strings.Index(rendered, "```") >= strings.Index(rendered, commitLink) || strings.Index(rendered, commitLink) >= strings.Index(rendered, jobLink) || strings.Index(rendered, jobLink) >= strings.Index(rendered, "<details><summary>Log</summary>") {
 			t.Fatalf("unexpected command error ordering:\n%s", rendered)
 		}
 	})
@@ -170,7 +170,7 @@ func TestRenderWorkingDirLockMetadata(t *testing.T) {
 			},
 		}
 		rendered := newRenderer("en").Render(ctx, command.Result{ProjectResults: []command.ProjectResult{result}}, &events.CommentCommand{Name: command.Plan})
-		if !(strings.Index(rendered, "```\ncannot run") >= 0 && strings.Index(rendered, "- Commit:") > strings.Index(rendered, "```\ncannot run") && strings.Index(rendered, "rendered context") > strings.Index(rendered, "- Blocking job:")) {
+		if !strings.Contains(rendered, "```\ncannot run") || strings.Index(rendered, "- Commit:") <= strings.Index(rendered, "```\ncannot run") || strings.Index(rendered, "rendered context") <= strings.Index(rendered, "- Blocking job:") {
 			t.Fatalf("unexpected unwrapped error ordering:\n%s", rendered)
 		}
 	})
@@ -188,7 +188,7 @@ func TestRenderWorkingDirLockMetadata(t *testing.T) {
 		}
 		rendered := newRenderer("en").Render(ctx, command.Result{ProjectResults: []command.ProjectResult{result}}, &events.CommentCommand{Name: command.Plan})
 		closeDetails := strings.Index(rendered, "</details>")
-		if !(strings.Index(rendered, "rendered context") < closeDetails && closeDetails < strings.Index(rendered, "- Commit:") && strings.Index(rendered, "- Commit:") < strings.Index(rendered, "- Blocking job:")) {
+		if strings.Index(rendered, "rendered context") >= closeDetails || closeDetails >= strings.Index(rendered, "- Commit:") || strings.Index(rendered, "- Commit:") >= strings.Index(rendered, "- Blocking job:") {
 			t.Fatalf("unexpected wrapped error ordering:\n%s", rendered)
 		}
 	})

--- a/server/events/mocks/mock_working_dir_locker.go
+++ b/server/events/mocks/mock_working_dir_locker.go
@@ -5,6 +5,7 @@ package mocks
 
 import (
 	pegomock "github.com/petergtz/pegomock/v4"
+	events "github.com/runatlantis/atlantis/server/events"
 	command "github.com/runatlantis/atlantis/server/events/command"
 	"reflect"
 	"time"
@@ -40,11 +41,11 @@ func (mock *MockWorkingDirLocker) HasCommandLock(repoFullName string, pullNum in
 	return _ret0
 }
 
-func (mock *MockWorkingDirLocker) TryLock(repoFullName string, pullNum int, workspace string, path string, projectName string, cmdName command.Name) (func(), error) {
+func (mock *MockWorkingDirLocker) TryLock(repoFullName string, pullNum int, workspace string, path string, projectName string, cmdName command.Name, metadata events.WorkingDirLockMetadata) (func(), error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockWorkingDirLocker().")
 	}
-	_params := []pegomock.Param{repoFullName, pullNum, workspace, path, projectName, cmdName}
+	_params := []pegomock.Param{repoFullName, pullNum, workspace, path, projectName, cmdName, metadata}
 	_result := pegomock.GetGenericMockFrom(mock).Invoke("TryLock", _params, []reflect.Type{reflect.TypeOf((*func())(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
 	var _ret0 func()
 	var _ret1 error
@@ -59,11 +60,11 @@ func (mock *MockWorkingDirLocker) TryLock(repoFullName string, pullNum int, work
 	return _ret0, _ret1
 }
 
-func (mock *MockWorkingDirLocker) TryLockPull(repoFullName string, pullNum int, cmdName command.Name) (func(), error) {
+func (mock *MockWorkingDirLocker) TryLockPull(repoFullName string, pullNum int, cmdName command.Name, metadata events.WorkingDirLockMetadata) (func(), error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockWorkingDirLocker().")
 	}
-	_params := []pegomock.Param{repoFullName, pullNum, cmdName}
+	_params := []pegomock.Param{repoFullName, pullNum, cmdName, metadata}
 	_result := pegomock.GetGenericMockFrom(mock).Invoke("TryLockPull", _params, []reflect.Type{reflect.TypeOf((*func())(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
 	var _ret0 func()
 	var _ret1 error
@@ -164,8 +165,8 @@ func (c *MockWorkingDirLocker_HasCommandLock_OngoingVerification) GetAllCaptured
 	return
 }
 
-func (verifier *VerifierMockWorkingDirLocker) TryLock(repoFullName string, pullNum int, workspace string, path string, projectName string, cmdName command.Name) *MockWorkingDirLocker_TryLock_OngoingVerification {
-	_params := []pegomock.Param{repoFullName, pullNum, workspace, path, projectName, cmdName}
+func (verifier *VerifierMockWorkingDirLocker) TryLock(repoFullName string, pullNum int, workspace string, path string, projectName string, cmdName command.Name, metadata events.WorkingDirLockMetadata) *MockWorkingDirLocker_TryLock_OngoingVerification {
+	_params := []pegomock.Param{repoFullName, pullNum, workspace, path, projectName, cmdName, metadata}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "TryLock", _params, verifier.timeout)
 	return &MockWorkingDirLocker_TryLock_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -175,12 +176,12 @@ type MockWorkingDirLocker_TryLock_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockWorkingDirLocker_TryLock_OngoingVerification) GetCapturedArguments() (string, int, string, string, string, command.Name) {
-	repoFullName, pullNum, workspace, path, projectName, cmdName := c.GetAllCapturedArguments()
-	return repoFullName[len(repoFullName)-1], pullNum[len(pullNum)-1], workspace[len(workspace)-1], path[len(path)-1], projectName[len(projectName)-1], cmdName[len(cmdName)-1]
+func (c *MockWorkingDirLocker_TryLock_OngoingVerification) GetCapturedArguments() (string, int, string, string, string, command.Name, events.WorkingDirLockMetadata) {
+	repoFullName, pullNum, workspace, path, projectName, cmdName, metadata := c.GetAllCapturedArguments()
+	return repoFullName[len(repoFullName)-1], pullNum[len(pullNum)-1], workspace[len(workspace)-1], path[len(path)-1], projectName[len(projectName)-1], cmdName[len(cmdName)-1], metadata[len(metadata)-1]
 }
 
-func (c *MockWorkingDirLocker_TryLock_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []int, _param2 []string, _param3 []string, _param4 []string, _param5 []command.Name) {
+func (c *MockWorkingDirLocker_TryLock_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []int, _param2 []string, _param3 []string, _param4 []string, _param5 []command.Name, _param6 []events.WorkingDirLockMetadata) {
 	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(_params) > 0 {
 		if len(_params) > 0 {
@@ -219,12 +220,18 @@ func (c *MockWorkingDirLocker_TryLock_OngoingVerification) GetAllCapturedArgumen
 				_param5[u] = param.(command.Name)
 			}
 		}
+		if len(_params) > 6 {
+			_param6 = make([]events.WorkingDirLockMetadata, len(c.methodInvocations))
+			for u, param := range _params[6] {
+				_param6[u] = param.(events.WorkingDirLockMetadata)
+			}
+		}
 	}
 	return
 }
 
-func (verifier *VerifierMockWorkingDirLocker) TryLockPull(repoFullName string, pullNum int, cmdName command.Name) *MockWorkingDirLocker_TryLockPull_OngoingVerification {
-	_params := []pegomock.Param{repoFullName, pullNum, cmdName}
+func (verifier *VerifierMockWorkingDirLocker) TryLockPull(repoFullName string, pullNum int, cmdName command.Name, metadata events.WorkingDirLockMetadata) *MockWorkingDirLocker_TryLockPull_OngoingVerification {
+	_params := []pegomock.Param{repoFullName, pullNum, cmdName, metadata}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "TryLockPull", _params, verifier.timeout)
 	return &MockWorkingDirLocker_TryLockPull_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -234,12 +241,12 @@ type MockWorkingDirLocker_TryLockPull_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockWorkingDirLocker_TryLockPull_OngoingVerification) GetCapturedArguments() (string, int, command.Name) {
-	repoFullName, pullNum, cmdName := c.GetAllCapturedArguments()
-	return repoFullName[len(repoFullName)-1], pullNum[len(pullNum)-1], cmdName[len(cmdName)-1]
+func (c *MockWorkingDirLocker_TryLockPull_OngoingVerification) GetCapturedArguments() (string, int, command.Name, events.WorkingDirLockMetadata) {
+	repoFullName, pullNum, cmdName, metadata := c.GetAllCapturedArguments()
+	return repoFullName[len(repoFullName)-1], pullNum[len(pullNum)-1], cmdName[len(cmdName)-1], metadata[len(metadata)-1]
 }
 
-func (c *MockWorkingDirLocker_TryLockPull_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []int, _param2 []command.Name) {
+func (c *MockWorkingDirLocker_TryLockPull_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []int, _param2 []command.Name, _param3 []events.WorkingDirLockMetadata) {
 	_params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(_params) > 0 {
 		if len(_params) > 0 {
@@ -258,6 +265,12 @@ func (c *MockWorkingDirLocker_TryLockPull_OngoingVerification) GetAllCapturedArg
 			_param2 = make([]command.Name, len(c.methodInvocations))
 			for u, param := range _params[2] {
 				_param2[u] = param.(command.Name)
+			}
+		}
+		if len(_params) > 3 {
+			_param3 = make([]events.WorkingDirLockMetadata, len(c.methodInvocations))
+			for u, param := range _params[3] {
+				_param3[u] = param.(events.WorkingDirLockMetadata)
 			}
 		}
 	}

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -395,7 +395,7 @@ func (p *PlanCommandRunner) lockPullForPlan(ctx *command.Context, cmd PullComman
 	if p.workingDirLocker == nil {
 		return func() {}, true
 	}
-	unlockFn, err := p.workingDirLocker.TryLockPull(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, command.Plan)
+	unlockFn, err := p.workingDirLocker.TryLockPull(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, command.Plan, WorkingDirLockMetadataForPull(ctx.Pull))
 	if err != nil {
 		p.handleNoProjectPlanStateError(ctx, cmd, err)
 		return nil, false
@@ -509,7 +509,7 @@ func (p *PlanCommandRunner) deletePlansWithPostDelete(ctx *command.Context, post
 		}
 	}()
 	for _, plan := range plans {
-		unlockFn, err := p.workingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, plan.Workspace, plan.RepoRelDir, plan.ProjectName, command.Plan)
+		unlockFn, err := p.workingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, plan.Workspace, plan.RepoRelDir, plan.ProjectName, command.Plan, WorkingDirLockMetadataForPull(ctx.Pull))
 		if err != nil {
 			return nil, fmt.Errorf("locking pending plan for dir %q workspace %q project %q before deleting: %w", plan.RepoRelDir, plan.Workspace, plan.ProjectName, err)
 		}

--- a/server/events/post_workflow_hooks_command_runner.go
+++ b/server/events/post_workflow_hooks_command_runner.go
@@ -55,7 +55,7 @@ func (w *DefaultPostWorkflowHooksCommandRunner) RunPostHooks(ctx *command.Contex
 
 	ctx.Log.Info("Post-workflow hooks configured, running...")
 
-	unlockFn, err := w.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, DefaultWorkspace, DefaultRepoRelDir, "", cmd.Name)
+	unlockFn, err := w.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, DefaultWorkspace, DefaultRepoRelDir, "", cmd.Name, WorkingDirLockMetadataForPull(ctx.Pull))
 	if err != nil {
 		return err
 	}

--- a/server/events/post_workflow_hooks_command_runner_test.go
+++ b/server/events/post_workflow_hooks_command_runner_test.go
@@ -169,7 +169,7 @@ func TestRunPostHooks_Clone(t *testing.T) {
 		postWh.GlobalCfg = globalCfg
 
 		When(postWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-			events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(unlockFn, nil)
+			events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(unlockFn, nil)
 		When(postWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))).ThenReturn(repoDir, nil)
 		When(whPostWorkflowHookRunner.Run(Any[models.WorkflowHookCommandContext](), Eq(testHook.RunCommand), Any[string](),
@@ -210,7 +210,7 @@ func TestRunPostHooks_Clone(t *testing.T) {
 		expectedCtx.HookDescription = "Post workflow hook #0"
 
 		When(postWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-			events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(unlockFn, nil)
+			events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(unlockFn, nil)
 		When(postWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))).ThenReturn(repoDir, nil)
 		When(whPostWorkflowHookRunner.Run(
@@ -260,7 +260,7 @@ func TestRunPostHooks_Clone(t *testing.T) {
 
 		whPostWorkflowHookRunner.VerifyWasCalled(Never()).Run(Any[models.WorkflowHookCommandContext](),
 			Eq(testHook.RunCommand), Eq(defaultShell), Eq(defaultShellArgs), Eq(repoDir))
-		postWhWorkingDirLocker.VerifyWasCalled(Never()).TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace, "path", "", command.Plan)
+		postWhWorkingDirLocker.VerifyWasCalled(Never()).TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace, "path", "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))
 		postWhWorkingDir.VerifyWasCalled(Never()).Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))
 	})
@@ -281,7 +281,7 @@ func TestRunPostHooks_Clone(t *testing.T) {
 		postWh.GlobalCfg = globalCfg
 
 		When(postWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-			events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(func() {}, errors.New("some error"))
+			events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(func() {}, errors.New("some error"))
 
 		err := postWh.RunPostHooks(ctx, planCmd)
 
@@ -314,7 +314,7 @@ func TestRunPostHooks_Clone(t *testing.T) {
 		postWh.GlobalCfg = globalCfg
 
 		When(postWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-			events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(unlockFn, nil)
+			events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(unlockFn, nil)
 		When(postWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))).ThenReturn(repoDir, errors.New("some error"))
 
@@ -349,7 +349,7 @@ func TestRunPostHooks_Clone(t *testing.T) {
 		postWh.GlobalCfg = globalCfg
 
 		When(postWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-			events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(unlockFn, nil)
+			events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(unlockFn, nil)
 		When(postWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))).ThenReturn(repoDir, nil)
 		When(whPostWorkflowHookRunner.Run(Any[models.WorkflowHookCommandContext](), Eq(testHook.RunCommand),
@@ -394,7 +394,7 @@ func TestRunPostHooks_Clone(t *testing.T) {
 		expectedCtx.ProjectName = "*"
 
 		When(postWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-			events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(unlockFn, nil)
+			events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(unlockFn, nil)
 		When(postWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))).ThenReturn(repoDir, nil)
 		When(whPostWorkflowHookRunner.Run(
@@ -439,7 +439,7 @@ func TestRunPostHooks_Clone(t *testing.T) {
 		postWh.GlobalCfg = globalCfg
 
 		When(postWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-			events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(unlockFn, nil)
+			events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(unlockFn, nil)
 		When(postWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))).ThenReturn(repoDir, nil)
 		When(whPostWorkflowHookRunner.Run(Any[models.WorkflowHookCommandContext](), Eq(testHookWithShell.RunCommand),
@@ -475,7 +475,7 @@ func TestRunPostHooks_Clone(t *testing.T) {
 		postWh.GlobalCfg = globalCfg
 
 		When(postWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-			events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(unlockFn, nil)
+			events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(unlockFn, nil)
 		When(postWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))).ThenReturn(repoDir, nil)
 		When(whPostWorkflowHookRunner.Run(Any[models.WorkflowHookCommandContext](), Eq(testHook.RunCommand),
@@ -511,7 +511,7 @@ func TestRunPostHooks_Clone(t *testing.T) {
 		postWh.GlobalCfg = globalCfg
 
 		When(postWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-			events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(unlockFn, nil)
+			events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(unlockFn, nil)
 		When(postWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))).ThenReturn(repoDir, nil)
 		When(whPostWorkflowHookRunner.Run(Any[models.WorkflowHookCommandContext](), Eq(testHookWithShellandShellArgs.RunCommand),
@@ -548,7 +548,7 @@ func TestRunPostHooks_Clone(t *testing.T) {
 		preWh.GlobalCfg = globalCfg
 
 		When(preWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-			events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(unlockFn, nil)
+			events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(unlockFn, nil)
 		When(preWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))).ThenReturn(repoDir, nil)
 		When(whPreWorkflowHookRunner.Run(Any[models.WorkflowHookCommandContext](),
@@ -584,7 +584,7 @@ func TestRunPostHooks_Clone(t *testing.T) {
 		preWh.GlobalCfg = globalCfg
 
 		When(preWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-			events.DefaultRepoRelDir, "", command.Apply)).ThenReturn(unlockFn, nil)
+			events.DefaultRepoRelDir, "", command.Apply, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(unlockFn, nil)
 		When(preWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))).ThenReturn(repoDir, nil)
 		When(whPreWorkflowHookRunner.Run(Any[models.WorkflowHookCommandContext](), Eq(testHookWithPlanCommand.RunCommand),
@@ -620,7 +620,7 @@ func TestRunPostHooks_Clone(t *testing.T) {
 		preWh.GlobalCfg = globalCfg
 
 		When(preWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-			events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(unlockFn, nil)
+			events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(unlockFn, nil)
 		When(preWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))).ThenReturn(repoDir, nil)
 		When(whPreWorkflowHookRunner.Run(Any[models.WorkflowHookCommandContext](), Eq(testHookWithPlanApplyCommands.RunCommand),
@@ -664,7 +664,7 @@ func TestRunPostHooksSuppressesVCSStatus(t *testing.T) {
 				PostWorkflowHooks: []*valid.WorkflowHook{&hook},
 			}}}
 			When(postWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-				events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(func() {}, nil)
+				events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(func() {}, nil)
 			When(postWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 				Eq(events.DefaultWorkspace))).ThenReturn(repoDir, nil)
 			var capturedHookCtx models.WorkflowHookCommandContext

--- a/server/events/pre_workflow_hooks_command_runner.go
+++ b/server/events/pre_workflow_hooks_command_runner.go
@@ -54,7 +54,7 @@ func (w *DefaultPreWorkflowHooksCommandRunner) RunPreHooks(ctx *command.Context,
 
 	ctx.Log.Info("Pre-workflow hooks configured, running...")
 
-	unlockFn, err := w.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, DefaultWorkspace, DefaultRepoRelDir, "", cmd.Name)
+	unlockFn, err := w.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, DefaultWorkspace, DefaultRepoRelDir, "", cmd.Name, WorkingDirLockMetadataForPull(ctx.Pull))
 	if err != nil {
 		return err
 	}

--- a/server/events/pre_workflow_hooks_command_runner_test.go
+++ b/server/events/pre_workflow_hooks_command_runner_test.go
@@ -146,7 +146,7 @@ func TestRunPreHooks_Clone(t *testing.T) {
 		preWh.GlobalCfg = globalCfg
 
 		When(preWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-			events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(unlockFn, nil)
+			events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(unlockFn, nil)
 		When(preWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))).ThenReturn(repoDir, nil)
 		When(whPreWorkflowHookRunner.Run(Any[models.WorkflowHookCommandContext](), Eq(testHook.RunCommand),
@@ -187,7 +187,7 @@ func TestRunPreHooks_Clone(t *testing.T) {
 
 		whPreWorkflowHookRunner.VerifyWasCalled(Never()).Run(Any[models.WorkflowHookCommandContext](), Eq(testHook.RunCommand),
 			Eq(defaultShell), Eq(defaultShellArgs), Eq(repoDir))
-		preWhWorkingDirLocker.VerifyWasCalled(Never()).TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace, "", "", command.Plan)
+		preWhWorkingDirLocker.VerifyWasCalled(Never()).TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace, "", "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))
 		preWhWorkingDir.VerifyWasCalled(Never()).Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))
 	})
@@ -209,7 +209,7 @@ func TestRunPreHooks_Clone(t *testing.T) {
 		preWh.GlobalCfg = globalCfg
 
 		When(preWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-			events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(func() {}, errors.New("some error"))
+			events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(func() {}, errors.New("some error"))
 
 		err := preWh.RunPreHooks(ctx, planCmd)
 
@@ -242,7 +242,7 @@ func TestRunPreHooks_Clone(t *testing.T) {
 		preWh.GlobalCfg = globalCfg
 
 		When(preWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-			events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(unlockFn, nil)
+			events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(unlockFn, nil)
 		When(preWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))).ThenReturn(repoDir, errors.New("some error"))
 
@@ -277,7 +277,7 @@ func TestRunPreHooks_Clone(t *testing.T) {
 		preWh.GlobalCfg = globalCfg
 
 		When(preWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-			events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(unlockFn, nil)
+			events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(unlockFn, nil)
 		When(preWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))).ThenReturn(repoDir, nil)
 		When(whPreWorkflowHookRunner.Run(Any[models.WorkflowHookCommandContext](), Eq(testHook.RunCommand),
@@ -323,7 +323,7 @@ func TestRunPreHooks_Clone(t *testing.T) {
 		preWh.GlobalCfg = globalCfg
 
 		When(preWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-			events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(unlockFn, nil)
+			events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(unlockFn, nil)
 		When(preWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))).ThenReturn(repoDir, nil)
 		When(whPreWorkflowHookRunner.Run(
@@ -368,7 +368,7 @@ func TestRunPreHooks_Clone(t *testing.T) {
 		preWh.GlobalCfg = globalCfg
 
 		When(preWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-			events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(unlockFn, nil)
+			events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(unlockFn, nil)
 		When(preWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))).ThenReturn(repoDir, nil)
 		When(whPreWorkflowHookRunner.Run(Any[models.WorkflowHookCommandContext](), Eq(testHookWithShell.RunCommand),
@@ -404,7 +404,7 @@ func TestRunPreHooks_Clone(t *testing.T) {
 		preWh.GlobalCfg = globalCfg
 
 		When(preWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-			events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(unlockFn, nil)
+			events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(unlockFn, nil)
 		When(preWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))).ThenReturn(repoDir, nil)
 		When(whPreWorkflowHookRunner.Run(Any[models.WorkflowHookCommandContext](), Eq(testHook.RunCommand),
@@ -440,7 +440,7 @@ func TestRunPreHooks_Clone(t *testing.T) {
 		preWh.GlobalCfg = globalCfg
 
 		When(preWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-			events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(unlockFn, nil)
+			events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(unlockFn, nil)
 		When(preWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))).ThenReturn(repoDir, nil)
 		When(whPreWorkflowHookRunner.Run(Any[models.WorkflowHookCommandContext](), Eq(testHookWithShellandShellArgs.RunCommand),
@@ -477,7 +477,7 @@ func TestRunPreHooks_Clone(t *testing.T) {
 		preWh.GlobalCfg = globalCfg
 
 		When(preWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-			events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(unlockFn, nil)
+			events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(unlockFn, nil)
 		When(preWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))).ThenReturn(repoDir, nil)
 		When(whPreWorkflowHookRunner.Run(Any[models.WorkflowHookCommandContext](), Eq(testHookWithPlanCommand.RunCommand),
@@ -513,7 +513,7 @@ func TestRunPreHooks_Clone(t *testing.T) {
 		preWh.GlobalCfg = globalCfg
 
 		When(preWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-			events.DefaultRepoRelDir, "", command.Apply)).ThenReturn(unlockFn, nil)
+			events.DefaultRepoRelDir, "", command.Apply, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(unlockFn, nil)
 		When(preWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))).ThenReturn(repoDir, nil)
 		When(whPreWorkflowHookRunner.Run(Any[models.WorkflowHookCommandContext](), Eq(testHookWithPlanCommand.RunCommand),
@@ -549,7 +549,7 @@ func TestRunPreHooks_Clone(t *testing.T) {
 		preWh.GlobalCfg = globalCfg
 
 		When(preWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-			events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(unlockFn, nil)
+			events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(unlockFn, nil)
 		When(preWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 			Eq(events.DefaultWorkspace))).ThenReturn(repoDir, nil)
 		When(whPreWorkflowHookRunner.Run(Any[models.WorkflowHookCommandContext](), Eq(testHookWithPlanApplyCommands.RunCommand),
@@ -593,7 +593,7 @@ func TestRunPreHooksSuppressesVCSStatus(t *testing.T) {
 				PreWorkflowHooks: []*valid.WorkflowHook{&hook},
 			}}}
 			When(preWhWorkingDirLocker.TryLock(testdata.GithubRepo.FullName, newPull.Num, events.DefaultWorkspace,
-				events.DefaultRepoRelDir, "", command.Plan)).ThenReturn(func() {}, nil)
+				events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadataForPull(newPull))).ThenReturn(func() {}, nil)
 			When(preWhWorkingDir.Clone(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(newPull),
 				Eq(events.DefaultWorkspace))).ThenReturn(repoDir, nil)
 			var capturedHookCtx models.WorkflowHookCommandContext

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -781,7 +781,7 @@ func (p *DefaultProjectCommandBuilder) discoverAllProjectDirs(ctx *command.Conte
 func (p *DefaultProjectCommandBuilder) buildAllProjectsByCfg(ctx *command.Context, cmdName command.Name, subCmdName string, commentFlags []string, verbose bool) ([]command.ProjectContext, error) {
 	workspace := DefaultWorkspace
 
-	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, workspace, DefaultRepoRelDir, "", cmdName)
+	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, workspace, DefaultRepoRelDir, "", cmdName, WorkingDirLockMetadataForPull(ctx.Pull))
 	if err != nil {
 		ctx.Log.Warn("workspace was locked")
 		return nil, err
@@ -872,7 +872,7 @@ func (p *DefaultProjectCommandBuilder) buildAllCommandsByCfg(ctx *command.Contex
 	// Need to lock the workspace we're about to clone to.
 	workspace := DefaultWorkspace
 
-	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, workspace, DefaultRepoRelDir, "", cmdName)
+	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, workspace, DefaultRepoRelDir, "", cmdName, WorkingDirLockMetadataForPull(ctx.Pull))
 	if err != nil {
 		ctx.Log.Warn("workspace was locked")
 		return nil, err
@@ -960,7 +960,7 @@ func (p *DefaultProjectCommandBuilder) buildProjectPlanCommand(ctx *command.Cont
 	var pcc []command.ProjectContext
 
 	ctx.Log.Debug("building plan command")
-	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, workspace, DefaultRepoRelDir, cmd.ProjectName, cmd.Name)
+	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, workspace, DefaultRepoRelDir, cmd.ProjectName, cmd.Name, WorkingDirLockMetadataForPull(ctx.Pull))
 	if err != nil {
 		return pcc, err
 	}
@@ -1297,7 +1297,7 @@ func (p *DefaultProjectCommandBuilder) buildAllProjectCommandsByPlan(ctx *comman
 	var cmds []command.ProjectContext
 	for _, plan := range plans {
 		// Lock all the directories we need to run the command in
-		unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, plan.Workspace, plan.RepoRelDir, plan.ProjectName, commentCmd.Name)
+		unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, plan.Workspace, plan.RepoRelDir, plan.ProjectName, commentCmd.Name, WorkingDirLockMetadataForPull(ctx.Pull))
 		if err != nil {
 			return nil, err
 		}
@@ -1573,7 +1573,7 @@ func (p *DefaultProjectCommandBuilder) buildProjectCommand(ctx *command.Context,
 		return projCtx, ErrIgnoredTargetedDir
 	}
 
-	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, workspace, DefaultRepoRelDir, cmd.ProjectName, cmd.Name)
+	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, workspace, DefaultRepoRelDir, cmd.ProjectName, cmd.Name, WorkingDirLockMetadataForPull(ctx.Pull))
 	if err != nil {
 		return projCtx, err
 	}

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -2266,7 +2266,7 @@ autodiscover:
 	terraformClient := tfclientmocks.NewMockClient()
 	userConfig := defaultUserConfig
 	locker := events.NewDefaultWorkingDirLocker()
-	unlockPlan, err := locker.TryLock(repo.FullName, pull.Num, events.DefaultWorkspace, events.DefaultRepoRelDir, "", command.Plan)
+	unlockPlan, err := locker.TryLock(repo.FullName, pull.Num, events.DefaultWorkspace, events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 	defer unlockPlan()
 
@@ -2350,7 +2350,7 @@ func TestDefaultProjectCommandBuilder_BuildTargetedApply_MergeCheckoutIgnoredTar
 	terraformClient := tfclientmocks.NewMockClient()
 	userConfig := defaultUserConfig
 	locker := events.NewDefaultWorkingDirLocker()
-	unlockPlan, err := locker.TryLock(repo.FullName, pull.Num, events.DefaultWorkspace, events.DefaultRepoRelDir, "", command.Plan)
+	unlockPlan, err := locker.TryLock(repo.FullName, pull.Num, events.DefaultWorkspace, events.DefaultRepoRelDir, "", command.Plan, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 	defer unlockPlan()
 

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -19,6 +19,7 @@ import (
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/events/vcs"
 	"github.com/runatlantis/atlantis/server/events/webhooks"
+	"github.com/runatlantis/atlantis/server/jobs"
 	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/utils"
 )
@@ -339,10 +340,23 @@ type DefaultProjectCommandRunner struct {
 	WorkingDir                WorkingDir
 	Webhooks                  WebhooksSender
 	WorkingDirLocker          WorkingDirLocker
+	ProjectJobURLGenerator    jobs.ProjectJobURLGenerator
 	CommandRequirementHandler CommandRequirementHandler
 	CancellationTracker       CancellationTracker
 	ApplyPlanValidator        ApplyPlanValidator
 	PlanStore                 runtime.PlanStore
+}
+
+func (p *DefaultProjectCommandRunner) workingDirLockMetadata(ctx command.ProjectContext) WorkingDirLockMetadata {
+	if p.ProjectJobURLGenerator == nil {
+		return WorkingDirLockMetadataForProject(ctx, "")
+	}
+	jobURL, err := p.ProjectJobURLGenerator.GenerateProjectJobURL(ctx)
+	if err != nil {
+		ctx.Log.Warn("generating project job URL: %v", err)
+		jobURL = ""
+	}
+	return WorkingDirLockMetadataForProject(ctx, jobURL)
 }
 
 // Plan runs terraform plan for the project described by ctx.
@@ -426,7 +440,7 @@ func (p *DefaultProjectCommandRunner) doApprovePolicies(ctx command.ProjectConte
 	ctx.Log.Debug("acquired lock for project")
 
 	// Acquire internal lock for the directory we're going to operate in.
-	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.ApprovePolicies, WorkingDirLockMetadataForPull(ctx.Pull))
+	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.ApprovePolicies, p.workingDirLockMetadata(ctx))
 	if err != nil {
 		return nil, "", err
 	}
@@ -543,7 +557,7 @@ func (p *DefaultProjectCommandRunner) doPolicyCheck(ctx command.ProjectContext) 
 	// Acquire internal lock for the directory we're going to operate in.
 	// We should refactor this to keep the lock for the duration of plan and policy check since as of now
 	// there is a small gap where we don't have the lock and if we can't get this here, we should just unlock the PR.
-	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.PolicyCheck, WorkingDirLockMetadataForPull(ctx.Pull))
+	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.PolicyCheck, p.workingDirLockMetadata(ctx))
 	if err != nil {
 		return nil, "", err
 	}
@@ -792,7 +806,7 @@ func (p *DefaultProjectCommandRunner) doPlan(ctx command.ProjectContext) (*model
 	ctx.Log.Debug("acquired lock for project")
 
 	// Acquire internal lock for the directory we're going to operate in.
-	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.Plan, WorkingDirLockMetadataForPull(ctx.Pull))
+	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.Plan, p.workingDirLockMetadata(ctx))
 	if err != nil {
 		if unlockErr := lockAttempt.UnlockFn(); unlockErr != nil {
 			ctx.Log.Err("error unlocking state after plan error: %v", unlockErr)
@@ -908,7 +922,7 @@ func (p *DefaultProjectCommandRunner) doApply(ctx command.ProjectContext) (apply
 	ctx.Log.Debug("acquired lock for project")
 
 	// Acquire internal lock for the directory we're going to operate in.
-	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.Apply, WorkingDirLockMetadataForPull(ctx.Pull))
+	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.Apply, p.workingDirLockMetadata(ctx))
 	if err != nil {
 		return "", "", "", err
 	}
@@ -992,7 +1006,7 @@ func (p *DefaultProjectCommandRunner) doVersion(ctx command.ProjectContext) (ver
 	}
 
 	// Acquire internal lock for the directory we're going to operate in.
-	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.Version, WorkingDirLockMetadataForPull(ctx.Pull))
+	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.Version, p.workingDirLockMetadata(ctx))
 	if err != nil {
 		return "", "", err
 	}
@@ -1036,7 +1050,7 @@ func (p *DefaultProjectCommandRunner) doImport(ctx command.ProjectContext) (out 
 	ctx.Log.Debug("acquired lock for project")
 
 	// Acquire internal lock for the directory we're going to operate in.
-	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.Import, WorkingDirLockMetadataForPull(ctx.Pull))
+	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.Import, p.workingDirLockMetadata(ctx))
 	if err != nil {
 		return nil, "", err
 	}
@@ -1080,7 +1094,7 @@ func (p *DefaultProjectCommandRunner) doStateRm(ctx command.ProjectContext) (out
 	ctx.Log.Debug("acquired lock for project")
 
 	// Acquire internal lock for the directory we're going to operate in.
-	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.State, WorkingDirLockMetadataForPull(ctx.Pull))
+	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.State, p.workingDirLockMetadata(ctx))
 	if err != nil {
 		return nil, "", err
 	}

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -426,7 +426,7 @@ func (p *DefaultProjectCommandRunner) doApprovePolicies(ctx command.ProjectConte
 	ctx.Log.Debug("acquired lock for project")
 
 	// Acquire internal lock for the directory we're going to operate in.
-	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.ApprovePolicies)
+	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.ApprovePolicies, WorkingDirLockMetadataForPull(ctx.Pull))
 	if err != nil {
 		return nil, "", err
 	}
@@ -543,7 +543,7 @@ func (p *DefaultProjectCommandRunner) doPolicyCheck(ctx command.ProjectContext) 
 	// Acquire internal lock for the directory we're going to operate in.
 	// We should refactor this to keep the lock for the duration of plan and policy check since as of now
 	// there is a small gap where we don't have the lock and if we can't get this here, we should just unlock the PR.
-	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.PolicyCheck)
+	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.PolicyCheck, WorkingDirLockMetadataForPull(ctx.Pull))
 	if err != nil {
 		return nil, "", err
 	}
@@ -792,7 +792,7 @@ func (p *DefaultProjectCommandRunner) doPlan(ctx command.ProjectContext) (*model
 	ctx.Log.Debug("acquired lock for project")
 
 	// Acquire internal lock for the directory we're going to operate in.
-	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.Plan)
+	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.Plan, WorkingDirLockMetadataForPull(ctx.Pull))
 	if err != nil {
 		if unlockErr := lockAttempt.UnlockFn(); unlockErr != nil {
 			ctx.Log.Err("error unlocking state after plan error: %v", unlockErr)
@@ -908,7 +908,7 @@ func (p *DefaultProjectCommandRunner) doApply(ctx command.ProjectContext) (apply
 	ctx.Log.Debug("acquired lock for project")
 
 	// Acquire internal lock for the directory we're going to operate in.
-	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.Apply)
+	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.Apply, WorkingDirLockMetadataForPull(ctx.Pull))
 	if err != nil {
 		return "", "", "", err
 	}
@@ -992,7 +992,7 @@ func (p *DefaultProjectCommandRunner) doVersion(ctx command.ProjectContext) (ver
 	}
 
 	// Acquire internal lock for the directory we're going to operate in.
-	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.Version)
+	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.Version, WorkingDirLockMetadataForPull(ctx.Pull))
 	if err != nil {
 		return "", "", err
 	}
@@ -1036,7 +1036,7 @@ func (p *DefaultProjectCommandRunner) doImport(ctx command.ProjectContext) (out 
 	ctx.Log.Debug("acquired lock for project")
 
 	// Acquire internal lock for the directory we're going to operate in.
-	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.Import)
+	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.Import, WorkingDirLockMetadataForPull(ctx.Pull))
 	if err != nil {
 		return nil, "", err
 	}
@@ -1080,7 +1080,7 @@ func (p *DefaultProjectCommandRunner) doStateRm(ctx command.ProjectContext) (out
 	ctx.Log.Debug("acquired lock for project")
 
 	// Acquire internal lock for the directory we're going to operate in.
-	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.State)
+	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.State, WorkingDirLockMetadataForPull(ctx.Pull))
 	if err != nil {
 		return nil, "", err
 	}

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -2700,12 +2700,12 @@ func (f fakeLivePullHeadFetcher) GetLivePullIdentity(command.ProjectContext) (mo
 	return models.PullRequest{HeadCommit: f.head, BaseBranch: f.base}, f.err
 }
 
-func (l *trackingWorkingDirLocker) TryLock(string, int, string, string, string, command.Name) (func(), error) {
+func (l *trackingWorkingDirLocker) TryLock(string, int, string, string, string, command.Name, events.WorkingDirLockMetadata) (func(), error) {
 	l.locked = true
 	return func() { l.locked = false }, nil
 }
 
-func (l *trackingWorkingDirLocker) TryLockPull(string, int, command.Name) (func(), error) {
+func (l *trackingWorkingDirLocker) TryLockPull(string, int, command.Name, events.WorkingDirLockMetadata) (func(), error) {
 	l.locked = true
 	return func() { l.locked = false }, nil
 }

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -125,6 +125,60 @@ func TestDefaultProjectCommandRunner_Plan(t *testing.T) {
 	}
 }
 
+func TestDefaultProjectCommandRunner_ProjectLockJobURL(t *testing.T) {
+	const jobURL = "https://atlantis.example.com/jobs/job-id"
+	tests := []struct {
+		name        string
+		generateURL string
+		generateErr error
+		wantJobURL  string
+	}{
+		{name: "generated URL", generateURL: jobURL, wantJobURL: jobURL},
+		{name: "generation failure", generateURL: jobURL, generateErr: errors.New("route unavailable")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RegisterMockTestingT(t)
+			mockWorkingDir := mocks.NewMockWorkingDir()
+			mockVersion := mocks.NewMockStepRunner()
+			mockJobURLGenerator := jobmocks.NewMockProjectJobURLGenerator()
+			workingDirLocker := &trackingWorkingDirLocker{}
+			runner := events.DefaultProjectCommandRunner{
+				VersionStepRunner:      mockVersion,
+				WorkingDir:             mockWorkingDir,
+				WorkingDirLocker:       workingDirLocker,
+				ProjectJobURLGenerator: mockJobURLGenerator,
+			}
+			repoDir := t.TempDir()
+			ctx := command.ProjectContext{
+				Log:         logging.NewNoopLogger(t),
+				Steps:       []valid.Step{{StepName: "version"}},
+				Workspace:   "default",
+				RepoRelDir:  ".",
+				ProjectName: "project",
+				JobID:       "job-id",
+				Pull: models.PullRequest{
+					Num:        1,
+					HeadCommit: "head-sha",
+					BaseRepo:   models.Repo{FullName: "owner/repo"},
+				},
+			}
+			When(mockWorkingDir.GetWorkingDir(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(repoDir, nil)
+			When(mockWorkingDir.GitReadLock(ctx.Pull.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(func() {})
+			When(mockVersion.Run(ctx, nil, repoDir, map[string]string{})).ThenReturn("version", nil)
+			When(mockJobURLGenerator.GenerateProjectJobURL(ctx)).ThenReturn(tt.generateURL, tt.generateErr)
+
+			result := runner.Version(ctx)
+
+			Ok(t, result.Error)
+			Equals(t, "version", result.VersionSuccess)
+			Equals(t, "head-sha", workingDirLocker.metadata.HeadCommit)
+			Equals(t, tt.wantJobURL, workingDirLocker.metadata.JobURL)
+		})
+	}
+}
+
 func TestDefaultProjectCommandRunner_PlanSuppressesCustomRunStepStreaming(t *testing.T) {
 	RegisterMockTestingT(t)
 	mockRun := mocks.NewMockCustomStepRunner()
@@ -2657,7 +2711,8 @@ func TestProjectCommandRunner_ApplyValidationFailureDoesNotLaunderStalePlanAsErr
 }
 
 type trackingWorkingDirLocker struct {
-	locked bool
+	locked   bool
+	metadata events.WorkingDirLockMetadata
 }
 
 // restoringPlanStore writes contents to planPath on Load, simulating an
@@ -2700,8 +2755,9 @@ func (f fakeLivePullHeadFetcher) GetLivePullIdentity(command.ProjectContext) (mo
 	return models.PullRequest{HeadCommit: f.head, BaseBranch: f.base}, f.err
 }
 
-func (l *trackingWorkingDirLocker) TryLock(string, int, string, string, string, command.Name, events.WorkingDirLockMetadata) (func(), error) {
+func (l *trackingWorkingDirLocker) TryLock(_ string, _ int, _ string, _ string, _ string, _ command.Name, metadata events.WorkingDirLockMetadata) (func(), error) {
 	l.locked = true
+	l.metadata = metadata
 	return func() { l.locked = false }, nil
 }
 

--- a/server/events/templates/i18n/es/lock_metadata.tmpl
+++ b/server/events/templates/i18n/es/lock_metadata.tmpl
@@ -1,0 +1,14 @@
+{{ define "lockMetadata" -}}
+{{- if or .CommitURL .JobURL .MultipleJobs }}
+
+{{- if .CommitURL }}
+- Commit: [{{ .HeadCommit }}]({{ .CommitURL }})
+{{- end }}
+{{- if .JobURL }}
+- Trabajo bloqueante: [Ver ejecución de Atlantis]({{ .JobURL }})
+{{- end }}
+{{- if .MultipleJobs }}
+- Actualmente se están ejecutando varios trabajos de Atlantis para este commit.
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/server/events/templates/i18n/es/unwrapped_err.tmpl
+++ b/server/events/templates/i18n/es/unwrapped_err.tmpl
@@ -3,7 +3,22 @@
 ```
 {{ .Error }}
 ```
+{{- if or .CommitURL .JobURL .MultipleJobs }}
+
+{{- if .CommitURL }}
+- Commit: [{{ .HeadCommit }}]({{ .CommitURL }})
+{{- end }}
+{{- if .JobURL }}
+- Trabajo bloqueante: [Ver ejecución de Atlantis]({{ .JobURL }})
+{{- end }}
+{{- if .MultipleJobs }}
+- Actualmente se están ejecutando varios trabajos de Atlantis para este commit.
+{{- end }}
+{{- end }}
 {{ if ne .RenderedContext "" -}}
+{{ if or .CommitURL .JobURL .MultipleJobs }}
+
+{{ end -}}
 {{ .RenderedContext }}
 {{ end -}}
 {{ end -}}

--- a/server/events/templates/i18n/es/unwrapped_err.tmpl
+++ b/server/events/templates/i18n/es/unwrapped_err.tmpl
@@ -3,18 +3,7 @@
 ```
 {{ .Error }}
 ```
-{{- if or .CommitURL .JobURL .MultipleJobs }}
-
-{{- if .CommitURL }}
-- Commit: [{{ .HeadCommit }}]({{ .CommitURL }})
-{{- end }}
-{{- if .JobURL }}
-- Trabajo bloqueante: [Ver ejecución de Atlantis]({{ .JobURL }})
-{{- end }}
-{{- if .MultipleJobs }}
-- Actualmente se están ejecutando varios trabajos de Atlantis para este commit.
-{{- end }}
-{{- end }}
+{{- template "lockMetadata" . }}
 {{ if ne .RenderedContext "" -}}
 {{ if or .CommitURL .JobURL .MultipleJobs }}
 

--- a/server/events/templates/i18n/es/wrapped_err.tmpl
+++ b/server/events/templates/i18n/es/wrapped_err.tmpl
@@ -9,4 +9,16 @@
 {{ .RenderedContext }}
 {{- end }}
 </details>
+{{- if or .CommitURL .JobURL .MultipleJobs }}
+
+{{- if .CommitURL }}
+- Commit: [{{ .HeadCommit }}]({{ .CommitURL }})
+{{- end }}
+{{- if .JobURL }}
+- Trabajo bloqueante: [Ver ejecución de Atlantis]({{ .JobURL }})
+{{- end }}
+{{- if .MultipleJobs }}
+- Actualmente se están ejecutando varios trabajos de Atlantis para este commit.
+{{- end }}
+{{- end }}
 {{ end -}}

--- a/server/events/templates/i18n/es/wrapped_err.tmpl
+++ b/server/events/templates/i18n/es/wrapped_err.tmpl
@@ -9,16 +9,5 @@
 {{ .RenderedContext }}
 {{- end }}
 </details>
-{{- if or .CommitURL .JobURL .MultipleJobs }}
-
-{{- if .CommitURL }}
-- Commit: [{{ .HeadCommit }}]({{ .CommitURL }})
-{{- end }}
-{{- if .JobURL }}
-- Trabajo bloqueante: [Ver ejecución de Atlantis]({{ .JobURL }})
-{{- end }}
-{{- if .MultipleJobs }}
-- Actualmente se están ejecutando varios trabajos de Atlantis para este commit.
-{{- end }}
-{{- end }}
+{{- template "lockMetadata" . }}
 {{ end -}}

--- a/server/events/templates/lock_metadata.tmpl
+++ b/server/events/templates/lock_metadata.tmpl
@@ -1,0 +1,14 @@
+{{ define "lockMetadata" -}}
+{{- if or .CommitURL .JobURL .MultipleJobs }}
+
+{{- if .CommitURL }}
+- Commit: [{{ .HeadCommit }}]({{ .CommitURL }})
+{{- end }}
+{{- if .JobURL }}
+- Blocking job: [View Atlantis execution]({{ .JobURL }})
+{{- end }}
+{{- if .MultipleJobs }}
+- Multiple Atlantis jobs are currently running for this commit.
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/server/events/templates/unwrapped_err.tmpl
+++ b/server/events/templates/unwrapped_err.tmpl
@@ -3,7 +3,22 @@
 ```
 {{ .Error }}
 ```
+{{- if or .CommitURL .JobURL .MultipleJobs }}
+
+{{- if .CommitURL }}
+- Commit: [{{ .HeadCommit }}]({{ .CommitURL }})
+{{- end }}
+{{- if .JobURL }}
+- Blocking job: [View Atlantis execution]({{ .JobURL }})
+{{- end }}
+{{- if .MultipleJobs }}
+- Multiple Atlantis jobs are currently running for this commit.
+{{- end }}
+{{- end }}
 {{ if ne .RenderedContext "" -}}
+{{ if or .CommitURL .JobURL .MultipleJobs }}
+
+{{ end -}}
 {{ .RenderedContext }}
 {{ end -}}
 {{ end -}}

--- a/server/events/templates/unwrapped_err.tmpl
+++ b/server/events/templates/unwrapped_err.tmpl
@@ -3,18 +3,7 @@
 ```
 {{ .Error }}
 ```
-{{- if or .CommitURL .JobURL .MultipleJobs }}
-
-{{- if .CommitURL }}
-- Commit: [{{ .HeadCommit }}]({{ .CommitURL }})
-{{- end }}
-{{- if .JobURL }}
-- Blocking job: [View Atlantis execution]({{ .JobURL }})
-{{- end }}
-{{- if .MultipleJobs }}
-- Multiple Atlantis jobs are currently running for this commit.
-{{- end }}
-{{- end }}
+{{- template "lockMetadata" . }}
 {{ if ne .RenderedContext "" -}}
 {{ if or .CommitURL .JobURL .MultipleJobs }}
 

--- a/server/events/templates/wrapped_err.tmpl
+++ b/server/events/templates/wrapped_err.tmpl
@@ -9,4 +9,16 @@
 {{ .RenderedContext }}
 {{- end }}
 </details>
+{{- if or .CommitURL .JobURL .MultipleJobs }}
+
+{{- if .CommitURL }}
+- Commit: [{{ .HeadCommit }}]({{ .CommitURL }})
+{{- end }}
+{{- if .JobURL }}
+- Blocking job: [View Atlantis execution]({{ .JobURL }})
+{{- end }}
+{{- if .MultipleJobs }}
+- Multiple Atlantis jobs are currently running for this commit.
+{{- end }}
+{{- end }}
 {{ end -}}

--- a/server/events/templates/wrapped_err.tmpl
+++ b/server/events/templates/wrapped_err.tmpl
@@ -9,16 +9,5 @@
 {{ .RenderedContext }}
 {{- end }}
 </details>
-{{- if or .CommitURL .JobURL .MultipleJobs }}
-
-{{- if .CommitURL }}
-- Commit: [{{ .HeadCommit }}]({{ .CommitURL }})
-{{- end }}
-{{- if .JobURL }}
-- Blocking job: [View Atlantis execution]({{ .JobURL }})
-{{- end }}
-{{- if .MultipleJobs }}
-- Multiple Atlantis jobs are currently running for this commit.
-{{- end }}
-{{- end }}
+{{- template "lockMetadata" . }}
 {{ end -}}

--- a/server/events/working_dir_locker.go
+++ b/server/events/working_dir_locker.go
@@ -6,10 +6,12 @@ package events
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 	"sync"
 
 	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/events/models"
 )
 
 //go:generate go tool pegomock generate --package mocks -o mocks/mock_working_dir_locker.go WorkingDirLocker
@@ -19,15 +21,25 @@ import (
 // this from happening because a specific repo/pull/workspace has a single workspace
 // on disk and we haven't written Atlantis (yet) to handle concurrent execution
 // within this workspace.
+type WorkingDirLockMetadata struct {
+	HeadCommit string
+	CommitURL  string
+}
+
+type workingDirLock struct {
+	Command command.Name
+	WorkingDirLockMetadata
+}
+
 type WorkingDirLocker interface {
 	// TryLockPull tries to acquire a pull-level lock for a command. It is used to
 	// coordinate commands that can make pull-wide plan state inconsistent.
-	TryLockPull(repoFullName string, pullNum int, cmdName command.Name) (func(), error)
+	TryLockPull(repoFullName string, pullNum int, cmdName command.Name, metadata WorkingDirLockMetadata) (func(), error)
 	// TryLock tries to acquire a lock for this repo, pull, workspace, and path.
 	// It returns a function that should be used to unlock the workspace and
 	// an error if the workspace is already locked. The error is expected to
 	// be printed to the pull request.
-	TryLock(repoFullName string, pullNum int, workspace string, path string, projectName string, cmdName command.Name) (func(), error)
+	TryLock(repoFullName string, pullNum int, workspace string, path string, projectName string, cmdName command.Name, metadata WorkingDirLockMetadata) (func(), error)
 	// HasCommandLock reports whether this pull request has an active lock for cmdName.
 	HasCommandLock(repoFullName string, pullNum int, cmdName command.Name) bool
 	// UnlockByPull unlocks all workspaces for a specific pull request
@@ -39,44 +51,44 @@ type DefaultWorkingDirLocker struct {
 	// mutex prevents against multiple threads calling functions on this struct
 	// concurrently. It's only used for entry/exit to each function.
 	mutex sync.Mutex
-	// locks is a map of workspaces showing the name of the command locking it
-	locks map[string]command.Name
+	// locks is a map of workspaces and their owning command metadata.
+	locks map[string]workingDirLock
 }
 
 // NewDefaultWorkingDirLocker is a constructor.
 func NewDefaultWorkingDirLocker() *DefaultWorkingDirLocker {
-	return &DefaultWorkingDirLocker{locks: make(map[string]command.Name)}
+	return &DefaultWorkingDirLocker{locks: make(map[string]workingDirLock)}
 }
 
-func (d *DefaultWorkingDirLocker) TryLock(repoFullName string, pullNum int, workspace string, path string, projectName string, cmdName command.Name) (func(), error) {
+func (d *DefaultWorkingDirLocker) TryLock(repoFullName string, pullNum int, workspace string, path string, projectName string, cmdName command.Name, metadata WorkingDirLockMetadata) (func(), error) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
 	workspaceKey := d.workspaceKey(repoFullName, pullNum, workspace, path, projectName)
 	if currentLock, exists := d.locks[workspaceKey]; exists {
-		return func() {}, fmt.Errorf("cannot run %q: the %s workspace at path %s is currently locked for this pull request by %q.\n"+
-			"Wait until the previous command is complete and try again", cmdName, workspace, path, currentLock)
+		return func() {}, fmt.Errorf("cannot run %q: the %s workspace at path %s is currently locked for this pull request by %q%s.\n"+
+			"Wait until the previous command is complete and try again", cmdName, workspace, path, currentLock.Command, formatCommitSuffix(currentLock))
 	}
-	d.locks[workspaceKey] = cmdName
+	d.locks[workspaceKey] = workingDirLock{Command: cmdName, WorkingDirLockMetadata: metadata}
 	return func() {
 		d.unlock(repoFullName, pullNum, workspace, path, projectName)
 	}, nil
 }
 
-func (d *DefaultWorkingDirLocker) TryLockPull(repoFullName string, pullNum int, cmdName command.Name) (func(), error) {
+func (d *DefaultWorkingDirLocker) TryLockPull(repoFullName string, pullNum int, cmdName command.Name, metadata WorkingDirLockMetadata) (func(), error) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
 	pullKey := d.pullKey(repoFullName, pullNum)
 	if currentLock, exists := d.locks[pullKey]; exists {
-		return func() {}, fmt.Errorf("cannot run %q: pull request %d is currently locked by %q.\n"+
-			"Wait until the previous command is complete and try again", cmdName, pullNum, currentLock)
+		return func() {}, fmt.Errorf("cannot run %q: pull request %d is currently locked by %q%s.\n"+
+			"Wait until the previous command is complete and try again", cmdName, pullNum, currentLock.Command, formatCommitSuffix(currentLock))
 	}
 	if currentLock, exists := d.findCommandLock(repoFullName, pullNum, command.Plan); exists {
-		return func() {}, fmt.Errorf("cannot run %q: pull request %d is currently locked by %q.\n"+
-			"Wait until the previous command is complete and try again", cmdName, pullNum, currentLock)
+		return func() {}, fmt.Errorf("cannot run %q: pull request %d is currently locked by %q%s.\n"+
+			"Wait until the previous command is complete and try again", cmdName, pullNum, currentLock.Command, formatCommitSuffix(currentLock))
 	}
-	d.locks[pullKey] = cmdName
+	d.locks[pullKey] = workingDirLock{Command: cmdName, WorkingDirLockMetadata: metadata}
 	return func() {
 		d.unlockPull(repoFullName, pullNum)
 	}, nil
@@ -90,14 +102,50 @@ func (d *DefaultWorkingDirLocker) HasCommandLock(repoFullName string, pullNum in
 	return exists
 }
 
-func (d *DefaultWorkingDirLocker) findCommandLock(repoFullName string, pullNum int, cmdName command.Name) (command.Name, bool) {
+func (d *DefaultWorkingDirLocker) findCommandLock(repoFullName string, pullNum int, cmdName command.Name) (workingDirLock, bool) {
 	prefix := d.pullLockPrefix(repoFullName, pullNum)
 	for key, currentLock := range d.locks {
-		if strings.HasPrefix(key, prefix) && currentLock == cmdName {
+		if strings.HasPrefix(key, prefix) && currentLock.Command == cmdName {
 			return currentLock, true
 		}
 	}
-	return cmdName, false
+	return workingDirLock{Command: cmdName}, false
+}
+
+func formatCommitSuffix(lock workingDirLock) string {
+	if lock.HeadCommit == "" {
+		return ""
+	}
+	commitRef := lock.HeadCommit
+	if lock.CommitURL != "" {
+		commitRef = fmt.Sprintf("[%s](%s)", lock.HeadCommit, lock.CommitURL)
+	}
+	return " for commit " + commitRef
+}
+
+func WorkingDirLockMetadataForPull(pull models.PullRequest) WorkingDirLockMetadata {
+	metadata := WorkingDirLockMetadata{HeadCommit: pull.HeadCommit}
+	if pull.HeadCommit == "" {
+		return metadata
+	}
+
+	switch pull.BaseRepo.VCSHost.Type {
+	case models.Github, models.Gitlab, models.Gitea:
+		repoURL, err := url.Parse(pull.BaseRepo.CloneURL)
+		if err != nil || (repoURL.Scheme != "http" && repoURL.Scheme != "https") || repoURL.Host == "" {
+			return metadata
+		}
+		repoURL.User = nil
+		repoURL.RawQuery = ""
+		repoURL.Fragment = ""
+		commitPath := "/commit/"
+		if pull.BaseRepo.VCSHost.Type == models.Gitlab {
+			commitPath = "/-/commit/"
+		}
+		repoURL.Path = strings.TrimSuffix(repoURL.Path, ".git") + commitPath + pull.HeadCommit
+		metadata.CommitURL = repoURL.String()
+	}
+	return metadata
 }
 
 // UnlockByPull unlocks all workspaces for a specific pull request

--- a/server/events/working_dir_locker.go
+++ b/server/events/working_dir_locker.go
@@ -132,6 +132,9 @@ func WorkingDirLockMetadataForPull(pull models.PullRequest) WorkingDirLockMetada
 		return metadata
 	}
 
+	// PullRequest has no head repository metadata, so commit links use the base
+	// repository. Fork commits are normally exposed there via the PR ref, though
+	// the link can be unavailable before that ref exists or after it is garbage-collected.
 	switch pull.BaseRepo.VCSHost.Type {
 	case models.Github, models.Gitlab, models.Gitea:
 		repoURL, err := url.Parse(pull.BaseRepo.CloneURL)

--- a/server/events/working_dir_locker.go
+++ b/server/events/working_dir_locker.go
@@ -24,6 +24,17 @@ import (
 type WorkingDirLockMetadata struct {
 	HeadCommit string
 	CommitURL  string
+	JobURL     string
+}
+
+type workingDirLockError struct {
+	message      string
+	metadata     WorkingDirLockMetadata
+	multipleJobs bool
+}
+
+func (e *workingDirLockError) Error() string {
+	return e.message
 }
 
 type workingDirLock struct {
@@ -66,8 +77,11 @@ func (d *DefaultWorkingDirLocker) TryLock(repoFullName string, pullNum int, work
 
 	workspaceKey := d.workspaceKey(repoFullName, pullNum, workspace, path, projectName)
 	if currentLock, exists := d.locks[workspaceKey]; exists {
-		return func() {}, fmt.Errorf("cannot run %q: the %s workspace at path %s is currently locked for this pull request by %q%s.\n"+
-			"Wait until the previous command is complete and try again", cmdName, workspace, path, currentLock.Command, formatCommitSuffix(currentLock))
+		return func() {}, &workingDirLockError{
+			message: fmt.Sprintf("cannot run %q: the %s workspace at path %s is currently locked for this pull request by %q%s.\n"+
+				"Wait until the previous command is complete and try again", cmdName, workspace, path, currentLock.Command, formatCommitSuffix(currentLock)),
+			metadata: currentLock.WorkingDirLockMetadata,
+		}
 	}
 	d.locks[workspaceKey] = workingDirLock{Command: cmdName, WorkingDirLockMetadata: metadata}
 	return func() {
@@ -81,12 +95,10 @@ func (d *DefaultWorkingDirLocker) TryLockPull(repoFullName string, pullNum int, 
 
 	pullKey := d.pullKey(repoFullName, pullNum)
 	if currentLock, exists := d.locks[pullKey]; exists {
-		return func() {}, fmt.Errorf("cannot run %q: pull request %d is currently locked by %q%s.\n"+
-			"Wait until the previous command is complete and try again", cmdName, pullNum, currentLock.Command, formatCommitSuffix(currentLock))
+		return func() {}, d.pullLockError(repoFullName, pullNum, cmdName, currentLock)
 	}
 	if currentLock, exists := d.findCommandLock(repoFullName, pullNum, command.Plan); exists {
-		return func() {}, fmt.Errorf("cannot run %q: pull request %d is currently locked by %q%s.\n"+
-			"Wait until the previous command is complete and try again", cmdName, pullNum, currentLock.Command, formatCommitSuffix(currentLock))
+		return func() {}, d.pullLockError(repoFullName, pullNum, cmdName, currentLock)
 	}
 	d.locks[pullKey] = workingDirLock{Command: cmdName, WorkingDirLockMetadata: metadata}
 	return func() {
@@ -112,18 +124,34 @@ func (d *DefaultWorkingDirLocker) findCommandLock(repoFullName string, pullNum i
 	return workingDirLock{Command: cmdName}, false
 }
 
+func (d *DefaultWorkingDirLocker) pullLockError(repoFullName string, pullNum int, cmdName command.Name, currentLock workingDirLock) error {
+	metadata := currentLock.WorkingDirLockMetadata
+	metadata.JobURL = ""
+	jobURLs := make(map[string]struct{})
+	prefix := d.pullLockPrefix(repoFullName, pullNum)
+	pullKey := d.pullKey(repoFullName, pullNum)
+	for key, lock := range d.locks {
+		if key != pullKey && strings.HasPrefix(key, prefix) && lock.Command == currentLock.Command && lock.JobURL != "" {
+			jobURLs[lock.JobURL] = struct{}{}
+		}
+	}
+
+	multipleJobs := len(jobURLs) > 1
+	if len(jobURLs) == 1 {
+		for jobURL := range jobURLs {
+			metadata.JobURL = jobURL
+		}
+	}
+	message := fmt.Sprintf("cannot run %q: pull request %d is currently locked by %q%s.\n"+
+		"Wait until the previous command is complete and try again", cmdName, pullNum, currentLock.Command, formatCommitSuffix(currentLock))
+	return &workingDirLockError{message: message, metadata: metadata, multipleJobs: multipleJobs}
+}
+
 func formatCommitSuffix(lock workingDirLock) string {
 	if lock.HeadCommit == "" {
 		return ""
 	}
-	// This message is rendered inside a fenced code block in PR comments, so
-	// markdown links would show literally. We emit the plain full SHA and, when
-	// available, the raw commit URL in parentheses so it can be copied and opened.
-	commitRef := lock.HeadCommit
-	if lock.CommitURL != "" {
-		commitRef = fmt.Sprintf("%s (%s)", lock.HeadCommit, lock.CommitURL)
-	}
-	return " for commit " + commitRef
+	return " for commit " + lock.HeadCommit
 }
 
 func WorkingDirLockMetadataForPull(pull models.PullRequest) WorkingDirLockMetadata {
@@ -151,6 +179,12 @@ func WorkingDirLockMetadataForPull(pull models.PullRequest) WorkingDirLockMetada
 		repoURL.Path = strings.TrimSuffix(repoURL.Path, ".git") + commitPath + pull.HeadCommit
 		metadata.CommitURL = repoURL.String()
 	}
+	return metadata
+}
+
+func WorkingDirLockMetadataForProject(ctx command.ProjectContext, jobURL string) WorkingDirLockMetadata {
+	metadata := WorkingDirLockMetadataForPull(ctx.Pull)
+	metadata.JobURL = jobURL
 	return metadata
 }
 

--- a/server/events/working_dir_locker.go
+++ b/server/events/working_dir_locker.go
@@ -116,9 +116,12 @@ func formatCommitSuffix(lock workingDirLock) string {
 	if lock.HeadCommit == "" {
 		return ""
 	}
+	// This message is rendered inside a fenced code block in PR comments, so
+	// markdown links would show literally. We emit the plain full SHA and, when
+	// available, the raw commit URL in parentheses so it can be copied and opened.
 	commitRef := lock.HeadCommit
 	if lock.CommitURL != "" {
-		commitRef = fmt.Sprintf("[%s](%s)", lock.HeadCommit, lock.CommitURL)
+		commitRef = fmt.Sprintf("%s (%s)", lock.HeadCommit, lock.CommitURL)
 	}
 	return " for commit " + commitRef
 }

--- a/server/events/working_dir_locker.go
+++ b/server/events/working_dir_locker.go
@@ -6,7 +6,6 @@ package events
 
 import (
 	"fmt"
-	"net/url"
 	"strings"
 	"sync"
 
@@ -97,7 +96,11 @@ func (d *DefaultWorkingDirLocker) TryLockPull(repoFullName string, pullNum int, 
 	if currentLock, exists := d.locks[pullKey]; exists {
 		return func() {}, d.pullLockError(repoFullName, pullNum, cmdName, currentLock)
 	}
-	if currentLock, exists := d.findCommandLock(repoFullName, pullNum, command.Plan); exists {
+	currentLock, exists := d.findCommandLock(repoFullName, pullNum, command.Plan, metadata.HeadCommit)
+	if !exists && metadata.HeadCommit != "" {
+		currentLock, exists = d.findCommandLock(repoFullName, pullNum, command.Plan, "")
+	}
+	if exists {
 		return func() {}, d.pullLockError(repoFullName, pullNum, cmdName, currentLock)
 	}
 	d.locks[pullKey] = workingDirLock{Command: cmdName, WorkingDirLockMetadata: metadata}
@@ -110,18 +113,21 @@ func (d *DefaultWorkingDirLocker) HasCommandLock(repoFullName string, pullNum in
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	_, exists := d.findCommandLock(repoFullName, pullNum, cmdName)
+	_, exists := d.findCommandLock(repoFullName, pullNum, cmdName, "")
 	return exists
 }
 
-func (d *DefaultWorkingDirLocker) findCommandLock(repoFullName string, pullNum int, cmdName command.Name) (workingDirLock, bool) {
+func (d *DefaultWorkingDirLocker) findCommandLock(repoFullName string, pullNum int, cmdName command.Name, headCommit string) (workingDirLock, bool) {
 	prefix := d.pullLockPrefix(repoFullName, pullNum)
+	var match workingDirLock
+	var matchKey string
 	for key, currentLock := range d.locks {
-		if strings.HasPrefix(key, prefix) && currentLock.Command == cmdName {
-			return currentLock, true
+		if strings.HasPrefix(key, prefix) && currentLock.Command == cmdName && (headCommit == "" || currentLock.HeadCommit == headCommit) && (matchKey == "" || key < matchKey) {
+			match = currentLock
+			matchKey = key
 		}
 	}
-	return workingDirLock{Command: cmdName}, false
+	return match, matchKey != ""
 }
 
 func (d *DefaultWorkingDirLocker) pullLockError(repoFullName string, pullNum int, cmdName command.Name, currentLock workingDirLock) error {
@@ -131,7 +137,7 @@ func (d *DefaultWorkingDirLocker) pullLockError(repoFullName string, pullNum int
 	prefix := d.pullLockPrefix(repoFullName, pullNum)
 	pullKey := d.pullKey(repoFullName, pullNum)
 	for key, lock := range d.locks {
-		if key != pullKey && strings.HasPrefix(key, prefix) && lock.Command == currentLock.Command && lock.JobURL != "" {
+		if key != pullKey && strings.HasPrefix(key, prefix) && lock.Command == currentLock.Command && lock.HeadCommit == currentLock.HeadCommit && lock.JobURL != "" {
 			jobURLs[lock.JobURL] = struct{}{}
 		}
 	}
@@ -151,33 +157,21 @@ func formatCommitSuffix(lock workingDirLock) string {
 	if lock.HeadCommit == "" {
 		return ""
 	}
-	return " for commit " + lock.HeadCommit
+	return " for commit " + shortSHA(lock.HeadCommit)
 }
 
 func WorkingDirLockMetadataForPull(pull models.PullRequest) WorkingDirLockMetadata {
 	metadata := WorkingDirLockMetadata{HeadCommit: pull.HeadCommit}
-	if pull.HeadCommit == "" {
+	if pull.HeadCommit == "" || pull.URL == "" {
 		return metadata
 	}
 
-	// PullRequest has no head repository metadata, so commit links use the base
-	// repository. Fork commits are normally exposed there via the PR ref, though
-	// the link can be unavailable before that ref exists or after it is garbage-collected.
+	pullURL := strings.TrimRight(pull.URL, "/")
 	switch pull.BaseRepo.VCSHost.Type {
-	case models.Github, models.Gitlab, models.Gitea:
-		repoURL, err := url.Parse(pull.BaseRepo.CloneURL)
-		if err != nil || (repoURL.Scheme != "http" && repoURL.Scheme != "https") || repoURL.Host == "" {
-			return metadata
-		}
-		repoURL.User = nil
-		repoURL.RawQuery = ""
-		repoURL.Fragment = ""
-		commitPath := "/commit/"
-		if pull.BaseRepo.VCSHost.Type == models.Gitlab {
-			commitPath = "/-/commit/"
-		}
-		repoURL.Path = strings.TrimSuffix(repoURL.Path, ".git") + commitPath + pull.HeadCommit
-		metadata.CommitURL = repoURL.String()
+	case models.Github, models.Gitea:
+		metadata.CommitURL = pullURL + "/commits/" + pull.HeadCommit
+	case models.Gitlab:
+		metadata.CommitURL = pullURL + "/diffs?commit_id=" + pull.HeadCommit
 	}
 	return metadata
 }

--- a/server/events/working_dir_locker_internal_test.go
+++ b/server/events/working_dir_locker_internal_test.go
@@ -1,0 +1,80 @@
+// Copyright 2017 HootSuite Media Inc.
+// SPDX-License-Identifier: Apache-2.0
+// Modified hereafter by contributors to runatlantis/atlantis.
+
+package events
+
+import (
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/events/models"
+)
+
+func TestWorkingDirLockMetadata(t *testing.T) {
+	const sha = "0123456789abcdef0123456789abcdef01234567"
+	tests := []struct {
+		name     string
+		hostType models.VCSHostType
+		cloneURL string
+		wantURL  string
+	}{
+		{
+			name:     "GitHub strips credentials and git suffix",
+			hostType: models.Github,
+			cloneURL: "https://user:token@github.com/owner/repo.git",
+			wantURL:  "https://github.com/owner/repo/commit/" + sha,
+		},
+		{
+			name:     "GitLab uses canonical commit path and preserves host subpath",
+			hostType: models.Gitlab,
+			cloneURL: "https://gitlab.example.com/gitlab/group/repo.git",
+			wantURL:  "https://gitlab.example.com/gitlab/group/repo/-/commit/" + sha,
+		},
+		{
+			name:     "Gitea",
+			hostType: models.Gitea,
+			cloneURL: "https://gitea.example.com/owner/repo.git",
+			wantURL:  "https://gitea.example.com/owner/repo/commit/" + sha,
+		},
+		{
+			name:     "unsupported provider falls back to SHA",
+			hostType: models.BitbucketCloud,
+			cloneURL: "https://bitbucket.org/owner/repo.git",
+		},
+		{
+			name:     "non-HTTP clone URL falls back to SHA",
+			hostType: models.Github,
+			cloneURL: "git@github.com:owner/repo.git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metadata := WorkingDirLockMetadataForPull(models.PullRequest{
+				HeadCommit: sha,
+				BaseRepo: models.Repo{
+					CloneURL: tt.cloneURL,
+					VCSHost:  models.VCSHost{Type: tt.hostType},
+				},
+			})
+			if metadata.HeadCommit != sha {
+				t.Fatalf("expected head commit %q, got %q", sha, metadata.HeadCommit)
+			}
+			if metadata.CommitURL != tt.wantURL {
+				t.Fatalf("expected commit URL %q, got %q", tt.wantURL, metadata.CommitURL)
+			}
+		})
+	}
+}
+
+func TestWorkingDirLockMetadataWithoutHeadCommit(t *testing.T) {
+	metadata := WorkingDirLockMetadataForPull(models.PullRequest{
+		BaseRepo: models.Repo{
+			CloneURL: "https://github.com/owner/repo.git",
+			VCSHost:  models.VCSHost{Type: models.Github},
+		},
+	})
+	if metadata != (WorkingDirLockMetadata{}) {
+		t.Fatalf("expected empty metadata, got %#v", metadata)
+	}
+}

--- a/server/events/working_dir_locker_internal_test.go
+++ b/server/events/working_dir_locker_internal_test.go
@@ -19,9 +19,9 @@ func TestWorkingDirLockMetadata(t *testing.T) {
 		wantURL  string
 	}{
 		{
-			name:     "GitHub strips credentials and git suffix",
+			name:     "GitHub strips URL-escaped credentials and git suffix",
 			hostType: models.Github,
-			cloneURL: "https://user:token@github.com/owner/repo.git",
+			cloneURL: "https://user:p%40ss%2Fw%3Ford%23@github.com/owner/repo.git",
 			wantURL:  "https://github.com/owner/repo/commit/" + sha,
 		},
 		{

--- a/server/events/working_dir_locker_internal_test.go
+++ b/server/events/working_dir_locker_internal_test.go
@@ -7,6 +7,7 @@ package events
 import (
 	"testing"
 
+	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
 )
 
@@ -76,5 +77,90 @@ func TestWorkingDirLockMetadataWithoutHeadCommit(t *testing.T) {
 	})
 	if metadata != (WorkingDirLockMetadata{}) {
 		t.Fatalf("expected empty metadata, got %#v", metadata)
+	}
+}
+
+func TestWorkingDirLockMetadataForProject(t *testing.T) {
+	ctx := command.ProjectContext{Pull: models.PullRequest{HeadCommit: "sha"}}
+	metadata := WorkingDirLockMetadataForProject(ctx, "https://atlantis.example.com/jobs/job-id")
+	if metadata.HeadCommit != "sha" || metadata.JobURL != "https://atlantis.example.com/jobs/job-id" {
+		t.Fatalf("unexpected metadata: %#v", metadata)
+	}
+}
+
+func TestWorkingDirLockErrorUsesOwnerMetadata(t *testing.T) {
+	locker := NewDefaultWorkingDirLocker()
+	owner := WorkingDirLockMetadata{HeadCommit: "owner-sha", CommitURL: "owner-commit", JobURL: "owner-job"}
+	_, err := locker.TryLock("owner/repo", 1, "default", ".", "project", command.Plan, owner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = locker.TryLock("owner/repo", 1, "default", ".", "project", command.Apply, WorkingDirLockMetadata{HeadCommit: "loser-sha", CommitURL: "loser-commit", JobURL: "loser-job"})
+	lockErr, ok := err.(*workingDirLockError)
+	if !ok {
+		t.Fatalf("expected typed lock error, got %T", err)
+	}
+	if lockErr.metadata != owner {
+		t.Fatalf("expected owner metadata %#v, got %#v", owner, lockErr.metadata)
+	}
+}
+
+func TestTryLockPullUsesBlockingPlanProjectMetadata(t *testing.T) {
+	locker := NewDefaultWorkingDirLocker()
+	owner := WorkingDirLockMetadata{HeadCommit: "owner-sha", CommitURL: "owner-commit", JobURL: "owner-job"}
+	_, err := locker.TryLock("owner/repo", 1, "default", ".", "project", command.Plan, owner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = locker.TryLockPull("owner/repo", 1, command.Apply, WorkingDirLockMetadata{})
+	lockErr, ok := err.(*workingDirLockError)
+	if !ok {
+		t.Fatalf("expected typed lock error, got %T", err)
+	}
+	if lockErr.metadata != owner || lockErr.multipleJobs {
+		t.Fatalf("unexpected lock error: %#v", lockErr)
+	}
+}
+
+func TestTryLockPullSelectsActiveProjectJobs(t *testing.T) {
+	const repo = "owner/repo"
+	const jobURL = "https://atlantis.example.com/jobs/job-id"
+	tests := []struct {
+		name         string
+		jobURLs      []string
+		wantJobURL   string
+		multipleJobs bool
+	}{
+		{name: "zero"},
+		{name: "one", jobURLs: []string{jobURL}, wantJobURL: jobURL},
+		{name: "duplicate URL is one job", jobURLs: []string{jobURL, jobURL}, wantJobURL: jobURL},
+		{name: "multiple", jobURLs: []string{jobURL + "-1", jobURL + "-2"}, multipleJobs: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			locker := NewDefaultWorkingDirLocker()
+			_, err := locker.TryLockPull(repo, 1, command.Plan, WorkingDirLockMetadata{HeadCommit: "owner-sha", JobURL: "pull-job-is-ignored"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			for i, url := range tt.jobURLs {
+				_, err = locker.TryLock(repo, 1, "workspace", ".", []string{"a", "b"}[i], command.Plan, WorkingDirLockMetadata{JobURL: url})
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			_, err = locker.TryLockPull(repo, 1, command.Apply, WorkingDirLockMetadata{JobURL: "loser-job"})
+			lockErr, ok := err.(*workingDirLockError)
+			if !ok {
+				t.Fatalf("expected typed lock error, got %T", err)
+			}
+			if lockErr.metadata.HeadCommit != "owner-sha" || lockErr.metadata.JobURL != tt.wantJobURL || lockErr.multipleJobs != tt.multipleJobs {
+				t.Fatalf("unexpected lock error: %#v", lockErr)
+			}
+			if lockErr.Error() != "cannot run \"apply\": pull request 1 is currently locked by \"plan\" for commit owner-sha.\nWait until the previous command is complete and try again" {
+				t.Fatalf("unexpected lock error message: %s", lockErr)
+			}
+		})
 	}
 }

--- a/server/events/working_dir_locker_internal_test.go
+++ b/server/events/working_dir_locker_internal_test.go
@@ -16,36 +16,35 @@ func TestWorkingDirLockMetadata(t *testing.T) {
 	tests := []struct {
 		name     string
 		hostType models.VCSHostType
-		cloneURL string
+		pullURL  string
 		wantURL  string
 	}{
 		{
-			name:     "GitHub strips URL-escaped credentials and git suffix",
+			name:     "GitHub uses the fork-safe pull commit route",
 			hostType: models.Github,
-			cloneURL: "https://user:p%40ss%2Fw%3Ford%23@github.com/owner/repo.git",
-			wantURL:  "https://github.com/owner/repo/commit/" + sha,
+			pullURL:  "https://github.com/owner/repo/pull/123",
+			wantURL:  "https://github.com/owner/repo/pull/123/commits/" + sha,
 		},
 		{
-			name:     "GitLab uses canonical commit path and preserves host subpath",
+			name:     "GitLab uses the merge request diff route",
 			hostType: models.Gitlab,
-			cloneURL: "https://gitlab.example.com/gitlab/group/repo.git",
-			wantURL:  "https://gitlab.example.com/gitlab/group/repo/-/commit/" + sha,
+			pullURL:  "https://gitlab.example.com/gitlab/group/repo/-/merge_requests/123",
+			wantURL:  "https://gitlab.example.com/gitlab/group/repo/-/merge_requests/123/diffs?commit_id=" + sha,
 		},
 		{
-			name:     "Gitea",
+			name:     "Gitea uses the pull commit route",
 			hostType: models.Gitea,
-			cloneURL: "https://gitea.example.com/owner/repo.git",
-			wantURL:  "https://gitea.example.com/owner/repo/commit/" + sha,
+			pullURL:  "https://gitea.example.com/owner/repo/pulls/123/",
+			wantURL:  "https://gitea.example.com/owner/repo/pulls/123/commits/" + sha,
 		},
 		{
 			name:     "unsupported provider falls back to SHA",
 			hostType: models.BitbucketCloud,
-			cloneURL: "https://bitbucket.org/owner/repo.git",
+			pullURL:  "https://bitbucket.org/owner/repo/pull-requests/123",
 		},
 		{
-			name:     "non-HTTP clone URL falls back to SHA",
+			name:     "missing pull URL falls back to SHA",
 			hostType: models.Github,
-			cloneURL: "git@github.com:owner/repo.git",
 		},
 	}
 
@@ -53,10 +52,8 @@ func TestWorkingDirLockMetadata(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			metadata := WorkingDirLockMetadataForPull(models.PullRequest{
 				HeadCommit: sha,
-				BaseRepo: models.Repo{
-					CloneURL: tt.cloneURL,
-					VCSHost:  models.VCSHost{Type: tt.hostType},
-				},
+				URL:        tt.pullURL,
+				BaseRepo:   models.Repo{VCSHost: models.VCSHost{Type: tt.hostType}},
 			})
 			if metadata.HeadCommit != sha {
 				t.Fatalf("expected head commit %q, got %q", sha, metadata.HeadCommit)
@@ -70,10 +67,8 @@ func TestWorkingDirLockMetadata(t *testing.T) {
 
 func TestWorkingDirLockMetadataWithoutHeadCommit(t *testing.T) {
 	metadata := WorkingDirLockMetadataForPull(models.PullRequest{
-		BaseRepo: models.Repo{
-			CloneURL: "https://github.com/owner/repo.git",
-			VCSHost:  models.VCSHost{Type: models.Github},
-		},
+		URL:      "https://github.com/owner/repo/pull/123",
+		BaseRepo: models.Repo{VCSHost: models.VCSHost{Type: models.Github}},
 	})
 	if metadata != (WorkingDirLockMetadata{}) {
 		t.Fatalf("expected empty metadata, got %#v", metadata)
@@ -122,6 +117,50 @@ func TestTryLockPullUsesBlockingPlanProjectMetadata(t *testing.T) {
 	}
 }
 
+func TestTryLockPullKeepsBlockingCommitMetadataTogether(t *testing.T) {
+	const repo = "owner/repo"
+	locker := NewDefaultWorkingDirLocker()
+	_, err := locker.TryLockPull(repo, 1, command.Plan, WorkingDirLockMetadata{HeadCommit: "old", CommitURL: "old-commit"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, metadata := range []WorkingDirLockMetadata{
+		{HeadCommit: "old", JobURL: "old-job"},
+		{HeadCommit: "new", JobURL: "new-job"},
+	} {
+		_, err = locker.TryLock(repo, 1, "workspace", ".", []string{"old", "new"}[i], command.Plan, metadata)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, err = locker.TryLockPull(repo, 1, command.Apply, WorkingDirLockMetadata{HeadCommit: "new"})
+	lockErr := err.(*workingDirLockError)
+	if lockErr.metadata.HeadCommit != "old" || lockErr.metadata.CommitURL != "old-commit" || lockErr.metadata.JobURL != "old-job" || lockErr.multipleJobs {
+		t.Fatalf("mixed blocking commits: %#v", lockErr)
+	}
+}
+
+func TestTryLockPullFindsPlanForCurrentCommit(t *testing.T) {
+	const repo = "owner/repo"
+	locker := NewDefaultWorkingDirLocker()
+	for i, metadata := range []WorkingDirLockMetadata{
+		{HeadCommit: "old", JobURL: "old-job"},
+		{HeadCommit: "new", JobURL: "new-job"},
+	} {
+		_, err := locker.TryLock(repo, 1, "workspace", ".", []string{"old", "new"}[i], command.Plan, metadata)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, err := locker.TryLockPull(repo, 1, command.Apply, WorkingDirLockMetadata{HeadCommit: "new"})
+	lockErr := err.(*workingDirLockError)
+	if lockErr.metadata.HeadCommit != "new" || lockErr.metadata.JobURL != "new-job" || lockErr.multipleJobs {
+		t.Fatalf("selected wrong blocking commit: %#v", lockErr)
+	}
+}
+
 func TestTryLockPullSelectsActiveProjectJobs(t *testing.T) {
 	const repo = "owner/repo"
 	const jobURL = "https://atlantis.example.com/jobs/job-id"
@@ -145,7 +184,7 @@ func TestTryLockPullSelectsActiveProjectJobs(t *testing.T) {
 				t.Fatal(err)
 			}
 			for i, url := range tt.jobURLs {
-				_, err = locker.TryLock(repo, 1, "workspace", ".", []string{"a", "b"}[i], command.Plan, WorkingDirLockMetadata{JobURL: url})
+				_, err = locker.TryLock(repo, 1, "workspace", ".", []string{"a", "b"}[i], command.Plan, WorkingDirLockMetadata{HeadCommit: "owner-sha", JobURL: url})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -158,7 +197,7 @@ func TestTryLockPullSelectsActiveProjectJobs(t *testing.T) {
 			if lockErr.metadata.HeadCommit != "owner-sha" || lockErr.metadata.JobURL != tt.wantJobURL || lockErr.multipleJobs != tt.multipleJobs {
 				t.Fatalf("unexpected lock error: %#v", lockErr)
 			}
-			if lockErr.Error() != "cannot run \"apply\": pull request 1 is currently locked by \"plan\" for commit owner-sha.\nWait until the previous command is complete and try again" {
+			if lockErr.Error() != "cannot run \"apply\": pull request 1 is currently locked by \"plan\" for commit owner-s.\nWait until the previous command is complete and try again" {
 				t.Fatalf("unexpected lock error message: %s", lockErr)
 			}
 		})

--- a/server/events/working_dir_locker_test.go
+++ b/server/events/working_dir_locker_test.go
@@ -5,6 +5,7 @@
 package events_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/runatlantis/atlantis/server/events"
@@ -46,7 +47,7 @@ func TestTryLockIncludesCommitMetadata(t *testing.T) {
 		want     string
 	}{
 		{name: "sha", metadata: events.WorkingDirLockMetadata{HeadCommit: sha}, want: "by \"plan\" for commit " + sha + "."},
-		{name: "url", metadata: events.WorkingDirLockMetadata{HeadCommit: sha, CommitURL: commitURL}, want: "by \"plan\" for commit " + sha + " (" + commitURL + ")."},
+		{name: "url remains structured", metadata: events.WorkingDirLockMetadata{HeadCommit: sha, CommitURL: commitURL}, want: "by \"plan\" for commit " + sha + "."},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -66,7 +67,8 @@ func TestTryLockPullIncludesCommitMetadata(t *testing.T) {
 	_, err := locker.TryLockPull(repo, 1, command.Plan, events.WorkingDirLockMetadata{HeadCommit: sha, CommitURL: commitURL})
 	Ok(t, err)
 	_, err = locker.TryLockPull(repo, 1, command.Apply, events.WorkingDirLockMetadata{})
-	ErrContains(t, "by \"plan\" for commit "+sha+" ("+commitURL+").", err)
+	ErrContains(t, "by \"plan\" for commit "+sha+".", err)
+	Assert(t, !strings.Contains(err.Error(), commitURL), "expected commit URL to remain out of plain error: %s", err)
 }
 
 func TestTryLockSameCommand(t *testing.T) {

--- a/server/events/working_dir_locker_test.go
+++ b/server/events/working_dir_locker_test.go
@@ -46,7 +46,7 @@ func TestTryLockIncludesCommitMetadata(t *testing.T) {
 		want     string
 	}{
 		{name: "sha", metadata: events.WorkingDirLockMetadata{HeadCommit: sha}, want: "by \"plan\" for commit " + sha + "."},
-		{name: "link", metadata: events.WorkingDirLockMetadata{HeadCommit: sha, CommitURL: commitURL}, want: "by \"plan\" for commit [" + sha + "](" + commitURL + ")."},
+		{name: "url", metadata: events.WorkingDirLockMetadata{HeadCommit: sha, CommitURL: commitURL}, want: "by \"plan\" for commit " + sha + " (" + commitURL + ")."},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -66,7 +66,7 @@ func TestTryLockPullIncludesCommitMetadata(t *testing.T) {
 	_, err := locker.TryLockPull(repo, 1, command.Plan, events.WorkingDirLockMetadata{HeadCommit: sha, CommitURL: commitURL})
 	Ok(t, err)
 	_, err = locker.TryLockPull(repo, 1, command.Apply, events.WorkingDirLockMetadata{})
-	ErrContains(t, "by \"plan\" for commit ["+sha+"]("+commitURL+").", err)
+	ErrContains(t, "by \"plan\" for commit "+sha+" ("+commitURL+").", err)
 }
 
 func TestTryLockSameCommand(t *testing.T) {

--- a/server/events/working_dir_locker_test.go
+++ b/server/events/working_dir_locker_test.go
@@ -22,35 +22,68 @@ func TestTryLock(t *testing.T) {
 	locker := events.NewDefaultWorkingDirLocker()
 
 	// The first lock should succeed.
-	unlockFn, err := locker.TryLock(repo, 1, workspace, path, projectName, cmd)
+	unlockFn, err := locker.TryLock(repo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 
 	// Now another lock for the same repo, workspace, projectName and pull should fail
-	_, err = locker.TryLock(repo, 1, workspace, path, projectName, command.Apply)
+	_, err = locker.TryLock(repo, 1, workspace, path, projectName, command.Apply, events.WorkingDirLockMetadata{})
 	ErrEquals(t, "cannot run \"apply\": the default workspace at path . is currently locked for this pull request by \"plan\".\n"+
 		"Wait until the previous command is complete and try again", err)
 
 	// Unlock should work.
 	unlockFn()
-	_, err = locker.TryLock(repo, 1, workspace, path, projectName, cmd)
+	_, err = locker.TryLock(repo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err)
+}
+
+func TestTryLockIncludesCommitMetadata(t *testing.T) {
+	const sha = "0123456789abcdef0123456789abcdef01234567"
+	const commitURL = "https://github.com/owner/repo/commit/0123456789abcdef0123456789abcdef01234567"
+
+	tests := []struct {
+		name     string
+		metadata events.WorkingDirLockMetadata
+		want     string
+	}{
+		{name: "sha", metadata: events.WorkingDirLockMetadata{HeadCommit: sha}, want: "by \"plan\" for commit " + sha + "."},
+		{name: "link", metadata: events.WorkingDirLockMetadata{HeadCommit: sha, CommitURL: commitURL}, want: "by \"plan\" for commit [" + sha + "](" + commitURL + ")."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			locker := events.NewDefaultWorkingDirLocker()
+			_, err := locker.TryLock(repo, 1, workspace, path, projectName, command.Plan, tt.metadata)
+			Ok(t, err)
+			_, err = locker.TryLock(repo, 1, workspace, path, projectName, command.Apply, events.WorkingDirLockMetadata{})
+			ErrContains(t, tt.want, err)
+		})
+	}
+}
+
+func TestTryLockPullIncludesCommitMetadata(t *testing.T) {
+	const sha = "0123456789abcdef0123456789abcdef01234567"
+	const commitURL = "https://github.com/owner/repo/commit/0123456789abcdef0123456789abcdef01234567"
+	locker := events.NewDefaultWorkingDirLocker()
+	_, err := locker.TryLockPull(repo, 1, command.Plan, events.WorkingDirLockMetadata{HeadCommit: sha, CommitURL: commitURL})
+	Ok(t, err)
+	_, err = locker.TryLockPull(repo, 1, command.Apply, events.WorkingDirLockMetadata{})
+	ErrContains(t, "by \"plan\" for commit ["+sha+"]("+commitURL+").", err)
 }
 
 func TestTryLockSameCommand(t *testing.T) {
 	locker := events.NewDefaultWorkingDirLocker()
 
 	// The first lock should succeed.
-	unlockFn, err := locker.TryLock(repo, 1, workspace, path, projectName, command.Import)
+	unlockFn, err := locker.TryLock(repo, 1, workspace, path, projectName, command.Import, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 
 	// Now another lock for the same repo, workspace, projectName and pull should fail
-	_, err = locker.TryLock(repo, 1, workspace, path, projectName, command.Import)
+	_, err = locker.TryLock(repo, 1, workspace, path, projectName, command.Import, events.WorkingDirLockMetadata{})
 	ErrEquals(t, "cannot run \"import\": the default workspace at path . is currently locked for this pull request by \"import\".\n"+
 		"Wait until the previous command is complete and try again", err)
 
 	// Unlock should work.
 	unlockFn()
-	_, err = locker.TryLock(repo, 1, workspace, path, projectName, cmd)
+	_, err = locker.TryLock(repo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 }
 
@@ -58,15 +91,15 @@ func TestTryLockDifferentWorkspaces(t *testing.T) {
 	locker := events.NewDefaultWorkingDirLocker()
 
 	t.Log("a lock for the same repo and pull but different workspace should succeed")
-	_, err := locker.TryLock(repo, 1, workspace, path, projectName, cmd)
+	_, err := locker.TryLock(repo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err)
-	_, err = locker.TryLock(repo, 1, "new-workspace", path, projectName, cmd)
+	_, err = locker.TryLock(repo, 1, "new-workspace", path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 
 	t.Log("and both should now be locked")
-	_, err = locker.TryLock(repo, 1, workspace, path, projectName, cmd)
+	_, err = locker.TryLock(repo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Assert(t, err != nil, "exp err")
-	_, err = locker.TryLock(repo, 1, "new-workspace", path, projectName, cmd)
+	_, err = locker.TryLock(repo, 1, "new-workspace", path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Assert(t, err != nil, "exp err")
 }
 
@@ -74,16 +107,16 @@ func TestTryLockDifferentRepo(t *testing.T) {
 	locker := events.NewDefaultWorkingDirLocker()
 
 	t.Log("a lock for a different repo but the same workspace and pull should succeed")
-	_, err := locker.TryLock(repo, 1, workspace, path, projectName, cmd)
+	_, err := locker.TryLock(repo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 	newRepo := "owner/newrepo"
-	_, err = locker.TryLock(newRepo, 1, workspace, path, projectName, cmd)
+	_, err = locker.TryLock(newRepo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 
 	t.Log("and both should now be locked")
-	_, err = locker.TryLock(repo, 1, workspace, path, projectName, cmd)
+	_, err = locker.TryLock(repo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	ErrContains(t, "currently locked", err)
-	_, err = locker.TryLock(newRepo, 1, workspace, path, projectName, cmd)
+	_, err = locker.TryLock(newRepo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	ErrContains(t, "currently locked", err)
 }
 
@@ -91,16 +124,16 @@ func TestTryLockDifferentPulls(t *testing.T) {
 	locker := events.NewDefaultWorkingDirLocker()
 
 	t.Log("a lock for a different pull but the same repo, workspace, projectName should succeed")
-	_, err := locker.TryLock(repo, 1, workspace, path, projectName, cmd)
+	_, err := locker.TryLock(repo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 	newPull := 2
-	_, err = locker.TryLock(repo, newPull, workspace, path, projectName, cmd)
+	_, err = locker.TryLock(repo, newPull, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 
 	t.Log("and both should now be locked")
-	_, err = locker.TryLock(repo, 1, workspace, path, projectName, cmd)
+	_, err = locker.TryLock(repo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	ErrContains(t, "currently locked", err)
-	_, err = locker.TryLock(repo, newPull, workspace, path, projectName, cmd)
+	_, err = locker.TryLock(repo, newPull, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	ErrContains(t, "currently locked", err)
 }
 
@@ -108,16 +141,16 @@ func TestTryLockDifferentPaths(t *testing.T) {
 	locker := events.NewDefaultWorkingDirLocker()
 
 	t.Log("a lock for a different path but the same repo, pull, projectName and workspace should succeed")
-	_, err := locker.TryLock(repo, 1, workspace, path, projectName, cmd)
+	_, err := locker.TryLock(repo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 	newPath := "new-path"
-	_, err = locker.TryLock(repo, 1, workspace, newPath, projectName, cmd)
+	_, err = locker.TryLock(repo, 1, workspace, newPath, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 
 	t.Log("and both should now be locked")
-	_, err = locker.TryLock(repo, 1, workspace, path, projectName, cmd)
+	_, err = locker.TryLock(repo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	ErrContains(t, "currently locked", err)
-	_, err = locker.TryLock(repo, 1, workspace, newPath, projectName, cmd)
+	_, err = locker.TryLock(repo, 1, workspace, newPath, projectName, cmd, events.WorkingDirLockMetadata{})
 	ErrContains(t, "currently locked", err)
 }
 
@@ -125,16 +158,16 @@ func TestTryLockDifferentProjectNames(t *testing.T) {
 	locker := events.NewDefaultWorkingDirLocker()
 
 	t.Log("a lock for a different projectName but the same repo, pull, path and workspace should succeed")
-	_, err := locker.TryLock(repo, 1, workspace, path, projectName, cmd)
+	_, err := locker.TryLock(repo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 	newProjectName := "new-project"
-	_, err = locker.TryLock(repo, 1, workspace, path, newProjectName, cmd)
+	_, err = locker.TryLock(repo, 1, workspace, path, newProjectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 
 	t.Log("and both should now be locked")
-	_, err = locker.TryLock(repo, 1, workspace, path, projectName, cmd)
+	_, err = locker.TryLock(repo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	ErrContains(t, "currently locked", err)
-	_, err = locker.TryLock(repo, 1, workspace, path, newProjectName, cmd)
+	_, err = locker.TryLock(repo, 1, workspace, path, newProjectName, cmd, events.WorkingDirLockMetadata{})
 	ErrContains(t, "currently locked", err)
 }
 
@@ -142,84 +175,84 @@ func TestUnlock(t *testing.T) {
 	locker := events.NewDefaultWorkingDirLocker()
 
 	t.Log("unlocking should work")
-	unlockFn, err := locker.TryLock(repo, 1, workspace, path, projectName, cmd)
+	unlockFn, err := locker.TryLock(repo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 	unlockFn()
-	_, err = locker.TryLock(repo, 1, workspace, "", projectName, cmd)
+	_, err = locker.TryLock(repo, 1, workspace, "", projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 }
 
 func TestUnlockDifferentWorkspaces(t *testing.T) {
 	locker := events.NewDefaultWorkingDirLocker()
 	t.Log("unlocking should work for different workspaces")
-	unlockFn1, err1 := locker.TryLock(repo, 1, workspace, path, projectName, cmd)
+	unlockFn1, err1 := locker.TryLock(repo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err1)
-	unlockFn2, err2 := locker.TryLock(repo, 1, "new-workspace", path, projectName, cmd)
+	unlockFn2, err2 := locker.TryLock(repo, 1, "new-workspace", path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err2)
 	unlockFn1()
 	unlockFn2()
 
-	_, err := locker.TryLock(repo, 1, workspace, path, projectName, cmd)
+	_, err := locker.TryLock(repo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err)
-	_, err = locker.TryLock(repo, 1, "new-workspace", path, projectName, cmd)
+	_, err = locker.TryLock(repo, 1, "new-workspace", path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 }
 
 func TestUnlockDifferentRepos(t *testing.T) {
 	locker := events.NewDefaultWorkingDirLocker()
 	t.Log("unlocking should work for different repos")
-	unlockFn1, err1 := locker.TryLock(repo, 1, workspace, path, projectName, cmd)
+	unlockFn1, err1 := locker.TryLock(repo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err1)
 	newRepo := "owner/newrepo"
-	unlockFn2, err2 := locker.TryLock(newRepo, 1, workspace, path, projectName, cmd)
+	unlockFn2, err2 := locker.TryLock(newRepo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err2)
 	unlockFn1()
 	unlockFn2()
 
-	_, err := locker.TryLock(repo, 1, workspace, path, projectName, cmd)
+	_, err := locker.TryLock(repo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err)
-	_, err = locker.TryLock(newRepo, 1, workspace, path, projectName, cmd)
+	_, err = locker.TryLock(newRepo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 }
 
 func TestUnlockDifferentPulls(t *testing.T) {
 	locker := events.NewDefaultWorkingDirLocker()
 	t.Log("unlocking should work for different pulls")
-	unlockFn1, err1 := locker.TryLock(repo, 1, workspace, path, projectName, cmd)
+	unlockFn1, err1 := locker.TryLock(repo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err1)
 	newPull := 2
-	unlockFn2, err2 := locker.TryLock(repo, newPull, workspace, path, projectName, cmd)
+	unlockFn2, err2 := locker.TryLock(repo, newPull, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err2)
 	unlockFn1()
 	unlockFn2()
 
-	_, err := locker.TryLock(repo, 1, workspace, path, projectName, cmd)
+	_, err := locker.TryLock(repo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err)
-	_, err = locker.TryLock(repo, newPull, workspace, path, projectName, cmd)
+	_, err = locker.TryLock(repo, newPull, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 }
 
 func TestUnlockDifferentProjectNames(t *testing.T) {
 	locker := events.NewDefaultWorkingDirLocker()
 	t.Log("unlocking should work for different projects")
-	unlockFn1, err1 := locker.TryLock(repo, 1, workspace, path, projectName, cmd)
+	unlockFn1, err1 := locker.TryLock(repo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err1)
 	newProjectName := "new-project"
-	unlockFn2, err2 := locker.TryLock(repo, 1, workspace, path, newProjectName, cmd)
+	unlockFn2, err2 := locker.TryLock(repo, 1, workspace, path, newProjectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err2)
 	unlockFn1()
 	unlockFn2()
 
-	_, err := locker.TryLock(repo, 1, workspace, path, projectName, cmd)
+	_, err := locker.TryLock(repo, 1, workspace, path, projectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err)
-	_, err = locker.TryLock(repo, 1, workspace, path, newProjectName, cmd)
+	_, err = locker.TryLock(repo, 1, workspace, path, newProjectName, cmd, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 }
 
 func TestWorkingDirLocker_HasCommandLockDoesNotCrossMatchSlashNestedRepoNames(t *testing.T) {
 	locker := events.NewDefaultWorkingDirLocker()
 
-	unlock, err := locker.TryLockPull("group/repo/1", 2, command.Plan)
+	unlock, err := locker.TryLockPull("group/repo/1", 2, command.Plan, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 	defer unlock()
 
@@ -230,11 +263,11 @@ func TestWorkingDirLocker_HasCommandLockDoesNotCrossMatchSlashNestedRepoNames(t 
 func TestWorkingDirLocker_TryLockPullDoesNotCrossMatchSlashNestedRepoNames(t *testing.T) {
 	locker := events.NewDefaultWorkingDirLocker()
 
-	unlock, err := locker.TryLockPull("group/repo/1", 2, command.Plan)
+	unlock, err := locker.TryLockPull("group/repo/1", 2, command.Plan, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 	defer unlock()
 
-	unlockParent, err := locker.TryLockPull("group/repo", 1, command.Apply)
+	unlockParent, err := locker.TryLockPull("group/repo", 1, command.Apply, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 	defer unlockParent()
 }
@@ -242,13 +275,13 @@ func TestWorkingDirLocker_TryLockPullDoesNotCrossMatchSlashNestedRepoNames(t *te
 func TestWorkingDirLocker_PullLockExactRepoAndPullIsolation(t *testing.T) {
 	locker := events.NewDefaultWorkingDirLocker()
 
-	unlock, err := locker.TryLockPull("group/repo/12", 3, command.Plan)
+	unlock, err := locker.TryLockPull("group/repo/12", 3, command.Plan, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 	defer unlock()
 
 	Assert(t, locker.HasCommandLock("group/repo/12", 3, command.Plan), "expected exact repo/pull lock")
 	Assert(t, !locker.HasCommandLock("group/repo", 12, command.Plan), "did not expect pull prefix to match nested repo path")
-	unlockOther, err := locker.TryLockPull("group/repo", 12, command.Apply)
+	unlockOther, err := locker.TryLockPull("group/repo", 12, command.Apply, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 	defer unlockOther()
 }
@@ -256,14 +289,14 @@ func TestWorkingDirLocker_PullLockExactRepoAndPullIsolation(t *testing.T) {
 func TestWorkingDirLocker_ProjectLocksStillUseExactWorkspaceDirProjectIdentity(t *testing.T) {
 	locker := events.NewDefaultWorkingDirLocker()
 
-	unlock, err := locker.TryLock("group/repo/1", 2, "default", "dir", "proj", command.Plan)
+	unlock, err := locker.TryLock("group/repo/1", 2, "default", "dir", "proj", command.Plan, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 	defer unlock()
 
 	Assert(t, locker.HasCommandLock("group/repo/1", 2, command.Plan), "expected exact project lock to count as command lock")
 	Assert(t, !locker.HasCommandLock("group/repo", 1, command.Plan), "did not expect nested repo project lock to match parent repo/pull")
-	_, err = locker.TryLock("group/repo/1", 2, "default", "dir", "proj", command.Apply)
+	_, err = locker.TryLock("group/repo/1", 2, "default", "dir", "proj", command.Apply, events.WorkingDirLockMetadata{})
 	ErrContains(t, "currently locked", err)
-	_, err = locker.TryLock("group/repo/1", 2, "default", "dir", "other", command.Apply)
+	_, err = locker.TryLock("group/repo/1", 2, "default", "dir", "other", command.Apply, events.WorkingDirLockMetadata{})
 	Ok(t, err)
 }

--- a/server/events/working_dir_locker_test.go
+++ b/server/events/working_dir_locker_test.go
@@ -46,8 +46,8 @@ func TestTryLockIncludesCommitMetadata(t *testing.T) {
 		metadata events.WorkingDirLockMetadata
 		want     string
 	}{
-		{name: "sha", metadata: events.WorkingDirLockMetadata{HeadCommit: sha}, want: "by \"plan\" for commit " + sha + "."},
-		{name: "url remains structured", metadata: events.WorkingDirLockMetadata{HeadCommit: sha, CommitURL: commitURL}, want: "by \"plan\" for commit " + sha + "."},
+		{name: "sha", metadata: events.WorkingDirLockMetadata{HeadCommit: sha}, want: "by \"plan\" for commit 0123456."},
+		{name: "url remains structured", metadata: events.WorkingDirLockMetadata{HeadCommit: sha, CommitURL: commitURL}, want: "by \"plan\" for commit 0123456."},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -67,7 +67,7 @@ func TestTryLockPullIncludesCommitMetadata(t *testing.T) {
 	_, err := locker.TryLockPull(repo, 1, command.Plan, events.WorkingDirLockMetadata{HeadCommit: sha, CommitURL: commitURL})
 	Ok(t, err)
 	_, err = locker.TryLockPull(repo, 1, command.Apply, events.WorkingDirLockMetadata{})
-	ErrContains(t, "by \"plan\" for commit "+sha+".", err)
+	ErrContains(t, "by \"plan\" for commit 0123456.", err)
 	Assert(t, !strings.Contains(err.Error(), commitURL), "expected commit URL to remain out of plain error: %s", err)
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -811,6 +811,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		WorkingDir:                workingDir,
 		Webhooks:                  webhooksManager,
 		WorkingDirLocker:          workingDirLocker,
+		ProjectJobURLGenerator:    router,
 		CommandRequirementHandler: applyRequirementHandler,
 		CancellationTracker:       cancellationTracker,
 		ApplyPlanValidator:        &events.DefaultApplyPlanValidator{PullStatusFetcher: database, LivePullHeadFetcher: livePullHeadFetcher},


### PR DESCRIPTION
## What this solves

When a command is blocked by Atlantis' transient working-directory lock, the current message identifies the command holding the lock but not the commit it is running against. On active pull requests this makes it difficult to tell whether Atlantis is still processing an older push.

This change stores the pull request head commit alongside in-memory workspace and pull locks and includes it in lock-conflict messages. For GitHub, GitLab, and Gitea repositories, the full SHA is followed by the plain commit URL in parentheses when a safe HTTP(S) URL can be derived; otherwise it falls back to the SHA alone. Existing messages remain unchanged when commit metadata is unavailable.

Lock acquisition, release, and persistence semantics are unchanged.

Closes #303.

## Validation

- `go test ./server/events -count=1`
- `go test ./server/... -run '^$'` (compile all server packages and tests)
- Added coverage for workspace and pull-level conflicts, SHA-only rendering, SHA-and-URL rendering, and the existing no-metadata behavior.

## Deployment verification

A practical end-to-end check is to deploy this branch's image to a non-production Atlantis environment, start a deliberately slow `atlantis plan` on a test PR, then issue a conflicting `atlantis plan` or `atlantis apply` before it completes. The PR comment should identify the owning command and show the full commit SHA and URL. Pushing a second commit while the first command runs makes the behavior particularly clear: the lock message should reference the older commit which owns the lock.

