### PR TITLE
feat: add --allow-partial-apply flag to allow applying a subset of planned projects

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -49,6 +49,7 @@ const (
 	AllowCommandsFlag                = "allow-commands"
 	BlockedExtraArgsFlag             = "blocked-extra-args"
 	AllowForkPRsFlag                 = "allow-fork-prs"
+	AllowPartialApplyFlag            = "allow-partial-apply"
 	AtlantisURLFlag                  = "atlantis-url"
 	AutoDiscoverModeFlag             = "autodiscover-mode"
 	AutomergeFlag                    = "automerge"
@@ -538,6 +539,10 @@ var stringFlags = map[string]stringFlag{
 var boolFlags = map[string]boolFlag{
 	AllowForkPRsFlag: {
 		description:  "Allow Atlantis to run on pull requests from forks. A security issue for public repos.",
+		defaultValue: false,
+	},
+	AllowPartialApplyFlag: {
+		description:  "Allow \"atlantis apply\" (without flags) to apply the subset of projects that have valid plans, skipping projects whose plans errored or are missing, instead of failing the whole command. Useful for workflows with inter-project dependencies (e.g. Terragrunt) that require iterative plan/apply cycles.",
 		defaultValue: false,
 	},
 	AutoplanModules: {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -49,6 +49,7 @@ const (
 	AllowCommandsFlag                = "allow-commands"
 	BlockedExtraArgsFlag             = "blocked-extra-args"
 	AllowForkPRsFlag                 = "allow-fork-prs"
+	AllowPartialApplyFlag            = "allow-partial-apply"
 	AtlantisURLFlag                  = "atlantis-url"
 	AutoDiscoverModeFlag             = "autodiscover-mode"
 	AutomergeFlag                    = "automerge"
@@ -533,6 +534,10 @@ var stringFlags = map[string]stringFlag{
 var boolFlags = map[string]boolFlag{
 	AllowForkPRsFlag: {
 		description:  "Allow Atlantis to run on pull requests from forks. A security issue for public repos.",
+		defaultValue: false,
+	},
+	AllowPartialApplyFlag: {
+		description: "Allow \"atlantis apply\" (without flags) to apply the subset of projects that have valid plans, skipping projects whose plans errored or are missing, instead of failing the whole command. Useful for workflows with inter-project dependencies (e.g. Terragrunt) that require iterative plan/apply cycles.",
 		defaultValue: false,
 	},
 	AutoplanModules: {

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -59,6 +59,7 @@ var testFlags = map[string]any{
 	AllowCommandsFlag:                "version,plan,apply,unlock,import,approve_policies",
 	BlockedExtraArgsFlag:             "-chdir,--chdir,-plugin-dir,--plugin-dir",
 	AllowForkPRsFlag:                 true,
+	AllowPartialApplyFlag:            true,
 	APISecretFlag:                    "",
 	AutoDiscoverModeFlag:             "auto",
 	AutomergeFlag:                    true,

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -96,6 +96,26 @@ Atlantis will automatically run `terraform plan`
 which can run arbitrary code if given a malicious Terraform configuration.
 :::
 
+### `--allow-partial-apply` <Badge text="v0.47.0+" type="info"/>
+
+```bash
+atlantis server --allow-partial-apply
+# or
+ATLANTIS_ALLOW_PARTIAL_APPLY=true
+```
+
+Allow `atlantis apply` (without flags) to apply the subset of projects that have
+valid plans, skipping projects whose plans errored or are missing, instead of
+failing the whole command. Defaults to `false`.
+
+This is useful for workflows with inter-project dependencies (e.g. Terragrunt)
+where dependent projects cannot plan successfully until their upstream projects
+have been applied, requiring iterative plan/apply cycles within one pull request.
+
+Skipped projects are logged as warnings. Staleness checks still apply: plans are
+rejected if the pull request head or base branch changed since they were created,
+and applies are blocked while a plan is running.
+
 ### `--api-secret` <Badge text="v0.22.2+" type="info"/>
 
 ```bash

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1492,6 +1492,7 @@ func setupE2E(t *testing.T, repoDir string, opt setupOption) (events_controllers
 		"",
 		false,
 		false,
+		false,
 		"auto",
 		statsScope,
 		terraformClient,

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -90,6 +90,7 @@ func NewInstrumentedProjectCommandBuilder(
 	RestrictFileList bool,
 	DefaultTFDistribution string,
 	SilenceNoProjects bool,
+	AllowPartialApply bool,
 	IncludeGitUntrackedFiles bool,
 	AutoDiscoverMode string,
 	scope tally.Scope,
@@ -123,6 +124,7 @@ func NewInstrumentedProjectCommandBuilder(
 			RestrictFileList,
 			DefaultTFDistribution,
 			SilenceNoProjects,
+			AllowPartialApply,
 			IncludeGitUntrackedFiles,
 			AutoDiscoverMode,
 			scope,
@@ -154,6 +156,7 @@ func NewProjectCommandBuilder(
 	RestrictFileList bool,
 	DefaultTFDistribution string,
 	SilenceNoProjects bool,
+	AllowPartialApply bool,
 	IncludeGitUntrackedFiles bool,
 	AutoDiscoverMode string,
 	scope tally.Scope,
@@ -179,6 +182,7 @@ func NewProjectCommandBuilder(
 		RestrictFileList:         RestrictFileList,
 		DefaultTFDistribution:    DefaultTFDistribution,
 		SilenceNoProjects:        SilenceNoProjects,
+		AllowPartialApply:        AllowPartialApply,
 		IncludeGitUntrackedFiles: IncludeGitUntrackedFiles,
 		AutoDiscoverMode:         AutoDiscoverMode,
 		ProjectCommandContextBuilder: NewProjectCommandContextBuilder(
@@ -299,6 +303,10 @@ type DefaultProjectCommandBuilder struct {
 	DefaultTFDistribution string
 	// User config option: Ignore PR if none of the modified files are part of a project.
 	SilenceNoProjects bool
+	// User config option: Allow the generic apply command to apply the subset of
+	// projects with valid plans, skipping projects whose plans errored or are
+	// missing, instead of failing the whole command.
+	AllowPartialApply bool
 	// User config option: Include git untracked files in the modified file list.
 	IncludeGitUntrackedFiles bool
 	// User config option: Controls auto-discovery of projects in a repository.
@@ -1289,7 +1297,12 @@ func (p *DefaultProjectCommandBuilder) buildAllProjectCommandsByPlan(ctx *comman
 		if p.WorkingDirLocker != nil {
 			hasActivePlan = p.WorkingDirLocker.HasCommandLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, command.Plan)
 		}
-		if err := ValidatePlansForApplyWithActivePlan(ctx, plans, hasActivePlan); err != nil {
+		if p.AllowPartialApply {
+			plans, err = filterPlansForPartialApply(ctx, plans, hasActivePlan)
+			if err != nil {
+				return nil, err
+			}
+		} else if err := ValidatePlansForApplyWithActivePlan(ctx, plans, hasActivePlan); err != nil {
 			return nil, err
 		}
 	}
@@ -1373,6 +1386,49 @@ func ValidatePlansForApplyWithCurrentPull(ctx *command.Context, plans []PendingP
 		return validateFoundPlans(ctx, plans)
 	}
 	return validateNoPlansFound(ctx, hasActivePlan)
+}
+
+// filterPlansForPartialApply returns the subset of discovered plans that are
+// valid to apply for the current PR head. Unlike strict validation, projects
+// whose plans errored, have a non-applyable status, or are missing a plan file
+// are skipped with a warning instead of failing the whole command. Staleness
+// and in-flight-plan checks still fail the command.
+func filterPlansForPartialApply(ctx *command.Context, plans []PendingPlan, hasActivePlan bool) ([]PendingPlan, error) {
+	if hasActivePlan {
+		return nil, fmt.Errorf("a plan is currently running for this pull request; wait for it to finish before applying")
+	}
+	if ctx.PullStatus == nil {
+		return nil, fmt.Errorf("no recorded plan status found; run `atlantis plan` before apply")
+	}
+	if err := pullStatusApplyEligibilityError(ctx.Pull, ctx.PullStatus.Pull, "plans"); err != nil {
+		return nil, err
+	}
+
+	var applyable []PendingPlan
+	planKeys := make(map[applyPlanKey]struct{}, len(plans))
+	for _, plan := range plans {
+		planKeys[newApplyPlanKey(plan.Workspace, plan.RepoRelDir, plan.ProjectName)] = struct{}{}
+		proj := findProjectInPullStatus(ctx.PullStatus, plan.Workspace, plan.RepoRelDir, plan.ProjectName)
+		if proj == nil {
+			ctx.Log.Warn("partial apply: skipping plan for dir %q workspace %q project %q because no matching plan status exists", plan.RepoRelDir, plan.Workspace, plan.ProjectName)
+			continue
+		}
+		if !statusAllowedForDiscoveredPlan(proj.Status) {
+			ctx.Log.Warn("partial apply: skipping plan for dir %q workspace %q project %q because status %q is not applyable", plan.RepoRelDir, plan.Workspace, plan.ProjectName, proj.Status.String())
+			continue
+		}
+		applyable = append(applyable, plan)
+	}
+	for _, proj := range ctx.PullStatus.Projects {
+		if _, ok := planKeys[newApplyPlanKey(proj.Workspace, proj.RepoRelDir, proj.ProjectName)]; ok {
+			continue
+		}
+		if statusIsSafeWithoutPlanFile(proj.Status) {
+			continue
+		}
+		ctx.Log.Warn("partial apply: skipping project dir %q workspace %q project %q with status %q because no plan file exists; run `atlantis plan` to include it", proj.RepoRelDir, proj.Workspace, proj.ProjectName, proj.Status.String())
+	}
+	return applyable, nil
 }
 
 func validateFoundPlans(ctx *command.Context, plans []PendingPlan) error {

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -91,6 +91,7 @@ func NewInstrumentedProjectCommandBuilder(
 	RestrictFileList bool,
 	DefaultTFDistribution string,
 	SilenceNoProjects bool,
+	AllowPartialApply bool,
 	IncludeGitUntrackedFiles bool,
 	AutoDiscoverMode string,
 	scope tally.Scope,
@@ -124,6 +125,7 @@ func NewInstrumentedProjectCommandBuilder(
 		RestrictFileList,
 		DefaultTFDistribution,
 		SilenceNoProjects,
+		AllowPartialApply,
 		IncludeGitUntrackedFiles,
 		AutoDiscoverMode,
 		scope,
@@ -159,6 +161,7 @@ func NewProjectCommandBuilder(
 	RestrictFileList bool,
 	DefaultTFDistribution string,
 	SilenceNoProjects bool,
+	AllowPartialApply bool,
 	IncludeGitUntrackedFiles bool,
 	AutoDiscoverMode string,
 	scope tally.Scope,
@@ -184,6 +187,7 @@ func NewProjectCommandBuilder(
 		RestrictFileList:         RestrictFileList,
 		DefaultTFDistribution:    DefaultTFDistribution,
 		SilenceNoProjects:        SilenceNoProjects,
+		AllowPartialApply:        AllowPartialApply,
 		IncludeGitUntrackedFiles: IncludeGitUntrackedFiles,
 		AutoDiscoverMode:         AutoDiscoverMode,
 		ProjectCommandContextBuilder: NewProjectCommandContextBuilder(
@@ -304,6 +308,10 @@ type DefaultProjectCommandBuilder struct {
 	DefaultTFDistribution string
 	// User config option: Ignore PR if none of the modified files are part of a project.
 	SilenceNoProjects bool
+	// User config option: Allow the generic apply command to apply the subset of
+	// projects with valid plans, skipping projects whose plans errored or are
+	// missing, instead of failing the whole command.
+	AllowPartialApply bool
 	// User config option: Include git untracked files in the modified file list.
 	IncludeGitUntrackedFiles bool
 	// User config option: Controls auto-discovery of projects in a repository.
@@ -1334,7 +1342,12 @@ func (p *DefaultProjectCommandBuilder) buildAllProjectCommandsByPlan(ctx *comman
 		if p.WorkingDirLocker != nil {
 			hasActivePlan = p.WorkingDirLocker.HasCommandLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, command.Plan)
 		}
-		if err := ValidatePlansForApplyWithActivePlan(ctx, plans, hasActivePlan); err != nil {
+		if p.AllowPartialApply {
+			plans, err = filterPlansForPartialApply(ctx, plans, hasActivePlan)
+			if err != nil {
+				return nil, err
+			}
+		} else if err := ValidatePlansForApplyWithActivePlan(ctx, plans, hasActivePlan); err != nil {
 			return nil, err
 		}
 	}
@@ -1418,6 +1431,49 @@ func ValidatePlansForApplyWithCurrentPull(ctx *command.Context, plans []PendingP
 		return validateFoundPlans(ctx, plans)
 	}
 	return validateNoPlansFound(ctx, hasActivePlan)
+}
+
+// filterPlansForPartialApply returns the subset of discovered plans that are
+// valid to apply for the current PR head. Unlike strict validation, projects
+// whose plans errored, have a non-applyable status, or are missing a plan file
+// are skipped with a warning instead of failing the whole command. Staleness
+// and in-flight-plan checks still fail the command.
+func filterPlansForPartialApply(ctx *command.Context, plans []PendingPlan, hasActivePlan bool) ([]PendingPlan, error) {
+	if hasActivePlan {
+		return nil, fmt.Errorf("a plan is currently running for this pull request; wait for it to finish before applying")
+	}
+	if ctx.PullStatus == nil {
+		return nil, fmt.Errorf("no recorded plan status found; run `atlantis plan` before apply")
+	}
+	if err := pullStatusApplyEligibilityError(ctx.Pull, ctx.PullStatus.Pull, "plans"); err != nil {
+		return nil, err
+	}
+
+	var applyable []PendingPlan
+	planKeys := make(map[applyPlanKey]struct{}, len(plans))
+	for _, plan := range plans {
+		planKeys[newApplyPlanKey(plan.Workspace, plan.RepoRelDir, plan.ProjectName)] = struct{}{}
+		proj := findProjectInPullStatus(ctx.PullStatus, plan.Workspace, plan.RepoRelDir, plan.ProjectName)
+		if proj == nil {
+			ctx.Log.Warn("partial apply: skipping plan for dir %q workspace %q project %q because no matching plan status exists", plan.RepoRelDir, plan.Workspace, plan.ProjectName)
+			continue
+		}
+		if !statusAllowedForDiscoveredPlan(proj.Status) {
+			ctx.Log.Warn("partial apply: skipping plan for dir %q workspace %q project %q because status %q is not applyable", plan.RepoRelDir, plan.Workspace, plan.ProjectName, proj.Status.String())
+			continue
+		}
+		applyable = append(applyable, plan)
+	}
+	for _, proj := range ctx.PullStatus.Projects {
+		if _, ok := planKeys[newApplyPlanKey(proj.Workspace, proj.RepoRelDir, proj.ProjectName)]; ok {
+			continue
+		}
+		if statusIsSafeWithoutPlanFile(proj.Status) {
+			continue
+		}
+		ctx.Log.Warn("partial apply: skipping project dir %q workspace %q project %q with status %q because no plan file exists; run `atlantis plan` to include it", proj.RepoRelDir, proj.Workspace, proj.ProjectName, proj.Status.String())
+	}
+	return applyable, nil
 }
 
 func validateFoundPlans(ctx *command.Context, plans []PendingPlan) error {

--- a/server/events/project_command_builder_internal_test.go
+++ b/server/events/project_command_builder_internal_test.go
@@ -683,6 +683,7 @@ projects:
 				"",
 				false,
 				false,
+				false,
 				"auto",
 				statsScope,
 				terraformClient,
@@ -901,6 +902,7 @@ projects:
 				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl",
 				false,
 				"",
+				false,
 				false,
 				false,
 				"auto",
@@ -1154,6 +1156,7 @@ workflows:
 				"",
 				false,
 				false,
+				false,
 				"auto",
 				statsScope,
 				terraformClient,
@@ -1307,6 +1310,7 @@ projects:
 				false,
 				"",
 				true,
+				false,
 				false,
 				"auto",
 				statsScope,
@@ -1553,6 +1557,7 @@ autodiscover:
 				"",
 				true,
 				false,
+				false,
 				"auto",
 				statsScope,
 				terraformClient,
@@ -1605,4 +1610,123 @@ func mustVersion(v string) *version.Version {
 		panic(err)
 	}
 	return vers
+}
+
+func TestFilterPlansForPartialApply_SkipsErroredAndUnplannedProjects(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+				{RepoRelDir: "proj2", Workspace: "default", Status: models.ErroredPlanStatus},
+			},
+		},
+	}
+	plans := []PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default"},
+	}
+
+	applyable, err := filterPlansForPartialApply(ctx, plans, false)
+
+	Ok(t, err)
+	Equals(t, 1, len(applyable))
+	Equals(t, "proj1", applyable[0].RepoRelDir)
+}
+
+func TestFilterPlansForPartialApply_FiltersPlanWithNonApplyableStatus(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+				{RepoRelDir: "proj2", Workspace: "default", Status: models.ErroredPlanStatus},
+			},
+		},
+	}
+	plans := []PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default"},
+		{RepoRelDir: "proj2", Workspace: "default"},
+	}
+
+	applyable, err := filterPlansForPartialApply(ctx, plans, false)
+
+	Ok(t, err)
+	Equals(t, 1, len(applyable))
+	Equals(t, "proj1", applyable[0].RepoRelDir)
+}
+
+func TestFilterPlansForPartialApply_FiltersPlanWithoutMatchingStatus(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	plans := []PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default"},
+		{RepoRelDir: "proj2", Workspace: "default"},
+	}
+
+	applyable, err := filterPlansForPartialApply(ctx, plans, false)
+
+	Ok(t, err)
+	Equals(t, 1, len(applyable))
+	Equals(t, "proj1", applyable[0].RepoRelDir)
+}
+
+func TestFilterPlansForPartialApply_StillRejectsStaleHead(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "new-sha"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "old-sha"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	plans := []PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default"},
+	}
+
+	_, err := filterPlansForPartialApply(ctx, plans, false)
+
+	Assert(t, err != nil, "expected stale head to be rejected even with partial apply")
+}
+
+func TestFilterPlansForPartialApply_StillRejectsNilPullStatus(t *testing.T) {
+	ctx := &command.Context{
+		Log:        logging.NewNoopLogger(t),
+		Pull:       models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: nil,
+	}
+
+	_, err := filterPlansForPartialApply(ctx, nil, false)
+
+	Assert(t, err != nil, "expected nil pull status to be rejected even with partial apply")
+}
+
+func TestFilterPlansForPartialApply_StillRejectsActivePlan(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+
+	_, err := filterPlansForPartialApply(ctx, nil, true)
+
+	Assert(t, err != nil, "expected in-flight plan to be rejected even with partial apply")
 }

--- a/server/events/project_command_builder_internal_test.go
+++ b/server/events/project_command_builder_internal_test.go
@@ -684,6 +684,7 @@ projects:
 				"",
 				false,
 				false,
+				false,
 				"auto",
 				statsScope,
 				terraformClient,
@@ -906,6 +907,7 @@ projects:
 				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl",
 				false,
 				"",
+				false,
 				false,
 				false,
 				"auto",
@@ -1163,6 +1165,7 @@ workflows:
 				"",
 				false,
 				false,
+				false,
 				"auto",
 				statsScope,
 				terraformClient,
@@ -1320,6 +1323,7 @@ projects:
 				false,
 				"",
 				true,
+				false,
 				false,
 				"auto",
 				statsScope,
@@ -1566,6 +1570,7 @@ autodiscover:
 				"",
 				true,
 				false,
+				false,
 				"auto",
 				statsScope,
 				terraformClient,
@@ -1618,4 +1623,123 @@ func mustVersion(v string) *version.Version {
 		panic(err)
 	}
 	return vers
+}
+
+func TestFilterPlansForPartialApply_SkipsErroredAndUnplannedProjects(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+				{RepoRelDir: "proj2", Workspace: "default", Status: models.ErroredPlanStatus},
+			},
+		},
+	}
+	plans := []PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default"},
+	}
+
+	applyable, err := filterPlansForPartialApply(ctx, plans, false)
+
+	Ok(t, err)
+	Equals(t, 1, len(applyable))
+	Equals(t, "proj1", applyable[0].RepoRelDir)
+}
+
+func TestFilterPlansForPartialApply_FiltersPlanWithNonApplyableStatus(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+				{RepoRelDir: "proj2", Workspace: "default", Status: models.ErroredPlanStatus},
+			},
+		},
+	}
+	plans := []PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default"},
+		{RepoRelDir: "proj2", Workspace: "default"},
+	}
+
+	applyable, err := filterPlansForPartialApply(ctx, plans, false)
+
+	Ok(t, err)
+	Equals(t, 1, len(applyable))
+	Equals(t, "proj1", applyable[0].RepoRelDir)
+}
+
+func TestFilterPlansForPartialApply_FiltersPlanWithoutMatchingStatus(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	plans := []PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default"},
+		{RepoRelDir: "proj2", Workspace: "default"},
+	}
+
+	applyable, err := filterPlansForPartialApply(ctx, plans, false)
+
+	Ok(t, err)
+	Equals(t, 1, len(applyable))
+	Equals(t, "proj1", applyable[0].RepoRelDir)
+}
+
+func TestFilterPlansForPartialApply_StillRejectsStaleHead(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "new-sha"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "old-sha"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+	plans := []PendingPlan{
+		{RepoRelDir: "proj1", Workspace: "default"},
+	}
+
+	_, err := filterPlansForPartialApply(ctx, plans, false)
+
+	Assert(t, err != nil, "expected stale head to be rejected even with partial apply")
+}
+
+func TestFilterPlansForPartialApply_StillRejectsNilPullStatus(t *testing.T) {
+	ctx := &command.Context{
+		Log:        logging.NewNoopLogger(t),
+		Pull:       models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: nil,
+	}
+
+	_, err := filterPlansForPartialApply(ctx, nil, false)
+
+	Assert(t, err != nil, "expected nil pull status to be rejected even with partial apply")
+}
+
+func TestFilterPlansForPartialApply_StillRejectsActivePlan(t *testing.T) {
+	ctx := &command.Context{
+		Log:  logging.NewNoopLogger(t),
+		Pull: models.PullRequest{HeadCommit: "abc123"},
+		PullStatus: &models.PullStatus{
+			Pull: models.PullRequest{HeadCommit: "abc123"},
+			Projects: []models.ProjectStatus{
+				{RepoRelDir: "proj1", Workspace: "default", Status: models.PlannedPlanStatus},
+			},
+		},
+	}
+
+	_, err := filterPlansForPartialApply(ctx, nil, true)
+
+	Assert(t, err != nil, "expected in-flight plan to be rejected even with partial apply")
 }

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -43,6 +43,7 @@ var defaultUserConfig = struct {
 	RestrictFileList         bool
 	DefaultTFDistribution    string
 	SilenceNoProjects        bool
+	AllowPartialApply        bool
 	IncludeGitUntrackedFiles bool
 	AutoDiscoverMode         string
 }{
@@ -56,6 +57,7 @@ var defaultUserConfig = struct {
 	RestrictFileList:         false,
 	DefaultTFDistribution:    "",
 	SilenceNoProjects:        false,
+	AllowPartialApply:        false,
 	IncludeGitUntrackedFiles: false,
 	AutoDiscoverMode:         "auto",
 }
@@ -291,6 +293,7 @@ terraform {
 				userConfig.RestrictFileList,
 				userConfig.DefaultTFDistribution,
 				userConfig.SilenceNoProjects,
+				userConfig.AllowPartialApply,
 				userConfig.IncludeGitUntrackedFiles,
 				userConfig.AutoDiscoverMode,
 				scope,
@@ -392,7 +395,7 @@ func TestDefaultProjectCommandBuilder_OpenTofuWorkspaceDetection(t *testing.T) {
 				"**/*.tf,**/*.tf.json,**/*.tfvars,**/*.tfvars.json,**/*.tofu,**/*.tofu.json,**/terragrunt.hcl,**/.terraform.lock.hcl",
 				false,
 				c.distribution,
-				false, false,
+				false, false, false,
 				"auto",
 				scope,
 				terraformClient, &runtime.LocalPlanStore{},
@@ -780,6 +783,7 @@ projects:
 					userConfig.RestrictFileList,
 					userConfig.DefaultTFDistribution,
 					c.Silenced,
+					userConfig.AllowPartialApply,
 					userConfig.IncludeGitUntrackedFiles,
 					c.AutoDiscoverModeUserCfg,
 					scope,
@@ -876,6 +880,7 @@ func TestDefaultProjectCommandBuilder_BuildPlanCommandsDiscoverAllProjectsSkipsM
 		defaultUserConfig.RestrictFileList,
 		defaultUserConfig.DefaultTFDistribution,
 		defaultUserConfig.SilenceNoProjects,
+		defaultUserConfig.AllowPartialApply,
 		defaultUserConfig.IncludeGitUntrackedFiles,
 		defaultUserConfig.AutoDiscoverMode,
 		scope,
@@ -963,6 +968,7 @@ func TestDefaultProjectCommandBuilder_BuildPlanCommandsDiscoverAllProjectsConfig
 		defaultUserConfig.RestrictFileList,
 		defaultUserConfig.DefaultTFDistribution,
 		defaultUserConfig.SilenceNoProjects,
+		defaultUserConfig.AllowPartialApply,
 		defaultUserConfig.IncludeGitUntrackedFiles,
 		defaultUserConfig.AutoDiscoverMode,
 		scope,
@@ -1043,6 +1049,7 @@ func TestDefaultProjectCommandBuilder_PathSelectorRespectsBranchFilteredProjects
 		defaultUserConfig.RestrictFileList,
 		defaultUserConfig.DefaultTFDistribution,
 		defaultUserConfig.SilenceNoProjects,
+		defaultUserConfig.AllowPartialApply,
 		defaultUserConfig.IncludeGitUntrackedFiles,
 		defaultUserConfig.AutoDiscoverMode,
 		scope,
@@ -1139,6 +1146,7 @@ func TestDefaultProjectCommandBuilder_BuildPlanCommandsDiscoverAllProjectsAPITea
 				defaultUserConfig.RestrictFileList,
 				defaultUserConfig.DefaultTFDistribution,
 				defaultUserConfig.SilenceNoProjects,
+				defaultUserConfig.AllowPartialApply,
 				defaultUserConfig.IncludeGitUntrackedFiles,
 				defaultUserConfig.AutoDiscoverMode,
 				scope,
@@ -1228,6 +1236,7 @@ func TestDefaultProjectCommandBuilder_BuildTargetedCommand_IgnorePaths(t *testin
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -1315,6 +1324,7 @@ func TestDefaultProjectCommandBuilder_BuildWorkspaceOnlyCommand_IgnorePathsNotSk
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -1387,6 +1397,7 @@ func TestDefaultProjectCommandBuilder_BuildTargetedNonPlanCommand_IgnorePathsWit
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -1501,6 +1512,7 @@ projects:
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -1565,6 +1577,7 @@ func TestDefaultProjectCommandBuilder_ShouldIgnoreTargetedDirUsesHeadCommitForRe
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -1630,6 +1643,7 @@ func TestDefaultProjectCommandBuilder_ShouldIgnoreTargetedDirRespectsGlobProject
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -1701,6 +1715,7 @@ func TestDefaultProjectCommandBuilder_ShouldIgnoreTargetedDirFailsOpenWhenRemote
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -1762,6 +1777,7 @@ func TestDefaultProjectCommandBuilder_ShouldIgnoreTargetedDirAllowsAuthoritative
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -1824,6 +1840,7 @@ func TestDefaultProjectCommandBuilder_ShouldIgnoreTargetedDirUsesGlobalIgnoreWhe
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -1899,6 +1916,7 @@ func TestDefaultProjectCommandBuilder_ShouldIgnoreTargetedDirFileDownloadUnsuppo
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -1960,6 +1978,7 @@ func TestDefaultProjectCommandBuilder_ShouldIgnoreTargetedDirFileDownloadUnsuppo
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -2036,6 +2055,7 @@ func TestDefaultProjectCommandBuilder_ShouldIgnoreTargetedDirMergeCheckoutWithLo
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -2094,6 +2114,7 @@ func TestDefaultProjectCommandBuilder_ShouldIgnoreTargetedDirMergeCheckoutWithou
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -2179,6 +2200,7 @@ autodiscover:
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -2292,6 +2314,7 @@ autodiscover:
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -2376,6 +2399,7 @@ func TestDefaultProjectCommandBuilder_BuildTargetedApply_MergeCheckoutIgnoredTar
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -2455,6 +2479,7 @@ projects:
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -2893,6 +2918,7 @@ projects:
 				userConfig.RestrictFileList,
 				userConfig.DefaultTFDistribution,
 				userConfig.SilenceNoProjects,
+				userConfig.AllowPartialApply,
 				userConfig.IncludeGitUntrackedFiles,
 				userConfig.AutoDiscoverMode,
 				scope,
@@ -2997,6 +3023,7 @@ projects:
 		false,
 		"",
 		defaultUserConfig.SilenceNoProjects,
+		defaultUserConfig.AllowPartialApply,
 		defaultUserConfig.IncludeGitUntrackedFiles,
 		defaultUserConfig.AutoDiscoverMode,
 		scope,
@@ -3364,6 +3391,7 @@ projects:
 				userConfig.RestrictFileList,
 				userConfig.DefaultTFDistribution,
 				userConfig.SilenceNoProjects,
+				userConfig.AllowPartialApply,
 				userConfig.IncludeGitUntrackedFiles,
 				userConfig.AutoDiscoverMode,
 				scope,
@@ -3463,6 +3491,7 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply(t *testing.T) {
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -3505,6 +3534,120 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply(t *testing.T) {
 	emptyFileHash := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 	for _, ctx := range ctxs {
 		Equals(t, emptyFileHash, ctx.ExpectedPlanHash)
+	}
+}
+
+// Test the generic apply behavior when some projects have errored plans (e.g.
+// Terragrunt projects whose dependencies haven't been applied yet). With
+// AllowPartialApply disabled the whole command errors; with it enabled the
+// planned subset is applied and errored projects are skipped.
+func TestDefaultProjectCommandBuilder_BuildMultiApply_PartialApply(t *testing.T) {
+	cases := []struct {
+		name              string
+		allowPartialApply bool
+		expErr            string
+		expCtxs           int
+	}{
+		{
+			name:              "strict validation fails when a project errored during plan",
+			allowPartialApply: false,
+			expErr:            "cannot be applied without a plan file",
+		},
+		{
+			name:              "partial apply skips errored project and applies planned subset",
+			allowPartialApply: true,
+			expCtxs:           1,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			RegisterMockTestingT(t)
+			tmpDir := DirStructure(t, map[string]any{
+				"workspace1": map[string]any{
+					"project1": map[string]any{
+						"main.tf":           nil,
+						"workspace1.tfplan": nil,
+					},
+					// project2's plan errored (e.g. unapplied Terragrunt
+					// dependency) so no plan file exists.
+					"project2": map[string]any{
+						"main.tf": nil,
+					},
+				},
+			})
+			runCmd(t, filepath.Join(tmpDir, "workspace1"), "git", "init")
+
+			workingDir := mocks.NewMockWorkingDir()
+			When(workingDir.GetPullDir(
+				Any[models.Repo](),
+				Any[models.PullRequest]())).
+				ThenReturn(tmpDir, nil)
+
+			logger := logging.NewNoopLogger(t)
+			userConfig := defaultUserConfig
+
+			scope := metricstest.NewLoggingScope(t, logger, "atlantis")
+			terraformClient := tfclientmocks.NewMockClient()
+
+			builder := events.NewProjectCommandBuilder(
+				false,
+				&config.ParserValidator{},
+				&events.DefaultProjectFinder{},
+				nil,
+				workingDir,
+				events.NewDefaultWorkingDirLocker(),
+				valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{}),
+				&events.DefaultPendingPlanFinder{},
+				&events.CommentParser{ExecutableName: "atlantis"},
+				userConfig.SkipCloneNoChanges,
+				userConfig.EnableRegExpCmd,
+				userConfig.EnableAutoMerge,
+				userConfig.EnableParallelPlan,
+				userConfig.EnableParallelApply,
+				userConfig.AutoDetectModuleFiles,
+				userConfig.AutoplanFileList,
+				userConfig.RestrictFileList,
+				userConfig.DefaultTFDistribution,
+				userConfig.SilenceNoProjects,
+				c.allowPartialApply,
+				userConfig.IncludeGitUntrackedFiles,
+				userConfig.AutoDiscoverMode,
+				scope,
+				terraformClient, &runtime.LocalPlanStore{},
+			)
+
+			ctxs, err := builder.BuildApplyCommands(
+				&command.Context{
+					Log:   logger,
+					Scope: scope,
+					Pull:  models.PullRequest{HeadCommit: "abc123"},
+					PullStatus: &models.PullStatus{
+						Pull: models.PullRequest{HeadCommit: "abc123"},
+						Projects: []models.ProjectStatus{
+							{RepoRelDir: "project1", Workspace: "workspace1", Status: models.PlannedPlanStatus},
+							{RepoRelDir: "project2", Workspace: "workspace1", Status: models.ErroredPlanStatus},
+						},
+					},
+				},
+				&events.CommentCommand{
+					RepoRelDir:  "",
+					Flags:       nil,
+					Name:        command.Apply,
+					Verbose:     false,
+					Workspace:   "",
+					ProjectName: "",
+				})
+			if c.expErr != "" {
+				Assert(t, err != nil, "expected error")
+				Assert(t, strings.Contains(err.Error(), c.expErr), "expected %q in error, got: %s", c.expErr, err)
+				return
+			}
+			Ok(t, err)
+			Equals(t, c.expCtxs, len(ctxs))
+			Equals(t, "project1", ctxs[0].RepoRelDir)
+			Equals(t, "workspace1", ctxs[0].Workspace)
+		})
 	}
 }
 
@@ -3585,6 +3728,7 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply_IgnorePaths(t *testing.T) 
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -3701,6 +3845,7 @@ autodiscover:
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -3818,6 +3963,7 @@ autodiscover:
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -3911,6 +4057,7 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply_ExplicitPlanInIgnoredPath(
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -4008,6 +4155,7 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply_IgnoreStaleNamedPlanInIgno
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -4100,6 +4248,7 @@ projects:
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -4189,6 +4338,7 @@ func TestDefaultProjectCommandBuilder_EscapeArgs(t *testing.T) {
 				userConfig.RestrictFileList,
 				userConfig.DefaultTFDistribution,
 				userConfig.SilenceNoProjects,
+				userConfig.AllowPartialApply,
 				userConfig.IncludeGitUntrackedFiles,
 				userConfig.AutoDiscoverMode,
 				scope,
@@ -4380,6 +4530,7 @@ projects:
 				userConfig.RestrictFileList,
 				userConfig.DefaultTFDistribution,
 				userConfig.SilenceNoProjects,
+				userConfig.AllowPartialApply,
 				userConfig.IncludeGitUntrackedFiles,
 				userConfig.AutoDiscoverMode,
 				scope,
@@ -4525,6 +4676,7 @@ projects:
 			userConfig.RestrictFileList,
 			userConfig.DefaultTFDistribution,
 			userConfig.SilenceNoProjects,
+			userConfig.AllowPartialApply,
 			c.IncludeGitUntrackedFiles,
 			userConfig.AutoDiscoverMode,
 			scope,
@@ -4610,6 +4762,7 @@ func TestDefaultProjectCommandBuilder_WithPolicyCheckEnabled_BuildAutoplanComman
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -4699,6 +4852,7 @@ func TestDefaultProjectCommandBuilder_BuildVersionCommand(t *testing.T) {
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -4830,6 +4984,7 @@ func TestDefaultProjectCommandBuilder_BuildPlanCommands_Single_With_RestrictFile
 				userConfig.RestrictFileList,
 				userConfig.DefaultTFDistribution,
 				userConfig.SilenceNoProjects,
+				userConfig.AllowPartialApply,
 				userConfig.IncludeGitUntrackedFiles,
 				userConfig.AutoDiscoverMode,
 				scope,
@@ -4942,6 +5097,7 @@ func TestDefaultProjectCommandBuilder_BuildPlanCommands_with_IncludeGitUntracked
 				userConfig.RestrictFileList,
 				userConfig.DefaultTFDistribution,
 				userConfig.SilenceNoProjects,
+				userConfig.AllowPartialApply,
 				userConfig.IncludeGitUntrackedFiles,
 				userConfig.AutoDiscoverMode,
 				scope,
@@ -5743,6 +5899,7 @@ func TestDefaultProjectCommandBuilder_ExternalPlanStoreRecovery(t *testing.T) {
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -5926,6 +6083,7 @@ func TestDefaultProjectCommandBuilder_ExternalPlanStoreRecovery_MultiWorkspace(t
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -6036,6 +6194,7 @@ func TestDefaultProjectCommandBuilder_ExternalPlanStoreRecovery_SeparateSharePla
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -6125,6 +6284,7 @@ func TestDefaultProjectCommandBuilder_ExternalPlanStoreRecovery_OnlyNonDefaultWo
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -6203,6 +6363,7 @@ func TestDefaultProjectCommandBuilder_LocalPlanStoreRecovery_SeparateSharePlanDi
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -6292,6 +6453,7 @@ projects:
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -41,6 +41,7 @@ var defaultUserConfig = struct {
 	RestrictFileList         bool
 	DefaultTFDistribution    string
 	SilenceNoProjects        bool
+	AllowPartialApply        bool
 	IncludeGitUntrackedFiles bool
 	AutoDiscoverMode         string
 }{
@@ -54,6 +55,7 @@ var defaultUserConfig = struct {
 	RestrictFileList:         false,
 	DefaultTFDistribution:    "",
 	SilenceNoProjects:        false,
+	AllowPartialApply:        false,
 	IncludeGitUntrackedFiles: false,
 	AutoDiscoverMode:         "auto",
 }
@@ -289,6 +291,7 @@ terraform {
 				userConfig.RestrictFileList,
 				userConfig.DefaultTFDistribution,
 				userConfig.SilenceNoProjects,
+				userConfig.AllowPartialApply,
 				userConfig.IncludeGitUntrackedFiles,
 				userConfig.AutoDiscoverMode,
 				scope,
@@ -390,7 +393,7 @@ func TestDefaultProjectCommandBuilder_OpenTofuWorkspaceDetection(t *testing.T) {
 				"**/*.tf,**/*.tf.json,**/*.tfvars,**/*.tfvars.json,**/*.tofu,**/*.tofu.json,**/terragrunt.hcl,**/.terraform.lock.hcl",
 				false,
 				c.distribution,
-				false, false,
+				false, false, false,
 				"auto",
 				scope,
 				terraformClient, &runtime.LocalPlanStore{},
@@ -778,6 +781,7 @@ projects:
 					userConfig.RestrictFileList,
 					userConfig.DefaultTFDistribution,
 					c.Silenced,
+					userConfig.AllowPartialApply,
 					userConfig.IncludeGitUntrackedFiles,
 					c.AutoDiscoverModeUserCfg,
 					scope,
@@ -874,6 +878,7 @@ func TestDefaultProjectCommandBuilder_BuildPlanCommandsDiscoverAllProjectsSkipsM
 		defaultUserConfig.RestrictFileList,
 		defaultUserConfig.DefaultTFDistribution,
 		defaultUserConfig.SilenceNoProjects,
+		defaultUserConfig.AllowPartialApply,
 		defaultUserConfig.IncludeGitUntrackedFiles,
 		defaultUserConfig.AutoDiscoverMode,
 		scope,
@@ -961,6 +966,7 @@ func TestDefaultProjectCommandBuilder_BuildPlanCommandsDiscoverAllProjectsConfig
 		defaultUserConfig.RestrictFileList,
 		defaultUserConfig.DefaultTFDistribution,
 		defaultUserConfig.SilenceNoProjects,
+		defaultUserConfig.AllowPartialApply,
 		defaultUserConfig.IncludeGitUntrackedFiles,
 		defaultUserConfig.AutoDiscoverMode,
 		scope,
@@ -1041,6 +1047,7 @@ func TestDefaultProjectCommandBuilder_PathSelectorRespectsBranchFilteredProjects
 		defaultUserConfig.RestrictFileList,
 		defaultUserConfig.DefaultTFDistribution,
 		defaultUserConfig.SilenceNoProjects,
+		defaultUserConfig.AllowPartialApply,
 		defaultUserConfig.IncludeGitUntrackedFiles,
 		defaultUserConfig.AutoDiscoverMode,
 		scope,
@@ -1137,6 +1144,7 @@ func TestDefaultProjectCommandBuilder_BuildPlanCommandsDiscoverAllProjectsAPITea
 				defaultUserConfig.RestrictFileList,
 				defaultUserConfig.DefaultTFDistribution,
 				defaultUserConfig.SilenceNoProjects,
+				defaultUserConfig.AllowPartialApply,
 				defaultUserConfig.IncludeGitUntrackedFiles,
 				defaultUserConfig.AutoDiscoverMode,
 				scope,
@@ -1226,6 +1234,7 @@ func TestDefaultProjectCommandBuilder_BuildTargetedCommand_IgnorePaths(t *testin
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -1313,6 +1322,7 @@ func TestDefaultProjectCommandBuilder_BuildWorkspaceOnlyCommand_IgnorePathsNotSk
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -1385,6 +1395,7 @@ func TestDefaultProjectCommandBuilder_BuildTargetedNonPlanCommand_IgnorePathsWit
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -1499,6 +1510,7 @@ projects:
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -1563,6 +1575,7 @@ func TestDefaultProjectCommandBuilder_ShouldIgnoreTargetedDirUsesHeadCommitForRe
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -1628,6 +1641,7 @@ func TestDefaultProjectCommandBuilder_ShouldIgnoreTargetedDirRespectsGlobProject
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -1699,6 +1713,7 @@ func TestDefaultProjectCommandBuilder_ShouldIgnoreTargetedDirFailsOpenWhenRemote
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -1760,6 +1775,7 @@ func TestDefaultProjectCommandBuilder_ShouldIgnoreTargetedDirAllowsAuthoritative
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -1822,6 +1838,7 @@ func TestDefaultProjectCommandBuilder_ShouldIgnoreTargetedDirUsesGlobalIgnoreWhe
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -1897,6 +1914,7 @@ func TestDefaultProjectCommandBuilder_ShouldIgnoreTargetedDirFileDownloadUnsuppo
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -1958,6 +1976,7 @@ func TestDefaultProjectCommandBuilder_ShouldIgnoreTargetedDirFileDownloadUnsuppo
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -2034,6 +2053,7 @@ func TestDefaultProjectCommandBuilder_ShouldIgnoreTargetedDirMergeCheckoutWithLo
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -2092,6 +2112,7 @@ func TestDefaultProjectCommandBuilder_ShouldIgnoreTargetedDirMergeCheckoutWithou
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -2177,6 +2198,7 @@ autodiscover:
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -2290,6 +2312,7 @@ autodiscover:
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -2374,6 +2397,7 @@ func TestDefaultProjectCommandBuilder_BuildTargetedApply_MergeCheckoutIgnoredTar
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -2453,6 +2477,7 @@ projects:
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -2891,6 +2916,7 @@ projects:
 				userConfig.RestrictFileList,
 				userConfig.DefaultTFDistribution,
 				userConfig.SilenceNoProjects,
+				userConfig.AllowPartialApply,
 				userConfig.IncludeGitUntrackedFiles,
 				userConfig.AutoDiscoverMode,
 				scope,
@@ -2995,6 +3021,7 @@ projects:
 		false,
 		"",
 		defaultUserConfig.SilenceNoProjects,
+		defaultUserConfig.AllowPartialApply,
 		defaultUserConfig.IncludeGitUntrackedFiles,
 		defaultUserConfig.AutoDiscoverMode,
 		scope,
@@ -3362,6 +3389,7 @@ projects:
 				userConfig.RestrictFileList,
 				userConfig.DefaultTFDistribution,
 				userConfig.SilenceNoProjects,
+				userConfig.AllowPartialApply,
 				userConfig.IncludeGitUntrackedFiles,
 				userConfig.AutoDiscoverMode,
 				scope,
@@ -3461,6 +3489,7 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply(t *testing.T) {
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -3503,6 +3532,120 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply(t *testing.T) {
 	emptyFileHash := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 	for _, ctx := range ctxs {
 		Equals(t, emptyFileHash, ctx.ExpectedPlanHash)
+	}
+}
+
+// Test the generic apply behavior when some projects have errored plans (e.g.
+// Terragrunt projects whose dependencies haven't been applied yet). With
+// AllowPartialApply disabled the whole command errors; with it enabled the
+// planned subset is applied and errored projects are skipped.
+func TestDefaultProjectCommandBuilder_BuildMultiApply_PartialApply(t *testing.T) {
+	cases := []struct {
+		name              string
+		allowPartialApply bool
+		expErr            string
+		expCtxs           int
+	}{
+		{
+			name:              "strict validation fails when a project errored during plan",
+			allowPartialApply: false,
+			expErr:            "cannot be applied without a plan file",
+		},
+		{
+			name:              "partial apply skips errored project and applies planned subset",
+			allowPartialApply: true,
+			expCtxs:           1,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			RegisterMockTestingT(t)
+			tmpDir := DirStructure(t, map[string]any{
+				"workspace1": map[string]any{
+					"project1": map[string]any{
+						"main.tf":           nil,
+						"workspace1.tfplan": nil,
+					},
+					// project2's plan errored (e.g. unapplied Terragrunt
+					// dependency) so no plan file exists.
+					"project2": map[string]any{
+						"main.tf": nil,
+					},
+				},
+			})
+			runCmd(t, filepath.Join(tmpDir, "workspace1"), "git", "init")
+
+			workingDir := mocks.NewMockWorkingDir()
+			When(workingDir.GetPullDir(
+				Any[models.Repo](),
+				Any[models.PullRequest]())).
+				ThenReturn(tmpDir, nil)
+
+			logger := logging.NewNoopLogger(t)
+			userConfig := defaultUserConfig
+
+			scope := metricstest.NewLoggingScope(t, logger, "atlantis")
+			terraformClient := tfclientmocks.NewMockClient()
+
+			builder := events.NewProjectCommandBuilder(
+				false,
+				&config.ParserValidator{},
+				&events.DefaultProjectFinder{},
+				nil,
+				workingDir,
+				events.NewDefaultWorkingDirLocker(),
+				valid.NewGlobalCfgFromArgs(valid.GlobalCfgArgs{}),
+				&events.DefaultPendingPlanFinder{},
+				&events.CommentParser{ExecutableName: "atlantis"},
+				userConfig.SkipCloneNoChanges,
+				userConfig.EnableRegExpCmd,
+				userConfig.EnableAutoMerge,
+				userConfig.EnableParallelPlan,
+				userConfig.EnableParallelApply,
+				userConfig.AutoDetectModuleFiles,
+				userConfig.AutoplanFileList,
+				userConfig.RestrictFileList,
+				userConfig.DefaultTFDistribution,
+				userConfig.SilenceNoProjects,
+				c.allowPartialApply,
+				userConfig.IncludeGitUntrackedFiles,
+				userConfig.AutoDiscoverMode,
+				scope,
+				terraformClient, &runtime.LocalPlanStore{},
+			)
+
+			ctxs, err := builder.BuildApplyCommands(
+				&command.Context{
+					Log:   logger,
+					Scope: scope,
+					Pull:  models.PullRequest{HeadCommit: "abc123"},
+					PullStatus: &models.PullStatus{
+						Pull: models.PullRequest{HeadCommit: "abc123"},
+						Projects: []models.ProjectStatus{
+							{RepoRelDir: "project1", Workspace: "workspace1", Status: models.PlannedPlanStatus},
+							{RepoRelDir: "project2", Workspace: "workspace1", Status: models.ErroredPlanStatus},
+						},
+					},
+				},
+				&events.CommentCommand{
+					RepoRelDir:  "",
+					Flags:       nil,
+					Name:        command.Apply,
+					Verbose:     false,
+					Workspace:   "",
+					ProjectName: "",
+				})
+			if c.expErr != "" {
+				Assert(t, err != nil, "expected error")
+				Assert(t, strings.Contains(err.Error(), c.expErr), "expected %q in error, got: %s", c.expErr, err)
+				return
+			}
+			Ok(t, err)
+			Equals(t, c.expCtxs, len(ctxs))
+			Equals(t, "project1", ctxs[0].RepoRelDir)
+			Equals(t, "workspace1", ctxs[0].Workspace)
+		})
 	}
 }
 
@@ -3583,6 +3726,7 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply_IgnorePaths(t *testing.T) 
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -3699,6 +3843,7 @@ autodiscover:
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -3816,6 +3961,7 @@ autodiscover:
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -3909,6 +4055,7 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply_ExplicitPlanInIgnoredPath(
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -4006,6 +4153,7 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply_IgnoreStaleNamedPlanInIgno
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -4098,6 +4246,7 @@ projects:
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -4187,6 +4336,7 @@ func TestDefaultProjectCommandBuilder_EscapeArgs(t *testing.T) {
 				userConfig.RestrictFileList,
 				userConfig.DefaultTFDistribution,
 				userConfig.SilenceNoProjects,
+				userConfig.AllowPartialApply,
 				userConfig.IncludeGitUntrackedFiles,
 				userConfig.AutoDiscoverMode,
 				scope,
@@ -4378,6 +4528,7 @@ projects:
 				userConfig.RestrictFileList,
 				userConfig.DefaultTFDistribution,
 				userConfig.SilenceNoProjects,
+				userConfig.AllowPartialApply,
 				userConfig.IncludeGitUntrackedFiles,
 				userConfig.AutoDiscoverMode,
 				scope,
@@ -4523,6 +4674,7 @@ projects:
 			userConfig.RestrictFileList,
 			userConfig.DefaultTFDistribution,
 			userConfig.SilenceNoProjects,
+			userConfig.AllowPartialApply,
 			c.IncludeGitUntrackedFiles,
 			userConfig.AutoDiscoverMode,
 			scope,
@@ -4608,6 +4760,7 @@ func TestDefaultProjectCommandBuilder_WithPolicyCheckEnabled_BuildAutoplanComman
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -4697,6 +4850,7 @@ func TestDefaultProjectCommandBuilder_BuildVersionCommand(t *testing.T) {
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -4828,6 +4982,7 @@ func TestDefaultProjectCommandBuilder_BuildPlanCommands_Single_With_RestrictFile
 				userConfig.RestrictFileList,
 				userConfig.DefaultTFDistribution,
 				userConfig.SilenceNoProjects,
+				userConfig.AllowPartialApply,
 				userConfig.IncludeGitUntrackedFiles,
 				userConfig.AutoDiscoverMode,
 				scope,
@@ -4940,6 +5095,7 @@ func TestDefaultProjectCommandBuilder_BuildPlanCommands_with_IncludeGitUntracked
 				userConfig.RestrictFileList,
 				userConfig.DefaultTFDistribution,
 				userConfig.SilenceNoProjects,
+				userConfig.AllowPartialApply,
 				userConfig.IncludeGitUntrackedFiles,
 				userConfig.AutoDiscoverMode,
 				scope,
@@ -5741,6 +5897,7 @@ func TestDefaultProjectCommandBuilder_ExternalPlanStoreRecovery(t *testing.T) {
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,
@@ -5916,6 +6073,7 @@ func TestDefaultProjectCommandBuilder_ExternalPlanStoreRecovery_MultiWorkspace(t
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverMode,
 		scope,

--- a/server/server.go
+++ b/server/server.go
@@ -735,6 +735,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverModeFlag,
 		statsScope,

--- a/server/server.go
+++ b/server/server.go
@@ -763,6 +763,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		userConfig.RestrictFileList,
 		userConfig.DefaultTFDistribution,
 		userConfig.SilenceNoProjects,
+		userConfig.AllowPartialApply,
 		userConfig.IncludeGitUntrackedFiles,
 		userConfig.AutoDiscoverModeFlag,
 		statsScope,

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -18,6 +18,7 @@ import (
 // the config is parsed from a YAML file.
 type UserConfig struct {
 	AllowForkPRs                bool   `mapstructure:"allow-fork-prs"`
+	AllowPartialApply           bool   `mapstructure:"allow-partial-apply"`
 	AllowCommands               string `mapstructure:"allow-commands"`
 	BlockedExtraArgs            string `mapstructure:"blocked-extra-args"`
 	AtlantisURL                 string `mapstructure:"atlantis-url"`


### PR DESCRIPTION
## what

Adds an opt-in server flag `--allow-partial-apply` (`ATLANTIS_ALLOW_PARTIAL_APPLY`, default `false`). When enabled, the generic `atlantis apply` command applies the subset of projects that have valid plans and skips projects whose plans errored or are missing (each skipped project is logged as a warning), instead of failing the whole command.

Default behavior is unchanged: with the flag off, the strict validation from #6605 applies as-is.

## why

The apply plan-state validation introduced in #6605 rejects the generic `atlantis apply` when **any** project in the recorded pull status has an errored plan or a missing plan file.

This breaks workflows with inter-project dependencies — most commonly Terragrunt `dependency` blocks — where dependent projects legitimately cannot plan until their upstream projects have been applied. Before v0.46.0, users iterated `plan` → `apply` → `plan` → `apply` within one PR, with each generic apply applying the successfully-planned subset. With v0.46.0 the first apply is hard-blocked because the dependent projects have `ErroredPlanStatus`, so the iteration can never start.

Related reports of the strictness of the new validation affecting existing workflows: #6641, #6642.

Even with the flag enabled, these checks still fail the command, preserving the core safety intent of #6605:

- a recorded pull status must exist
- head commit / base branch staleness validation
- in-flight plan detection ("a plan is currently running")
- per-project plan hash and status validation at execution time

## tests

- Unit tests for the new `filterPlansForPartialApply` covering: skipping errored/unplanned projects, filtering discovered plans with non-applyable or missing status, and that stale-head, nil pull status, and in-flight-plan conditions still error.
- Builder-level test `TestDefaultProjectCommandBuilder_BuildMultiApply_PartialApply` simulating the Terragrunt scenario (one planned project, one errored): strict mode fails the command, partial-apply mode builds only the planned project.
- `go test ./server/events ./server ./cmd` pass.

## references

- #6605 (introduced the strict validation)
- #6529 (original safety issue)
- Documentation added to `runatlantis.io/docs/server-configuration.md`