### PR TITLE
chore(deps): update lodash-es to 4.18.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3262,9 +3262,9 @@
       }
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
## Summary

- update the transitive `lodash-es` lockfile entry from 4.17.23 to 4.18.1
- clear the code-injection and prototype-pollution advisories without changing direct dependencies
- leave the VitePress/Vite major migration and its build-time advisories for separate evaluation

## Testing

- `npm ci --ignore-scripts`
- `npm explain lodash-es`
- `npm ls --all`
- `npm run website:build`
- `npm audit --json` (drops from five vulnerable package nodes to four; the remaining Vite/VitePress chain has no supported in-place fix)
- `git diff --check`

## Compatibility

`dagre-d3-es` already permits `lodash-es` `^4.17.21`; this is a lockfile-only supported update. No application defaults, documentation behavior, Node requirement, or public API changes.

## References

- https://github.com/lodash/lodash/releases/tag/4.18.1
- https://github.com/lodash/lodash/releases/tag/4.18.0
- https://github.com/advisories/GHSA-r5fr-rjxr-66jc
- https://github.com/advisories/GHSA-f23m-r3pf-42rh
