### PR TITLE
fix: ignore HTML comment trailers when parsing commands

### DIFF
--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -61,6 +61,12 @@ var DefaultBlockedExtraArgs = []string{
 // and pasting GitHub comments.
 var multiLineRegex = regexp.MustCompile(`.*\r?\n[^\r\n]+`)
 
+// htmlCommentRegex matches HTML comments, which render as nothing in the VCS UI.
+// Third-party integrations (Linear, for example) append them as metadata trailers
+// to comments a user typed, which would otherwise make an ordinary command look
+// like a multi-line comment and get ignored.
+var htmlCommentRegex = regexp.MustCompile(`(?s)<!--.*?-->`)
+
 //go:generate go tool pegomock generate --package mocks -o mocks/mock_comment_parsing.go CommentParsing
 
 // CommentParsing handles parsing pull request comments.
@@ -154,7 +160,7 @@ type CommentParseResult struct {
 // - atlantis approve_policies
 // - atlantis import ADDRESS ID
 func (e *CommentParser) Parse(rawComment string, vcsHost models.VCSHostType) CommentParseResult {
-	comment := strings.TrimSpace(rawComment)
+	comment := strings.TrimSpace(htmlCommentRegex.ReplaceAllString(rawComment, ""))
 	comment = strings.Trim(comment, "`")
 
 	if multiLineRegex.MatchString(comment) {

--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -77,10 +77,44 @@ func TestParse_Ignored(t *testing.T) {
 		"atlantis plan\nbut with newlines",
 		"terraform plan\nbut with newlines",
 		"This shouldn't error, but it does.",
+		"<!-- linear:isThreadRoot -->",
+		"atlantis plan\nbut with newlines\n<!-- linear:isThreadRoot -->",
 	}
 	for _, c := range ignoreComments {
 		r := commentParser.Parse(c, models.Github)
 		Assert(t, r.Ignore, "expected Ignore to be true for comment %q", c)
+	}
+}
+
+func TestParse_HTMLCommentTrailers(t *testing.T) {
+	cases := []struct {
+		name    string
+		comment string
+	}{
+		{
+			name:    "trailer appended by a third-party VCS client",
+			comment: "atlantis plan\n<!-- linear:isThreadRoot -->",
+		},
+		{
+			name:    "leading html comment",
+			comment: "<!-- linear:isThreadRoot -->\natlantis plan",
+		},
+		{
+			name:    "multi-line html comment",
+			comment: "atlantis plan\n<!-- linear:isThreadRoot\n  more metadata\n-->",
+		},
+		{
+			name:    "several html comments",
+			comment: "<!-- one -->\natlantis plan\n<!-- two -->",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := commentParser.Parse(c.comment, models.Github)
+			Assert(t, !r.Ignore, "expected comment %q not to be ignored", c.comment)
+			Equals(t, "", r.CommentResponse)
+			Equals(t, command.Plan, r.Command.Name)
+		})
 	}
 }
 


### PR DESCRIPTION
## what

- Strip HTML comments (`<!-- ... -->`) from a pull request comment before deciding whether it is a multi-line comment that should be ignored.
- Add `TestParse_HTMLCommentTrailers` covering trailing, leading, multi-line and repeated HTML comments, plus two new cases in `TestParse_Ignored`.

## why

- `CommentParser.Parse` bails out with `Ignore: true` as soon as `multiLineRegex` matches, i.e. as soon as there is a second non-empty line.
- Third-party VCS integrations append invisible metadata to comments a user typed. Linear's GitHub sync, for example, posts:

  ```
  atlantis apply
  <!-- linear:isThreadRoot -->
  ```

  In the GitHub UI this renders as a plain `atlantis apply`, but the raw body has a non-empty second line, so Atlantis ignores it and never replies. From the user's point of view the command silently does nothing.
- HTML comments render as nothing in every supported VCS, so removing them before the multi-line check restores the intent of that check (reject genuine prose) without weakening it.
- Genuinely multi-line comments are still ignored: `"atlantis plan\nbut with newlines\n<!-- trailer -->"` reduces to `"atlantis plan\nbut with newlines"` and is rejected as before. A body containing only an HTML comment reduces to the empty string and is ignored by the existing `len(args) < 1` guard.

## tests

- [x] Added `TestParse_HTMLCommentTrailers` in `server/events/comment_parser_test.go`, asserting the four HTML-comment placements all parse as a `plan` command with no comment response.
- [x] Extended `TestParse_Ignored` with a body that is only an HTML comment and with a genuinely multi-line body carrying a trailer, to pin the behaviour that this change must not alter.
- [ ] Not run locally: no Go toolchain available in my environment, so I relied on CI. The change is a pure string transformation ahead of existing logic and the reasoning for every existing test case is spelled out above.

## references

- closes #6643

## AI usage

Assisted by Claude, disclosed with an `Assisted-by:` trailer on the commit per [AI_USAGE_POLICY.md](https://github.com/runatlantis/atlantis/blob/main/AI_USAGE_POLICY.md). The issue carries only the `bug` label (no `triage`/`needs-discussion`).