### PR TITLE
fix(github): proactively pace pull request comments

### DIFF
--- a/cmd/help_fmt.go
+++ b/cmd/help_fmt.go
@@ -19,7 +19,7 @@ import (
 //	 <description>
 //
 // We use it over the default template so that the output it easier to read.
-func usageTmpl(stringFlags map[string]stringFlag, intFlags map[string]intFlag, boolFlags map[string]boolFlag) string {
+func usageTmpl(stringFlags map[string]stringFlag, intFlags map[string]intFlag, boolFlags map[string]boolFlag, durationFlags map[string]durationFlag) string {
 	var flagNames []string
 	for name, f := range stringFlags {
 		if f.hidden {
@@ -34,6 +34,12 @@ func usageTmpl(stringFlags map[string]stringFlag, intFlags map[string]intFlag, b
 		flagNames = append(flagNames, name)
 	}
 	for name, f := range intFlags {
+		if f.hidden {
+			continue
+		}
+		flagNames = append(flagNames, name)
+	}
+	for name, f := range durationFlags {
 		if f.hidden {
 			continue
 		}
@@ -65,6 +71,13 @@ func usageTmpl(stringFlags map[string]stringFlag, intFlags map[string]intFlag, b
 			descripWithDefault := f.description
 			if f.defaultValue != 0 {
 				descripWithDefault += fmt.Sprintf(" (default %d)", f.defaultValue)
+			}
+			descrip = to80CharCols(descripWithDefault)
+			isBool = false
+		} else if f, ok := durationFlags[name]; ok {
+			descripWithDefault := f.description
+			if f.defaultValue != 0 {
+				descripWithDefault += fmt.Sprintf(" (default %s)", f.defaultValue)
 			}
 			descrip = to80CharCols(descripWithDefault)
 			isBool = false

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/moby/patternmatcher"
@@ -38,7 +39,7 @@ const (
 // To add a new flag you must:
 // 1. Add a const with the flag name (in alphabetic order).
 // 2. Add a new field to server.UserConfig and set the mapstructure tag equal to the flag name.
-// 3. Add your flag's description etc. to the stringFlags, intFlags, or boolFlags slices.
+// 3. Add your flag's description etc. to the corresponding flags map.
 const (
 	// Flag names.
 	ADWebhookPasswordFlag            = "azuredevops-webhook-password" // nolint: gosec
@@ -86,6 +87,7 @@ const (
 	ExecutableName                   = "executable-name"
 	FailOnPreWorkflowHookError       = "fail-on-pre-workflow-hook-error"
 	HideUnchangedPlanComments        = "hide-unchanged-plan-comments"
+	GHCommentIntervalFlag            = "gh-comment-interval"
 	GHHostnameFlag                   = "gh-hostname"
 	GHTeamAllowlistFlag              = "gh-team-allowlist"
 	GHTokenFlag                      = "gh-token"
@@ -180,6 +182,7 @@ const (
 	DefaultEmojiReaction                = ""
 	DefaultExecutableName               = "atlantis"
 	DefaultMarkdownTemplateOverridesDir = "~/.markdown_templates"
+	DefaultGHCommentInterval            = time.Second
 	DefaultGHHostname                   = "github.com"
 	DefaultGiteaBaseURL                 = "https://gitea.com"
 	DefaultGiteaPageSize                = 30
@@ -696,6 +699,14 @@ var boolFlags = map[string]boolFlag{
 		defaultValue: true,
 	},
 }
+
+var durationFlags = map[string]durationFlag{
+	GHCommentIntervalFlag: {
+		description:  "Minimum interval between GitHub pull request comments. Set to 0 to disable proactive comment pacing.",
+		defaultValue: DefaultGHCommentInterval,
+	},
+}
+
 var intFlags = map[string]intFlag{
 	CheckoutDepthFlag: {
 		description: fmt.Sprintf("Used only if --%s=%s.", CheckoutStrategyFlag, CheckoutStrategyMerge) +
@@ -765,6 +776,11 @@ type int64Flag struct {
 	defaultValue int64
 	hidden       bool
 }
+type durationFlag struct {
+	description  string
+	defaultValue time.Duration
+	hidden       bool
+}
 type boolFlag struct {
 	description  string
 	defaultValue bool
@@ -826,7 +842,7 @@ func (s *ServerCmd) Init() *cobra.Command {
 	s.Viper.AutomaticEnv()
 	s.Viper.SetTypeByDefaultValue(true)
 
-	c.SetUsageTemplate(usageTmpl(stringFlags, intFlags, boolFlags))
+	c.SetUsageTemplate(usageTmpl(stringFlags, intFlags, boolFlags, durationFlags))
 	// If a user passes in an invalid flag, tell them what the flag was.
 	c.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
 		s.printErr(err)
@@ -866,6 +882,19 @@ func (s *ServerCmd) Init() *cobra.Command {
 			usage = fmt.Sprintf("%s (default %d)", usage, f.defaultValue)
 		}
 		c.Flags().Int(name, 0, usage+"\n")
+		if f.hidden {
+			c.Flags().MarkHidden(name) // nolint: errcheck
+		}
+		s.Viper.BindPFlag(name, c.Flags().Lookup(name)) // nolint: errcheck
+	}
+
+	// Set duration flags.
+	for name, f := range durationFlags {
+		usage := f.description
+		if f.defaultValue != 0 {
+			usage = fmt.Sprintf("%s (default %s)", usage, f.defaultValue)
+		}
+		c.Flags().Duration(name, 0, usage+"\n")
 		if f.hidden {
 			c.Flags().MarkHidden(name) // nolint: errcheck
 		}
@@ -984,6 +1013,9 @@ func (s *ServerCmd) setDefaults(c *server.UserConfig, v *viper.Viper) {
 	if c.GithubHostname == "" {
 		c.GithubHostname = DefaultGHHostname
 	}
+	if !v.IsSet(GHCommentIntervalFlag) {
+		c.GithubCommentInterval = DefaultGHCommentInterval
+	}
 	if c.GitlabHostname == "" {
 		c.GitlabHostname = DefaultGitlabHostname
 	}
@@ -1062,6 +1094,10 @@ func (s *ServerCmd) setDefaults(c *server.UserConfig, v *viper.Viper) {
 }
 
 func (s *ServerCmd) validate(userConfig server.UserConfig) error {
+	if userConfig.GithubCommentInterval < 0 {
+		return fmt.Errorf("--%s must be non-negative", GHCommentIntervalFlag)
+	}
+
 	userConfig.LogLevel = strings.ToLower(userConfig.LogLevel)
 	if !isValidLogLevel(userConfig.LogLevel) {
 		return fmt.Errorf("invalid log level: must be one of %v", ValidLogLevels)

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -15,6 +15,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"go.yaml.in/yaml/v4"
 
@@ -83,6 +84,7 @@ var testFlags = map[string]any{
 	ExecutableName:                   "atlantis",
 	FailOnPreWorkflowHookError:       false,
 	GHAllowMergeableBypassApply:      false,
+	GHCommentIntervalFlag:            2 * time.Second,
 	GHHostnameFlag:                   "ghhostname",
 	GHTeamAllowlistFlag:              "",
 	GHTokenFlag:                      "token",
@@ -222,6 +224,10 @@ func TestExecute_Defaults(t *testing.T) {
 		Equals(t, cfg.defaultValue, configVal(t, passedConfig, flag))
 	}
 	for flag, cfg := range intFlags {
+		t.Log(flag)
+		Equals(t, cfg.defaultValue, configVal(t, passedConfig, flag))
+	}
+	for flag, cfg := range durationFlags {
 		t.Log(flag)
 		Equals(t, cfg.defaultValue, configVal(t, passedConfig, flag))
 	}
@@ -489,6 +495,23 @@ func TestExecute_NoConfigFlag(t *testing.T) {
 	}, t)
 	err := c.Execute()
 	Ok(t, err)
+}
+
+func TestExecute_GithubCommentInterval(t *testing.T) {
+	t.Run("zero disables pacing", func(t *testing.T) {
+		c := setupWithDefaults(map[string]any{
+			GHCommentIntervalFlag: 0,
+		}, t)
+		Ok(t, c.Execute())
+		Equals(t, time.Duration(0), passedConfig.GithubCommentInterval)
+	})
+
+	t.Run("negative is rejected", func(t *testing.T) {
+		c := setupWithDefaults(map[string]any{
+			GHCommentIntervalFlag: -time.Second,
+		}, t)
+		ErrEquals(t, "--gh-comment-interval must be non-negative", c.Execute())
+	})
 }
 
 func TestExecute_ConfigFileExtension(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.6
 	golang.org/x/term v0.43.0
 	golang.org/x/text v0.37.0
+	golang.org/x/time v0.12.0
 )
 
 require (
@@ -146,7 +147,6 @@ require (
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
-	golang.org/x/time v0.12.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -793,6 +793,18 @@ ATLANTIS_GH_APP_SLUG="myappslug"
 
 A slugged version of GitHub app name shown in pull requests comments, etc (not `Atlantis App` but something like `atlantis-app`). Atlantis uses the value of this parameter to identify the comments it has left on GitHub pull requests. This is used for functions such as `--hide-prev-plan-comments`. You need to obtain this value from your GitHub app, one way is to go to your App settings and open "Public page" from the left sidebar. Your `--gh-app-slug` value will be the last part of the URL, e.g `https://github.com/apps/<slug>`.
 
+### `--gh-comment-interval`
+
+```bash
+atlantis server --gh-comment-interval=1s
+# or
+ATLANTIS_GH_COMMENT_INTERVAL=1s
+```
+
+Minimum interval between GitHub pull request comments. Defaults to `1s`. Set to `0` to disable proactive comment pacing.
+
+The interval applies across all pull requests handled by an Atlantis instance and between parts of split command output. It complements `--max-comments-per-command`, which limits the number of comments, and does not replace reactive handling of GitHub secondary rate limits.
+
 ### `--gh-hostname` <Badge text="v0.1.3+" type="info"/>
 
 ```bash

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -187,8 +187,6 @@ func (p *PlanCommandRunner) runAutoplan(ctx *command.Context) {
 		result.PlansDeleted = true
 	}
 
-	p.pullUpdater.updatePull(ctx, AutoplanCommand{}, result)
-
 	pullStatus, err := p.dbUpdater.updateDB(ctx, ctx.Pull, result.ProjectResults)
 	if err != nil {
 		ctx.Log.Err("writing results: %s", err)
@@ -196,6 +194,7 @@ func (p *PlanCommandRunner) runAutoplan(ctx *command.Context) {
 
 	p.updateCommitStatus(ctx, pullStatus, command.Plan)
 	p.updateCommitStatus(ctx, pullStatus, command.Apply)
+	p.pullUpdater.updatePull(ctx, AutoplanCommand{}, result)
 
 	// Check if there are any planned projects and if there are any errors or if plans are being deleted
 	if len(policyCheckCmds) > 0 &&
@@ -334,11 +333,6 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 		result.PlansDeleted = true
 	}
 
-	p.pullUpdater.updatePull(
-		ctx,
-		cmd,
-		result)
-
 	var pullStatus models.PullStatus
 	if noProjectPullStatus != nil {
 		pullStatus = *noProjectPullStatus
@@ -349,11 +343,13 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 	}
 	if err != nil {
 		ctx.Log.Err("writing results: %s", err)
+		p.pullUpdater.updatePull(ctx, cmd, result)
 		return
 	}
 
 	p.updateCommitStatus(ctx, pullStatus, command.Plan)
 	p.updateCommitStatus(ctx, pullStatus, command.Apply)
+	p.pullUpdater.updatePull(ctx, cmd, result)
 
 	// Runs policy checks step after all plans are successful.
 	// This step does not approve any policies that require approval.

--- a/server/events/plan_command_runner_test.go
+++ b/server/events/plan_command_runner_test.go
@@ -194,6 +194,87 @@ func TestPlanCommandRunner_IgnoredTargetedDirNoOp(t *testing.T) {
 	projectCommandRunner.VerifyWasCalled(Never()).Plan(Any[command.ProjectContext]())
 }
 
+func TestPlanCommandRunner_FinalizesBeforeCommenting(t *testing.T) {
+	cases := []struct {
+		name    string
+		trigger command.Trigger
+	}{
+		{name: "manual plan", trigger: command.CommentTrigger},
+		{name: "autoplan", trigger: command.AutoTrigger},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			RegisterMockTestingT(t)
+			vcsClient := setup(t)
+			modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num}
+			cmd := &events.CommentCommand{Name: command.Plan, RepoRelDir: "terraform"}
+			ctx := &command.Context{
+				User:     testdata.User,
+				Log:      logging.NewNoopLogger(t),
+				Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+				Pull:     modelPull,
+				HeadRepo: testdata.GithubRepo,
+				Trigger:  testCase.trigger,
+			}
+			projectCtx := command.ProjectContext{
+				CommandName: command.Plan,
+				RepoRelDir:  "terraform",
+				Workspace:   events.DefaultWorkspace,
+				BaseRepo:    testdata.GithubRepo,
+				Pull:        modelPull,
+			}
+
+			if testCase.trigger == command.AutoTrigger {
+				When(projectCommandBuilder.BuildAutoplanCommands(ctx)).ThenReturn([]command.ProjectContext{projectCtx}, nil)
+				pullDir := t.TempDir()
+				When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(pullDir, nil)
+				When(pendingPlanFinder.Find(pullDir)).ThenReturn([]events.PendingPlan{}, nil)
+			} else {
+				When(projectCommandBuilder.BuildPlanCommands(ctx, cmd)).ThenReturn([]command.ProjectContext{projectCtx}, nil)
+			}
+			When(projectCommandRunner.Plan(projectCtx)).ThenReturn(command.ProjectCommandOutput{Error: errors.New("plan failed")})
+
+			statusUpdated := false
+			When(commitUpdater.UpdateCombinedCount(
+				Any[logging.SimpleLogging](),
+				Any[models.Repo](),
+				Any[models.PullRequest](),
+				Any[models.CommitStatus](),
+				Eq[command.Name](command.Plan),
+				Any[models.ProjectCounts](),
+			)).Then(func([]Param) ReturnValues {
+				statusUpdated = true
+				return ReturnValues{nil}
+			})
+			When(vcsClient.CreateComment(
+				Any[logging.SimpleLogging](),
+				Any[models.Repo](),
+				Any[int](),
+				Any[string](),
+				Any[string](),
+			)).Then(func([]Param) ReturnValues {
+				pullStatus, err := dbUpdater.Database.GetPullStatus(modelPull)
+				Ok(t, err)
+				Assert(t, pullStatus != nil, "expected persisted pull status before comment")
+				Equals(t, 1, pullStatus.StatusCount(models.ErroredPlanStatus))
+				Assert(t, statusUpdated, "expected final plan status before comment")
+				return ReturnValues{errors.New("comment failed")}
+			})
+
+			planCommandRunner.Run(ctx, cmd)
+
+			pullStatus, err := dbUpdater.Database.GetPullStatus(modelPull)
+			Ok(t, err)
+			Assert(t, pullStatus != nil, "expected persisted pull status")
+			Equals(t, 1, pullStatus.StatusCount(models.ErroredPlanStatus))
+			Assert(t, statusUpdated, "expected final plan status")
+			vcsClient.VerifyWasCalledOnce().CreateComment(
+				Any[logging.SimpleLogging](), Any[models.Repo](), Any[int](), Any[string](), Any[string]())
+		})
+	}
+}
+
 func TestPlanCommandRunner_ExecutionOrder(t *testing.T) {
 	logger := logging.NewNoopLogger(t)
 	RegisterMockTestingT(t)

--- a/server/events/vcs/github/client.go
+++ b/server/events/vcs/github/client.go
@@ -24,6 +24,7 @@ import (
 	"github.com/runatlantis/atlantis/server/events/vcs/common"
 	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/shurcooL/githubv4"
+	"golang.org/x/time/rate"
 )
 
 // maxCommentLength is the maximum number of chars allowed in a single comment
@@ -77,6 +78,7 @@ type Client struct {
 	ctx                   context.Context
 	config                Config
 	maxCommentsPerCommand int
+	commentLimiter        *rate.Limiter
 	repoIdCache           GitHubRepoIdCache
 }
 
@@ -110,6 +112,10 @@ type GithubPRReviewSummary struct {
 // NewClient returns a valid GitHub client.
 
 func New(hostname string, credentials Credentials, config Config, maxCommentsPerCommand int, logger logging.SimpleLogging) (*Client, error) {
+	if config.CommentInterval < 0 {
+		return nil, fmt.Errorf("github comment interval must be non-negative")
+	}
+
 	logger.Debug("Creating new GitHub client for host: %s", hostname)
 	transport, err := credentials.Client()
 	if err != nil {
@@ -154,8 +160,16 @@ func New(hostname string, credentials Credentials, config Config, maxCommentsPer
 		ctx:                   context.Background(),
 		config:                config,
 		maxCommentsPerCommand: maxCommentsPerCommand,
+		commentLimiter:        newCommentLimiter(config.CommentInterval),
 		repoIdCache:           NewGitHubRepoIdCache(),
 	}, nil
+}
+
+func newCommentLimiter(interval time.Duration) *rate.Limiter {
+	if interval == 0 {
+		return rate.NewLimiter(rate.Inf, 1)
+	}
+	return rate.NewLimiter(rate.Every(interval), 1)
 }
 
 func newSecondaryRateLimitHTTPClient(client *http.Client) *http.Client {
@@ -229,6 +243,9 @@ func (g *Client) CreateComment(logger logging.SimpleLogging, repo models.Repo, p
 
 	comments := common.SplitComment(logger, comment, maxCommentLength, g.maxCommentsPerCommand, command)
 	for i := range comments {
+		if err := g.commentLimiter.Wait(g.ctx); err != nil {
+			return fmt.Errorf("waiting to create github comment: %w", err)
+		}
 		_, resp, err := g.client.Issues.CreateComment(g.ctx, repo.Owner, repo.Name, pullNum, &github.IssueComment{Body: &comments[i]})
 		if resp != nil {
 			logger.Debug("POST /repos/%v/%v/issues/%d/comments returned: %v", repo.Owner, repo.Name, pullNum, resp.StatusCode)

--- a/server/events/vcs/github/client_internal_test.go
+++ b/server/events/vcs/github/client_internal_test.go
@@ -32,6 +32,11 @@ func TestNew_NonGithub(t *testing.T) {
 	// moment the shurcooL library doesn't expose it.
 }
 
+func TestNew_NegativeCommentInterval(t *testing.T) {
+	_, err := New("github.com", &UserCredentials{"user", "pass", ""}, Config{CommentInterval: -time.Second}, 0, logging.NewNoopLogger(t))
+	ErrEquals(t, "github comment interval must be non-negative", err)
+}
+
 func TestNewSecondaryRateLimitHTTPClientDoesNotApplyPrimaryLimits(t *testing.T) {
 	var requests []string
 	baseTransport := roundTripFunc(func(req *http.Request) (*http.Response, error) {

--- a/server/events/vcs/github/client_test.go
+++ b/server/events/vcs/github/client_test.go
@@ -13,6 +13,8 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1554,6 +1556,62 @@ func TestClient_SplitComments(t *testing.T) {
 	Equals(t, 4, len(githubComments))
 	Assert(t, strings.Contains(firstSplit, command.Plan.String()), fmt.Sprintf("comment should contain the command name but was %q", firstSplit))
 	Assert(t, strings.Contains(secondSplit, "continued from previous comment"), fmt.Sprintf("comment should contain no reference to the command name but was %q", secondSplit))
+}
+
+func TestClient_CommentIntervalSharedAcrossConcurrentSplitComments(t *testing.T) {
+	logger := logging.NewNoopLogger(t)
+	commentInterval := 25 * time.Millisecond
+	var requestCount atomic.Int32
+
+	testServer := httptest.NewTLSServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost || r.URL.Path != "/api/v3/repos/runatlantis/atlantis/issues/1/comments" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			requestCount.Add(1)
+			w.WriteHeader(http.StatusCreated)
+		}))
+	t.Cleanup(testServer.Close)
+
+	testServerURL, err := url.Parse(testServer.URL)
+	Ok(t, err)
+	client, err := github.New(
+		testServerURL.Host,
+		&github.UserCredentials{"user", "pass", ""},
+		github.Config{CommentInterval: commentInterval},
+		0,
+		logger,
+	)
+	Ok(t, err)
+	defer disableSSLVerification()()
+
+	repo := models.Repo{Owner: "runatlantis", Name: "atlantis"}
+	comment := strings.Repeat("a", 65537)
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var waitGroup sync.WaitGroup
+	for range 2 {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			<-start
+			errs <- client.CreateComment(logger, repo, 1, comment, command.Plan.String())
+		}()
+	}
+	started := time.Now()
+	close(start)
+	waitGroup.Wait()
+	elapsed := time.Since(started)
+	close(errs)
+	for err := range errs {
+		Ok(t, err)
+	}
+
+	Equals(t, int32(4), requestCount.Load())
+	minimumElapsed := 3*commentInterval - 5*time.Millisecond
+	Assert(t, elapsed >= minimumElapsed, "expected shared comment pacing to take at least %s, got %s", minimumElapsed, elapsed)
 }
 
 // Test that we retry the get pull request call if it 404s.

--- a/server/events/vcs/github/config.go
+++ b/server/events/vcs/github/config.go
@@ -3,7 +3,10 @@
 
 package github
 
+import "time"
+
 // GithubConfig allows for custom github-specific functionality and behavior
 type Config struct {
 	AllowMergeableBypassApply bool
+	CommentInterval           time.Duration
 }

--- a/server/server.go
+++ b/server/server.go
@@ -228,10 +228,9 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	}
 
 	if userConfig.GithubUser != "" || userConfig.GithubAppID != 0 {
-		if userConfig.GithubAllowMergeableBypassApply {
-			githubConfig = github.Config{
-				AllowMergeableBypassApply: true,
-			}
+		githubConfig = github.Config{
+			AllowMergeableBypassApply: userConfig.GithubAllowMergeableBypassApply,
+			CommentInterval:           userConfig.GithubCommentInterval,
 		}
 		supportedVCSHosts = append(supportedVCSHosts, models.Github)
 		if userConfig.GithubUser != "" {

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/events/command"
@@ -113,6 +114,8 @@ type UserConfig struct {
 	RepoConfig                      string `mapstructure:"repo-config"`
 	RepoConfigJSON                  string `mapstructure:"repo-config-json"`
 	RepoAllowlist                   string `mapstructure:"repo-allowlist"`
+
+	GithubCommentInterval time.Duration `mapstructure:"gh-comment-interval"`
 
 	// SilenceNoProjects is whether Atlantis should respond to a PR if no projects are found.
 	SilenceNoProjects   bool `mapstructure:"silence-no-projects"`


### PR DESCRIPTION
## what

- Add `--gh-comment-interval` / `ATLANTIS_GH_COMMENT_INTERVAL` to proactively pace GitHub pull request comments. The default is `1s`; `0` disables proactive pacing.
- Share one concurrency-safe limiter across all `CreateComment` calls made by an Atlantis GitHub client, including parts of split command output.
- Persist plan results and publish final plan/apply commit statuses before publishing the plan comment for both manual plans and autoplans.
- Document the setting and cover defaults, overrides, validation, concurrent split comments, existing reactive retries, and finalization when comment publication fails.

## why

[#4932](https://github.com/runatlantis/atlantis/issues/4932) reports that large plans can trigger GitHub secondary rate limits while Atlantis publishes many comments. In v0.28.5, the reporter observed that the plan remained pending and could not be applied after comment publication failed, while v0.23.5 still finalized the plan despite receiving the same 403 response.

Atlantis currently limits comment count and reacts after GitHub reports a secondary limit, but it does not proactively space comment creation. Split comments are submitted back-to-back, and plan comments are published before plan results and final commit statuses are persisted. This leaves avoidable comment bursts and puts a potentially long reactive wait on the finalization path.

GitHub's [REST API best practices](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api#pause-between-mutative-requests) recommend waiting at least one second between mutative requests. A one-second default limits a single client's initial comment creation attempts to roughly 60 per minute, below GitHub's general 80 content-generating requests per minute guideline. It cannot guarantee that secondary limits never occur because content limits are shared with other activity, can be lower or undisclosed, and multiple Atlantis instances may share credentials.

### behavior evolution

| Version | Change | Remaining gap |
| --- | --- | --- |
| v0.23.5 | The #4932 reporter observed comment 403s after roughly 100 comments, but plan state and statuses still finalized. | Comment publication could still exceed GitHub's secondary content limits. |
| v0.28.5 | #4932 reports the same comment limit leaving plan statuses pending and plans unavailable for apply. | Comment publication remained ahead of durable plan finalization. |
| [v0.29.0](https://github.com/runatlantis/atlantis/releases/tag/v0.29.0) | [#3905](https://github.com/runatlantis/atlantis/pull/3905) added `--max-comments-per-command`, with a default limit of 100. | This bounds volume but does not pace the comments that are published. |
| [v0.33.0](https://github.com/runatlantis/atlantis/releases/tag/v0.33.0) | [#5226](https://github.com/runatlantis/atlantis/pull/5226) added reactive GitHub secondary-rate-limit sleep and retry, initially with a one-minute accumulated total sleep limit. | Protection only starts after a 403/429, and the accumulated sleep ceiling eventually disabled waiting. |
| [v0.35.0](https://github.com/runatlantis/atlantis/releases/tag/v0.35.0) | [#5591](https://github.com/runatlantis/atlantis/pull/5591) removed the total sleep limit so reactive protection continues for as long as GitHub requires. | Comment creation is still bursty before a secondary limit is detected. |
| [v0.46.0](https://github.com/runatlantis/atlantis/releases/tag/v0.46.0) | Reactive secondary-limit handling remains uncapped. | Split comments are still submitted without proactive spacing, and plan comments still precede durable finalization. |

### why this does not restore the v0.33.0 total sleep limit

The v0.33.0 option capped the **accumulated time spent reactively sleeping**. Once that one-minute budget was exhausted, later requests stopped waiting, which defeated the protection precisely for high-volume installations. That is why #5591 removed it in v0.35.0.

This change adds no sleep budget or retry ceiling. It introduces a **minimum interval before each comment creation request**. The interval continues to apply regardless of how long Atlantis has been running, while the existing reactive limiter remains unchanged and can still wait for GitHub's requested cooldown without a total sleep cap.

### how this fixes the failure mode

1. Plan results are written to the database first.
2. Final combined plan/apply statuses are updated next.
3. The plan comment is then published through the shared comment limiter.
4. Existing policy-check behavior continues after the plan comment.

If comment publication is slow or ultimately fails, the plan state and final statuses are already durable. Concurrent plan comments and multipart output also share the same cadence instead of each producing an independent burst.

Comment publication remains synchronous, and the existing pull-wide plan lock remains held until publication finishes. The first comment is immediate; at the default interval, `N` comment parts add a minimum of approximately `N-1` seconds. Operators can tune the interval or explicitly set it to `0` if they need the previous behavior.

## tests

- [x] `env -u TF_PLUGIN_CACHE_DIR make test`
- [x] `make check-fmt`
- [x] `make build-service`
- [x] `go test -race -short ./server/events/vcs/github -run TestClient_CommentIntervalSharedAcrossConcurrentSplitComments -count=3`
- [x] Stress-ran the new pacing, reactive retry, finalization-order, and configuration tests.

## references

- Closes #4932
- Related: #3322
- Related: #3756
- Comment-count limit: #3905, released in v0.29.0
- Reactive secondary-limit handling: #5226, released in v0.33.0
- Removal of the accumulated total sleep limit: #5591, released in v0.35.0
- [GitHub REST API best practices](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api)
- [GitHub REST API rate limits](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api)
