### PR TITLE
fix: don't silence autodiscovered projects during apply when repo has explicit projects

### DIFF
--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -1651,8 +1651,12 @@ func (p *DefaultProjectCommandBuilder) buildProjectCommandCtxWithCfg(ctx *comman
 				)...)
 		}
 	} else {
-		// Ignore the project if silenced with projects set in the repo config
-		if p.SilenceNoProjects && repoCfgPtr != nil && len(repoCfgPtr.Projects) > 0 {
+		// Ignore the project if silenced with projects set in the repo config.
+		// When autodiscover is enabled, a dir without an explicit YAML entry may
+		// still be a legitimate project found by PendingPlanFinder (apply-all) or
+		// changed-file discovery (plan). Don't silence it in that case.
+		if p.SilenceNoProjects && repoCfgPtr != nil && len(repoCfgPtr.Projects) > 0 &&
+			!p.autoDiscoverModeEnabled(ctx, *repoCfgPtr) {
 			ctx.Log.Debug("silencing is in effect, project will be ignored")
 			return []command.ProjectContext{}, nil
 		}

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -5647,6 +5647,173 @@ func TestValidatePlansForApply_CurrentHeadEmptyAllowsValidation(t *testing.T) {
 	Ok(t, err)
 }
 
+func TestDefaultProjectCommandBuilder_SilenceNoProjects_AutodiscoverEnabled_DoesNotSilenceUnmatchedDir(t *testing.T) {
+	// Regression test: when SilenceNoProjects=true, a repo has explicit projects in
+	// atlantis.yaml, AND autodiscover is enabled, a dir not listed as an explicit
+	// project must NOT be silenced — it may be a legitimate project found by
+	// PendingPlanFinder (apply-all) or changed-file discovery (plan).
+	RegisterMockTestingT(t)
+
+	atlantisYAML := `
+version: 3
+autodiscover:
+  mode: auto
+projects:
+  - name: explicit-project
+    dir: dir-a
+    workspace: default
+`
+	tmpDir := DirStructure(t, map[string]any{
+		"default": map[string]any{
+			"atlantis.yaml": atlantisYAML,
+			"dir-a": map[string]any{
+				"main.tf":        nil,
+				"default.tfplan": nil,
+			},
+			"dir-b": map[string]any{
+				"main.tf":        nil,
+				"default.tfplan": nil,
+			},
+		},
+	})
+	runCmd(t, filepath.Join(tmpDir, "default"), "git", "init")
+
+	workingDir := mocks.NewMockWorkingDir()
+	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(tmpDir, nil)
+	When(workingDir.GetWorkingDir(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).
+		ThenReturn(filepath.Join(tmpDir, "default"), nil)
+
+	logger := logging.NewNoopLogger(t)
+	scope := metricstest.NewLoggingScope(t, logger, "atlantis")
+	globalCfgArgs := valid.GlobalCfgArgs{AllowAllRepoSettings: true}
+	terraformClient := tfclientmocks.NewMockClient()
+
+	userConfig := defaultUserConfig
+	userConfig.SilenceNoProjects = true
+	userConfig.AutoDiscoverMode = "auto"
+
+	builder := events.NewProjectCommandBuilder(
+		false,
+		&config.ParserValidator{},
+		&events.DefaultProjectFinder{},
+		nil,
+		workingDir,
+		events.NewDefaultWorkingDirLocker(),
+		valid.NewGlobalCfgFromArgs(globalCfgArgs),
+		&events.DefaultPendingPlanFinder{},
+		&events.CommentParser{ExecutableName: "atlantis"},
+		userConfig.SkipCloneNoChanges,
+		userConfig.EnableRegExpCmd,
+		userConfig.EnableAutoMerge,
+		userConfig.EnableParallelPlan,
+		userConfig.EnableParallelApply,
+		userConfig.AutoDetectModuleFiles,
+		userConfig.AutoplanFileList,
+		userConfig.RestrictFileList,
+		userConfig.DefaultTFDistribution,
+		userConfig.SilenceNoProjects,
+		userConfig.IncludeGitUntrackedFiles,
+		userConfig.AutoDiscoverMode,
+		scope,
+		terraformClient,
+	)
+
+	cmdCtx := &command.Context{Log: logger, Scope: scope}
+
+	// dir-b is not in the explicit projects list but autodiscover is on —
+	// it must not be silenced during apply.
+	applyCtxs, err := builder.BuildApplyCommands(cmdCtx, &events.CommentCommand{
+		Name:      command.Apply,
+		RepoRelDir: "dir-b",
+		Workspace: "default",
+	})
+	Ok(t, err)
+	Equals(t, 1, len(applyCtxs))
+	Equals(t, "dir-b", applyCtxs[0].RepoRelDir)
+}
+
+func TestDefaultProjectCommandBuilder_SilenceNoProjects_AutodiscoverDisabled_SilencesUnmatchedDir(t *testing.T) {
+	// When autodiscover is disabled, a dir not listed in explicit projects must
+	// still be silenced when SilenceNoProjects=true.
+	RegisterMockTestingT(t)
+
+	atlantisYAML := `
+version: 3
+autodiscover:
+  mode: disabled
+projects:
+  - name: explicit-project
+    dir: dir-a
+    workspace: default
+`
+	tmpDir := DirStructure(t, map[string]any{
+		"default": map[string]any{
+			"atlantis.yaml": atlantisYAML,
+			"dir-a": map[string]any{
+				"main.tf":        nil,
+				"default.tfplan": nil,
+			},
+			"dir-b": map[string]any{
+				"main.tf":        nil,
+				"default.tfplan": nil,
+			},
+		},
+	})
+	runCmd(t, filepath.Join(tmpDir, "default"), "git", "init")
+
+	workingDir := mocks.NewMockWorkingDir()
+	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(tmpDir, nil)
+	When(workingDir.GetWorkingDir(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).
+		ThenReturn(filepath.Join(tmpDir, "default"), nil)
+
+	logger := logging.NewNoopLogger(t)
+	scope := metricstest.NewLoggingScope(t, logger, "atlantis")
+	globalCfgArgs := valid.GlobalCfgArgs{AllowAllRepoSettings: true}
+	terraformClient := tfclientmocks.NewMockClient()
+
+	userConfig := defaultUserConfig
+	userConfig.SilenceNoProjects = true
+	userConfig.AutoDiscoverMode = "disabled"
+
+	builder := events.NewProjectCommandBuilder(
+		false,
+		&config.ParserValidator{},
+		&events.DefaultProjectFinder{},
+		nil,
+		workingDir,
+		events.NewDefaultWorkingDirLocker(),
+		valid.NewGlobalCfgFromArgs(globalCfgArgs),
+		&events.DefaultPendingPlanFinder{},
+		&events.CommentParser{ExecutableName: "atlantis"},
+		userConfig.SkipCloneNoChanges,
+		userConfig.EnableRegExpCmd,
+		userConfig.EnableAutoMerge,
+		userConfig.EnableParallelPlan,
+		userConfig.EnableParallelApply,
+		userConfig.AutoDetectModuleFiles,
+		userConfig.AutoplanFileList,
+		userConfig.RestrictFileList,
+		userConfig.DefaultTFDistribution,
+		userConfig.SilenceNoProjects,
+		userConfig.IncludeGitUntrackedFiles,
+		userConfig.AutoDiscoverMode,
+		scope,
+		terraformClient,
+	)
+
+	cmdCtx := &command.Context{Log: logger, Scope: scope}
+
+	// dir-b is not in the explicit projects list and autodiscover is off —
+	// it must be silenced (empty result, no error).
+	applyCtxs, err := builder.BuildApplyCommands(cmdCtx, &events.CommentCommand{
+		Name:      command.Apply,
+		RepoRelDir: "dir-b",
+		Workspace: "default",
+	})
+	Ok(t, err)
+	Equals(t, 0, len(applyCtxs))
+}
+
 func TestValidatePlansForApply_StatusHeadEmptyFailsWhenCurrentHeadKnown(t *testing.T) {
 	ctx := &command.Context{
 		Log:  logging.NewNoopLogger(t),


### PR DESCRIPTION

 ## what
  - When ATLANTIS_SILENCE_NO_PROJECTS=true and a repo has explicit projects in atlantis.yaml, any directory picked up by autodiscover or changed-file discovery was silently dropped during atlantis apply even though a valid pending plan file
  existed for it.
  - Guard the silence condition with autoDiscoverModeEnabled so that directories without an explicit YAML entry are not silenced when autodiscover is on — they may be legitimate projects found by PendingPlanFinder or changed-file discovery
  during the plan phase.

  ## why
  - In project_command_builder.go, buildProjectCommandCtxWithCfg only checked whether the repo had any explicit projects at all — not whether the current directory was legitimately discovered.
  - The plan phase is more permissive than apply: a directory can be planned (and a plan comment posted) but then silently skipped during apply because the silence condition is evaluated independently at each command.
  - The project is silently dropped with no error and no PR comment — the developer sees a successful plan but the autodiscovered project is never applied, and the pending plan file sits on disk indefinitely.

  ## tests
  - Tested with a repo that has autodiscover: mode: auto and explicit projects defined — autodiscovered project is now correctly applied after plan.
  - Verified that a repo with autodiscover: mode: disabled and a directory not in the explicit list is still correctly silenced.
## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

