### PR TITLE
fix: handle pre-v0.44.0 int-shaped PolicySetStatus.Approvals on read

### DIFF
--- a/server/core/boltdb/boltdb_test.go
+++ b/server/core/boltdb/boltdb_test.go
@@ -1312,9 +1312,18 @@ func TestPullStatus_UpdateNewCommit_PreservesPolicyApprovals(t *testing.T) {
 
 // TestPullStatus_UpdateOverwritesCorruptData verifies that
 // UpdatePullWithResults tolerates a pre-existing pull-status blob whose JSON
-// no longer matches the current Go shape (e.g. after upgrading across a
-// PullStatus schema change). The corrupt entry should be logged and
-// overwritten rather than causing every subsequent plan to fail.
+// no longer matches the current Go shape at all (e.g. after an incompatible
+// PullStatus schema change this repo doesn't know how to interpret). The
+// corrupt entry should be logged and overwritten rather than causing every
+// subsequent plan to fail.
+//
+// Note this is deliberately NOT the pre-v0.44.0 int-shaped
+// PolicySetStatus.Approvals format (see #6693) - that specific legacy shape
+// is now handled gracefully by PolicySetStatus.UnmarshalJSON rather than
+// being treated as corrupt; see TestPullStatus_UpdateHandlesLegacyPolicyApprovals
+// below for that case. This test uses a value (a string) that isn't valid in
+// either the current or legacy shape, to keep covering the truly-unreadable
+// fallback.
 func TestPullStatus_UpdateOverwritesCorruptData(t *testing.T) {
 	tmp := t.TempDir()
 
@@ -1348,7 +1357,7 @@ func TestPullStatus_UpdateOverwritesCorruptData(t *testing.T) {
 	// that the current Go types cannot unmarshal.
 	key := fmt.Appendf(nil, "%s::%s::%d",
 		pull.BaseRepo.VCSHost.Hostname, pull.BaseRepo.FullName, pull.Num)
-	corrupt := []byte(`{"Projects":[{"Workspace":"default","RepoRelDir":"mydir","ProjectName":"","PolicyStatus":[{"PolicySetName":"policy1","Passed":false,"Approvals":2}],"Status":0}],"Pull":{"Num":1}}`)
+	corrupt := []byte(`{"Projects":[{"Workspace":"default","RepoRelDir":"mydir","ProjectName":"","PolicyStatus":[{"PolicySetName":"policy1","Passed":false,"Approvals":"bogus"}],"Status":0}],"Pull":{"Num":1}}`)
 	raw, err := bolt.Open(filepath.Join(tmp, "atlantis.db"), 0600, nil)
 	Ok(t, err)
 	err = raw.Update(func(tx *bolt.Tx) error {
@@ -1385,6 +1394,85 @@ func TestPullStatus_UpdateOverwritesCorruptData(t *testing.T) {
 	Assert(t, got != nil, "expected non-nil pull status")
 	Equals(t, 1, len(got.Projects))
 	Equals(t, models.PlannedPlanStatus, got.Projects[0].Status)
+}
+
+// TestPullStatus_UpdateHandlesLegacyPolicyApprovals is the counterpart to
+// TestPullStatus_UpdateOverwritesCorruptData: it verifies the real bug from
+// #6693. A pull-status blob persisted before v0.44.0 (#6271), where
+// PolicySetStatus.Approvals was a plain int rather than
+// []PolicySetApproval, must be read successfully (not discarded as corrupt)
+// - with approvals reset to none, since real approver identities were never
+// stored in that format - and its policy status preserved across a
+// subsequent commit the same way a current-format entry would be.
+func TestPullStatus_UpdateHandlesLegacyPolicyApprovals(t *testing.T) {
+	tmp := t.TempDir()
+
+	pull := models.PullRequest{
+		Num:        1,
+		HeadCommit: "sha-A",
+		URL:        "url",
+		HeadBranch: "head",
+		BaseBranch: "base",
+		Author:     "lkysow",
+		State:      models.OpenPullState,
+		BaseRepo: models.Repo{
+			FullName:          "runatlantis/atlantis",
+			Owner:             "runatlantis",
+			Name:              "atlantis",
+			CloneURL:          "clone-url",
+			SanitizedCloneURL: "clone-url",
+			VCSHost: models.VCSHost{
+				Hostname: "github.com",
+				Type:     models.Github,
+			},
+		},
+	}
+
+	b, err := boltdb.New(tmp)
+	Ok(t, err)
+	Ok(t, b.Close())
+
+	// Inject a pre-v0.44.0 pull-status blob: Approvals is a plain int (2)
+	// rather than []PolicySetApproval, at the same commit ("sha-A") as the
+	// pull being updated below.
+	key := fmt.Appendf(nil, "%s::%s::%d",
+		pull.BaseRepo.VCSHost.Hostname, pull.BaseRepo.FullName, pull.Num)
+	legacy := []byte(`{"Projects":[{"Workspace":"default","RepoRelDir":"mydir","ProjectName":"","PolicyStatus":[{"PolicySetName":"policy1","Passed":false,"Approvals":2,"Hashes":["h1"]}],"Status":0}],"Pull":{"Num":1,"HeadCommit":"sha-A"}}`)
+	raw, err := bolt.Open(filepath.Join(tmp, "atlantis.db"), 0600, nil)
+	Ok(t, err)
+	Ok(t, raw.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket([]byte("pulls")).Put(key, legacy)
+	}))
+	Ok(t, raw.Close())
+
+	b, err = boltdb.New(tmp)
+	Ok(t, err)
+	defer b.Close()
+
+	// A plain read must succeed, not error out as it did before the fix.
+	readBack, err := b.GetPullStatus(pull)
+	Ok(t, err)
+	Assert(t, readBack != nil, "expected non-nil pull status")
+	Equals(t, 1, len(readBack.Projects[0].PolicyStatus))
+	Equals(t, 0, len(readBack.Projects[0].PolicyStatus[0].Approvals))
+
+	// Push a plan result at the same commit; the (approval-reset) policy
+	// status should be preserved, same as the current-format case.
+	status, err := b.UpdatePullWithResults(pull, []command.ProjectResult{
+		{
+			Command:    command.Plan,
+			RepoRelDir: "mydir",
+			Workspace:  "default",
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PlanSuccess: &models.PlanSuccess{TerraformOutput: "plan output"},
+			},
+		},
+	})
+	Ok(t, err)
+	Equals(t, 1, len(status.Projects))
+	Assert(t, len(status.Projects[0].PolicyStatus) > 0, "expected legacy policy status to be preserved, not discarded")
+	Equals(t, "policy1", status.Projects[0].PolicyStatus[0].PolicySetName)
+	Equals(t, 0, len(status.Projects[0].PolicyStatus[0].Approvals))
 }
 
 // newTestDB returns a TestDB using a temporary path.

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -10,6 +10,7 @@ package models
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -498,6 +499,44 @@ type PolicySetStatus struct {
 	Approvals       []PolicySetApproval
 	Hashes          []string
 	PolicyItemRegex string
+}
+
+// UnmarshalJSON provides backward compatibility for PullStatus records
+// persisted to BoltDB before v0.44.0 (#6271), where Approvals was a plain
+// int count rather than []PolicySetApproval. Without this, reading such a
+// record (e.g. on `apply`) fails outright with a JSON type error.
+//
+// Legacy int-shaped records can't be reconstructed with real approver
+// identities (that information was never stored), so they deserialize with
+// zero approvals rather than an invented/anonymous approval - the pull will
+// need a fresh approval after upgrading, same as if it had none before.
+func (pss *PolicySetStatus) UnmarshalJSON(data []byte) error {
+	type alias PolicySetStatus
+	aux := struct {
+		Approvals json.RawMessage
+		*alias
+	}{
+		alias: (*alias)(pss),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if len(aux.Approvals) == 0 {
+		return nil
+	}
+
+	var approvals []PolicySetApproval
+	if err := json.Unmarshal(aux.Approvals, &approvals); err == nil {
+		pss.Approvals = approvals
+		return nil
+	}
+
+	var legacyCount int
+	if err := json.Unmarshal(aux.Approvals, &legacyCount); err != nil {
+		return fmt.Errorf("unmarshaling PolicySetStatus.Approvals: not a []PolicySetApproval or legacy int: %w", err)
+	}
+	pss.Approvals = nil
+	return nil
 }
 
 // GetCurApprovals returns the number of approvals that cover all hashes in this policy set.

--- a/server/events/models/models_test.go
+++ b/server/events/models/models_test.go
@@ -5,6 +5,7 @@
 package models_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -970,6 +971,156 @@ func TestPolicySetStatus_OwnerHasFullyApproved(t *testing.T) {
 			Equals(t, c.expected, c.status.OwnerHasFullyApproved(c.owner))
 		})
 	}
+}
+
+// Regression test for #6693: pull status records persisted to BoltDB before
+// v0.44.0 (#6271) stored Approvals as a plain int count. Deserializing such a
+// record must not fail outright - it should come back with zero approvals,
+// since the real approver identities were never stored in that format.
+func TestPolicySetStatus_UnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		description string
+		json        string
+		expected    models.PolicySetStatus
+		expectErr   bool
+	}{
+		{
+			description: "current format with approvals",
+			json: `{
+				"PolicySetName": "policy1",
+				"Passed": true,
+				"Approvals": [{"Approver": "user1", "Hashes": ["h1", "h2"]}],
+				"Hashes": ["h1", "h2"],
+				"PolicyItemRegex": ""
+			}`,
+			expected: models.PolicySetStatus{
+				PolicySetName: "policy1",
+				Passed:        true,
+				Approvals:     []models.PolicySetApproval{{Approver: "user1", Hashes: []string{"h1", "h2"}}},
+				Hashes:        []string{"h1", "h2"},
+			},
+		},
+		{
+			description: "current format with no approvals",
+			json: `{
+				"PolicySetName": "policy1",
+				"Passed": false,
+				"Approvals": null,
+				"Hashes": ["h1"]
+			}`,
+			expected: models.PolicySetStatus{
+				PolicySetName: "policy1",
+				Hashes:        []string{"h1"},
+			},
+		},
+		{
+			description: "legacy pre-v0.44.0 format with an int approval count",
+			json: `{
+				"PolicySetName": "policy1",
+				"Passed": false,
+				"Approvals": 2,
+				"Hashes": ["h1"]
+			}`,
+			expected: models.PolicySetStatus{
+				PolicySetName: "policy1",
+				Hashes:        []string{"h1"},
+			},
+		},
+		{
+			description: "legacy format with a zero approval count",
+			json: `{
+				"PolicySetName": "policy1",
+				"Approvals": 0,
+				"Hashes": ["h1"]
+			}`,
+			expected: models.PolicySetStatus{
+				PolicySetName: "policy1",
+				Hashes:        []string{"h1"},
+			},
+		},
+		{
+			description: "approvals field missing entirely",
+			json:        `{"PolicySetName": "policy1", "Hashes": ["h1"]}`,
+			expected: models.PolicySetStatus{
+				PolicySetName: "policy1",
+				Hashes:        []string{"h1"},
+			},
+		},
+		{
+			description: "approvals is neither an array nor an int",
+			json:        `{"PolicySetName": "policy1", "Approvals": "bogus"}`,
+			expectErr:   true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			var actual models.PolicySetStatus
+			err := json.Unmarshal([]byte(c.json), &actual)
+			if c.expectErr {
+				Assert(t, err != nil, "expected an error, got nil")
+				return
+			}
+			Ok(t, err)
+			Equals(t, c.expected, actual)
+		})
+	}
+}
+
+// Round-trip sanity check: marshaling then unmarshaling a PolicySetStatus with
+// real approvals (the normal, current-format case) must be lossless.
+func TestPolicySetStatus_MarshalUnmarshalRoundTrip(t *testing.T) {
+	orig := models.PolicySetStatus{
+		PolicySetName: "policy1",
+		Passed:        true,
+		Approvals: []models.PolicySetApproval{
+			{Approver: "user1", Hashes: []string{"h1", "h2"}},
+			{Approver: "user2", Hashes: []string{"h1"}},
+		},
+		Hashes:          []string{"h1", "h2"},
+		PolicyItemRegex: "some-regex",
+	}
+
+	data, err := json.Marshal(orig)
+	Ok(t, err)
+
+	var roundTripped models.PolicySetStatus
+	Ok(t, json.Unmarshal(data, &roundTripped))
+	Equals(t, orig, roundTripped)
+}
+
+// End-to-end regression test for #6693: a full PullStatus record, as actually
+// persisted to and read from BoltDB, with a nested pre-v0.44.0 legacy
+// PolicySetStatus.Approvals int. Before the fix, reading this record (e.g.
+// via GetPullStatus on `apply`) failed outright with a JSON type error.
+func TestPullStatus_UnmarshalJSON_LegacyNestedPolicyApprovals(t *testing.T) {
+	blob := `{
+		"Projects": [
+			{
+				"Workspace": "default",
+				"RepoRelDir": ".",
+				"ProjectName": "",
+				"PolicyStatus": [
+					{
+						"PolicySetName": "policy1",
+						"Passed": false,
+						"Approvals": 3,
+						"Hashes": ["h1"]
+					}
+				],
+				"Status": 0
+			}
+		],
+		"Pull": {}
+	}`
+
+	var status models.PullStatus
+	Ok(t, json.Unmarshal([]byte(blob), &status))
+
+	Equals(t, 1, len(status.Projects))
+	Equals(t, 1, len(status.Projects[0].PolicyStatus))
+	Assert(t, status.Projects[0].PolicyStatus[0].Approvals == nil,
+		"expected legacy int Approvals to deserialize to nil, got %v", status.Projects[0].PolicyStatus[0].Approvals)
+	Equals(t, "policy1", status.Projects[0].PolicyStatus[0].PolicySetName)
 }
 
 func TestNewPolicySetResult(t *testing.T) {


### PR DESCRIPTION
## Summary

Pull-status records persisted to BoltDB before v0.44.0 fail to deserialize, breaking commands like `apply` that need to read the current plan/policy status for a pull that hasn't had a fresh plan since upgrading.

## Root cause

`PolicySetStatus.Approvals` changed from `int` to `[]PolicySetApproval` in #6271 (v0.44.0), with no migration or backward-compat handling added for records already persisted in the old format.

`UpdatePullWithResults` already tolerates this on the write path — it catches the deserialization error, logs a warning, and discards the unreadable record, since the next `plan` overwrites it with fresh data ([boltdb.go#L416-L423](https://github.com/runatlantis/atlantis/blob/main/server/core/boltdb/boltdb.go#L416-L423)). But `GetPullStatus` and other read-only callers propagate the error directly ([boltdb.go#L520-L536](https://github.com/runatlantis/atlantis/blob/main/server/core/boltdb/boltdb.go#L520-L536)), so any pull whose only persisted record predates the upgrade fails outright on `apply` (or anything else that just reads status) until some other command happens to trigger a rewrite.

## Fix

Added a custom `PolicySetStatus.UnmarshalJSON` (`server/events/models/models.go`) that accepts `Approvals` as either the current `[]PolicySetApproval` or the legacy `int`.

A legacy int count can't be turned into real approver identities — that information was never stored in that format — so it deserializes as zero approvals; the pull will need a fresh approval after upgrading, same as if it had none before. But every other field on the record (policy set name, hashes, pass/fail state, and the rest of the surrounding `PullStatus`/`ProjectStatus`) is preserved, rather than the whole record being discarded as it currently is on the write path.

I went with fixing deserialization directly (Dosu's suggestion in the issue comments) over a BoltDB startup migration, since it's a smaller, self-contained change that doesn't need to walk every existing record in the DB at startup, and produces the same practical outcome (approvals reset, nothing else lost).

## Test plan

- [x] `go build ./...`
- [x] Added `TestPolicySetStatus_UnmarshalJSON` in `server/events/models/models_test.go`: covers current-format (with/without approvals), the legacy int format (including a zero count), a missing `Approvals` field, and an invalid shape that should still error
- [x] Added `TestPolicySetStatus_MarshalUnmarshalRoundTrip` confirming normal marshal→unmarshal of current-format data is lossless
- [x] Added `TestPullStatus_UnmarshalJSON_LegacyNestedPolicyApprovals`, decoding a full `PullStatus` blob (as actually read from BoltDB) with a nested legacy `PolicySetStatus`, matching the real crash shape
- [x] Updated the existing `TestPullStatus_UpdateOverwritesCorruptData` in `server/core/boltdb/boltdb_test.go`: it used the legacy int-Approvals shape as its "unreadable" fixture, which is no longer accurate now that this shape is handled gracefully — changed the fixture to a value invalid in both shapes, to keep it covering the genuinely-unreadable fallback, and updated its doc comment accordingly
- [x] Added `TestPullStatus_UpdateHandlesLegacyPolicyApprovals`, the counterpart end-to-end test: injects a real legacy-format blob directly into a BoltDB bucket, confirms `GetPullStatus` now succeeds (previously it would error), and confirms the (approval-reset) policy status is preserved across a subsequent commit update, the same as the current-format case already does
- [x] `go test ./server/events/models/... ./server/core/boltdb/...` — all green
- [x] `go vet` clean on both packages

Fixes #6693