### PR TITLE
Avoid populating requirements until the very end

### DIFF
--- a/server/core/config/raw/global_cfg.go
+++ b/server/core/config/raw/global_cfg.go
@@ -322,48 +322,57 @@ func (r Repo) ToValid(workflows map[string]valid.Workflow, globalPlanReqs []stri
 	var mergedImportReqs []string
 	mergedImportReqs = append(mergedImportReqs, r.ImportRequirements...)
 
-	// only add global reqs if they don't exist already.
-OuterGlobalPlanReqs:
-	for _, globalReq := range globalPlanReqs {
-		for _, currReq := range r.PlanRequirements {
-			if globalReq == currReq {
-				continue OuterGlobalPlanReqs
+	// Only merge in global reqs when this entry explicitly sets the
+	// requirement. Leaving the slice nil signals to getMatchingCfg that this
+	// entry does not override the requirement, so earlier matching entries
+	// (e.g. a broader `/.*/` rule) are preserved.
+	if r.PlanRequirements != nil {
+	OuterGlobalPlanReqs:
+		for _, globalReq := range globalPlanReqs {
+			for _, currReq := range r.PlanRequirements {
+				if globalReq == currReq {
+					continue OuterGlobalPlanReqs
+				}
 			}
-		}
 
-		// dont add policy_check step if repo have it explicitly disabled
-		if globalReq == valid.PoliciesPassedCommandReq && r.PolicyCheck != nil && !*r.PolicyCheck {
-			continue
+			// dont add policy_check step if repo have it explicitly disabled
+			if globalReq == valid.PoliciesPassedCommandReq && r.PolicyCheck != nil && !*r.PolicyCheck {
+				continue
+			}
+			mergedPlanReqs = append(mergedPlanReqs, globalReq)
 		}
-		mergedPlanReqs = append(mergedPlanReqs, globalReq)
 	}
-OuterGlobalApplyReqs:
-	for _, globalReq := range globalApplyReqs {
-		for _, currReq := range r.ApplyRequirements {
-			if globalReq == currReq {
-				continue OuterGlobalApplyReqs
+	if r.ApplyRequirements != nil {
+	OuterGlobalApplyReqs:
+		for _, globalReq := range globalApplyReqs {
+			for _, currReq := range r.ApplyRequirements {
+				if globalReq == currReq {
+					continue OuterGlobalApplyReqs
+				}
 			}
-		}
 
-		// dont add policy_check step if repo have it explicitly disabled
-		if globalReq == valid.PoliciesPassedCommandReq && r.PolicyCheck != nil && !*r.PolicyCheck {
-			continue
+			// dont add policy_check step if repo have it explicitly disabled
+			if globalReq == valid.PoliciesPassedCommandReq && r.PolicyCheck != nil && !*r.PolicyCheck {
+				continue
+			}
+			mergedApplyReqs = append(mergedApplyReqs, globalReq)
 		}
-		mergedApplyReqs = append(mergedApplyReqs, globalReq)
 	}
-OuterGlobalImportReqs:
-	for _, globalReq := range globalImportReqs {
-		for _, currReq := range r.ImportRequirements {
-			if globalReq == currReq {
-				continue OuterGlobalImportReqs
+	if r.ImportRequirements != nil {
+	OuterGlobalImportReqs:
+		for _, globalReq := range globalImportReqs {
+			for _, currReq := range r.ImportRequirements {
+				if globalReq == currReq {
+					continue OuterGlobalImportReqs
+				}
 			}
-		}
 
-		// dont add policy_check step if repo have it explicitly disabled
-		if globalReq == valid.PoliciesPassedCommandReq && r.PolicyCheck != nil && !*r.PolicyCheck {
-			continue
+			// dont add policy_check step if repo have it explicitly disabled
+			if globalReq == valid.PoliciesPassedCommandReq && r.PolicyCheck != nil && !*r.PolicyCheck {
+				continue
+			}
+			mergedImportReqs = append(mergedImportReqs, globalReq)
 		}
-		mergedImportReqs = append(mergedImportReqs, globalReq)
 	}
 
 	var autoDiscover *valid.AutoDiscover

--- a/server/core/config/valid/global_cfg_test.go
+++ b/server/core/config/valid/global_cfg_test.go
@@ -1459,6 +1459,45 @@ repos:
 				CustomPolicyCheck:  false,
 			},
 		},
+		// Regression test for the bug where a later repo entry that does not set
+		// *_requirements would wipe out the requirements inherited from an
+		// earlier matching entry, because policies_passed was being appended to
+		// the (otherwise nil) requirement slice and getMatchingCfg's "last
+		// non-nil wins" logic would treat that as an override.
+		"policy check does not clobber earlier repo requirements when later entry omits them": {
+			gPolicyCheck: true,
+			gCfg: `
+repos:
+- id: /.*/
+  plan_requirements: [approved, mergeable, undiverged]
+  apply_requirements: [approved, mergeable, undiverged]
+  import_requirements: [approved, mergeable, undiverged]
+- id: github.com/example/terraform
+  allow_custom_workflows: true
+`,
+			repoID: "github.com/example/terraform",
+			proj: valid.Project{
+				Dir:         "mydir",
+				Workspace:   "myworkspace",
+				Name:        String("myname"),
+				PolicyCheck: Bool(true),
+			},
+			repoWorkflows: nil,
+			exp: valid.MergedProjectCfg{
+				PlanRequirements:   []string{"approved", "mergeable", "undiverged"},
+				ApplyRequirements:  []string{"approved", "mergeable", "undiverged", "policies_passed"},
+				ImportRequirements: []string{"approved", "mergeable", "undiverged"},
+				Workflow:           defaultWorkflow,
+				RepoRelDir:         "mydir",
+				Workspace:          "myworkspace",
+				Name:               "myname",
+				AutoplanEnabled:    false,
+				PolicySets:         emptyPolicySets,
+				RepoLocks:          valid.DefaultRepoLocks,
+				PolicyCheck:        true,
+				CustomPolicyCheck:  false,
+			},
+		},
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
this ensures that policies_passed doesn't clobber other inherited requirements

## what

Don't push "policies_passed" into empty lists; only append to already created slices.

## why

If we instantiate a slice, we'll block the inheritance of loosely defined repository settings.

## tests

Added tests to verify that this works.

## references

closes #6649 6649
