### PR TITLE
fix: read pull status with a legacy policy approval count

### DIFF
--- a/server/core/boltdb/boltdb_test.go
+++ b/server/core/boltdb/boltdb_test.go
@@ -1344,11 +1344,12 @@ func TestPullStatus_UpdateOverwritesCorruptData(t *testing.T) {
 	Ok(t, err)
 	Ok(t, b.Close())
 
-	// Inject a corrupt pull-status blob simulating a legacy on-disk shape
-	// that the current Go types cannot unmarshal.
+	// Inject a corrupt pull-status blob whose Status is a string where the
+	// current Go shape has an int. A legacy int Approvals is no longer corrupt;
+	// see TestPullStatus_PreservesLegacyPolicyApprovals.
 	key := fmt.Appendf(nil, "%s::%s::%d",
 		pull.BaseRepo.VCSHost.Hostname, pull.BaseRepo.FullName, pull.Num)
-	corrupt := []byte(`{"Projects":[{"Workspace":"default","RepoRelDir":"mydir","ProjectName":"","PolicyStatus":[{"PolicySetName":"policy1","Passed":false,"Approvals":2}],"Status":0}],"Pull":{"Num":1}}`)
+	corrupt := []byte(`{"Projects":[{"Workspace":"default","RepoRelDir":"mydir","ProjectName":"","PolicyStatus":[{"PolicySetName":"policy1","Passed":false}],"Status":"planned"}],"Pull":{"Num":1}}`)
 	raw, err := bolt.Open(filepath.Join(tmp, "atlantis.db"), 0600, nil)
 	Ok(t, err)
 	err = raw.Update(func(tx *bolt.Tx) error {
@@ -1385,6 +1386,63 @@ func TestPullStatus_UpdateOverwritesCorruptData(t *testing.T) {
 	Assert(t, got != nil, "expected non-nil pull status")
 	Equals(t, 1, len(got.Projects))
 	Equals(t, models.PlannedPlanStatus, got.Projects[0].Status)
+}
+
+// TestPullStatus_PreservesLegacyPolicyApprovals verifies that a pull status
+// written before approvals recorded an approver still loads, instead of being
+// treated as corrupt and overwritten.
+func TestPullStatus_PreservesLegacyPolicyApprovals(t *testing.T) {
+	tmp := t.TempDir()
+
+	pull := models.PullRequest{
+		Num:        1,
+		HeadCommit: "sha-A",
+		URL:        "url",
+		HeadBranch: "head",
+		BaseBranch: "base",
+		Author:     "lkysow",
+		State:      models.OpenPullState,
+		BaseRepo: models.Repo{
+			FullName:          "runatlantis/atlantis",
+			Owner:             "runatlantis",
+			Name:              "atlantis",
+			CloneURL:          "clone-url",
+			SanitizedCloneURL: "clone-url",
+			VCSHost: models.VCSHost{
+				Hostname: "github.com",
+				Type:     models.Github,
+			},
+		},
+	}
+
+	b, err := boltdb.New(tmp)
+	Ok(t, err)
+	Ok(t, b.Close())
+
+	key := fmt.Appendf(nil, "%s::%s::%d",
+		pull.BaseRepo.VCSHost.Hostname, pull.BaseRepo.FullName, pull.Num)
+	legacy := []byte(`{"Projects":[{"Workspace":"default","RepoRelDir":"mydir","ProjectName":"","PolicyStatus":[{"PolicySetName":"policy1","Passed":true,"Approvals":2}],"Status":2}],"Pull":{"Num":1}}`)
+	raw, err := bolt.Open(filepath.Join(tmp, "atlantis.db"), 0600, nil)
+	Ok(t, err)
+	Ok(t, raw.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket([]byte("pulls")).Put(key, legacy)
+	}))
+	Ok(t, raw.Close())
+
+	b, err = boltdb.New(tmp)
+	Ok(t, err)
+	defer b.Close()
+
+	got, err := b.GetPullStatus(pull)
+	Ok(t, err)
+	Assert(t, got != nil, "expected non-nil pull status")
+	Equals(t, 1, len(got.Projects))
+	Equals(t, "mydir", got.Projects[0].RepoRelDir)
+	// The policy set survives; the count yields no approvals, so it must be
+	// approved again rather than crediting an approver nobody recorded.
+	Equals(t, 1, len(got.Projects[0].PolicyStatus))
+	Equals(t, "policy1", got.Projects[0].PolicyStatus[0].PolicySetName)
+	Equals(t, 0, got.Projects[0].PolicyStatus[0].GetCurApprovals())
 }
 
 // newTestDB returns a TestDB using a temporary path.

--- a/server/core/redis/redis_test.go
+++ b/server/core/redis/redis_test.go
@@ -1391,11 +1391,12 @@ func TestPullStatus_UpdateOverwritesCorruptData(t *testing.T) {
 		},
 	}
 
-	// Inject a corrupt pull-status blob simulating a legacy on-disk shape
-	// that the current Go types cannot unmarshal (Approvals used to be int).
+	// Inject a corrupt pull-status blob whose Status is a string where the
+	// current Go shape has an int. A legacy int Approvals is no longer corrupt;
+	// see TestPullStatus_PreservesLegacyPolicyApprovals.
 	key := fmt.Sprintf("%s::%s::%d",
 		pull.BaseRepo.VCSHost.Hostname, pull.BaseRepo.FullName, pull.Num)
-	corrupt := `{"Projects":[{"Workspace":"default","RepoRelDir":"mydir","ProjectName":"","PolicyStatus":[{"PolicySetName":"policy1","Passed":false,"Approvals":2}],"Status":0}],"Pull":{"Num":1}}`
+	corrupt := `{"Projects":[{"Workspace":"default","RepoRelDir":"mydir","ProjectName":"","PolicyStatus":[{"PolicySetName":"policy1","Passed":false}],"Status":"planned"}],"Pull":{"Num":1}}`
 	Ok(t, s.Set(key, corrupt))
 
 	// Write fresh results. This must succeed despite the unreadable prior entry.
@@ -1421,6 +1422,51 @@ func TestPullStatus_UpdateOverwritesCorruptData(t *testing.T) {
 	Assert(t, got != nil, "expected non-nil pull status")
 	Equals(t, 1, len(got.Projects))
 	Equals(t, models.PlannedPlanStatus, got.Projects[0].Status)
+}
+
+// TestPullStatus_PreservesLegacyPolicyApprovals verifies that a pull status
+// written before approvals recorded an approver still loads, instead of being
+// treated as corrupt and overwritten.
+func TestPullStatus_PreservesLegacyPolicyApprovals(t *testing.T) {
+	s := miniredis.RunT(t)
+	rdb := newTestRedis(s)
+
+	pull := models.PullRequest{
+		Num:        1,
+		HeadCommit: "sha-A",
+		URL:        "url",
+		HeadBranch: "head",
+		BaseBranch: "base",
+		Author:     "lkysow",
+		State:      models.OpenPullState,
+		BaseRepo: models.Repo{
+			FullName:          "runatlantis/atlantis",
+			Owner:             "runatlantis",
+			Name:              "atlantis",
+			CloneURL:          "clone-url",
+			SanitizedCloneURL: "clone-url",
+			VCSHost: models.VCSHost{
+				Hostname: "github.com",
+				Type:     models.Github,
+			},
+		},
+	}
+
+	key := fmt.Sprintf("%s::%s::%d",
+		pull.BaseRepo.VCSHost.Hostname, pull.BaseRepo.FullName, pull.Num)
+	legacy := `{"Projects":[{"Workspace":"default","RepoRelDir":"mydir","ProjectName":"","PolicyStatus":[{"PolicySetName":"policy1","Passed":true,"Approvals":2}],"Status":2}],"Pull":{"Num":1}}`
+	Ok(t, s.Set(key, legacy))
+
+	got, err := rdb.GetPullStatus(pull)
+	Ok(t, err)
+	Assert(t, got != nil, "expected non-nil pull status")
+	Equals(t, 1, len(got.Projects))
+	Equals(t, "mydir", got.Projects[0].RepoRelDir)
+	// The policy set survives; the count yields no approvals, so it must be
+	// approved again rather than crediting an approver nobody recorded.
+	Equals(t, 1, len(got.Projects[0].PolicyStatus))
+	Equals(t, "policy1", got.Projects[0].PolicyStatus[0].PolicySetName)
+	Equals(t, 0, got.Projects[0].PolicyStatus[0].GetCurApprovals())
 }
 
 func newTestRedis(mr *miniredis.Miniredis) *redis.RedisDB {

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -10,6 +10,7 @@ package models
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -495,9 +496,37 @@ func ApprovalCoversAllHashes(approvalHashes, required []string) bool {
 type PolicySetStatus struct {
 	PolicySetName   string
 	Passed          bool
-	Approvals       []PolicySetApproval
+	Approvals       PolicySetApprovals
 	Hashes          []string
 	PolicyItemRegex string
+}
+
+// PolicySetApprovals is assignable to and from []PolicySetApproval. It exists
+// only to carry the UnmarshalJSON below, which is declared here rather than on
+// PolicySetStatus so that the struct keeps decoding on encoding/json's native
+// path; an Unmarshaler costs a second parse of whatever it covers.
+type PolicySetApprovals []PolicySetApproval
+
+// UnmarshalJSON also accepts the bare count written before approvals recorded
+// an approver, treating it as no approvals: the count named nobody, and an
+// approval cannot be revived without inventing an approver.
+func (psa *PolicySetApprovals) UnmarshalJSON(data []byte) error {
+	// json validates the document before calling an Unmarshaler, so the first
+	// byte identifies the value.
+	if len(data) == 0 {
+		*psa = nil
+		return nil
+	}
+
+	switch data[0] {
+	case '[':
+		return json.Unmarshal(data, (*[]PolicySetApproval)(psa))
+	case 'n', '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9': // null or count
+		*psa = nil
+		return nil
+	default:
+		return fmt.Errorf("policy set approvals are neither a list nor a count: %s", data)
+	}
 }
 
 // GetCurApprovals returns the number of approvals that cover all hashes in this policy set.

--- a/server/events/models/policyset_status_json_test.go
+++ b/server/events/models/policyset_status_json_test.go
@@ -1,0 +1,141 @@
+package models_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/events/models"
+	. "github.com/runatlantis/atlantis/testing"
+)
+
+func TestPolicySetStatus_UnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		name          string
+		json          string
+		expApprovals  models.PolicySetApprovals
+		expName       string
+		expPassed     bool
+		expHashes     []string
+		expErrContain string
+	}{
+		{
+			name:         "approvals as a list",
+			json:         `{"PolicySetName":"zero_trust","Passed":true,"Approvals":[{"Approver":"alice","Hashes":["h1"]}],"Hashes":["h1"]}`,
+			expName:      "zero_trust",
+			expPassed:    true,
+			expApprovals: models.PolicySetApprovals{{Approver: "alice", Hashes: []string{"h1"}}},
+			expHashes:    []string{"h1"},
+		},
+		{
+			name:      "approvals as a count", // pre sticky-approvals server
+			json:      `{"PolicySetName":"zero_trust_policies","Passed":true,"Approvals":0}`,
+			expName:   "zero_trust_policies",
+			expPassed: true,
+		},
+		{
+			name:      "a non-zero count does not revive approvals",
+			json:      `{"PolicySetName":"zero_trust","Passed":false,"Approvals":3,"Hashes":["h1"]}`,
+			expName:   "zero_trust",
+			expHashes: []string{"h1"},
+		},
+		{
+			name:    "approvals null",
+			json:    `{"PolicySetName":"zero_trust","Approvals":null}`,
+			expName: "zero_trust",
+		},
+		{
+			name:    "approvals absent",
+			json:    `{"PolicySetName":"zero_trust"}`,
+			expName: "zero_trust",
+		},
+		{
+			name:         "empty list",
+			json:         `{"PolicySetName":"zero_trust","Approvals":[]}`,
+			expName:      "zero_trust",
+			expApprovals: models.PolicySetApprovals{},
+		},
+		{
+			name:          "approvals as a string",
+			json:          `{"PolicySetName":"zero_trust","Approvals":"two"}`,
+			expErrContain: "neither a list nor a count",
+		},
+		{
+			name:          "approvals as a bool",
+			json:          `{"PolicySetName":"zero_trust","Approvals":true}`,
+			expErrContain: "neither a list nor a count",
+		},
+		{
+			name:          "approvals as an object",
+			json:          `{"PolicySetName":"zero_trust","Approvals":{"alice":1}}`,
+			expErrContain: "neither a list nor a count",
+		},
+		{
+			name:          "malformed json is still rejected",
+			json:          `{"PolicySetName":"zero_trust","Approvals":[`,
+			expErrContain: "unexpected end of JSON input",
+		},
+		{
+			name:          "malformed list element",
+			json:          `{"PolicySetName":"zero_trust","Approvals":[{"Approver":5}]}`,
+			expErrContain: "cannot unmarshal",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var status models.PolicySetStatus
+			err := json.Unmarshal([]byte(c.json), &status)
+
+			if c.expErrContain != "" {
+				ErrContains(t, c.expErrContain, err)
+				return
+			}
+			Ok(t, err)
+			Equals(t, c.expName, status.PolicySetName)
+			Equals(t, c.expPassed, status.Passed)
+			Equals(t, c.expApprovals, status.Approvals)
+			Equals(t, c.expHashes, status.Hashes)
+		})
+	}
+}
+
+// A count must leave the policy set unapproved, not credit an unnamed approver.
+func TestPolicySetStatus_LegacyCountYieldsNoApprovals(t *testing.T) {
+	var status models.PolicySetStatus
+	Ok(t, json.Unmarshal([]byte(`{"Approvals":5,"Hashes":["h1"]}`), &status))
+	Equals(t, 0, status.GetCurApprovals())
+}
+
+// The stored pull that could not be read.
+func TestPullStatus_UnmarshalLegacyPolicyApprovals(t *testing.T) {
+	stored := `{"Projects":[{"Workspace":"default","RepoRelDir":"tf/cloudflare-billing",` +
+		`"ProjectName":"cloudflare-billing",` +
+		`"PolicyStatus":[{"PolicySetName":"zero_trust_policies","Passed":true,"Approvals":0}],` +
+		`"Status":7}],"Pull":{"Num":14599,"HeadBranch":"branch","BaseBranch":"master","Author":"someone"}}`
+
+	var pull models.PullStatus
+	Ok(t, json.Unmarshal([]byte(stored), &pull))
+	Equals(t, 1, len(pull.Projects))
+	Equals(t, 1, len(pull.Projects[0].PolicyStatus))
+	Equals(t, "zero_trust_policies", pull.Projects[0].PolicyStatus[0].PolicySetName)
+	Equals(t, true, pull.Projects[0].PolicyStatus[0].Passed)
+	Equals(t, 14599, pull.Pull.Num)
+}
+
+// The wire format must be unchanged.
+func TestPolicySetStatus_RoundTrip(t *testing.T) {
+	original := models.PolicySetStatus{
+		PolicySetName:   "zero_trust",
+		Passed:          true,
+		Approvals:       models.PolicySetApprovals{{Approver: "alice", Hashes: []string{"h1", "h2"}}},
+		Hashes:          []string{"h1", "h2"},
+		PolicyItemRegex: ".*",
+	}
+
+	encoded, err := json.Marshal(original)
+	Ok(t, err)
+
+	var decoded models.PolicySetStatus
+	Ok(t, json.Unmarshal(encoded, &decoded))
+	Equals(t, original, decoded)
+}


### PR DESCRIPTION
## what

- decode `PolicySetStatus.Approvals` from both the current list and the bare int it used to be

## why

- `Approvals` was an int before it became a list, so a pull status written by an older server fails to load, and the next plan discards the whole entry as corrupt and loses every project's status
- a count named no approver, so it decodes to no approvals: the policy set gets approved again rather than crediting nobody
- the unmarshaller sits on the field's type, not on `PolicySetStatus`, so the struct keeps decoding on encoding/json's native path. an `Unmarshaler` costs a second parse of everything it covers

## tests

- [x] both encodings, plus null, absent, and the types that stay rejected
- [x] boltdb and redis: a legacy blob now loads instead of being overwritten
- [x] kept `TestPullStatus_UpdateOverwritesCorruptData`, repointed at a fixture that is still genuinely unreadable
