### PR TITLE
fix: include int64 flags in server help output

### DIFF
--- a/cmd/help_fmt.go
+++ b/cmd/help_fmt.go
@@ -19,9 +19,15 @@ import (
 //	 <description>
 //
 // We use it over the default template so that the output it easier to read.
-func usageTmpl(stringFlags map[string]stringFlag, intFlags map[string]intFlag, boolFlags map[string]boolFlag) string {
+func usageTmpl(stringFlags map[string]stringFlag, intFlags map[string]intFlag, boolFlags map[string]boolFlag, int64Flags map[string]int64Flag) string {
 	var flagNames []string
 	for name, f := range stringFlags {
+		if f.hidden {
+			continue
+		}
+		flagNames = append(flagNames, name)
+	}
+	for name, f := range int64Flags {
 		if f.hidden {
 			continue
 		}
@@ -62,6 +68,13 @@ func usageTmpl(stringFlags map[string]stringFlag, intFlags map[string]intFlag, b
 			descrip = to80CharCols(f.description)
 			isBool = true
 		} else if f, ok := intFlags[name]; ok {
+			descripWithDefault := f.description
+			if f.defaultValue != 0 {
+				descripWithDefault += fmt.Sprintf(" (default %d)", f.defaultValue)
+			}
+			descrip = to80CharCols(descripWithDefault)
+			isBool = false
+		} else if f, ok := int64Flags[name]; ok {
 			descripWithDefault := f.description
 			if f.defaultValue != 0 {
 				descripWithDefault += fmt.Sprintf(" (default %d)", f.defaultValue)

--- a/cmd/help_fmt_test.go
+++ b/cmd/help_fmt_test.go
@@ -29,3 +29,16 @@ func TestUsageTmplExcludesHiddenInt64Flags(t *testing.T) {
 		t.Error("usage template includes hidden int64 flag")
 	}
 }
+
+func TestUsageTmplRendersInt64Default(t *testing.T) {
+	withDefault := map[string]int64Flag{
+		"defaulted-int64-flag": {
+			description:  "flag with default",
+			defaultValue: 42,
+		},
+	}
+	out := usageTmpl(map[string]stringFlag{}, map[string]intFlag{}, map[string]boolFlag{}, withDefault)
+	if !strings.Contains(out, `(default 42)`) {
+		t.Error("usage template does not render the default value of an int64 flag")
+	}
+}

--- a/cmd/help_fmt_test.go
+++ b/cmd/help_fmt_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUsageTmplIncludesInt64Flags(t *testing.T) {
+	out := usageTmpl(stringFlags, intFlags, boolFlags, int64Flags)
+	for _, name := range []string{GHAppIDFlag, GHAppInstallationIDFlag} {
+		if !strings.Contains(out, "--"+name+"=<value>") {
+			t.Errorf("usage template does not include int64 flag %q", name)
+		}
+	}
+}
+
+func TestUsageTmplExcludesHiddenInt64Flags(t *testing.T) {
+	hidden := map[string]int64Flag{
+		"hidden-int64-flag": {
+			description: "hidden flag",
+			hidden:      true,
+		},
+	}
+	out := usageTmpl(map[string]stringFlag{}, map[string]intFlag{}, map[string]boolFlag{}, hidden)
+	if strings.Contains(out, "--hidden-int64-flag") {
+		t.Error("usage template includes hidden int64 flag")
+	}
+}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -831,7 +831,7 @@ func (s *ServerCmd) Init() *cobra.Command {
 	s.Viper.AutomaticEnv()
 	s.Viper.SetTypeByDefaultValue(true)
 
-	c.SetUsageTemplate(usageTmpl(stringFlags, intFlags, boolFlags))
+	c.SetUsageTemplate(usageTmpl(stringFlags, intFlags, boolFlags, int64Flags))
 	// If a user passes in an invalid flag, tell them what the flag was.
 	c.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
 		s.printErr(err)
@@ -908,6 +908,12 @@ func (s *ServerCmd) preRun() error {
 // which viper picks up and fails to parse as integers.
 func (s *ServerCmd) sanitizeKubernetesServiceLinks() {
 	for name, f := range intFlags {
+		val := s.Viper.GetString(name)
+		if strings.HasPrefix(val, "tcp://") || strings.HasPrefix(val, "udp://") {
+			s.Viper.Set(name, f.defaultValue)
+		}
+	}
+	for name, f := range int64Flags {
 		val := s.Viper.GetString(name)
 		if strings.HasPrefix(val, "tcp://") || strings.HasPrefix(val, "udp://") {
 			s.Viper.Set(name, f.defaultValue)

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -1466,6 +1466,22 @@ func TestSanitizeKubernetesServiceLinks_UDPIgnored(t *testing.T) {
 	Equals(t, DefaultRedisPort, passedConfig.RedisPort)
 }
 
+func TestSanitizeKubernetesServiceLinks_Int64Flags(t *testing.T) {
+	t.Log("Kubernetes service link env vars should also be sanitized for int64 flags")
+	envKey := "ATLANTIS_GH_APP_ID"
+	os.Setenv(envKey, "tcp://10.96.0.15:6379") // nolint: errcheck
+	defer os.Unsetenv(envKey)
+
+	c := setupWithDefaults(map[string]any{
+		GHUserFlag:        "user",
+		GHTokenFlag:       "token",
+		RepoAllowlistFlag: "*",
+	}, t)
+	err := c.Execute()
+	Ok(t, err)
+	Equals(t, int64(0), passedConfig.GithubAppID)
+}
+
 func TestDefaultAutoplanFileList_ContainsExpectedPatterns(t *testing.T) {
 	// Pin the public server default independently of the constant.
 	// If a pattern is accidentally removed, this test fails.


### PR DESCRIPTION
## What

`atlantis server --help` omits `--gh-app-id` and `--gh-app-installation-id`. Both flags are registered with cobra and work, but never appear in the help output, making GitHub App auth undiscoverable from the CLI.

## Why

The help renderer in `cmd/server.go` builds its usage template from only three of the four flag maps:

```go
c.SetUsageTemplate(usageTmpl(stringFlags, intFlags, boolFlags))
```

`usageTmpl` (`cmd/help_fmt.go`) therefore never sees `int64Flags`, so `--gh-app-id` and `--gh-app-installation-id` are silently dropped from the generated `Flags:` section.

## Changes

- `cmd/help_fmt.go`: accept `int64Flags` in `usageTmpl` and handle the `int64Flag` type in the lookup chain (including the non-zero default rendering).
- `cmd/server.go`: pass `int64Flags` when setting the usage template.
- `cmd/server.go`: extend `sanitizeKubernetesServiceLinks` to cover `int64Flags`, so a Kubernetes service-link env var such as `ATLANTIS_GH_APP_ID=tcp://...` is reset to its default instead of breaking viper parsing (the same collision the int flags were already protected against).
- `cmd/help_fmt_test.go`: new unit tests asserting the int64 flags appear in the usage template and hidden int64 flags stay excluded.
- `cmd/server_test.go`: new test asserting int64 flags are sanitized like int flags.

## Test plan

- `go build ./...`
- `go test ./cmd/`
- `atlantis server --help | grep gh-app-id` now lists both flags.

Fixes #6755