### PR TITLE
feat(azuredevops): support --azuredevops-token-file for rotated tokens

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -43,7 +43,8 @@ const (
 	// Flag names.
 	ADWebhookPasswordFlag            = "azuredevops-webhook-password" // nolint: gosec
 	ADWebhookUserFlag                = "azuredevops-webhook-user"
-	ADTokenFlag                      = "azuredevops-token" // nolint: gosec
+	ADTokenFlag                      = "azuredevops-token"      // nolint: gosec
+	ADTokenFileFlag                  = "azuredevops-token-file" // nolint: gosec
 	ADUserFlag                       = "azuredevops-user"
 	ADHostnameFlag                   = "azuredevops-hostname"
 	AllowCommandsFlag                = "allow-commands"
@@ -210,6 +211,13 @@ const (
 var stringFlags = map[string]stringFlag{
 	ADTokenFlag: {
 		description: "Azure DevOps token of API user. Can also be specified via the ATLANTIS_AZUREDEVOPS_TOKEN environment variable.",
+	},
+	ADTokenFileFlag: {
+		description: "A path to a file containing the Azure DevOps token of the API user. " +
+			"When set, the token is re-read from this file on every request and before each git operation, " +
+			"so an externally-rotated token is picked up without restarting Atlantis. " +
+			"Requires --write-git-creds for git operations. " +
+			"Can also be specified via the ATLANTIS_AZUREDEVOPS_TOKEN_FILE environment variable.",
 	},
 	ADUserFlag: {
 		description: "Azure DevOps username of API user.",
@@ -1110,12 +1118,17 @@ func (s *ServerCmd) validate(userConfig server.UserConfig) error {
 	// 5. bitbucket user and token set
 	// 6. azuredevops user and token set
 	// 7. any combination of the above
-	vcsErr := fmt.Errorf("--%s/--%s or --%s/--%s or --%s/--%s or --%s/--%s or --%s/--%s or --%s/--%s or --%s/--%s or --%s/--%s must be set", GHUserFlag, GHTokenFlag, GHUserFlag, GHTokenFileFlag, GHAppIDFlag, GHAppKeyFileFlag, GHAppIDFlag, GHAppKeyFlag, GiteaUserFlag, GiteaTokenFlag, GitlabUserFlag, GitlabTokenFlag, BitbucketUserFlag, BitbucketTokenFlag, ADUserFlag, ADTokenFlag)
+	vcsErr := fmt.Errorf("--%s/--%s or --%s/--%s or --%s/--%s or --%s/--%s or --%s/--%s or --%s/--%s or --%s/--%s or --%s/--%s or --%s/--%s must be set", GHUserFlag, GHTokenFlag, GHUserFlag, GHTokenFileFlag, GHAppIDFlag, GHAppKeyFileFlag, GHAppIDFlag, GHAppKeyFlag, GiteaUserFlag, GiteaTokenFlag, GitlabUserFlag, GitlabTokenFlag, BitbucketUserFlag, BitbucketTokenFlag, ADUserFlag, ADTokenFlag, ADUserFlag, ADTokenFileFlag)
 	if ((userConfig.GiteaUser == "") != (userConfig.GiteaToken == "")) ||
 		((userConfig.GitlabUser == "") != (userConfig.GitlabToken == "")) ||
 		((userConfig.BitbucketUser == "") != (userConfig.BitbucketToken == "")) ||
-		((userConfig.AzureDevopsUser == "") != (userConfig.AzureDevopsToken == "")) {
+		((userConfig.AzureDevopsUser == "") != (userConfig.AzureDevopsToken == "" && userConfig.AzureDevopsTokenFile == "")) {
 		return vcsErr
+	}
+	if userConfig.AzureDevopsUser != "" {
+		if (userConfig.AzureDevopsToken != "") && (userConfig.AzureDevopsTokenFile != "") {
+			return vcsErr
+		}
 	}
 	if userConfig.GithubUser != "" {
 		if (userConfig.GithubToken == "") == (userConfig.GithubTokenFile == "") {
@@ -1162,6 +1175,8 @@ func (s *ServerCmd) validate(userConfig server.UserConfig) error {
 
 	// Warn if any tokens have newlines.
 	for name, token := range map[string]string{
+		ADTokenFlag:                userConfig.AzureDevopsToken,
+		ADTokenFileFlag:            userConfig.AzureDevopsTokenFile,
 		GHTokenFlag:                userConfig.GithubToken,
 		GHTokenFileFlag:            userConfig.GithubTokenFile,
 		GHWebhookSecretFlag:        userConfig.GithubWebhookSecret,

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -50,6 +50,7 @@ func (s *ServerStarterMock) Start() error {
 var testFlags = map[string]any{
 	ADHostnameFlag:                   "dev.azure.com",
 	ADTokenFlag:                      "ad-token",
+	ADTokenFileFlag:                  "",
 	ADUserFlag:                       "ad-user",
 	ADWebhookPasswordFlag:            "ad-wh-pass",
 	ADWebhookUserFlag:                "ad-wh-user",
@@ -683,7 +684,7 @@ func TestExecute_ValidateSSLConfig(t *testing.T) {
 }
 
 func TestExecute_ValidateVCSConfig(t *testing.T) {
-	expErr := "--gh-user/--gh-token or --gh-user/--gh-token-file or --gh-app-id/--gh-app-key-file or --gh-app-id/--gh-app-key or --gitea-user/--gitea-token or --gitlab-user/--gitlab-token or --bitbucket-user/--bitbucket-token or --azuredevops-user/--azuredevops-token must be set"
+	expErr := "--gh-user/--gh-token or --gh-user/--gh-token-file or --gh-app-id/--gh-app-key-file or --gh-app-id/--gh-app-key or --gitea-user/--gitea-token or --gitlab-user/--gitlab-token or --bitbucket-user/--bitbucket-token or --azuredevops-user/--azuredevops-token or --azuredevops-user/--azuredevops-token-file must be set"
 	cases := []struct {
 		description string
 		flags       map[string]any
@@ -897,6 +898,30 @@ func TestExecute_ValidateVCSConfig(t *testing.T) {
 				ADTokenFlag: "token",
 			},
 			false,
+		},
+		{
+			"azuredevops user and azuredevops token-file set and should be successful",
+			map[string]any{
+				ADUserFlag:      "user",
+				ADTokenFileFlag: "/path/to/token",
+			},
+			false,
+		},
+		{
+			"just azuredevops token-file set",
+			map[string]any{
+				ADTokenFileFlag: "/path/to/token",
+			},
+			true,
+		},
+		{
+			"azuredevops user with both token and token-file set",
+			map[string]any{
+				ADUserFlag:      "user",
+				ADTokenFlag:     "token",
+				ADTokenFileFlag: "/path/to/token",
+			},
+			true,
 		},
 		{
 			"all set should be successful",

--- a/runatlantis.io/contributing/events-controller.md
+++ b/runatlantis.io/contributing/events-controller.md
@@ -86,7 +86,7 @@ documentation.
 - [BitBucket Pull Request](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Pull-request-events)
 - [GitHub Pull Request](https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request)
 - [GitLab Merge Request](https://docs.gitlab.com/user/project/integrations/webhook_events/#merge-request-events)
-- [Gitea Webhooks](https://docs.gitea.com/next/usage/webhooks)
+- [Gitea Webhooks](https://docs.gitea.com/1.24/usage/webhooks)
 
 </details>
 

--- a/runatlantis.io/docs/access-credentials.md
+++ b/runatlantis.io/docs/access-credentials.md
@@ -159,6 +159,10 @@ Since v0.30.0, a new permission for `Actions` has been added, which is required 
   * Member Entitlement Management (Read)
 * Record the access token
 
+::: tip Rotating the token
+Azure DevOps personal access tokens expire. To rotate the token without restarting Atlantis, write it to a file and start the server with [`--azuredevops-token-file`](server-configuration.md#azuredevops-token-file) instead of `--azuredevops-token`. The token is re-read from the file on every request, so an external process can replace it in place. Use it together with `--write-git-creds` so git operations also pick up the rotated token.
+:::
+
 ## Next Steps
 
 Once you've got your user and access token, you're ready to create a webhook secret. See [Creating a Webhook Secret](webhook-secrets.md).

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -284,6 +284,16 @@ ATLANTIS_AZUREDEVOPS_TOKEN="RandomStringProducedByAzureDevOps"
 
 Azure DevOps token of API user.
 
+### `--azuredevops-token-file`
+
+```bash
+atlantis server --azuredevops-token-file="/path/to/token"
+# or
+ATLANTIS_AZUREDEVOPS_TOKEN_FILE="/path/to/token"
+```
+
+Azure DevOps token of API user, read from a file. The token is loaded from disk on every request and before each git operation, so the token can be rotated by an external process without restarting the Atlantis server. Requires `--write-git-creds` for git operations. Cannot be used together with `--azuredevops-token`. If the file is temporarily unavailable or empty during a rotation, the last successfully written git credentials are retained.
+
 ### `--azuredevops-user` <Badge text="v0.9.0+" type="info"/>
 
 ```bash

--- a/server/events/vcs/azuredevops/client.go
+++ b/server/events/vcs/azuredevops/client.go
@@ -26,15 +26,68 @@ type Client struct {
 	UserName string
 }
 
-// NewClient returns a valid Azure DevOps client.
-func New(hostname string, userName string, token string) (*Client, error) {
-	tp := azuredevops.BasicAuthTransport{
-		Username: "",
-		Password: strings.TrimSpace(token),
+// tokenTransport is an http.RoundTripper that re-reads the token from the
+// configured Credentials on every request and applies it as basic auth. This
+// allows an externally-rotated token (e.g. written to a file) to be picked up
+// without restarting Atlantis. It holds no per-request mutable state, so it is
+// safe for concurrent use.
+type tokenTransport struct {
+	credentials Credentials
+	// base is the underlying transport used to perform the request. When nil,
+	// http.DefaultTransport is used (which is also what honours
+	// common.DisableSSLVerification in tests).
+	base http.RoundTripper
+}
+
+func (t *tokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	token, err := t.credentials.GetToken()
+	if err != nil {
+		return nil, fmt.Errorf("getting azure devops token: %w", err)
 	}
-	httpClient := tp.Client()
-	httpClient.Timeout = time.Second * 10
-	var adClient, err = azuredevops.NewClient(httpClient)
+	token = strings.TrimSpace(token)
+
+	// Fail fast with a clear error rather than sending an empty credential
+	// (which Azure DevOps answers with a generic 401 that is easily mistaken
+	// for a wrong token). This happens when the backing token file is briefly
+	// empty mid-rotation or was wiped; the next request recovers once the token
+	// is restored.
+	if token == "" {
+		return nil, errors.New("azure devops token is empty")
+	}
+
+	// The RoundTripper contract requires that we not modify the supplied
+	// request and that the transport be safe for concurrent use, so set the
+	// credentials on a clone rather than mutating shared state.
+	clone := req.Clone(req.Context())
+	clone.SetBasicAuth("", token)
+
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(clone)
+}
+
+// New returns a valid Azure DevOps client authenticating with a static token.
+func New(hostname string, userName string, token string) (*Client, error) {
+	return NewClientForCredentials(hostname, &PATCredentials{User: userName, Token: token})
+}
+
+// NewClientForCredentials returns a valid Azure DevOps client that obtains its
+// token from the provided Credentials on every request.
+func NewClientForCredentials(hostname string, credentials Credentials) (*Client, error) {
+	userName, err := credentials.GetUser()
+	if err != nil {
+		return nil, fmt.Errorf("getting azure devops user: %w", err)
+	}
+
+	httpClient := &http.Client{
+		Transport: &tokenTransport{
+			credentials: credentials,
+		},
+		Timeout: time.Second * 10,
+	}
+	adClient, err := azuredevops.NewClient(httpClient)
 	if err != nil {
 		return nil, err
 	}

--- a/server/events/vcs/azuredevops/client_constructor_test.go
+++ b/server/events/vcs/azuredevops/client_constructor_test.go
@@ -1,0 +1,59 @@
+// Copyright 2025 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package azuredevops_test
+
+import (
+	"errors"
+	"testing"
+
+	azuredevopsclient "github.com/runatlantis/atlantis/server/events/vcs/azuredevops"
+	. "github.com/runatlantis/atlantis/testing"
+)
+
+// fakeCredentials lets us exercise constructor error paths that PATCredentials
+// itself never triggers.
+type fakeCredentials struct {
+	user     string
+	userErr  error
+	token    string
+	tokenErr error
+}
+
+func (c fakeCredentials) GetUser() (string, error)  { return c.user, c.userErr }
+func (c fakeCredentials) GetToken() (string, error) { return c.token, c.tokenErr }
+
+func TestNew_SetsUserName(t *testing.T) {
+	client, err := azuredevopsclient.New("dev.azure.com", "some-user", "some-token")
+	Ok(t, err)
+	Equals(t, "some-user", client.UserName)
+}
+
+func TestNewClientForCredentials_DefaultHostname(t *testing.T) {
+	client, err := azuredevopsclient.NewClientForCredentials(
+		"dev.azure.com",
+		&azuredevopsclient.PATCredentials{User: "user", Token: "token"},
+	)
+	Ok(t, err)
+	Equals(t, "user", client.UserName)
+	Equals(t, "https://dev.azure.com/", client.Client.BaseURL.String())
+}
+
+func TestNewClientForCredentials_CustomHostname(t *testing.T) {
+	client, err := azuredevopsclient.NewClientForCredentials(
+		"myorg.visualstudio.com",
+		&azuredevopsclient.PATCredentials{User: "user", Token: "token"},
+	)
+	Ok(t, err)
+	Equals(t, "https://myorg.visualstudio.com/", client.Client.BaseURL.String())
+}
+
+func TestNewClientForCredentials_PropagatesGetUserError(t *testing.T) {
+	_, err := azuredevopsclient.NewClientForCredentials(
+		"dev.azure.com",
+		fakeCredentials{userErr: errors.New("boom")},
+	)
+	Assert(t, err != nil, "expected an error when GetUser fails")
+	ErrContains(t, "getting azure devops user", err)
+	ErrContains(t, "boom", err)
+}

--- a/server/events/vcs/azuredevops/client_transport_internal_test.go
+++ b/server/events/vcs/azuredevops/client_transport_internal_test.go
@@ -1,0 +1,212 @@
+// Copyright 2025 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package azuredevops
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	. "github.com/runatlantis/atlantis/testing"
+)
+
+// recorder is a concurrency-safe record of the basic-auth tokens seen by the
+// test server.
+type recorder struct {
+	mu     sync.Mutex
+	hit    bool
+	tokens []string
+}
+
+func (r *recorder) record(token string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.hit = true
+	r.tokens = append(r.tokens, token)
+}
+
+func (r *recorder) wasHit() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.hit
+}
+
+func (r *recorder) seen() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.tokens))
+	copy(out, r.tokens)
+	return out
+}
+
+// newRecordingServer returns an httptest server that records the basic-auth
+// password (the Azure DevOps token) of every request it receives.
+func newRecordingServer(t *testing.T, rec *recorder) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, password, _ := r.BasicAuth()
+		rec.record(password)
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+func doGet(t *testing.T, c *http.Client, url string) (*http.Response, error) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	Ok(t, err)
+	return c.Do(req)
+}
+
+func TestTokenTransport_RoundTrip_SendsStaticToken(t *testing.T) {
+	rec := &recorder{}
+	ts := newRecordingServer(t, rec)
+	defer ts.Close()
+
+	tr := &tokenTransport{
+		credentials: &PATCredentials{User: "user", Token: "static-token"},
+	}
+	client := &http.Client{Transport: tr}
+
+	resp, err := doGet(t, client, ts.URL)
+	Ok(t, err)
+	defer resp.Body.Close()
+
+	Equals(t, http.StatusOK, resp.StatusCode)
+	Equals(t, []string{"static-token"}, rec.seen())
+}
+
+func TestTokenTransport_RoundTrip_RereadsTokenPerRequest(t *testing.T) {
+	rec := &recorder{}
+	ts := newRecordingServer(t, rec)
+	defer ts.Close()
+
+	tmpDir := t.TempDir()
+	tokenFile := filepath.Join(tmpDir, "token")
+	Ok(t, os.WriteFile(tokenFile, []byte("token-1"), 0600))
+
+	tr := &tokenTransport{
+		credentials: &PATCredentials{User: "user", TokenFile: tokenFile},
+	}
+	client := &http.Client{Transport: tr}
+
+	resp1, err := doGet(t, client, ts.URL)
+	Ok(t, err)
+	resp1.Body.Close()
+
+	// Rotate the token on disk between requests; the next request must use the
+	// new value without recreating the client or transport.
+	Ok(t, os.WriteFile(tokenFile, []byte("token-2"), 0600))
+
+	resp2, err := doGet(t, client, ts.URL)
+	Ok(t, err)
+	resp2.Body.Close()
+
+	Equals(t, []string{"token-1", "token-2"}, rec.seen())
+}
+
+func TestTokenTransport_RoundTrip_TrimsWhitespace(t *testing.T) {
+	rec := &recorder{}
+	ts := newRecordingServer(t, rec)
+	defer ts.Close()
+
+	tmpDir := t.TempDir()
+	tokenFile := filepath.Join(tmpDir, "token")
+	Ok(t, os.WriteFile(tokenFile, []byte("  spaced-token\n"), 0600))
+
+	tr := &tokenTransport{
+		credentials: &PATCredentials{User: "user", TokenFile: tokenFile},
+	}
+	client := &http.Client{Transport: tr}
+
+	resp, err := doGet(t, client, ts.URL)
+	Ok(t, err)
+	resp.Body.Close()
+
+	Equals(t, []string{"spaced-token"}, rec.seen())
+}
+
+func TestTokenTransport_RoundTrip_ErrorWhenTokenUnavailable(t *testing.T) {
+	rec := &recorder{}
+	ts := newRecordingServer(t, rec)
+	defer ts.Close()
+
+	tr := &tokenTransport{
+		credentials: &PATCredentials{User: "user", TokenFile: "/does/not/exist"},
+	}
+	client := &http.Client{Transport: tr}
+
+	_, err := doGet(t, client, ts.URL)
+	Assert(t, err != nil, "expected an error when the token cannot be read")
+	Assert(t, !rec.wasHit(), "no request should reach the server when the token is unavailable")
+}
+
+func TestTokenTransport_RoundTrip_ErrorWhenTokenEmpty(t *testing.T) {
+	rec := &recorder{}
+	ts := newRecordingServer(t, rec)
+	defer ts.Close()
+
+	tmpDir := t.TempDir()
+	tokenFile := filepath.Join(tmpDir, "token")
+	// A wiped/empty (whitespace-only) token file.
+	Ok(t, os.WriteFile(tokenFile, []byte("  \n"), 0600))
+
+	tr := &tokenTransport{
+		credentials: &PATCredentials{User: "user", TokenFile: tokenFile},
+	}
+	client := &http.Client{Transport: tr}
+
+	_, err := doGet(t, client, ts.URL)
+	Assert(t, err != nil, "expected an error when the token is empty")
+	Assert(t, !rec.wasHit(), "no request should be sent with an empty token")
+
+	// Once the token is restored the very next request succeeds (self-healing).
+	Ok(t, os.WriteFile(tokenFile, []byte("restored-token"), 0600))
+	resp, err := doGet(t, client, ts.URL)
+	Ok(t, err)
+	resp.Body.Close()
+	Equals(t, []string{"restored-token"}, rec.seen())
+}
+
+// TestTokenTransport_RoundTrip_ConcurrentRequests ensures the transport is safe
+// for concurrent use (Atlantis serves many pull requests at once). It must not
+// share mutable state across requests; run with -race to catch regressions.
+func TestTokenTransport_RoundTrip_ConcurrentRequests(t *testing.T) {
+	rec := &recorder{}
+	ts := newRecordingServer(t, rec)
+	defer ts.Close()
+
+	tmpDir := t.TempDir()
+	tokenFile := filepath.Join(tmpDir, "token")
+	Ok(t, os.WriteFile(tokenFile, []byte("concurrent-token"), 0600))
+
+	tr := &tokenTransport{
+		credentials: &PATCredentials{User: "user", TokenFile: tokenFile},
+	}
+	client := &http.Client{Transport: tr}
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			resp, err := doGet(t, client, ts.URL)
+			if err != nil {
+				t.Errorf("request failed: %v", err)
+				return
+			}
+			resp.Body.Close()
+		}()
+	}
+	wg.Wait()
+
+	seen := rec.seen()
+	Equals(t, n, len(seen))
+	for _, tok := range seen {
+		Equals(t, "concurrent-token", tok)
+	}
+}

--- a/server/events/vcs/azuredevops/credentials.go
+++ b/server/events/vcs/azuredevops/credentials.go
@@ -1,0 +1,47 @@
+// Copyright 2025 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package azuredevops
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Credentials handles supplying the token used to authenticate with Azure
+// DevOps. Implementations may return a static token or re-read it from a file
+// on every call so that an externally-rotated token is picked up without
+// restarting Atlantis.
+type Credentials interface {
+	// GetToken returns the token used to authenticate API and git requests.
+	GetToken() (string, error)
+	// GetUser returns the username associated with the token.
+	GetUser() (string, error)
+}
+
+// PATCredentials implements Credentials for the personal access token flow. When
+// TokenFile is set the token is re-read from disk on every call, allowing an
+// external process to rotate the token without an Atlantis restart.
+type PATCredentials struct {
+	User      string
+	Token     string
+	TokenFile string
+}
+
+// GetUser returns the username for these credentials.
+func (c *PATCredentials) GetUser() (string, error) {
+	return c.User, nil
+}
+
+// GetToken returns the token, reading it from TokenFile when configured.
+func (c *PATCredentials) GetToken() (string, error) {
+	if c.TokenFile != "" {
+		content, err := os.ReadFile(c.TokenFile)
+		if err != nil {
+			return "", fmt.Errorf("reading azure devops token file %q: %w", c.TokenFile, err)
+		}
+		return strings.TrimSpace(string(content)), nil
+	}
+	return c.Token, nil
+}

--- a/server/events/vcs/azuredevops/credentials_test.go
+++ b/server/events/vcs/azuredevops/credentials_test.go
@@ -1,0 +1,127 @@
+// Copyright 2025 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package azuredevops_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/events/vcs/azuredevops"
+	. "github.com/runatlantis/atlantis/testing"
+)
+
+func TestPATCredentials_GetUser(t *testing.T) {
+	creds := &azuredevops.PATCredentials{User: "atlantis"}
+	user, err := creds.GetUser()
+	Ok(t, err)
+	Equals(t, "atlantis", user)
+}
+
+func TestPATCredentials_GetToken_Static(t *testing.T) {
+	creds := &azuredevops.PATCredentials{User: "atlantis", Token: "some-token"}
+	token, err := creds.GetToken()
+	Ok(t, err)
+	Equals(t, "some-token", token)
+}
+
+func TestPATCredentials_GetToken_FromFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	tokenFile := filepath.Join(tmpDir, "token")
+	Ok(t, os.WriteFile(tokenFile, []byte("first-token\n"), 0600))
+
+	creds := &azuredevops.PATCredentials{User: "atlantis", TokenFile: tokenFile}
+
+	token, err := creds.GetToken()
+	Ok(t, err)
+	Equals(t, "first-token", token)
+
+	// An externally-rotated token is picked up on the next read without
+	// recreating the credentials.
+	Ok(t, os.WriteFile(tokenFile, []byte("  second-token  \n"), 0600))
+	token, err = creds.GetToken()
+	Ok(t, err)
+	Equals(t, "second-token", token)
+}
+
+func TestPATCredentials_GetToken_FileTakesPrecedence(t *testing.T) {
+	tmpDir := t.TempDir()
+	tokenFile := filepath.Join(tmpDir, "token")
+	Ok(t, os.WriteFile(tokenFile, []byte("file-token"), 0600))
+
+	creds := &azuredevops.PATCredentials{User: "atlantis", Token: "static-token", TokenFile: tokenFile}
+	token, err := creds.GetToken()
+	Ok(t, err)
+	Equals(t, "file-token", token)
+}
+
+func TestPATCredentials_GetToken_MissingFile(t *testing.T) {
+	creds := &azuredevops.PATCredentials{User: "atlantis", TokenFile: "/does/not/exist"}
+	_, err := creds.GetToken()
+	Assert(t, err != nil, "expected an error when the token file is missing")
+}
+
+func TestPATCredentials_GetToken_EmptyWhenUnset(t *testing.T) {
+	creds := &azuredevops.PATCredentials{User: "atlantis"}
+	token, err := creds.GetToken()
+	Ok(t, err)
+	Equals(t, "", token)
+}
+
+func TestPATCredentials_GetToken_WhitespaceOnlyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	tokenFile := filepath.Join(tmpDir, "token")
+	Ok(t, os.WriteFile(tokenFile, []byte("   \n\t"), 0600))
+
+	creds := &azuredevops.PATCredentials{User: "atlantis", TokenFile: tokenFile}
+	token, err := creds.GetToken()
+	Ok(t, err)
+	Equals(t, "", token)
+}
+
+// TestPATCredentials_GetToken_KubernetesSecretRotation reproduces how the
+// kubelet (and the External Secrets Operator on top of it) exposes and rotates
+// a mounted secret: the user-facing file is a symlink to ..data/<key>, ..data
+// is itself a symlink to a timestamped directory, and a rotation atomically
+// swaps the ..data symlink. Because the token is re-read on every call and
+// os.ReadFile follows symlinks, the rotated value is picked up with no restart.
+func TestPATCredentials_GetToken_KubernetesSecretRotation(t *testing.T) {
+	mount := t.TempDir()
+
+	writeVersion := func(versionDir, content string) {
+		dir := filepath.Join(mount, versionDir)
+		Ok(t, os.Mkdir(dir, 0755))
+		Ok(t, os.WriteFile(filepath.Join(dir, "token"), []byte(content), 0600))
+	}
+
+	// Atomically repoint <mount>/..data at the given version directory, exactly
+	// as the kubelet does (write a temp symlink, then rename it over ..data).
+	swapData := func(versionDir string) {
+		tmp := filepath.Join(mount, "..data_tmp")
+		_ = os.Remove(tmp)
+		Ok(t, os.Symlink(versionDir, tmp))
+		Ok(t, os.Rename(tmp, filepath.Join(mount, "..data")))
+	}
+
+	writeVersion("..data_v1", "k8s-token-1")
+	swapData("..data_v1")
+	// The user-facing path Atlantis is configured with is a symlink chain:
+	// <mount>/token -> ..data/token -> ..data_v1/token
+	Ok(t, os.Symlink(filepath.Join("..data", "token"), filepath.Join(mount, "token")))
+
+	creds := &azuredevops.PATCredentials{User: "atlantis", TokenFile: filepath.Join(mount, "token")}
+
+	token, err := creds.GetToken()
+	Ok(t, err)
+	Equals(t, "k8s-token-1", token)
+
+	// The secret is rotated: a new version directory is written and the ..data
+	// symlink is atomically swapped to point at it.
+	writeVersion("..data_v2", "k8s-token-2")
+	swapData("..data_v2")
+
+	token, err = creds.GetToken()
+	Ok(t, err)
+	Equals(t, "k8s-token-2", token)
+}

--- a/server/events/vcs/azuredevops/token_rotator.go
+++ b/server/events/vcs/azuredevops/token_rotator.go
@@ -1,0 +1,93 @@
+// Copyright 2025 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package azuredevops
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/runatlantis/atlantis/server/events/vcs/common"
+	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/runatlantis/atlantis/server/scheduled"
+)
+
+// TokenRotator continuously refreshes the Azure DevOps token and rewrites the
+// ~/.git-credentials file so git operations always use a current token. This is
+// used together with --azuredevops-token-file so that an externally-rotated
+// token is picked up without restarting Atlantis.
+type TokenRotator interface {
+	Run()
+	GenerateJob() (scheduled.JobDefinition, error)
+}
+
+type tokenRotator struct {
+	log         logging.SimpleLogging
+	credentials Credentials
+	hostname    string
+	gitUser     string
+	homeDirPath string
+}
+
+// NewTokenRotator returns a TokenRotator that refreshes ~/.git-credentials for
+// Azure DevOps using the provided credentials.
+func NewTokenRotator(
+	log logging.SimpleLogging,
+	credentials Credentials,
+	hostname string,
+	gitUser string,
+	homeDirPath string) TokenRotator {
+
+	return &tokenRotator{
+		log:         log,
+		credentials: credentials,
+		hostname:    hostname,
+		gitUser:     gitUser,
+		homeDirPath: homeDirPath,
+	}
+}
+
+// make sure interface is implemented correctly
+var _ TokenRotator = (*tokenRotator)(nil)
+
+func (r *tokenRotator) GenerateJob() (scheduled.JobDefinition, error) {
+
+	return scheduled.JobDefinition{
+		Job:    r,
+		Period: 30 * time.Second,
+	}, r.rotate()
+}
+
+func (r *tokenRotator) Run() {
+	err := r.rotate()
+	if err != nil {
+		// at least log the error message here, as we want to notify the user that the token rotation wasn't successful
+		r.log.Err("%s", err.Error())
+	}
+}
+
+func (r *tokenRotator) rotate() error {
+	r.log.Debug("refreshing azure devops token for .git-credentials")
+
+	token, err := r.credentials.GetToken()
+	if err != nil {
+		return fmt.Errorf("getting azure devops token: %w", err)
+	}
+
+	// Guard against a transiently empty token (e.g. the backing secret was
+	// briefly empty mid-rotation or was accidentally wiped). Overwriting the
+	// last-good credential with an empty token would break git operations until
+	// the next cycle, so skip this refresh and keep the working credential.
+	if token == "" {
+		r.log.Warn("azure devops token is empty; keeping the last-good .git-credentials")
+		return nil
+	}
+	r.log.Debug("token successfully refreshed")
+
+	// Replace the existing line in place (keyed on user + hostname) so rotated
+	// tokens don't accumulate stale entries.
+	if err := common.WriteGitCreds(r.gitUser, token, r.hostname, r.homeDirPath, r.log, true); err != nil {
+		return fmt.Errorf("writing ~/.git-credentials file: %w", err)
+	}
+	return nil
+}

--- a/server/events/vcs/azuredevops/token_rotator_test.go
+++ b/server/events/vcs/azuredevops/token_rotator_test.go
@@ -1,0 +1,142 @@
+// Copyright 2025 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package azuredevops_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/runatlantis/atlantis/server/events/vcs/azuredevops"
+	"github.com/runatlantis/atlantis/server/logging"
+	. "github.com/runatlantis/atlantis/testing"
+)
+
+func Test_azuredevopsTokenRotator_GenerateJob(t *testing.T) {
+	tests := []struct {
+		name             string
+		credentials      azuredevops.Credentials
+		credsFileWritten bool
+		wantErr          bool
+	}{
+		{
+			name:             "should write .git-credentials file on start",
+			credentials:      &azuredevops.PATCredentials{User: "atlantis", Token: "some-token"},
+			credsFileWritten: true,
+			wantErr:          false,
+		},
+		{
+			name:             "should return an error if the token file is missing",
+			credentials:      &azuredevops.PATCredentials{User: "atlantis", TokenFile: "/does/not/exist"},
+			credsFileWritten: false,
+			wantErr:          true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			t.Setenv("HOME", tmpDir)
+			r := azuredevops.NewTokenRotator(logging.NewNoopLogger(t), tt.credentials, "dev.azure.com", "atlantis", tmpDir)
+			got, err := r.GenerateJob()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("azuredevopsTokenRotator.GenerateJob() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.credsFileWritten {
+				credsFileContent := fmt.Sprintf(`https://atlantis:some-token@%s`, "dev.azure.com")
+				actContents, err := os.ReadFile(filepath.Join(tmpDir, ".git-credentials"))
+				Ok(t, err)
+				Equals(t, credsFileContent, string(actContents))
+				Equals(t, 30*time.Second, got.Period)
+			}
+		})
+	}
+}
+
+func Test_azuredevopsTokenRotator_RefreshesFromFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	tokenFile := filepath.Join(tmpDir, "token")
+	Ok(t, os.WriteFile(tokenFile, []byte("first-token"), 0600))
+
+	creds := &azuredevops.PATCredentials{User: "atlantis", TokenFile: tokenFile}
+	r := azuredevops.NewTokenRotator(logging.NewNoopLogger(t), creds, "dev.azure.com", "atlantis", tmpDir)
+
+	_, err := r.GenerateJob()
+	Ok(t, err)
+	actContents, err := os.ReadFile(filepath.Join(tmpDir, ".git-credentials"))
+	Ok(t, err)
+	Equals(t, "https://atlantis:first-token@dev.azure.com", string(actContents))
+
+	// Simulate an external rotation of the token file and run the rotator
+	// again. The credentials line is replaced in place rather than appended.
+	Ok(t, os.WriteFile(tokenFile, []byte("second-token"), 0600))
+	r.Run()
+	actContents, err = os.ReadFile(filepath.Join(tmpDir, ".git-credentials"))
+	Ok(t, err)
+	Equals(t, "https://atlantis:second-token@dev.azure.com", string(actContents))
+}
+
+// Test_azuredevopsTokenRotator_PreservesCredsOnFailure ensures that a transient
+// failure to read the rotated token (e.g. the file is briefly unavailable)
+// leaves the previously-written ~/.git-credentials intact instead of clobbering
+// it, so in-flight git operations keep working.
+func Test_azuredevopsTokenRotator_PreservesCredsOnFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	tokenFile := filepath.Join(tmpDir, "token")
+	Ok(t, os.WriteFile(tokenFile, []byte("good-token"), 0600))
+
+	creds := &azuredevops.PATCredentials{User: "atlantis", TokenFile: tokenFile}
+	r := azuredevops.NewTokenRotator(logging.NewNoopLogger(t), creds, "dev.azure.com", "atlantis", tmpDir)
+
+	_, err := r.GenerateJob()
+	Ok(t, err)
+	credsPath := filepath.Join(tmpDir, ".git-credentials")
+	actContents, err := os.ReadFile(credsPath)
+	Ok(t, err)
+	Equals(t, "https://atlantis:good-token@dev.azure.com", string(actContents))
+
+	// The token file disappears; the next rotation must not overwrite the
+	// last-good credentials. Run() swallows and logs the error.
+	Ok(t, os.Remove(tokenFile))
+	r.Run()
+	actContents, err = os.ReadFile(credsPath)
+	Ok(t, err)
+	Equals(t, "https://atlantis:good-token@dev.azure.com", string(actContents))
+}
+
+// Test_azuredevopsTokenRotator_PreservesCredsOnEmptyToken ensures that a
+// transiently empty token (e.g. the backing secret was briefly empty mid-sync
+// or accidentally wiped) does not clobber the last-good ~/.git-credentials with
+// an empty credential, which would break git operations.
+func Test_azuredevopsTokenRotator_PreservesCredsOnEmptyToken(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	tokenFile := filepath.Join(tmpDir, "token")
+	Ok(t, os.WriteFile(tokenFile, []byte("good-token"), 0600))
+
+	creds := &azuredevops.PATCredentials{User: "atlantis", TokenFile: tokenFile}
+	r := azuredevops.NewTokenRotator(logging.NewNoopLogger(t), creds, "dev.azure.com", "atlantis", tmpDir)
+
+	_, err := r.GenerateJob()
+	Ok(t, err)
+	credsPath := filepath.Join(tmpDir, ".git-credentials")
+	actContents, err := os.ReadFile(credsPath)
+	Ok(t, err)
+	Equals(t, "https://atlantis:good-token@dev.azure.com", string(actContents))
+
+	// The secret is wiped to empty (whitespace-only here). The rotation must be
+	// skipped without error and the last-good credential left untouched.
+	Ok(t, os.WriteFile(tokenFile, []byte("  \n"), 0600))
+	r.Run()
+	actContents, err = os.ReadFile(credsPath)
+	Ok(t, err)
+	Equals(t, "https://atlantis:good-token@dev.azure.com", string(actContents))
+}

--- a/server/server.go
+++ b/server/server.go
@@ -189,6 +189,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	var bitbucketCloudClient *bitbucketcloud.Client
 	var bitbucketServerClient *bitbucketserver.Client
 	var azuredevopsClient *azuredevops.Client
+	var azuredevopsCredentials azuredevops.Credentials
 	var giteaClient *gitea.Client
 
 	policyChecksEnabled := false
@@ -315,8 +316,14 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	if userConfig.AzureDevopsUser != "" {
 		supportedVCSHosts = append(supportedVCSHosts, models.AzureDevops)
 
+		azuredevopsCredentials = &azuredevops.PATCredentials{
+			User:      userConfig.AzureDevopsUser,
+			Token:     userConfig.AzureDevopsToken,
+			TokenFile: userConfig.AzureDevopsTokenFile,
+		}
+
 		var err error
-		azuredevopsClient, err = azuredevops.New(userConfig.AzureDevOpsHostname, userConfig.AzureDevopsUser, userConfig.AzureDevopsToken)
+		azuredevopsClient, err = azuredevops.NewClientForCredentials(userConfig.AzureDevOpsHostname, azuredevopsCredentials)
 		if err != nil {
 			return nil, err
 		}
@@ -368,7 +375,11 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 			}
 		}
 		if userConfig.AzureDevopsUser != "" {
-			if err := common.WriteGitCreds(userConfig.AzureDevopsUser, userConfig.AzureDevopsToken, "dev.azure.com", home, logger, false); err != nil {
+			token, err := azuredevopsCredentials.GetToken()
+			if err != nil {
+				return nil, err
+			}
+			if err := common.WriteGitCreds(userConfig.AzureDevopsUser, token, "dev.azure.com", home, logger, false); err != nil {
 				return nil, err
 			}
 		}
@@ -578,6 +589,15 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	if userConfig.GithubUser != "" && userConfig.GithubTokenFile != "" && userConfig.WriteGitCreds {
 		githubTokenRotator := github.NewTokenRotator(logger, githubCredentials, userConfig.GithubHostname, userConfig.GithubUser, home)
 		tokenJd, err := githubTokenRotator.GenerateJob()
+		if err != nil {
+			return nil, fmt.Errorf("could not write credentials: %w", err)
+		}
+		scheduledExecutorService.AddJob(tokenJd)
+	}
+
+	if userConfig.AzureDevopsUser != "" && userConfig.AzureDevopsTokenFile != "" && userConfig.WriteGitCreds {
+		azuredevopsTokenRotator := azuredevops.NewTokenRotator(logger, azuredevopsCredentials, "dev.azure.com", userConfig.AzureDevopsUser, home)
+		tokenJd, err := azuredevopsTokenRotator.GenerateJob()
 		if err != nil {
 			return nil, fmt.Errorf("could not write credentials: %w", err)
 		}

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -28,6 +28,7 @@ type UserConfig struct {
 	AutoplanModules             bool   `mapstructure:"autoplan-modules"`
 	AutoplanModulesFromProjects string `mapstructure:"autoplan-modules-from-projects"`
 	AzureDevopsToken            string `mapstructure:"azuredevops-token"`
+	AzureDevopsTokenFile        string `mapstructure:"azuredevops-token-file"`
 	AzureDevopsUser             string `mapstructure:"azuredevops-user"`
 	AzureDevopsWebhookPassword  string `mapstructure:"azuredevops-webhook-password"`
 	AzureDevopsWebhookUser      string `mapstructure:"azuredevops-webhook-user"`


### PR DESCRIPTION
## what

- Add a `--azuredevops-token-file` / `ATLANTIS_AZUREDEVOPS_TOKEN_FILE` option that mirrors `--gh-token-file`.
- When set, the Azure DevOps REST client re-reads the token from disk on **every request** instead of capturing it once at startup.
- A background token rotator rewrites the matching line in `~/.git-credentials` in place so git clones/fetches keep using a fresh token (requires `--write-git-creds`).
- New `Credentials` abstraction in `server/events/vcs/azuredevops/credentials.go` with a PAT implementation that re-reads the file; a refreshing `http.RoundTripper` and `NewClientForCredentials` constructor in `client.go`; the existing `New(...)` stays for back-compat.
- `--azuredevops-token-file` is mutually exclusive with `--azuredevops-token` and requires `--write-git-creds` for git operations.
- Tests and docs alongside, matching the GitHub `--gh-token-file` equivalents.

## why

- Atlantis reads the Azure DevOps token once at startup and bakes it into a static transport plus a one-time write to `~/.git-credentials`; nothing ever re-reads it.
- ADO PATs expire (max 1 year), and Microsoft Entra service-principal / managed-identity tokens live only ~1 hour. Today the only way to hand Atlantis a fresh token is a **full restart** — miss the window and Atlantis silently stops commenting on PRs, setting statuses, merging, or cloning private modules.
- GitHub already solves this with `--gh-token-file` + a background rotator; this brings Azure DevOps to parity.
- It's the missing building block for native Microsoft Entra / service-principal / managed-identity support (#3298): once the token can refresh without a restart, an Entra credential type can sit on top of it as a follow-up.
- Deliberately small and self-contained: no new dependencies; existing `--azuredevops-token` behavior is unchanged.

## tests

- [x] Added unit tests for the PAT credentials file re-read (`credentials_test.go`).
- [x] Added internal tests for the refreshing round-tripper injecting the current token per request (`client_transport_internal_test.go`).
- [x] Added constructor tests for `NewClientForCredentials` (`client_constructor_test.go`).
- [x] Added token rotator tests covering the in-place `~/.git-credentials` rewrite (`token_rotator_test.go`).
- [x] Added flag validation tests in `cmd/server_test.go` (mutual exclusivity with `--azuredevops-token`, requires `--write-git-creds`).
- [x] `go build ./...`, `go test ./server/events/vcs/azuredevops/...` and `go test ./cmd/...` pass locally.

## references

- closes #6615
- building block for #3298 (Microsoft Entra / service-principal / managed-identity support)
