### PR TITLE
fix(gitlab): pass SHA to AcceptMergeRequest for GitLab 19.2 require-commit-sha

### DIFF
--- a/server/events/vcs/gitlab/client.go
+++ b/server/events/vcs/gitlab/client.go
@@ -752,6 +752,12 @@ func (g *Client) MergePull(logger logging.SimpleLogging, pull models.PullRequest
 		&gitlab.AcceptMergeRequestOptions{
 			MergeCommitMessage:       &commitMsg,
 			ShouldRemoveSourceBranch: &pullOptions.DeleteSourceBranchOnMerge,
+			// SHA is required by GitLab 19.2+ when "Require a commit SHA on the
+			// merge requests API" is enabled (default for groups created on
+			// 19.2+); the API returns 400 "SHA must be provided when merging"
+			// without it. It also acts as an optimistic-concurrency check that
+			// the source branch HEAD has not changed since the plan/apply.
+			SHA: &pull.HeadCommit,
 		})
 	if resp != nil {
 		logger.Debug("PUT /projects/%s/merge_requests/%d/merge returned: %d", pull.BaseRepo.FullName, pull.Num, resp.StatusCode)

--- a/server/events/vcs/gitlab/client_test.go
+++ b/server/events/vcs/gitlab/client_test.go
@@ -272,11 +272,18 @@ func TestClient_MergePull(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
+			var gotMergeSHA string
 			testServer := httptest.NewServer(
 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.RequestURI {
 					// The first request should hit this URL.
 					case "/api/v4/projects/runatlantis%2Fatlantis/merge_requests/1/merge":
+						body, _ := io.ReadAll(r.Body)
+						var opts struct {
+							SHA string `json:"sha"`
+						}
+						json.Unmarshal(body, &opts) // nolint: errcheck
+						gotMergeSHA = opts.SHA
 						w.WriteHeader(c.code)
 						w.Write(c.glResponse) // nolint: errcheck
 					case "/api/v4/projects/runatlantis%2Fatlantis/merge_requests/1":
@@ -304,7 +311,8 @@ func TestClient_MergePull(t *testing.T) {
 			err = client.MergePull(
 				logger,
 				models.PullRequest{
-					Num: 1,
+					Num:        1,
+					HeadCommit: "sha",
 					BaseRepo: models.Repo{
 						FullName: "runatlantis/atlantis",
 						Owner:    "runatlantis",
@@ -319,6 +327,9 @@ func TestClient_MergePull(t *testing.T) {
 				ErrContains(t, c.expErr, err)
 				ErrContains(t, "unable to merge merge request, it may not be in a mergeable state", err)
 			}
+			// GitLab 19.2+ ("Require a commit SHA on the merge requests API")
+			// rejects the merge call without a sha; assert MergePull sends it.
+			Equals(t, "sha", gotMergeSHA)
 		})
 	}
 }


### PR DESCRIPTION
Closes #6731

### Overview
On GitLab **19.2+**, Atlantis `automerge` fails after a successful `apply`:

```
unable to merge merge request, it may not be in a mergeable state:
PUT .../merge_requests/<iid>/merge: 400 {message: SHA must be provided when merging}
```

### Root cause
GitLab 19.2 introduced **"Require a commit SHA on the merge requests API"** ([docs](https://docs.gitlab.com/user/group/manage/#require-a-commit-sha-on-the-merge-requests-api)), **enabled by default for groups created on 19.2 or later**. When enabled, `PUT .../merge` **without** a `sha` parameter is rejected with `400 SHA must be provided when merging`.

`MergePull` in `server/events/vcs/gitlab/client.go` builds `AcceptMergeRequestOptions` without `SHA`, so automerge fails on any group where the setting is on. This affects all released versions (verified through v0.46.0).

### Change
Set `AcceptMergeRequestOptions.SHA` from `pull.HeadCommit` (already available in `MergePull`). Besides satisfying the GitLab 19.2 requirement, passing the SHA is good practice: it is an optimistic-concurrency check that the source branch HEAD did not change between `apply` and `merge`.

### Testing
`TestClient_MergePull` now asserts the merge request body carries the expected `sha`. `go test ./server/events/vcs/gitlab/ -run TestClient_MergePull` passes.

### References
- GitLab docs: https://docs.gitlab.com/user/group/manage/#require-a-commit-sha-on-the-merge-requests-api
- Merge API: https://docs.gitlab.com/api/merge_requests/#merge-a-merge-request