### PR TITLE
fix: don't run post-workflow hooks when skip-clone-no-changes skipped the clone

### DIFF
--- a/server/events/command/context.go
+++ b/server/events/command/context.go
@@ -104,6 +104,13 @@ type Context struct {
 	// Set true if the command was intentionally skipped without executing work.
 	CommandSkipped bool
 
+	// CloneSkipped is set true when project command building determined no
+	// project was modified (skip-clone-no-changes) and returned without
+	// cloning the repo. Unlike CommandSkipped (which covers targeted-ignore
+	// dirs), this specifically means no clone/working dir exists, so
+	// post-workflow hooks - which assume a clone - must not run.
+	CloneSkipped bool
+
 	// PreferLocalRepoCfgForTargetedIgnore makes targeted ignore checks read a
 	// cloned repo config before falling back to VCS content. This is used after
 	// pre-workflow hooks may have generated or updated atlantis.yaml.

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -244,6 +244,10 @@ func (c *DefaultCommandRunner) RunAutoplanCommand(baseRepo models.Repo, headRepo
 
 	autoPlanRunner.Run(ctx, nil)
 
+	if ctx.CloneSkipped {
+		return
+	}
+
 	c.PostWorkflowHooksCommandRunner.RunPostHooks(ctx, cmd) // nolint: errcheck
 }
 
@@ -560,7 +564,7 @@ func (c *DefaultCommandRunner) RunCommentCommand(baseRepo models.Repo, maybeHead
 	}
 
 	cmdRunner.Run(ctx, cmd)
-	if ctx.CommandSkipped {
+	if ctx.CommandSkipped || ctx.CloneSkipped {
 		return
 	}
 

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -2212,6 +2212,50 @@ func TestRunAutoplanCommand_DeletePlans(t *testing.T) {
 	pendingPlanFinder.VerifyWasCalledOnce().Find(tmp)
 }
 
+// Regression test for #6712: when project command building determines no
+// project was modified and skips the clone (setting ctx.CloneSkipped), post
+// workflow hooks - which assume a clone/working dir exists - must not run.
+// Previously RunPostHooks was called unconditionally after autoplan, forcing
+// an otherwise-skipped clone right back and defeating skip-clone-no-changes.
+func TestRunAutoplanCommand_SkipsPostHooksWhenCloneSkipped(t *testing.T) {
+	setup(t)
+	tmp := t.TempDir()
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num, HeadCommit: "abc123"}
+
+	When(projectCommandBuilder.BuildAutoplanCommands(Any[*command.Context]())).Then(func(args []Param) ReturnValues {
+		ctx := args[0].(*command.Context)
+		ctx.CloneSkipped = true
+		return ReturnValues{[]command.ProjectContext{}, nil}
+	})
+	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(tmp, nil)
+
+	ch.RunAutoplanCommand(testdata.GithubRepo, testdata.GithubRepo, modelPull, testdata.User)
+
+	postWorkflowHooksCommandRunner.(*mocks.MockPostWorkflowHooksCommandRunner).VerifyWasCalled(Never()).RunPostHooks(Any[*command.Context](), Any[*events.CommentCommand]())
+}
+
+// Comment-command counterpart of TestRunAutoplanCommand_SkipsPostHooksWhenCloneSkipped:
+// an "atlantis plan" comment that resolves to no modified projects (clone
+// skipped) must also not run post-workflow hooks. Regression test for #6712.
+func TestRunCommentCommand_SkipsPostHooksWhenCloneSkipped(t *testing.T) {
+	setup(t)
+	pull := &github.PullRequest{State: github.Ptr("open")}
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num}
+	cmd := &events.CommentCommand{Name: command.Plan}
+
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+	When(projectCommandBuilder.BuildPlanCommands(Any[*command.Context](), Eq(cmd))).Then(func(args []Param) ReturnValues {
+		ctx := args[0].(*command.Context)
+		ctx.CloneSkipped = true
+		return ReturnValues{[]command.ProjectContext{}, nil}
+	})
+
+	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, cmd)
+
+	postWorkflowHooksCommandRunner.(*mocks.MockPostWorkflowHooksCommandRunner).VerifyWasCalled(Never()).RunPostHooks(Any[*command.Context](), Any[*events.CommentCommand]())
+}
+
 func TestRunAutoplan_NoProjectsWritesCurrentEmptyPullStatus(t *testing.T) {
 	setup(t)
 	tmp := t.TempDir()

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -865,6 +865,10 @@ func (p *DefaultProjectCommandBuilder) buildAllCommandsByCfg(ctx *command.Contex
 			return nil, err
 		}
 		if shouldSkipClone {
+			// No projects were modified, so nothing was cloned. Post-workflow
+			// hooks assume a clone exists, so RunPostHooks must not run them.
+			// See https://github.com/runatlantis/atlantis/issues/6712
+			ctx.CloneSkipped = true
 			return []command.ProjectContext{}, nil
 		}
 	}

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -4538,7 +4538,7 @@ projects:
 			headRepo.Owner = "repoForker"
 		}
 
-		actCtxs, err = builder.BuildAutoplanCommands(&command.Context{
+		ctx := &command.Context{
 			HeadRepo: headRepo,
 			Pull: models.PullRequest{
 				BaseRepo: baseRepo,
@@ -4549,7 +4549,8 @@ projects:
 			PullRequestStatus: models.PullReqStatus{
 				MergeableStatus: models.MergeableStatus{IsMergeable: true},
 			},
-		})
+		}
+		actCtxs, err = builder.BuildAutoplanCommands(ctx)
 
 		Ok(t, err)
 		Equals(t, c.ExpectedCtxs, len(actCtxs))
@@ -4560,6 +4561,10 @@ projects:
 			_, actRepo, _, _ := res.GetCapturedArguments()
 			Equals(t, headRepo, actRepo)
 		}
+		// Regression test for #6712: ctx.CloneSkipped must be set exactly when
+		// the clone was actually skipped, so callers (e.g. RunPostHooks) know
+		// not to assume a working dir exists.
+		Equals(t, c.ExpectedClones == 0, ctx.CloneSkipped)
 	}
 }
 


### PR DESCRIPTION
## Summary

`skip-clone-no-changes` is silently bypassed when `post_workflow_hooks` are configured, causing unnecessary clone/working-dir activity on every PR update where no project was modified — reported as consuming ~500GB of accumulated storage in a production instance.

Observed log sequence:
1. `skipping repo clone since no project was modified`
2. `Post-workflow hooks configured, running...`
3. `repo was already cloned but branch is not at correct commit, updating to "..."`

## Root cause

`buildAllCommandsByCfg` in `server/events/project_command_builder.go` returns an empty `[]command.ProjectContext{}` when `shouldSkipClone` determines no configured project was modified — but it doesn't record anywhere that the clone was skipped.

Both `RunAutoplanCommand` and `RunCommentCommand` in `server/events/command_runner.go` then unconditionally call `PostWorkflowHooksCommandRunner.RunPostHooks(ctx, cmd)`, which itself calls `WorkingDir.Clone()` if any post-workflow hooks are configured, with no awareness of the skip-clone decision. So the clone that was just intentionally skipped happens anyway, a few seconds later, via the post-hook path.

I looked at reusing the existing `ctx.CommandSkipped` field, since `RunCommentCommand` already checks it before calling `RunPostHooks` — but that flag is for a different, unrelated case (`autodiscover.ignore_paths` targeted-dir skipping, set via `MarkCommandSkippedIfIgnoredTarget`/`MarkCommandSkippedIfIgnoredTargetedDir` in the same file). Reusing it here would conflate two different "skip" reasons and risk affecting the other code paths that already check `ctx.CommandSkipped` (e.g. in `server/controllers/api_controller.go`) for that unrelated purpose.

## Fix

- Added a new `ctx.CloneSkipped bool` field to `command.Context` (`server/events/command/context.go`), with a doc comment distinguishing it from `CommandSkipped`.
- `buildAllCommandsByCfg` sets `ctx.CloneSkipped = true` at the exact point it currently returns the empty project list due to `shouldSkipClone`.
- `RunAutoplanCommand` now returns before calling `RunPostHooks` if `ctx.CloneSkipped`.
- `RunCommentCommand`'s existing `if ctx.CommandSkipped { return }` guard is extended to `if ctx.CommandSkipped || ctx.CloneSkipped { return }`, since comment-triggered commands (`plan`, `apply`, `import`, `state rm`) go through the same `buildAllCommandsByCfg` skip-clone path.

## Test plan

- [x] `go build ./...`
- [x] Extended `TestDefaultProjectCommandBuilder_SkipCloneNoChanges` in `project_command_builder_test.go` to assert `ctx.CloneSkipped` is set exactly when the clone was actually skipped, across all existing table cases (including the autodiscover-enabled and untracked-files cases, which take a different path and must NOT set it)
- [x] Added `TestRunAutoplanCommand_SkipsPostHooksWhenCloneSkipped` and `TestRunCommentCommand_SkipsPostHooksWhenCloneSkipped` in `command_runner_test.go`, verifying `RunPostHooks` is never called (`VerifyWasCalled(Never())`) when the project command builder mock sets `ctx.CloneSkipped = true`
- [x] `go test ./server/events/...` passes; 3 pre-existing failures on my Windows dev machine (`TestVarFileAllowlistChecker_IsAllowlisted`, `TestClone_ReCloneOnBaseChangeForMergeStrategy`, and a flaky `TestDefaultProjectFinder_DetermineProjectsViaConfig` temp-dir cleanup race) reproduce identically against unmodified `main` via `git stash` — confirmed unrelated to this change

Fixes #6712