### PR TITLE
fix: accept successful applies without output

### DIFF
--- a/server/core/runtime/run_step_runner_test.go
+++ b/server/core/runtime/run_step_runner_test.go
@@ -48,6 +48,12 @@ func TestRunStepRunner_Run(t *testing.T) {
 			Version: "v2.3.4",
 		},
 		{
+			Command:           "echo hidden",
+			ExpOut:            "",
+			Version:           "v2.3.4",
+			PostProcessOutput: []valid.PostProcessRunOutputOption{valid.PostProcessRunOutputHide},
+		},
+		{
 			Command: `printf \'your main.tf file does not provide default region.\\ncheck\'`,
 			ExpOut:  "'your\n",
 		},

--- a/server/events/apply_command_runner_test.go
+++ b/server/events/apply_command_runner_test.go
@@ -262,6 +262,59 @@ func TestApplyCommandRunner_IsSilenced(t *testing.T) {
 	}
 }
 
+func TestApplyCommandRunner_EmptyApplyOutputIsSuccessful(t *testing.T) {
+	database := newTestBoltDB(t)
+	setup(t, func(tc *TestConfig) {
+		tc.database = database
+	})
+	pull := models.PullRequest{
+		BaseRepo:   testdata.GithubRepo,
+		State:      models.OpenPullState,
+		Num:        testdata.Pull.Num,
+		HeadCommit: "abc123",
+		BaseBranch: "main",
+	}
+	_, err := database.UpdatePullWithResults(pull, []command.ProjectResult{
+		plannedProjectResult("project", events.DefaultWorkspace, "project"),
+	})
+	Ok(t, err)
+
+	cmd := &events.CommentCommand{Name: command.Apply}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     pull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+	projectCtx := command.ProjectContext{
+		CommandName:       command.Apply,
+		RepoRelDir:        "project",
+		Workspace:         events.DefaultWorkspace,
+		ProjectName:       "project",
+		ProjectPlanStatus: models.PlannedPlanStatus,
+		Pull:              pull,
+	}
+	When(projectCommandBuilder.BuildApplyCommands(ctx, cmd)).ThenReturn([]command.ProjectContext{projectCtx}, nil)
+	When(projectCommandRunner.Apply(projectCtx)).ThenReturn(command.ProjectCommandOutput{})
+
+	applyCommandRunner.Run(ctx, cmd)
+
+	Assert(t, !ctx.CommandHasErrors, "successful apply with empty output was classified as failed")
+	pullStatus, err := database.GetPullStatus(pull)
+	Ok(t, err)
+	Equals(t, models.AppliedPlanStatus, pullStatus.Projects[0].Status)
+	commitUpdater.VerifyWasCalledOnce().UpdateCombinedCount(
+		Any[logging.SimpleLogging](),
+		Eq(testdata.GithubRepo),
+		Eq(pull),
+		Eq(models.SuccessCommitStatus),
+		Eq(command.Apply),
+		Eq(models.ProjectCounts{Success: 1, Total: 1}),
+	)
+}
+
 func TestApplyCommandRunner_IgnoredTargetedDirNoOp(t *testing.T) {
 	RegisterMockTestingT(t)
 	vcsClient := setup(t)

--- a/server/events/command/project_result.go
+++ b/server/events/command/project_result.go
@@ -99,8 +99,14 @@ func (p ProjectResult) PlanStatus() models.ProjectPlanStatus {
 
 // IsSuccessful returns true if this project result had no errors.
 func (p ProjectResult) IsSuccessful() bool {
-	if p.Command == Apply {
+	switch p.Command {
+	case Plan:
+		return p.PlanSuccess != nil
+	case PolicyCheck, ApprovePolicies:
+		return p.PolicyCheckResults != nil && p.Error == nil && p.Failure == ""
+	case Apply:
 		return p.Error == nil && p.Failure == ""
+	default:
+		return false
 	}
-	return p.PlanSuccess != nil || (p.PolicyCheckResults != nil && p.Error == nil && p.Failure == "") || p.ApplySuccess != ""
 }

--- a/server/events/command/project_result.go
+++ b/server/events/command/project_result.go
@@ -99,5 +99,8 @@ func (p ProjectResult) PlanStatus() models.ProjectPlanStatus {
 
 // IsSuccessful returns true if this project result had no errors.
 func (p ProjectResult) IsSuccessful() bool {
+	if p.Command == Apply {
+		return p.Error == nil && p.Failure == ""
+	}
 	return p.PlanSuccess != nil || (p.PolicyCheckResults != nil && p.Error == nil && p.Failure == "") || p.ApplySuccess != ""
 }

--- a/server/events/command/project_result.go
+++ b/server/events/command/project_result.go
@@ -97,7 +97,8 @@ func (p ProjectResult) PlanStatus() models.ProjectPlanStatus {
 	panic("PlanStatus() missing a combination")
 }
 
-// IsSuccessful returns true if this project result had no errors.
+// IsSuccessful reports whether a plan, policy check, policy approval, or apply
+// result satisfies its command-specific success criteria.
 func (p ProjectResult) IsSuccessful() bool {
 	switch p.Command {
 	case Plan:

--- a/server/events/command/project_result_test.go
+++ b/server/events/command/project_result_test.go
@@ -36,6 +36,15 @@ func TestProjectResult_IsSuccessful(t *testing.T) {
 			},
 			true,
 		},
+		"approve_policies success": {
+			command.ProjectResult{
+				Command: command.ApprovePolicies,
+				ProjectCommandOutput: command.ProjectCommandOutput{
+					PolicyCheckResults: &models.PolicyCheckResults{},
+				},
+			},
+			true,
+		},
 		"apply success": {
 			command.ProjectResult{
 				Command: command.Apply,
@@ -65,8 +74,23 @@ func TestProjectResult_IsSuccessful(t *testing.T) {
 			command.ProjectResult{Command: command.Plan},
 			false,
 		},
+		"plan does not use apply output as success": {
+			command.ProjectResult{
+				Command: command.Plan,
+				ProjectCommandOutput: command.ProjectCommandOutput{
+					ApplySuccess: "unexpected apply output",
+				},
+			},
+			false,
+		},
 		"policy check without result payload": {
 			command.ProjectResult{Command: command.PolicyCheck},
+			false,
+		},
+		"unsupported command": {
+			command.ProjectResult{
+				Command: command.Unlock,
+			},
 			false,
 		},
 		"failure": {

--- a/server/events/command/project_result_test.go
+++ b/server/events/command/project_result_test.go
@@ -20,6 +20,7 @@ func TestProjectResult_IsSuccessful(t *testing.T) {
 	}{
 		"plan success": {
 			command.ProjectResult{
+				Command: command.Plan,
 				ProjectCommandOutput: command.ProjectCommandOutput{
 					PlanSuccess: &models.PlanSuccess{},
 				},
@@ -28,6 +29,7 @@ func TestProjectResult_IsSuccessful(t *testing.T) {
 		},
 		"policy_check success": {
 			command.ProjectResult{
+				Command: command.PolicyCheck,
 				ProjectCommandOutput: command.ProjectCommandOutput{
 					PolicyCheckResults: &models.PolicyCheckResults{},
 				},
@@ -36,14 +38,40 @@ func TestProjectResult_IsSuccessful(t *testing.T) {
 		},
 		"apply success": {
 			command.ProjectResult{
+				Command: command.Apply,
 				ProjectCommandOutput: command.ProjectCommandOutput{
 					ApplySuccess: "success",
 				},
 			},
 			true,
 		},
+		"apply success with empty output": {
+			command.ProjectResult{
+				Command: command.Apply,
+			},
+			true,
+		},
+		"apply output with error": {
+			command.ProjectResult{
+				Command: command.Apply,
+				ProjectCommandOutput: command.ProjectCommandOutput{
+					ApplySuccess: "partial output",
+					Error:        errors.New("error"),
+				},
+			},
+			false,
+		},
+		"plan without success payload": {
+			command.ProjectResult{Command: command.Plan},
+			false,
+		},
+		"policy check without result payload": {
+			command.ProjectResult{Command: command.PolicyCheck},
+			false,
+		},
 		"failure": {
 			command.ProjectResult{
+				Command: command.Apply,
 				ProjectCommandOutput: command.ProjectCommandOutput{
 					Failure: "failure",
 				},
@@ -52,6 +80,7 @@ func TestProjectResult_IsSuccessful(t *testing.T) {
 		},
 		"error": {
 			command.ProjectResult{
+				Command: command.Apply,
 				ProjectCommandOutput: command.ProjectCommandOutput{
 					Error: errors.New("error"),
 				},

--- a/server/events/command/result_test.go
+++ b/server/events/command/result_test.go
@@ -60,6 +60,14 @@ func TestCommandResult_HasErrors(t *testing.T) {
 			},
 			exp: false,
 		},
+		"successful apply with empty output": {
+			cr: command.Result{
+				ProjectResults: []command.ProjectResult{
+					{Command: command.Apply},
+				},
+			},
+			exp: false,
+		},
 		"single errored project": {
 			cr: command.Result{
 				ProjectResults: []command.ProjectResult{


### PR DESCRIPTION
## what

- treat an apply as successful when it finishes without an error or failure, even if there is no rendered output
- cover silent apply commands and custom `run` steps using `output: hide`
- keep plan and policy-check success semantics unchanged

## why

- apply persistence already records this case as applied, but aggregate result handling was using non-empty output as the success signal
- that could leave a successful custom apply recorded as applied while the command itself was reported as failed
- I found this while tightening up the staged apply work in #6666
- ideally this and #6666 land in the same release, but I split them because this fixes existing behavior and #6666 introduces new functionality

## tests

- [x] `make test`
- [x] `go vet ./server/events ./server/events/command ./server/core/runtime`
- [x] exact `goimports` v0.43.0 audit
- [x] `make build-service`

## references

- uncovered while working on #6666
