### PR TITLE
fix: clarify undiverged requirement message

### DIFF
--- a/server/events/command_requirement_handler.go
+++ b/server/events/command_requirement_handler.go
@@ -114,7 +114,7 @@ func (a *DefaultCommandRequirementHandler) validateCommandRequirement(repoDir st
 				diverged = a.hasDiverged(repoDir, ctx, cmd, nil)
 			}
 			if diverged {
-				return fmt.Sprintf("Default branch must be rebased onto pull request before running %s.", cmd), nil
+				return fmt.Sprintf("Pull request branch must include the latest default branch commit before running %s.", cmd), nil
 			}
 		}
 	}

--- a/server/events/command_requirement_handler_test.go
+++ b/server/events/command_requirement_handler_test.go
@@ -101,7 +101,7 @@ func TestAggregateApplyRequirements_ValidatePlanProject(t *testing.T) {
 			setup: func(workingDir *mocks.MockWorkingDir) {
 				When(workingDir.HasDivergedFromPullHead(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(true)
 			},
-			wantFailure: "Default branch must be rebased onto pull request before running plan.",
+			wantFailure: "Pull request branch must include the latest default branch commit before running plan.",
 			wantErr:     assert.NoError,
 		},
 	}
@@ -229,7 +229,7 @@ func TestAggregateApplyRequirements_ValidateApplyProject(t *testing.T) {
 					Any[models.PullRequest](),
 				)).ThenReturn(true)
 			},
-			wantFailure: "Default branch must be rebased onto pull request before running apply.",
+			wantFailure: "Pull request branch must include the latest default branch commit before running apply.",
 			wantErr:     assert.NoError,
 		},
 		{
@@ -363,7 +363,7 @@ func TestAggregateApplyRequirements_ValidateApplyProject(t *testing.T) {
 			setup: func(workingDir *mocks.MockWorkingDir) {
 				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(true)
 			},
-			wantFailure: "Default branch must be rebased onto pull request before running apply.",
+			wantFailure: "Pull request branch must include the latest default branch commit before running apply.",
 			wantErr:     assert.NoError,
 		},
 	}
@@ -879,7 +879,7 @@ func TestAggregateApplyRequirements_ValidateImportProject(t *testing.T) {
 			setup: func(workingDir *mocks.MockWorkingDir) {
 				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(true)
 			},
-			wantFailure: "Default branch must be rebased onto pull request before running import.",
+			wantFailure: "Pull request branch must include the latest default branch commit before running import.",
 			wantErr:     assert.NoError,
 		},
 	}

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -745,7 +745,7 @@ func TestDefaultProjectCommandRunner_PlanUndivergedBlocksAfterMergeAgain(t *test
 
 	res := runner.Plan(ctx)
 
-	Equals(t, "Default branch must be rebased onto pull request before running plan.", res.Failure)
+	Equals(t, "Pull request branch must include the latest default branch commit before running plan.", res.Failure)
 	mockWorkingDir.VerifyWasCalledOnce().MergeAgain(
 		Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](), Any[string]())
 }
@@ -830,7 +830,7 @@ func TestDefaultProjectCommandRunner_PlanValidationFailureKeepsLockWhenDeletePla
 
 	res := runner.Plan(ctx)
 
-	Equals(t, "Default branch must be rebased onto pull request before running plan.", res.Failure)
+	Equals(t, "Pull request branch must include the latest default branch commit before running plan.", res.Failure)
 	Assert(t, res.Error != nil, "expected delete plan error")
 	Equals(t, "deleting stale plan after plan validation failure: delete failed", res.Error.Error())
 	Equals(t, 0, unlockCalls)
@@ -920,7 +920,7 @@ func TestDefaultProjectCommandRunner_ApplyDiverged(t *testing.T) {
 	When(mockWorkingDir.HasDiverged(ctx.Log, tmp, ctx.RepoRelDir, ctx.AutoplanWhenModified, ctx.Pull)).ThenReturn(true)
 
 	res := runner.Apply(ctx)
-	Equals(t, "Default branch must be rebased onto pull request before running apply.", res.Failure)
+	Equals(t, "Pull request branch must include the latest default branch commit before running apply.", res.Failure)
 }
 
 func TestProjectCommandRunner_ApplyRevalidatesPlanUnderLock(t *testing.T) {

--- a/server/events/undiverged_project_impact_test.go
+++ b/server/events/undiverged_project_impact_test.go
@@ -158,7 +158,7 @@ func TestDefaultCommandRequirementHandler_TargetedUndivergedFailsForImpactedConf
 
 	failure, err := handler.ValidateApplyProject(repoDir, ctx)
 	Ok(t, err)
-	Equals(t, "Default branch must be rebased onto pull request before running apply.", failure)
+	Equals(t, "Pull request branch must include the latest default branch commit before running apply.", failure)
 }
 
 func TestDefaultCommandRequirementHandler_TargetedUndivergedPassesForUnrelatedConfiguredChange(t *testing.T) {
@@ -227,7 +227,7 @@ func TestDefaultCommandRequirementHandler_TargetedUndivergedFallsBackWhenGenerat
 
 	failure, err := handler.ValidateApplyProject(repoDir, ctx)
 	Ok(t, err)
-	Equals(t, "Default branch must be rebased onto pull request before running apply.", failure)
+	Equals(t, "Pull request branch must include the latest default branch commit before running apply.", failure)
 }
 
 func TestDefaultCommandRequirementHandler_TargetedUndivergedFallsBackForEmptyConfiguredWhenModified(t *testing.T) {
@@ -250,7 +250,7 @@ func TestDefaultCommandRequirementHandler_TargetedUndivergedFallsBackForEmptyCon
 
 	failure, err := handler.ValidateApplyProject(repoDir, ctx)
 	Ok(t, err)
-	Equals(t, "Default branch must be rebased onto pull request before running apply.", failure)
+	Equals(t, "Pull request branch must include the latest default branch commit before running apply.", failure)
 }
 
 func TestDefaultCommandRequirementHandler_TargetedUndivergedFallsBackToFullCheckOnResolverError(t *testing.T) {


### PR DESCRIPTION
## what

- The `undiverged` message is over-prescriptive.  Rebase is one way to solve the problem, but not the only way.  The current message, taken literally, will confuse people.  It confused me!
- Update every assertion of the message for plan, apply, and import commands.

## why

- The current message says the default branch must be rebased onto the pull request, which reverses the usual rebase direction and implies rebasing is required.
- Merging the default branch into the pull request branch satisfies the same ancestry check without rewriting published history.

## tests

- [x] `go test ./server/events`
- [x] `make test`
- [x] Changed Go files pass `gofmt` and `goimports`

## references

- Related to #4051
- [Command requirements documentation](https://www.runatlantis.io/docs/command-requirements#undiverged)
