### PR TITLE
chore(deps): bump Alpine curl to 8.20.0-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -190,7 +190,7 @@ COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 # renovate: datasource=repology depName=alpine_3_23/ca-certificates versioning=loose
 ENV CA_CERTIFICATES_VERSION="20260611-r0"
 # renovate: datasource=repology depName=alpine_3_23/curl versioning=loose
-ENV CURL_VERSION="8.19.0-r0"
+ENV CURL_VERSION="8.20.0-r0"
 # renovate: datasource=repology depName=alpine_3_23/git versioning=loose
 ENV GIT_VERSION="2.52.0-r0"
 # renovate: datasource=repology depName=alpine_3_23/unzip versioning=loose


### PR DESCRIPTION
## What this PR does / why we need it

Alpine 3.23's package index now provides `curl-8.20.0-r0`. The previously pinned version `8.19.0-r0` is no longer resolvable, causing the alpine image build to fail with:

```
ERROR: unable to select packages:
  curl-8.20.0-r0:
    breaks: world[curl=8.19.0-r0]
```

This bumps the pinned `CURL_VERSION` env var from `8.19.0-r0` to `8.20.0-r0`.

## Checklist

- [x] Single-line change, no logic affected
- [x] Follows the existing `renovate`-managed pattern for pinned Alpine package versions