### PR TITLE
fix(web): respect base path when redirecting after discarding a plan

### DIFF
--- a/server/controllers/web_templates/templates/index.html.tmpl
+++ b/server/controllers/web_templates/templates/index.html.tmpl
@@ -13,7 +13,7 @@
         $("p.js-discard-success").show();
         setTimeout(function() {
           $("p.js-discard-success").fadeOut('slow',function(){
-            window.location.href = "/";
+            window.location.href = "{{ .CleanedBasePath }}/";
           })
         }, 5000); // <-- time in milliseconds
       }

--- a/server/controllers/web_templates/web_templates_test.go
+++ b/server/controllers/web_templates/web_templates_test.go
@@ -4,7 +4,9 @@
 package web_templates
 
 import (
+	"bytes"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,7 +15,8 @@ import (
 )
 
 func TestIndexTemplate(t *testing.T) {
-	err := IndexTemplate.Execute(io.Discard, IndexData{
+	var rendered bytes.Buffer
+	err := IndexTemplate.Execute(&rendered, IndexData{
 		Locks: []LockIndexData{
 			{
 				LockPath:      "lock path",
@@ -49,6 +52,9 @@ func TestIndexTemplate(t *testing.T) {
 		},
 	})
 	Ok(t, err)
+	// html/template escapes the leading slash in JS context, so "/path" renders as "\/path".
+	Assert(t, strings.Contains(rendered.String(), `window.location.href = "\/path/";`),
+		"expected the discard redirect to be prefixed with CleanedBasePath, got:\n%s", rendered.String())
 }
 
 func TestLockTemplate(t *testing.T) {


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

- The post-discard redirect on the locks index now uses `{{ .CleanedBasePath }}/` instead of a hardcoded `/`
- `TestIndexTemplate` now renders to a buffer and asserts the redirect includes the base path

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

- When Atlantis is served under a sub-path (e.g. `--atlantis-url=https://tools.example.com/atlantis`), discarding a plan sends the user to `https://tools.example.com/` (the proxy root) instead of back to the dashboard at `https://tools.example.com/atlantis/`. They end up outside Atlantis
- It looks like an oversight rather than intent. The same template already uses `CleanedBasePath` in 11 other places, and the redirect into this flow gets it right. `lock.html.tmpl` uses `window.location.replace("{{ .CleanedBasePath }}/?discard=true")`.
- Nothing changes for root-hosted deployments, where `CleanedBasePath` is empty and the value still renders as `/`

## tests

<!--
- [ ] I have tested my changes by ...
-->
- [x] `make test` passes
- [x] The new assertion fails against the old hardcoded `/` and passes with the fix
- [x] Verified the rendered output: `CleanedBasePath=""` gives `window.location.href = "/";` (identical to today), `CleanedBasePath="/path"` gives `window.location.href = "\/path/";`. By the way the `\/` is `html/template`'s JS-string escaping, which the browser reads as `/path/`.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- [`--atlantis-url` docs](https://www.runatlantis.io/docs/server-configuration.html#atlantis-url), "Supports a basepath if you're hosting Atlantis under a path", the configuration this affects
