### PR TITLE
fix: prevent validation comments from being parsed as commands

### DIFF
--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -689,7 +689,7 @@ func (c *DefaultCommandRunner) validateCtxAndComment(ctx *command.Context, comma
 			return false
 		}
 		ctx.Log.Info("command was run on a fork pull request which is disallowed")
-		if err := c.VCSClient.CreateComment(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull.Num, fmt.Sprintf("Atlantis commands can't be run on fork pull requests. To enable, set --%s  or, to disable this message, set --%s", c.AllowForkPRsFlag, c.SilenceForkPRErrorsFlag), ""); err != nil {
+		if err := c.VCSClient.CreateComment(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull.Num, fmt.Sprintf("Commands can't be run on fork pull requests. To enable, set --%s  or, to disable this message, set --%s", c.AllowForkPRsFlag, c.SilenceForkPRErrorsFlag), ""); err != nil {
 			ctx.Log.Err("unable to comment: %s", err)
 		}
 		return false
@@ -698,7 +698,7 @@ func (c *DefaultCommandRunner) validateCtxAndComment(ctx *command.Context, comma
 	if ctx.Pull.State != models.OpenPullState && commandName != command.Unlock {
 		ctx.Log.Info("command was run on closed pull request")
 		if shouldComment {
-			if err := c.VCSClient.CreateComment(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull.Num, "Atlantis commands can't be run on closed pull requests", ""); err != nil {
+			if err := c.VCSClient.CreateComment(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull.Num, "Commands can't be run on closed pull requests", ""); err != nil {
 				ctx.Log.Err("unable to comment: %s", err)
 			}
 		}

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -421,7 +421,7 @@ func TestRunCommentCommand_ForkPRDisabled(t *testing.T) {
 	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(&pull))).ThenReturn(modelPull, modelPull.BaseRepo, headRepo, nil)
 
 	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan})
-	commentMessage := fmt.Sprintf("Atlantis commands can't be run on fork pull requests. To enable, set --%s  or, to disable this message, set --%s", ch.AllowForkPRsFlag, ch.SilenceForkPRErrorsFlag)
+	commentMessage := fmt.Sprintf("Commands can't be run on fork pull requests. To enable, set --%s  or, to disable this message, set --%s", ch.AllowForkPRsFlag, ch.SilenceForkPRErrorsFlag)
 	vcsClient.VerifyWasCalledOnce().CreateComment(
 		Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull.Num), Eq(commentMessage), Eq(""))
 }
@@ -1118,7 +1118,7 @@ func TestRunCommentCommand_IgnoredTargetedDirValidatesPullBeforeIgnoreCheck(t *t
 				Owner:    "forkrepo",
 				FullName: "forkrepo/atlantis",
 			},
-			wantComment: fmt.Sprintf("Atlantis commands can't be run on fork pull requests. To enable, set --%s  or, to disable this message, set --%s", "allow-fork-prs-flag", ""),
+			wantComment: fmt.Sprintf("Commands can't be run on fork pull requests. To enable, set --%s  or, to disable this message, set --%s", "allow-fork-prs-flag", ""),
 		},
 		{
 			name: "closed pull request",
@@ -1128,7 +1128,7 @@ func TestRunCommentCommand_IgnoredTargetedDirValidatesPullBeforeIgnoreCheck(t *t
 				Num:      testdata.Pull.Num,
 			},
 			headRepo:    testdata.GithubRepo,
-			wantComment: "Atlantis commands can't be run on closed pull requests",
+			wantComment: "Commands can't be run on closed pull requests",
 		},
 		{
 			name: "base branch mismatch",
@@ -2003,7 +2003,7 @@ func TestRunCommentCommand_ClosedPull(t *testing.T) {
 
 	ch.RunCommentCommand(testdata.GithubRepo, &testdata.GithubRepo, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan})
 	vcsClient.VerifyWasCalledOnce().CreateComment(
-		Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull.Num), Eq("Atlantis commands can't be run on closed pull requests"), Eq(""))
+		Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull.Num), Eq("Commands can't be run on closed pull requests"), Eq(""))
 }
 
 func TestRunCommentCommand_MatchedBranch(t *testing.T) {


### PR DESCRIPTION
## what

- Remove the leading `Atlantis` command prefix from the validation comments used for closed and disallowed fork pull requests.
- Update the corresponding command runner tests to expect the revised comments.
- Preserve the existing validation behavior and fork-related flag guidance.

## why

- Atlantis-generated validation comments currently begin with `Atlantis`, which is also the default command prefix.
- GitHub sends the bot-generated comment back as another comment webhook event, causing Atlantis to treat its own response as a command candidate.
- The apostrophe in `can't` is then parsed as an opening quote, producing an additional `EOF found when expecting closing quote` error.
- Removing the command prefix from these non-command responses prevents them from being recognized as Atlantis commands without introducing broader VCS-specific self-author filtering.

## tests

- [x] `go test ./server/events -count=1`

## references

- Closes #6723
- Related to #3559