### PR TITLE
fix: bump alpine base image to 3.23.5 to update libssl3/libcrypto3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89
 # what distro is the image being built for
-ARG ALPINE_TAG=3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
+ARG ALPINE_TAG=3.23.5@sha256:fd791d74b68913cbb027c6546007b3f0d3bc45125f797758156952bc2d6daf40
 ARG DEBIAN_TAG=13.5-slim@sha256:28de0877c2189802884ccd20f15ee41c203573bd87bb6b883f5f46362d24c5c2
 # renovate: datasource=docker depName=golang versioning=docker
 ARG GOLANG_TAG=1.26.5-alpine3.24@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2


### PR DESCRIPTION
## what

- Bump the pinned `ALPINE_TAG` (and its digest) in the `Dockerfile` from `3.23.4` to `3.23.5` for the `alpine` target image.

## why

- `libssl3` and `libcrypto3` in the `alpine` target image are currently at `3.5.6-r0` and should be updated to `3.5.7-r0`.
- These packages are pulled in transitively from the Alpine base image rather than pinned explicitly, so the fix is to bump the base image tag/digest to a newer Alpine 3.23 patch release that ships the updated packages.

## tests

- [x] Built the `alpine` target locally (`docker build --target alpine ...`) and confirmed via `apk info -v` inside the resulting image that `libssl3-3.5.7-r0` and `libcrypto3-3.5.7-r0` are installed.

## references

- N/A
