### PR TITLE
feat: fetch fork PR head from base repo in the merge checkout strategy

### DIFF
--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -646,14 +646,19 @@ func (w *FileWorkspace) isBranchAtTargetRef(logger logging.SimpleLogging, c wrap
 }
 
 // usesPRSourceRemote reports whether the "source" remote (the PR's head repo,
-// e.g. a fork) is actually used to fetch the PR head. On the GitHub App path
-// mergeToBaseBranch fetches "pull/<n>/head" from origin instead (see
-// GithubAppEnabled handling there), so the source remote is never used and we
-// skip creating/updating it. Fetching the head repo otherwise only slows down
-// "git remote update"/"git fetch --all" and, when the App installation can't
-// read the fork, fails and makes recheckDiverged spuriously assume divergence.
+// e.g. a fork) is actually used to fetch the PR head. When we instead fetch
+// "pull/<n>/head" from origin — on the GitHub App path, or with the merge
+// checkout strategy (see mergeToBaseBranch) — the source remote is never used
+// and we skip creating/updating it. Both cases read the PR head from the base
+// repo, so a fork PR works even when the fork itself isn't reachable (no App
+// installation on it, or a base-repo-scoped token). Fetching the head repo
+// otherwise only slows down "git remote update"/"git fetch --all" and, when the
+// fork can't be read, fails and makes recheckDiverged spuriously assume divergence.
 func (w *FileWorkspace) usesPRSourceRemote(head models.Repo, p models.PullRequest) bool {
-	return head.VCSHost.Type != models.Github || !w.GithubAppEnabled || p.Num <= 0
+	if head.VCSHost.Type != models.Github || p.Num <= 0 {
+		return true
+	}
+	return !w.GithubAppEnabled && !w.CheckoutMerge
 }
 
 func (w *FileWorkspace) forceClone(logger logging.SimpleLogging, c wrappedGitContext) error {
@@ -826,7 +831,13 @@ func (w *FileWorkspace) wrappedGit(logger logging.SimpleLogging, c wrappedGitCon
 func (w *FileWorkspace) mergeToBaseBranch(logger logging.SimpleLogging, c wrappedGitContext) error {
 	fetchRef := fmt.Sprintf("+refs/heads/%s:", c.pr.HeadBranch)
 	fetchRemote := prSourceRemote
-	if c.head.VCSHost.Type == models.Github && w.GithubAppEnabled && c.pr.Num > 0 {
+	// Fetch the PR head from the base repo's refs/pull/<n>/head rather than the
+	// fork's "source" remote when we can: on the GitHub App path, or whenever the
+	// merge checkout strategy is used (the merge target already lives in the base
+	// repo). This lets fork PRs merge without access to the fork — the base repo
+	// exposes the head — which matters when there's no App installation on the
+	// fork or only a base-repo-scoped token is available.
+	if c.head.VCSHost.Type == models.Github && (w.GithubAppEnabled || w.CheckoutMerge) && c.pr.Num > 0 {
 		fetchRef = fmt.Sprintf("pull/%d/head:", c.pr.Num)
 		fetchRemote = "origin"
 	}

--- a/server/events/working_dir_internal_test.go
+++ b/server/events/working_dir_internal_test.go
@@ -35,3 +35,35 @@ func TestIsUnsafeNonPRRef(t *testing.T) {
 		})
 	}
 }
+
+func TestUsesPRSourceRemote(t *testing.T) {
+	github := models.Repo{VCSHost: models.VCSHost{Type: models.Github}}
+	gitlab := models.Repo{VCSHost: models.VCSHost{Type: models.Gitlab}}
+	for _, tc := range []struct {
+		name          string
+		head          models.Repo
+		num           int
+		appEnabled    bool
+		checkoutMerge bool
+		want          bool
+	}{
+		// GitHub PR: the source (fork) remote is skipped in favour of
+		// pull/<n>/head from origin when either the App path or the merge
+		// checkout strategy is used.
+		{name: "github token+branch uses source remote", head: github, num: 1, want: true},
+		{name: "github app skips source remote", head: github, num: 1, appEnabled: true, want: false},
+		{name: "github merge skips source remote", head: github, num: 1, checkoutMerge: true, want: false},
+		{name: "github app+merge skips source remote", head: github, num: 1, appEnabled: true, checkoutMerge: true, want: false},
+		// Non-GitHub always uses the source remote (no pull ref on origin).
+		{name: "gitlab merge still uses source remote", head: gitlab, num: 1, checkoutMerge: true, want: true},
+		// API-driven runs (num <= 0) have no pull ref, so keep the source remote.
+		{name: "github merge but non-PR uses source remote", head: github, num: -1, checkoutMerge: true, appEnabled: true, want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := &FileWorkspace{GithubAppEnabled: tc.appEnabled, CheckoutMerge: tc.checkoutMerge}
+			if got := w.usesPRSourceRemote(tc.head, models.PullRequest{Num: tc.num}); got != tc.want {
+				t.Fatalf("usesPRSourceRemote() = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}

--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -981,6 +981,10 @@ func TestClone_ResetOnWrongCommitWithMergeStrategy(t *testing.T) {
 	runCmd(t, repoDir, "git", "commit", "-m", "anotherfile")
 	expCommit := strings.TrimSpace(runCmd(t, repoDir, "git", "rev-parse", "HEAD"))
 
+	// The merge checkout strategy fetches the head as pull/<n>/head from origin
+	// (the base repo), so expose the head commit under that ref like GitHub does.
+	runCmd(t, repoDir, "git", "update-ref", "refs/pull/1/head", expCommit)
+
 	// Pretend that terraform has created plan files, we'll check for them later.
 	worktreeDir := filepath.Join(dataDir, "repos/1/default")
 	ignorePlanFiles(t, worktreeDir)


### PR DESCRIPTION
In the merge checkout strategy Atlantis clones the base branch and merges the PR head into it. The head was fetched from the PR's "source" remote (the head repo, e.g. a fork), which requires access to the fork — a problem when the GitHub App isn't installed on the fork, or the token is scoped to the base repo.

GitHub exposes every PR's head on the base repo as refs/pull/<n>/head, which the App path already uses. Extend that to the merge strategy: when merging a GitHub PR, fetch pull/<n>/head from origin instead of the fork's remote. This lets fork PRs run in merge mode without access to the fork. It is a no-op for same-repo PRs (same commit), and unchanged for the branch strategy and non-GitHub hosts.

This is what is needed to support forks in our environments. We run a controller app that issues scoped tokens from a single GitHub app to many hundreds of Atlantis instances. It is using app token, but the Atlantis instance isn't configured to run as an app. This token issuing process allows us to scale the provisioning of Atlantis instances in our org.