### PR TITLE
fix: remove smoothScrollDuration from jobs page terminal

### DIFF
--- a/server/controllers/web_templates/templates/project-jobs.html.tmpl
+++ b/server/controllers/web_templates/templates/project-jobs.html.tmpl
@@ -61,7 +61,7 @@
       function updateTerminalStatus(msg) {
           document.getElementsByTagName("footer")[0].innerText = msg;
       }
-      var term = new Terminal({scrollback: 15000, smoothScrollDuration:125 });
+      var term = new Terminal({scrollback: 15000});
       var socket = new WebSocket(
         (document.location.protocol === "http:" ? "ws://" : "wss://") +
         document.location.host +


### PR DESCRIPTION
## what

- Remove `smoothScrollDuration: 125` from the xterm.js `Terminal` constructor on the project jobs output page.

## why

- `smoothScrollDuration` is meant to animate discrete physical mouse-wheel scroll steps. On macOS trackpads, which send continuous inertial scroll events, this option fights the native momentum and makes scrolling on the jobs page choppy/stuttery.
- Dropping the option restores native scroll behavior for trackpad users while leaving mouse-wheel scrolling functional (xterm.js scrolls immediately without the animation).

## tests

- [ ] Not tested locally (requires a running Atlantis server + terminal WebSocket session to observe scroll behavior). This is a single-line template change with no logic branches to unit test.

## references

- Original bug report and root-cause analysis: runatlantis/atlantis#6696
