### PR TITLE
feat(github): add merge-queue automerge method

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/runatlantis/atlantis/server"
 	"github.com/runatlantis/atlantis/server/events/vcs/bitbucketcloud"
+	"github.com/runatlantis/atlantis/server/events/vcs/github"
 	"github.com/runatlantis/atlantis/server/i18n"
 	"github.com/runatlantis/atlantis/server/logging"
 )
@@ -251,7 +252,8 @@ var stringFlags = map[string]stringFlag{
 	},
 	AutomergeMethodFlag: {
 		description: "Default merge method to use when automerging pull requests, unless overridden by the --auto-merge-method comment flag. " +
-			"Valid values are 'merge', 'rebase', and 'squash'. Currently only implemented for GitHub.",
+			"Valid values are 'merge', 'rebase', 'squash', and 'merge-queue'. 'merge-queue' adds the pull request to the base branch's " +
+			"GitHub merge queue instead of merging it directly. Currently only implemented for GitHub.",
 		defaultValue: "",
 	},
 	AutoplanModulesFromProjects: {
@@ -753,7 +755,7 @@ var ValidLogLevels = []string{"debug", "info", "warn", "error"}
 
 // ValidAutomergeMethods are the valid merge methods that can be set for the
 // automerge-method flag.
-var ValidAutomergeMethods = []string{"merge", "rebase", "squash"}
+var ValidAutomergeMethods = []string{"merge", "rebase", "squash", github.MergeQueueMergeMethod}
 
 type stringFlag struct {
 	description  string

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -612,9 +612,14 @@ func TestExecute_ValidateAutomergeMethod(t *testing.T) {
 			"",
 		},
 		{
+			"merge-queue",
+			"merge-queue",
+			"",
+		},
+		{
 			"invalid method",
 			"fast-forward",
-			"invalid --automerge-method: must be one of [merge rebase squash]",
+			"invalid --automerge-method: must be one of [merge rebase squash merge-queue]",
 		},
 	}
 

--- a/runatlantis.io/docs/automerging.md
+++ b/runatlantis.io/docs/automerging.md
@@ -51,8 +51,45 @@ The `method` must be one of:
 - merge
 - rebase
 - squash
+- merge-queue
 
 This is currently only implemented for the GitHub VCS.
+
+## How to merge via the GitHub merge queue
+
+Setting the merge method to `merge-queue` makes Atlantis add the pull request to
+the base branch's [GitHub merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)
+instead of merging it directly.
+
+```shell
+atlantis server --automerge-method merge-queue
+```
+
+Unlike `merge`, `rebase` and `squash`, this doesn't describe how the commits are
+combined — that stays configured on the branch's merge queue ruleset. It only
+changes who performs the merge: Atlantis hands the pull request off and GitHub
+merges it once the queue's checks pass.
+
+Atlantis pins the enqueue request to the commit it applied, so if someone pushes
+to the branch between `atlantis apply` and the enqueue, GitHub rejects it and
+Atlantis comments with the failure rather than queueing code that was never
+planned.
+
+:::warning
+If `atlantis/apply` (or `atlantis/plan`) is a **required status check** on the
+base branch, it is also required on the merge group that GitHub builds, and
+nothing will post those statuses for the merge group's commit — the queue will
+stall. Either exclude the Atlantis checks from the branch's required checks, or
+run Atlantis with merge group support so it reports them.
+:::
+
+### Requirements
+
+- The base branch must have a merge queue enabled via a branch ruleset or
+  branch protection rule.
+- The Atlantis VCS user needs write access, and the pull request must satisfy
+  the branch's requirements for entering the queue (approvals, passing checks).
+  GitHub rejects the enqueue otherwise and Atlantis comments with the reason.
 
 ## Requirements
 

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -161,9 +161,11 @@ ATLANTIS_AUTOMERGE_METHOD="squash"
 ```
 
 Default merge method to use when automerging pull requests. Valid values are
-`merge`, `rebase`, and `squash`. When not set, the VCS provider's default merge
-method is used. This can be overridden per command with the `--auto-merge-method`
-comment flag. Currently only implemented for GitHub.
+`merge`, `rebase`, `squash`, and `merge-queue`. When not set, the VCS provider's
+default merge method is used. `merge-queue` adds the pull request to the base
+branch's [GitHub merge queue](automerging.md#how-to-merge-via-the-github-merge-queue)
+instead of merging it directly. This can be overridden per command with the
+`--auto-merge-method` comment flag. Currently only implemented for GitHub.
 
 ### `--autoplan-file-list` <Badge text="v0.15.0+" type="info"/>
 

--- a/runatlantis.io/docs/using-atlantis.md
+++ b/runatlantis.io/docs/using-atlantis.md
@@ -179,7 +179,7 @@ atlantis apply -w staging
 * `-p project` Apply the plan for this project. Refers to the name of the project configured in the repo's [`atlantis.yaml` file](repo-level-atlantis-yaml.md). Cannot be used at same time as `-d` or `-w`.
 * `-w workspace` Apply the plan for this [Terraform workspace](https://developer.hashicorp.com/terraform/language/state/workspaces). Ignore this if Terraform workspaces are unused.
 * `--auto-merge-disabled` Disable [automerge](automerging.md) for this apply command.
-* `--auto-merge-method method` Specify which [merge method](automerging.md#how-to-set-the-merge-method-for-automerge) use for the apply command if [automerge](automerging.md) is enabled. Implemented only for GitHub.
+* `--auto-merge-method method` Specify which [merge method](automerging.md#how-to-set-the-merge-method-for-automerge) to use for the apply command if [automerge](automerging.md) is enabled. One of `merge`, `rebase`, `squash`, or `merge-queue` (which adds the pull request to the [GitHub merge queue](automerging.md#how-to-merge-via-the-github-merge-queue) instead of merging it). Implemented only for GitHub.
 * `--verbose` Append Atlantis log to comment.
 
 ### Additional Terraform flags

--- a/server/events/automerger.go
+++ b/server/events/automerger.go
@@ -9,6 +9,7 @@ import (
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/events/vcs"
+	"github.com/runatlantis/atlantis/server/events/vcs/github"
 )
 
 type AutoMerger struct {
@@ -26,16 +27,23 @@ func (c *AutoMerger) automerge(ctx *command.Context, pullStatus models.PullStatu
 		}
 	}
 
-	// Comment that we're automerging the pull request.
-	if err := c.VCSClient.CreateComment(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull.Num, automergeComment, command.Apply.String()); err != nil {
-		ctx.Log.Err("failed to comment about automerge: %s", err)
-		// Commenting isn't required so continue.
-	}
-
 	// Fall back to the server-side default merge method when the comment
 	// command didn't specify one with --auto-merge-method.
 	if mergeMethod == "" {
 		mergeMethod = c.GlobalAutomergeMethod
+	}
+	// The merge queue doesn't merge the pull request, it hands it to the VCS to
+	// merge later, so say that instead of claiming we merged it.
+	queueing := mergeMethod == github.MergeQueueMergeMethod
+
+	// Comment that we're automerging the pull request.
+	startComment := automergeComment
+	if queueing {
+		startComment = automergeQueueComment
+	}
+	if err := c.VCSClient.CreateComment(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull.Num, startComment, command.Apply.String()); err != nil {
+		ctx.Log.Err("failed to comment about automerge: %s", err)
+		// Commenting isn't required so continue.
 	}
 
 	// Make the API call to perform the merge.
@@ -48,9 +56,13 @@ func (c *AutoMerger) automerge(ctx *command.Context, pullStatus models.PullStatu
 	if err != nil {
 		ctx.Log.Err("automerging failed: %s", err)
 
-		failureComment := fmt.Sprintf("Automerging failed:\n```\n%s\n```", err)
+		failureAction := "Automerging"
+		if queueing {
+			failureAction = "Adding to the merge queue"
+		}
+		failureComment := fmt.Sprintf("%s failed:\n```\n%s\n```", failureAction, err)
 		if commentErr := c.VCSClient.CreateComment(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull.Num, failureComment, command.Apply.String()); commentErr != nil {
-			ctx.Log.Err("failed to comment about automerge failing: %s", err)
+			ctx.Log.Err("failed to comment about automerge failing: %s", commentErr)
 		}
 	}
 }

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -732,3 +732,5 @@ func (c *DefaultCommandRunner) logPanics(baseRepo models.Repo, pullNum int, logg
 }
 
 var automergeComment = `Automatically merging because all plans have been successfully applied.`
+
+var automergeQueueComment = `Automatically adding to the merge queue because all plans have been successfully applied.`

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/runatlantis/atlantis/server/events/mocks"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/events/models/testdata"
+	vcsgithub "github.com/runatlantis/atlantis/server/events/vcs/github"
 	vcsmocks "github.com/runatlantis/atlantis/server/events/vcs/mocks"
 	. "github.com/runatlantis/atlantis/testing"
 	"go.uber.org/mock/gomock"
@@ -2697,6 +2698,27 @@ func TestApplyWithAutoMerge_CommentFlagOverridesGlobalMergeMethod(t *testing.T) 
 
 	ch.RunCommentCommand(testdata.GithubRepo, &testdata.GithubRepo, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Apply, AutoMergeMethod: "rebase"})
 	vcsClient.VerifyWasCalledOnce().MergePull(Any[logging.SimpleLogging](), Eq(modelPull), Eq(pullOptions))
+}
+
+func TestApplyWithAutoMerge_MergeQueueMethodCommentsThatItIsQueueing(t *testing.T) {
+	t.Log("if \"atlantis apply\" is run with automerge and the merge-queue merge" +
+		" method, the comment says we're queueing rather than merging")
+
+	vcsClient, modelPull := setupApplyWithAutoMerge(t)
+	autoMerger.GlobalAutomergeMethod = vcsgithub.MergeQueueMergeMethod
+	t.Cleanup(func() { autoMerger.GlobalAutomergeMethod = "" })
+
+	pullOptions := models.PullRequestOptions{
+		DeleteSourceBranchOnMerge: false,
+		MergeMethod:               vcsgithub.MergeQueueMergeMethod,
+	}
+
+	ch.RunCommentCommand(testdata.GithubRepo, &testdata.GithubRepo, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Apply})
+	vcsClient.VerifyWasCalledOnce().MergePull(Any[logging.SimpleLogging](), Eq(modelPull), Eq(pullOptions))
+	vcsClient.VerifyWasCalledOnce().CreateComment(
+		Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(modelPull.Num),
+		Eq("Automatically adding to the merge queue because all plans have been successfully applied."),
+		Eq("apply"))
 }
 
 func TestApplyWithAutoMerge_DisableAutomergeLabelStillMergesWhenLabelMissing(t *testing.T) {

--- a/server/events/vcs/github/client.go
+++ b/server/events/vcs/github/client.go
@@ -30,6 +30,13 @@ import (
 // by GitHub.
 const maxCommentLength = 65536
 
+// MergeQueueMergeMethod is the merge method that makes Atlantis add the pull
+// request to the base branch's GitHub merge queue instead of merging it itself.
+// Unlike merge/rebase/squash it doesn't describe how the commits are combined —
+// that's configured on the branch's merge queue ruleset — only who does the
+// merging.
+const MergeQueueMergeMethod = "merge-queue"
+
 var (
 	clientMutationID            = githubv4.NewString("atlantis")
 	pullRequestDismissalMessage = *githubv4.NewString("Dismissing reviews because of plan changes")
@@ -1004,6 +1011,12 @@ func (g *Client) UpdateStatus(logger logging.SimpleLogging, repo models.Repo, pu
 
 // MergePull merges the pull request.
 func (g *Client) MergePull(logger logging.SimpleLogging, pull models.PullRequest, pullOptions models.PullRequestOptions) error {
+	// The merge queue doesn't merge the pull request itself, it hands it off to
+	// GitHub, so it bypasses the merge method negotiation below entirely.
+	if pullOptions.MergeMethod == MergeQueueMergeMethod {
+		return g.enqueuePull(logger, pull)
+	}
+
 	logger.Debug("Merging GitHub pull request %d", pull.Num)
 	// Users can set their repo to disallow certain types of merging.
 	// We detect which types aren't allowed and use the type that is.
@@ -1027,7 +1040,9 @@ func (g *Client) MergePull(logger logging.SimpleLogging, pull models.PullRequest
 		squashMergeMethod:  repo.GetAllowSquashMerge,
 	}
 
-	mergeMethodsName := slices.Collect(maps.Keys(mergeMethodsAllow))
+	// MergeQueueMergeMethod is handled above and so isn't in mergeMethodsAllow,
+	// but it's still a value the user could legitimately have meant.
+	mergeMethodsName := append(slices.Collect(maps.Keys(mergeMethodsAllow)), MergeQueueMergeMethod)
 	sort.Strings(mergeMethodsName)
 
 	var method string
@@ -1077,6 +1092,69 @@ func (g *Client) MergePull(logger logging.SimpleLogging, pull models.PullRequest
 		return fmt.Errorf("could not merge pull request: %s", mergeResult.GetMessage())
 	}
 	return nil
+}
+
+// enqueuePull adds the pull request to the base branch's GitHub merge queue
+// instead of merging it. GitHub only exposes the merge queue through GraphQL,
+// so unlike MergePull this can't go through the REST client.
+func (g *Client) enqueuePull(logger logging.SimpleLogging, pull models.PullRequest) error {
+	logger.Debug("Adding GitHub pull request %d to the merge queue", pull.Num)
+
+	pullID, err := g.lookupPullRequestId(pull)
+	if err != nil {
+		return err
+	}
+
+	// https://docs.github.com/en/graphql/reference/mutations#enqueuepullrequest
+	var mutation struct {
+		EnqueuePullRequest struct {
+			MergeQueueEntry struct {
+				Position githubv4.Int
+				State    githubv4.String
+			}
+		} `graphql:"enqueuePullRequest(input: $input)"`
+	}
+
+	input := githubv4.EnqueuePullRequestInput{
+		PullRequestID:    pullID,
+		ClientMutationID: clientMutationID,
+	}
+	// Guard against a commit landing between the apply and the enqueue. GitHub
+	// rejects the mutation if the head has moved on, which is what we want:
+	// the queue would otherwise merge code that was never planned.
+	if pull.HeadCommit != "" {
+		input.ExpectedHeadOid = githubv4.NewGitObjectID(githubv4.GitObjectID(pull.HeadCommit))
+	}
+
+	if err := g.v4Client.Mutate(g.ctx, &mutation, input, nil); err != nil {
+		return fmt.Errorf("adding pull request to the merge queue: %w", err)
+	}
+
+	entry := mutation.EnqueuePullRequest.MergeQueueEntry
+	logger.Info("added GitHub pull request %d to the merge queue in position %d with state %q", pull.Num, entry.Position, entry.State)
+	return nil
+}
+
+// lookupPullRequestId resolves a pull request number to the GraphQL node ID
+// that the merge queue mutations take.
+func (g *Client) lookupPullRequestId(pull models.PullRequest) (githubv4.ID, error) {
+	var query struct {
+		Repository struct {
+			PullRequest struct {
+				ID githubv4.ID
+			} `graphql:"pullRequest(number: $number)"`
+		} `graphql:"repository(owner: $owner, name: $name)"`
+	}
+	variables := map[string]any{
+		"owner":  githubv4.String(pull.BaseRepo.Owner),
+		"name":   githubv4.String(pull.BaseRepo.Name),
+		"number": githubv4.Int(pull.Num), // #nosec G115: integer overflow conversion int -> int32
+	}
+
+	if err := g.v4Client.Query(g.ctx, &query, variables); err != nil {
+		return nil, fmt.Errorf("getting pull request id from GraphQL: %w", err)
+	}
+	return query.Repository.PullRequest.ID, nil
 }
 
 // MarkdownPullLink specifies the string used in a pull request comment to reference another pull request.

--- a/server/events/vcs/github/client_test.go
+++ b/server/events/vcs/github/client_test.go
@@ -1312,7 +1312,7 @@ func TestClient_MergePullCorrectMethod(t *testing.T) {
 			allowSquash:       true,
 			mergeMethodOption: "unknown",
 			expMethod:         "",
-			expErr:            "merge method 'unknown' is unknown. Specify one of the valid values: 'merge, rebase, squash'",
+			expErr:            "merge method 'unknown' is unknown. Specify one of the valid values: 'merge, merge-queue, rebase, squash'",
 		},
 	}
 
@@ -1396,6 +1396,92 @@ func TestClient_MergePullCorrectMethod(t *testing.T) {
 			} else {
 				ErrContains(t, c.expErr, err)
 			}
+		})
+	}
+}
+
+// Test that the merge-queue merge method hands the pull request off to GitHub's
+// merge queue over GraphQL rather than merging it over REST.
+func TestClient_MergePullMergeQueue(t *testing.T) {
+	logger := logging.NewNoopLogger(t)
+	cases := map[string]struct {
+		enqueueResp string
+		expErr      string
+	}{
+		"queued": {
+			enqueueResp: `{"data":{"enqueuePullRequest":{"mergeQueueEntry":{"position":3,"state":"QUEUED"}}}}`,
+		},
+		"merge queue not enabled": {
+			enqueueResp: `{"errors":[{"message":"Merge queue is not enabled on the base branch"}]}`,
+			expErr:      "adding pull request to the merge queue: Merge queue is not enabled on the base branch",
+		},
+		"head moved on": {
+			enqueueResp: `{"errors":[{"message":"Expected head OID does not match the pull request head"}]}`,
+			expErr:      "adding pull request to the merge queue: Expected head OID does not match the pull request head",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			var gotMutationBody string
+			testServer := httptest.NewTLSServer(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.RequestURI != "/api/graphql" {
+						// The REST merge endpoint must never be hit for this
+						// merge method.
+						t.Errorf("got unexpected request at %q", r.RequestURI)
+						http.Error(w, "not found", http.StatusNotFound)
+						return
+					}
+					body, err := io.ReadAll(r.Body)
+					Ok(t, err)
+					defer r.Body.Close() // nolint: errcheck
+
+					if strings.Contains(string(body), "enqueuePullRequest") {
+						gotMutationBody = string(body)
+						w.Write([]byte(c.enqueueResp)) // nolint: errcheck
+						return
+					}
+					// The node ID lookup that the mutation input needs.
+					w.Write([]byte(`{"data":{"repository":{"pullRequest":{"id":"PR_kwDOABCD"}}}}`)) // nolint: errcheck
+				}))
+			defer testServer.Close()
+			testServerURL, err := url.Parse(testServer.URL)
+			Ok(t, err)
+			client, err := github.New(testServerURL.Host, &github.UserCredentials{"user", "pass", ""}, github.Config{}, 0, logger)
+			Ok(t, err)
+			defer disableSSLVerification()()
+
+			err = client.MergePull(
+				logger,
+				models.PullRequest{
+					BaseRepo: models.Repo{
+						FullName: "runatlantis/atlantis",
+						Owner:    "runatlantis",
+						Name:     "atlantis",
+						VCSHost: models.VCSHost{
+							Type:     models.Github,
+							Hostname: "github.com",
+						},
+					},
+					Num:        1,
+					HeadCommit: "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+				}, models.PullRequestOptions{
+					MergeMethod: github.MergeQueueMergeMethod,
+				})
+
+			if c.expErr == "" {
+				Ok(t, err)
+			} else {
+				ErrContains(t, c.expErr, err)
+			}
+
+			// Whether or not the enqueue succeeded, we should have asked GitHub
+			// to enqueue the id we looked up, pinned to the head we applied.
+			Assert(t, strings.Contains(gotMutationBody, `"pullRequestId":"PR_kwDOABCD"`),
+				"expected mutation to carry the pull request node id, got %q", gotMutationBody)
+			Assert(t, strings.Contains(gotMutationBody, `"expectedHeadOid":"6dcb09b5b57875f334f61aebed695e2e4193db5e"`),
+				"expected mutation to pin the head commit, got %q", gotMutationBody)
 		})
 	}
 }


### PR DESCRIPTION
## what

- Add `merge-queue` as a fourth value for the `--automerge-method` server flag and the `--auto-merge-method` comment flag.
- When set, Atlantis adds the pull request to the base branch's [GitHub merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) instead of merging it, and GitHub merges it once the queue's checks pass.
- The enqueue is pinned to the commit Atlantis applied (`expectedHeadOid`), so a push landing between the apply and the enqueue is rejected by GitHub rather than queued.
- The automerge PR comment now says "Automatically adding to the merge queue…" instead of "Automatically merging…" when this method is used, and failures read "Adding to the merge queue failed:".
- Existing behavior is unchanged for `merge`, `rebase`, `squash`, and for an unset merge method.

## why

- Repositories that require a merge queue on their default branch can't use Atlantis automerge at all today: the REST merge endpoint that `MergePull` calls is rejected by branch protection, so automerge just fails and the PR has to be merged by hand.
- Handing the PR off to the queue is the natural mapping onto the existing merge method setting — it's still "how does this PR get merged", it just changes who performs the merge rather than how the commits are combined (which stays configured on the branch's merge queue ruleset).
- GitHub only exposes the merge queue through GraphQL, so this uses the `enqueuePullRequest` mutation on the `githubv4` client Atlantis already constructs, rather than the REST client.
- Pinning to the applied commit matters more here than for a direct merge: the queue introduces a real delay between "Atlantis finished applying" and "the code lands", so without the guard the queue could merge a commit that was never planned.

### Implementation notes

- `MergePull` short-circuits to the new `enqueuePull` before the repo merge method negotiation, since `merge-queue` isn't one of the repo's allowed merge commit types and has nothing to negotiate.
- `merge-queue` is still listed in the "unknown merge method" error so the message stays accurate.
- `ValidAutomergeMethods` references the constant from `server/events/vcs/github` rather than duplicating the literal. `cmd` already imports a vcs package (`bitbucketcloud`) so this introduces no new dependency direction.

### Known limitation

If `atlantis/plan` or `atlantis/apply` is a **required status check** on the base branch, it is also required on the merge group GitHub builds, and nothing posts those statuses for the merge group's commit — so the queue stalls. This is the same gap tracked in #5603 and being addressed by #6435. Until that lands, users of this flag need to keep the Atlantis checks out of the branch's required checks. This is documented as a warning in `automerging.md`.

## tests

- [x] `go build ./...`
- [x] `go test ./cmd/... ./server/events/...`
- [x] New `TestClient_MergePullMergeQueue` covers the enqueue path: successful queueing, merge queue not enabled on the branch, and a rejected `expectedHeadOid`. It asserts the REST merge endpoint is never called and that the mutation carries both the resolved node ID and the pinned head commit.
- [x] New `TestApplyWithAutoMerge_MergeQueueMethodCommentsThatItIsQueueing` covers the routing through the automerger and the queue-specific comment.
- [x] `TestExecute_ValidateAutomergeMethod` extended to accept `merge-queue` and to assert the updated validation error.
- [x] `TestClient_MergePullCorrectMethod` updated for the new value in the unknown-method error.
- [x] markdownlint clean on the changed docs.

## references

- closes #6758
- Related: #5603 (Atlantis compatibility with GitHub merge queue — the inbound half, handling `merge_group` webhooks)
- Related: #6435 (feat: add support for github merge queue)
- [`enqueuePullRequest` GraphQL mutation](https://docs.github.com/en/graphql/reference/mutations#enqueuepullrequest)
