### PR TITLE
feat: add support for OpenTelemetry Tracing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 !scripts/download-release.sh
 !server/
 !testdrive/
+!testing/
 !main.go
 !go.mod
 !go.sum

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,15 +43,22 @@ ENV BUILDER_BASH_VERSION="5.3.9-r1"
 RUN apk add --no-cache \
     bash=${BUILDER_BASH_VERSION}
 
+# Install the OpenTelemetry compile-time instrumentation tool (otelc) to build the atlantis binary with auto-instrumentation.
+# renovate: datasource=github-releases depName=open-telemetry/opentelemetry-go-compile-instrumentation versioning=semver
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go install go.opentelemetry.io/otelc/tool/cmd/otelc@v1.0.1
+
 COPY go.mod go.sum ./
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN --mount=type=cache,target=/go/pkg/mod \
     go mod graph | awk '{if ($1 !~ "@") print $2}' | xargs go get
 
 COPY . /app
+
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -ldflags "-s -w -X 'main.version=${ATLANTIS_VERSION}' -X 'main.commit=${ATLANTIS_COMMIT}' -X 'main.date=${ATLANTIS_DATE}'" -v -o atlantis .
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} otelc go build -ldflags "-s -w -X 'main.version=${ATLANTIS_VERSION}' -X 'main.commit=${ATLANTIS_COMMIT}' -X 'main.date=${ATLANTIS_DATE}'" -v -o atlantis .
 
 FROM debian:${DEBIAN_TAG} AS debian-base
 


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- Added [otelc](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation) as a build tool to the Dockerfile
- Adjusted go build to use `otelc` for compile-time instrumentation
- Adjusted `.dockerignore` to include directories required by `otelc go build`

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- Atlantis was missing OpenTelemetry tracing, which is helpful to track down issues and monitor the application in production environments.
- Using `otelc` at compile time is the simplest way to add this functionality. The alternative would be integrating the OpenTelemetry SDK directly into the source code, which has far more overhead. Also tried the OpenTelemetry Auto-Instrumentation feature from the OTel Operator, but that didn't work for Atlantis.

## tests

- [x] Tested by building the image and deploying it on my own cluster. Atlantis was working as expected. Used the following environment variables to send traces to an OTel Collector within the cluster:
```yaml
env:
  - name: OTEL_EXPORTER_OTLP_ENDPOINT
    value: "http://otel-traces-collector.monitoring.svc.cluster.local:4317"
  - name: OTEL_EXPORTER_OTLP_PROTOCOL
    value: grpc
  - name: OTEL_SERVICE_NAME
    value: atlantis
  - name: OTEL_METRICS_EXPORTER
    value: none
  - name: OTEL_LOGS_EXPORTER
    value: none
```


## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
Closes #4190 

