### PR TITLE
fix: suppress post-workflow hook VCS statuses when no projects matched

### DIFF
--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -221,8 +221,8 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 				}
 			}
 		} else {
-			// Suppress post-workflow hook VCS statuses so uninvolved instances
-			// don't create GitHub checks for hooks like notify/automerge.
+			// Suppress post-workflow hooks so uninvolved instances don't execute
+			// hooks or create GitHub checks (for example: notify/automerge).
 			ctx.SuppressVCSStatus = true
 		}
 		return

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -220,6 +220,10 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *CommentCommand) {
 					ctx.Log.Warn("unable to update commit status: %s", err)
 				}
 			}
+		} else {
+			// Suppress post-workflow hook VCS statuses so uninvolved instances
+			// don't create GitHub checks for hooks like notify/automerge.
+			ctx.SuppressVCSStatus = true
 		}
 		return
 	}

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -244,7 +244,9 @@ func (c *DefaultCommandRunner) RunAutoplanCommand(baseRepo models.Repo, headRepo
 
 	autoPlanRunner.Run(ctx, nil)
 
-	c.PostWorkflowHooksCommandRunner.RunPostHooks(ctx, cmd) // nolint: errcheck
+	if !ctx.SuppressVCSStatus {
+		c.PostWorkflowHooksCommandRunner.RunPostHooks(ctx, cmd) // nolint: errcheck
+	}
 }
 
 // commentUserDoesNotHavePermissions comments on the pull request that the user
@@ -560,7 +562,7 @@ func (c *DefaultCommandRunner) RunCommentCommand(baseRepo models.Repo, maybeHead
 	}
 
 	cmdRunner.Run(ctx, cmd)
-	if ctx.CommandSkipped {
+	if ctx.CommandSkipped || ctx.SuppressVCSStatus {
 		return
 	}
 

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -713,6 +713,40 @@ func TestRunCommentCommandApply_NoProjects_SilenceEnabled(t *testing.T) {
 	)
 }
 
+func TestRunCommentCommandPlan_SilenceVCSStatusNoProjects_SkipsPostWorkflowHooks(t *testing.T) {
+	t.Log("when silenceVCSStatusNoProjects=true and no projects match, RunPostHooks must not be called")
+	setup(t, func(tc *TestConfig) {
+		tc.silenceVCSStatusNoProjects = true
+		tc.SilenceNoProjects = true
+	})
+	var pull github.PullRequest
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState}
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(&pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(&pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+
+	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan})
+
+	postWorkflowHooksCommandRunner.(*mocks.MockPostWorkflowHooksCommandRunner).VerifyWasCalled(Never()).RunPostHooks(Any[*command.Context](), Any[*events.CommentCommand]())
+}
+
+func TestRunCommentCommandApply_SilenceVCSStatusNoProjects_SkipsPostWorkflowHooks(t *testing.T) {
+	t.Log("when silenceVCSStatusNoProjects=true and no projects match, RunPostHooks must not be called on apply")
+	setup(t, func(tc *TestConfig) {
+		tc.silenceVCSStatusNoProjects = true
+		tc.SilenceNoProjects = true
+	})
+	var pull github.PullRequest
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123", BaseBranch: "main"}
+	_, err := dbUpdater.Database.UpdatePullWithResults(modelPull, nil)
+	Ok(t, err)
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(&pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(&pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+
+	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Apply})
+
+	postWorkflowHooksCommandRunner.(*mocks.MockPostWorkflowHooksCommandRunner).VerifyWasCalled(Never()).RunPostHooks(Any[*command.Context](), Any[*events.CommentCommand]())
+}
+
 func TestRunApply_NoProjectsAfterEmptyPullStatusNoOpsSafely(t *testing.T) {
 	vcsClient := setup(t)
 	applyCommandRunner.SilenceNoProjects = true

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -162,8 +162,8 @@ func (p *PlanCommandRunner) runAutoplan(ctx *command.Context) {
 		} else {
 			// When silence is enabled and no projects are found, don't set any status
 			ctx.Log.Debug("silence enabled and no projects found - not setting any VCS status")
-			// Suppress post-workflow hook VCS statuses so uninvolved instances
-			// don't create GitHub checks for hooks like notify/automerge.
+			// Suppress post-workflow hooks so uninvolved instances don't execute
+			// hooks or create GitHub checks (for example: notify/automerge).
 			ctx.SuppressVCSStatus = true
 		}
 		return
@@ -305,8 +305,8 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 		} else {
 			// When silence is enabled and no projects are found, don't set any status
 			ctx.Log.Debug("silence enabled and no projects found - not setting any VCS status")
-			// Suppress post-workflow hook VCS statuses so uninvolved instances
-			// don't create GitHub checks for hooks like notify/automerge.
+			// Suppress post-workflow hooks so uninvolved instances don't execute
+			// hooks or create GitHub checks (for example: notify/automerge).
 			ctx.SuppressVCSStatus = true
 		}
 		return

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -162,6 +162,9 @@ func (p *PlanCommandRunner) runAutoplan(ctx *command.Context) {
 		} else {
 			// When silence is enabled and no projects are found, don't set any status
 			ctx.Log.Debug("silence enabled and no projects found - not setting any VCS status")
+			// Suppress post-workflow hook VCS statuses so uninvolved instances
+			// don't create GitHub checks for hooks like notify/automerge.
+			ctx.SuppressVCSStatus = true
 		}
 		return
 	}
@@ -302,6 +305,9 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 		} else {
 			// When silence is enabled and no projects are found, don't set any status
 			ctx.Log.Debug("silence enabled and no projects found - not setting any VCS status")
+			// Suppress post-workflow hook VCS statuses so uninvolved instances
+			// don't create GitHub checks for hooks like notify/automerge.
+			ctx.SuppressVCSStatus = true
 		}
 		return
 	}


### PR DESCRIPTION
 ---
  ## what
  - When ATLANTIS_SILENCE_VCS_STATUS_NO_PROJECTS=true, uninvolved instances in a multi-instance setup were still running RunPostHooks and creating GitHub checks for every post-workflow hook with a description field set.
  - Set ctx.SuppressVCSStatus=true in plan_command_runner and apply_command_runner when the silence-no-projects path is taken, and guard RunPostHooks in command_runner (both autoplan and comment paths) behind that flag so uninvolved instances
  stay fully silent.

  ## why
  - apply_command_runner.go never set ctx.SuppressVCSStatus = true in the 0-project silence path — only plan_command_runner.go did, leaving apply-triggered hooks unsuppressed.
  - command_runner.go never checked ctx.SuppressVCSStatus before calling RunPostHooks in either the autoplan or comment plan/apply paths, so the flag was set correctly but never acted upon.
  - In a multi-instance setup where each instance receives every webhook, this caused uninvolved instances to fire hook-based workflows (automerge, Slack notifications) and post spurious GitHub checks on every PR.

  ## tests
  - Tested with a multi-instance setup — uninvolved instances no longer create GitHub checks or run post-workflow hooks when no projects are matched.
  - Verified that the involved instance still runs post-workflow hooks correctly after plan/apply.
