### PR TITLE
fix: only require a managed plan file for managed apply workflows

### DIFF
--- a/runatlantis.io/docs/custom-workflows.md
+++ b/runatlantis.io/docs/custom-workflows.md
@@ -647,6 +647,11 @@ Full example, filtering output and masking matching text (`mySecret: "foo"` -> `
   * `PLANFILE` - Absolute path to the location where Atlantis expects the plan to
       either be generated (by plan) or already exist (if running apply). Can be used to
       override the built-in `plan`/`apply` commands, ex. `run: terraform plan -out $PLANFILE`.
+      A workflow whose `plan` and `apply` are both made up entirely of custom `run` steps
+      may write its plan to a path of its own choosing instead of `$PLANFILE`. Atlantis
+      does not require, hash, or delete a plan artifact for such a workflow; it still
+      validates the project's recorded plan state before running `apply`. As soon as a
+      workflow uses the built-in `plan` or `apply` step, the plan must be at `$PLANFILE`.
   * `SHOWFILE` - Absolute path to the location where Atlantis expects the plan in json format to
       either be generated (by show) or already exist (if running policy checks). Can be used to
       override the built-in `plan`/`apply` commands, ex. `run: terraform show -json $PLANFILE > $SHOWFILE`.

--- a/server/events/apply_plan_validator.go
+++ b/server/events/apply_plan_validator.go
@@ -21,6 +21,10 @@ import (
 
 type ApplyPlanValidator interface {
 	ValidateProjectPlan(ctx command.ProjectContext, absPath string) error
+	// ValidateProjectPlanStatus validates only durable plan state. It is used
+	// for workflows that do not consume the Atlantis convention plan file, so
+	// no plan artifact may be inspected or removed.
+	ValidateProjectPlanStatus(ctx command.ProjectContext) error
 }
 
 type ApplyCommandStartValidator interface {
@@ -38,6 +42,20 @@ type DefaultApplyPlanValidator struct {
 
 var errStaleCommandHead = errors.New("stale command head")
 
+// planRejectionError marks a durable-status failure that must also remove the
+// convention-managed plan artifact when one is being validated. Failures that
+// are not wrapped in it (for example a stale command head) leave the artifact
+// in place because another replica may have replaced it.
+type planRejectionError struct{ err error }
+
+func (e planRejectionError) Error() string { return e.err.Error() }
+
+func (e planRejectionError) Unwrap() error { return e.err }
+
+func rejectionErrorf(format string, args ...any) error {
+	return planRejectionError{err: fmt.Errorf(format, args...)}
+}
+
 func (v *DefaultApplyPlanValidator) ValidateCommandStartHead(ctx command.ProjectContext) error {
 	if v == nil || v.LivePullHeadFetcher == nil {
 		return nil
@@ -49,21 +67,26 @@ func (v *DefaultApplyPlanValidator) ValidateCommandStartHead(ctx command.Project
 	return validateCommandStartIdentity(ctx, livePull)
 }
 
-func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectContext, absPath string) error {
+// ValidateProjectPlanStatus validates durable plan state without inspecting or
+// removing any plan artifact. Workflows with a custom apply step manage their
+// own plan file, which Atlantis neither creates nor can locate.
+func (v *DefaultApplyPlanValidator) ValidateProjectPlanStatus(ctx command.ProjectContext) error {
 	if v == nil || v.PullStatusFetcher == nil {
 		return nil
 	}
-	planPath, err := safePlanFilePath(ctx, absPath)
-	if err != nil {
-		return err
-	}
+	return v.validateProjectPlanStatus(ctx)
+}
 
+// validateProjectPlanStatus only validates durable state. Failures that should
+// also discard a convention-managed plan artifact are wrapped in
+// planRejectionError; the caller decides whether an artifact exists to remove.
+func (v *DefaultApplyPlanValidator) validateProjectPlanStatus(ctx command.ProjectContext) error {
 	pullStatus, err := v.pullStatusForApply(ctx)
 	if err != nil {
 		return fmt.Errorf("fetching current plan status: %w", err)
 	}
 	if pullStatus == nil {
-		return rejectProjectPlan(planPath, "no current plan status found; run `atlantis plan` before apply")
+		return rejectionErrorf("no current plan status found; run `atlantis plan` before apply")
 	}
 
 	livePull, err := v.getLivePullIdentity(ctx)
@@ -83,27 +106,46 @@ func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectConte
 			return err
 		}
 	} else if err := pullStatusApplyEligibilityError(ctx.Pull, pullStatus.Pull, "recorded plan status"); err != nil {
-		return rejectProjectPlan(planPath, "%s", err)
+		return rejectionErrorf("%s", err)
 	}
 
 	proj := findProjectInPullStatus(pullStatus, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName)
 	if proj == nil {
-		return rejectProjectPlan(planPath,
+		return rejectionErrorf(
 			"no matching plan status exists for dir %q workspace %q project %q; run `atlantis plan`",
 			ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName,
 		)
 	}
 	if !statusAllowedForApplyExecution(proj.Status) {
 		if proj.Status == models.ErroredPolicyCheckStatus {
-			return rejectProjectPlan(planPath,
+			return rejectionErrorf(
 				"policy checks have errored for dir %q workspace %q project %q and cannot be applied; run `atlantis plan`",
 				ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName,
 			)
 		}
-		return rejectProjectPlan(planPath,
+		return rejectionErrorf(
 			"plan for dir %q workspace %q project %q has status %q and cannot be applied; run `atlantis plan`",
 			ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName, proj.Status.String(),
 		)
+	}
+	return nil
+}
+
+func (v *DefaultApplyPlanValidator) ValidateProjectPlan(ctx command.ProjectContext, absPath string) error {
+	if v == nil || v.PullStatusFetcher == nil {
+		return nil
+	}
+	planPath, err := safePlanFilePath(ctx, absPath)
+	if err != nil {
+		return err
+	}
+
+	if err := v.validateProjectPlanStatus(ctx); err != nil {
+		var rejection planRejectionError
+		if errors.As(err, &rejection) {
+			return rejectProjectPlan(planPath, "%s", rejection.err)
+		}
+		return err
 	}
 
 	if _, err := os.Stat(planPath); err != nil {

--- a/server/events/command/project_context.go
+++ b/server/events/command/project_context.go
@@ -81,6 +81,11 @@ type ProjectContext struct {
 	// ExpectedPlanHash is the SHA-256 hash of the plan file selected when the
 	// apply command was built.
 	ExpectedPlanHash string
+	// RequiresAtlantisManagedPlanFile is true when this project's workflow uses
+	// the built-in plan or apply step, meaning Atlantis owns the convention plan
+	// artifact (<workspace>.tfplan). Workflows built only from custom run steps
+	// manage their own plan file, so Atlantis must not require or inspect one.
+	RequiresAtlantisManagedPlanFile bool
 	//PullStatus is the status of the current pull request prior to this command.
 	PullStatus *models.PullStatus
 	// ProjectPolicyStatus is the status of policy sets of the current project prior to this command.

--- a/server/events/project_command_builder_internal_test.go
+++ b/server/events/project_command_builder_internal_test.go
@@ -6,6 +6,7 @@ package events
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	version "github.com/hashicorp/go-version"
@@ -729,6 +730,10 @@ projects:
 					c.expCtx.CommandName = cmd
 					// Init fields we couldn't in our cases map.
 					c.expCtx.Steps = expSteps
+					// Atlantis owns the convention plan artifact only when the
+					// workflow uses the built-in plan or apply step.
+					c.expCtx.RequiresAtlantisManagedPlanFile = slices.Contains(c.expPlanSteps, "plan") ||
+						slices.Contains(c.expApplySteps, "apply")
 					ctx.PolicySets = emptyPolicySets
 
 					// Job ID cannot be compared since its generated at random
@@ -950,6 +955,10 @@ projects:
 					c.expCtx.CommandName = cmd
 					// Init fields we couldn't in our cases map.
 					c.expCtx.Steps = expSteps
+					// Atlantis owns the convention plan artifact only when the
+					// workflow uses the built-in plan or apply step.
+					c.expCtx.RequiresAtlantisManagedPlanFile = slices.Contains(c.expPlanSteps, "plan") ||
+						slices.Contains(c.expApplySteps, "apply")
 					ctx.PolicySets = emptyPolicySets
 
 					// Job ID cannot be compared since its generated at random
@@ -1195,6 +1204,10 @@ workflows:
 				c.expCtx.CommandName = cmd
 				// Init fields we couldn't in our cases map.
 				c.expCtx.Steps = expSteps
+				// These cases only override policy_check, so plan and apply
+				// fall back to the built-in default steps and Atlantis owns
+				// the convention plan artifact.
+				c.expCtx.RequiresAtlantisManagedPlanFile = true
 				ctx.PolicySets = emptyPolicySets
 
 				// Job ID cannot be compared since its generated at random

--- a/server/events/project_command_context_builder.go
+++ b/server/events/project_command_context_builder.go
@@ -283,58 +283,59 @@ func newProjectCommandContext(ctx *command.Context,
 	}
 
 	return command.ProjectContext{
-		CommandName:                cmd,
-		SubCommand:                 subCommand,
-		ApplyCmd:                   applyCmd,
-		ApprovePoliciesCmd:         approvePoliciesCmd,
-		BaseRepo:                   ctx.Pull.BaseRepo,
-		EscapedCommentArgs:         escapedCommentArgs,
-		AutomergeEnabled:           automergeEnabled,
-		DeleteSourceBranchOnMerge:  projCfg.DeleteSourceBranchOnMerge,
-		RepoLocksMode:              projCfg.RepoLocks.Mode,
-		CustomPolicyCheck:          projCfg.CustomPolicyCheck,
-		ParallelApplyEnabled:       parallelApplyEnabled,
-		ParallelPlanEnabled:        parallelPlanEnabled,
-		ParallelPolicyCheckEnabled: parallelPlanEnabled,
-		DependsOn:                  projCfg.DependsOn,
-		AutoplanEnabled:            projCfg.AutoplanEnabled,
-		AutoplanWhenModified:       projCfg.AutoplanWhenModified,
-		Steps:                      steps,
-		HeadRepo:                   ctx.HeadRepo,
-		Log:                        ctx.Log,
-		Scope:                      scope,
-		ProjectPlanStatus:          projectPlanStatus,
-		ProjectPolicyStatus:        projectPolicyStatus,
-		Pull:                       ctx.Pull,
-		ProjectName:                projCfg.Name,
-		PlanRequirements:           projCfg.PlanRequirements,
-		ApplyRequirements:          projCfg.ApplyRequirements,
-		ImportRequirements:         projCfg.ImportRequirements,
-		RePlanCmd:                  planCmd,
-		RepoRelDir:                 projCfg.RepoRelDir,
-		RepoConfigVersion:          projCfg.RepoCfgVersion,
-		TerraformDistribution:      projCfg.TerraformDistribution,
-		TerraformVersion:           projCfg.TerraformVersion,
-		User:                       ctx.User,
-		Verbose:                    verbose,
-		Workspace:                  projCfg.Workspace,
-		PolicySets:                 policySets,
-		PolicySetTarget:            ctx.PolicySet,
-		ClearPolicyApproval:        ctx.ClearPolicyApproval,
-		PullReqStatus:              pullReqStatus,
-		PullStatus:                 pullStatus,
-		JobID:                      uuid.New().String(),
-		ExecutionOrderGroup:        projCfg.ExecutionOrderGroup,
-		AbortOnExecutionOrderFail:  abortOnExecutionOrderFail,
-		SilencePRComments:          projCfg.SilencePRComments,
-		TeamAllowlistChecker:       teamAllowlistChecker,
-		API:                        ctx.API,
-		SkipPRRequirements:         ctx.SkipPRRequirements,
-		RunPolicyChecks:            ctx.RunPolicyChecks,
-		SuppressVCSStatus:          ctx.SuppressVCSStatus,
-		SuppressJobOutput:          ctx.SuppressJobOutput,
-		SuppressApplyWebhooks:      ctx.SuppressApplyWebhooks,
-		FailOnMissingDependencies:  ctx.FailOnMissingDependencies,
+		CommandName:                     cmd,
+		SubCommand:                      subCommand,
+		ApplyCmd:                        applyCmd,
+		ApprovePoliciesCmd:              approvePoliciesCmd,
+		BaseRepo:                        ctx.Pull.BaseRepo,
+		EscapedCommentArgs:              escapedCommentArgs,
+		AutomergeEnabled:                automergeEnabled,
+		DeleteSourceBranchOnMerge:       projCfg.DeleteSourceBranchOnMerge,
+		RepoLocksMode:                   projCfg.RepoLocks.Mode,
+		CustomPolicyCheck:               projCfg.CustomPolicyCheck,
+		ParallelApplyEnabled:            parallelApplyEnabled,
+		ParallelPlanEnabled:             parallelPlanEnabled,
+		ParallelPolicyCheckEnabled:      parallelPlanEnabled,
+		DependsOn:                       projCfg.DependsOn,
+		AutoplanEnabled:                 projCfg.AutoplanEnabled,
+		AutoplanWhenModified:            projCfg.AutoplanWhenModified,
+		Steps:                           steps,
+		RequiresAtlantisManagedPlanFile: requiresAtlantisManagedPlanFile(projCfg.Workflow),
+		HeadRepo:                        ctx.HeadRepo,
+		Log:                             ctx.Log,
+		Scope:                           scope,
+		ProjectPlanStatus:               projectPlanStatus,
+		ProjectPolicyStatus:             projectPolicyStatus,
+		Pull:                            ctx.Pull,
+		ProjectName:                     projCfg.Name,
+		PlanRequirements:                projCfg.PlanRequirements,
+		ApplyRequirements:               projCfg.ApplyRequirements,
+		ImportRequirements:              projCfg.ImportRequirements,
+		RePlanCmd:                       planCmd,
+		RepoRelDir:                      projCfg.RepoRelDir,
+		RepoConfigVersion:               projCfg.RepoCfgVersion,
+		TerraformDistribution:           projCfg.TerraformDistribution,
+		TerraformVersion:                projCfg.TerraformVersion,
+		User:                            ctx.User,
+		Verbose:                         verbose,
+		Workspace:                       projCfg.Workspace,
+		PolicySets:                      policySets,
+		PolicySetTarget:                 ctx.PolicySet,
+		ClearPolicyApproval:             ctx.ClearPolicyApproval,
+		PullReqStatus:                   pullReqStatus,
+		PullStatus:                      pullStatus,
+		JobID:                           uuid.New().String(),
+		ExecutionOrderGroup:             projCfg.ExecutionOrderGroup,
+		AbortOnExecutionOrderFail:       abortOnExecutionOrderFail,
+		SilencePRComments:               projCfg.SilencePRComments,
+		TeamAllowlistChecker:            teamAllowlistChecker,
+		API:                             ctx.API,
+		SkipPRRequirements:              ctx.SkipPRRequirements,
+		RunPolicyChecks:                 ctx.RunPolicyChecks,
+		SuppressVCSStatus:               ctx.SuppressVCSStatus,
+		SuppressJobOutput:               ctx.SuppressJobOutput,
+		SuppressApplyWebhooks:           ctx.SuppressApplyWebhooks,
+		FailOnMissingDependencies:       ctx.FailOnMissingDependencies,
 	}
 }
 
@@ -348,4 +349,31 @@ func escapeArgs(args []string) []string {
 		escaped = append(escaped, escapedArg.String())
 	}
 	return escaped
+}
+
+// requiresAtlantisManagedPlanFile reports whether Atlantis owns the convention
+// plan artifact (<workspace>.tfplan) for this workflow. That is true when the
+// workflow uses the built-in plan step (Atlantis writes the file) or the
+// built-in apply step (Atlantis reads it). A workflow built only from custom
+// run steps writes its plan wherever the user's commands choose, so Atlantis
+// must not require, hash, or delete a convention plan file for it.
+func requiresAtlantisManagedPlanFile(workflow valid.Workflow) bool {
+	return hasAtlantisManagedPlanStep(workflow.Plan.Steps) || hasAtlantisManagedApplyStep(workflow.Apply.Steps)
+}
+
+func hasAtlantisManagedPlanStep(steps []valid.Step) bool {
+	return hasStepNamed(steps, "plan")
+}
+
+func hasAtlantisManagedApplyStep(steps []valid.Step) bool {
+	return hasStepNamed(steps, "apply")
+}
+
+func hasStepNamed(steps []valid.Step, name string) bool {
+	for _, step := range steps {
+		if step.StepName == name {
+			return true
+		}
+	}
+	return false
 }

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -935,13 +935,21 @@ func (p *DefaultProjectCommandRunner) doApply(ctx command.ProjectContext) (apply
 		return "", "", "", err
 	}
 
+	// Workflows assembled only from custom run steps manage their own plan
+	// artifact, so Atlantis cannot require or hash a convention plan file for
+	// them. Their durable plan state is still validated.
+	managedPlanFile := requiresManagedPlanFileForApply(ctx)
 	if p.ApplyPlanValidator != nil {
-		if err := p.ApplyPlanValidator.ValidateProjectPlan(ctx, absPath); err != nil {
+		if managedPlanFile {
+			if err := p.ApplyPlanValidator.ValidateProjectPlan(ctx, absPath); err != nil {
+				return "", "", "", err
+			}
+		} else if err := p.ApplyPlanValidator.ValidateProjectPlanStatus(ctx); err != nil {
 			return "", "", "", err
 		}
 	}
 	_, usingDefaultApplyPlanValidator := p.ApplyPlanValidator.(*DefaultApplyPlanValidator)
-	if ctx.CommandName == command.Apply && ctx.ExpectedPlanHash == "" && usingDefaultApplyPlanValidator {
+	if ctx.CommandName == command.Apply && managedPlanFile && ctx.ExpectedPlanHash == "" && usingDefaultApplyPlanValidator {
 		planPath, err := safePlanFilePath(ctx, absPath)
 		if err != nil {
 			return "", "", "", err
@@ -1200,4 +1208,13 @@ func getMissingPolicySetNames(policySets []valid.PolicySet, receivedCount int) [
 		missing = append(missing, policySets[i].Name)
 	}
 	return missing
+}
+
+// requiresManagedPlanFileForApply reports whether this apply must consume the
+// Atlantis convention plan artifact. It fails closed: the steps being executed
+// are authoritative, so a context that never had
+// RequiresAtlantisManagedPlanFile populated still validates the plan file when a
+// built-in apply step will read it.
+func requiresManagedPlanFileForApply(ctx command.ProjectContext) bool {
+	return ctx.RequiresAtlantisManagedPlanFile || hasAtlantisManagedApplyStep(ctx.Steps)
 }

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -2786,6 +2786,12 @@ func (v *assertLockedApplyPlanValidator) ValidateProjectPlan(command.ProjectCont
 	return nil
 }
 
+func (v *assertLockedApplyPlanValidator) ValidateProjectPlanStatus(command.ProjectContext) error {
+	v.called = true
+	Assert(v.t, v.locker.locked, "expected apply plan validation to run while working dir lock is held")
+	return nil
+}
+
 type sequencedApplyPlanValidator struct {
 	t      *testing.T
 	locker *trackingWorkingDirLocker
@@ -2806,6 +2812,10 @@ func (v *sequencedApplyPlanValidator) ValidateProjectPlan(command.ProjectContext
 		return v.errs[v.count]
 	}
 	return nil
+}
+
+func (v *sequencedApplyPlanValidator) ValidateProjectPlanStatus(ctx command.ProjectContext) error {
+	return v.ValidateProjectPlan(ctx, "")
 }
 
 type recordingStepRunner struct {
@@ -5250,4 +5260,166 @@ func TestDefaultProjectCommandRunner_PathTraversal(t *testing.T) {
 			})
 		}
 	}
+}
+
+// TestDefaultProjectCommandRunner_ApplyCustomPlanPathWorkflow reproduces the
+// regression reported in #6642: a workflow whose apply consists only of custom
+// `run` steps writes its plan to a custom path (e.g. atlantis.tfplan) rather
+// than the Atlantis convention path (<workspace>.tfplan). Apply must not be
+// rejected for a missing convention plan file that this workflow never creates.
+func TestDefaultProjectCommandRunner_ApplyCustomPlanPathWorkflow(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockRun := mocks.NewMockCustomStepRunner()
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockLocker := mocks.NewMockProjectLocker()
+	mockSender := mocks.NewMockWebhooksSender()
+	boltDB := newTestBoltDB(t)
+	repoDir := t.TempDir()
+
+	runner := events.DefaultProjectCommandRunner{
+		Locker:           mockLocker,
+		LockURLGenerator: mockURLGenerator{},
+		RunStepRunner:    mockRun,
+		WorkingDir:       mockWorkingDir,
+		WorkingDirLocker: events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: &events.DefaultCommandRequirementHandler{
+			WorkingDir: mockWorkingDir,
+		},
+		Webhooks:           mockSender,
+		ApplyPlanValidator: &events.DefaultApplyPlanValidator{PullStatusFetcher: boltDB},
+	}
+
+	When(mockWorkingDir.GetWorkingDir(
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Any[string](),
+	)).ThenReturn(repoDir, nil)
+	When(mockWorkingDir.GitReadLock(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).ThenReturn(func() {})
+	When(mockLocker.TryLock(
+		Any[logging.SimpleLogging](),
+		Any[models.PullRequest](),
+		Any[models.User](),
+		Any[string](),
+		Any[models.Project](),
+		AnyBool(),
+	)).ThenReturn(&events.TryLockResponse{
+		LockAcquired: true,
+		LockKey:      "lock-key",
+	}, nil)
+
+	ctx := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		Workspace:   "default",
+		RepoRelDir:  ".",
+		Steps: []valid.Step{
+			{StepName: "run", RunCommand: "terraform apply atlantis.tfplan"},
+		},
+		ApplyRequirements: []string{},
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+
+	// The custom workflow wrote its own plan artifact. The Atlantis convention
+	// plan file (default.tfplan) deliberately does not exist.
+	Ok(t, os.WriteFile(filepath.Join(repoDir, "atlantis.tfplan"), []byte("custom plan"), 0600))
+	_, err := os.Stat(filepath.Join(repoDir, runtime.GetPlanFilename(ctx.Workspace, ctx.ProjectName)))
+	Assert(t, os.IsNotExist(err), "convention plan file must not exist for this fixture")
+
+	_, err = boltDB.UpdatePullWithResults(ctx.Pull, []command.ProjectResult{
+		plannedProjectResult(ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName),
+	})
+	Ok(t, err)
+
+	When(mockRun.Run(
+		Any[command.ProjectContext](),
+		Any[*valid.CommandShell](),
+		Any[string](),
+		Any[string](),
+		Any[map[string]string](),
+		AnyBool(),
+		Any[[]valid.PostProcessRunOutputOption](),
+		Any[[]*regexp.Regexp](),
+	)).ThenReturn("apply output", nil)
+
+	res := runner.Apply(ctx)
+
+	Assert(t, res.Error == nil, "expected no error, got: %v", res.Error)
+	Assert(t, res.Failure == "", "expected no failure, got: %q", res.Failure)
+	Equals(t, "apply output", res.ApplySuccess)
+}
+
+// TestDefaultProjectCommandRunner_ApplyManagedPlanFileStillRequired guards the
+// #6642 fix against over-permitting: a workflow that uses the built-in apply
+// step must still be rejected when the convention plan file is absent.
+func TestDefaultProjectCommandRunner_ApplyManagedPlanFileStillRequired(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockApply := mocks.NewMockStepRunner()
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockLocker := mocks.NewMockProjectLocker()
+	mockSender := mocks.NewMockWebhooksSender()
+	boltDB := newTestBoltDB(t)
+	repoDir := t.TempDir()
+
+	runner := events.DefaultProjectCommandRunner{
+		Locker:           mockLocker,
+		LockURLGenerator: mockURLGenerator{},
+		ApplyStepRunner:  mockApply,
+		WorkingDir:       mockWorkingDir,
+		WorkingDirLocker: events.NewDefaultWorkingDirLocker(),
+		CommandRequirementHandler: &events.DefaultCommandRequirementHandler{
+			WorkingDir: mockWorkingDir,
+		},
+		Webhooks:           mockSender,
+		ApplyPlanValidator: &events.DefaultApplyPlanValidator{PullStatusFetcher: boltDB},
+	}
+
+	When(mockWorkingDir.GetWorkingDir(
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Any[string](),
+	)).ThenReturn(repoDir, nil)
+	When(mockWorkingDir.GitReadLock(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).ThenReturn(func() {})
+	When(mockLocker.TryLock(
+		Any[logging.SimpleLogging](),
+		Any[models.PullRequest](),
+		Any[models.User](),
+		Any[string](),
+		Any[models.Project](),
+		AnyBool(),
+	)).ThenReturn(&events.TryLockResponse{
+		LockAcquired: true,
+		LockKey:      "lock-key",
+	}, nil)
+
+	ctx := command.ProjectContext{
+		Log:         logging.NewNoopLogger(t),
+		CommandName: command.Apply,
+		Workspace:   "default",
+		RepoRelDir:  ".",
+		Steps: []valid.Step{
+			{StepName: "apply"},
+		},
+		RequiresAtlantisManagedPlanFile: true,
+		ApplyRequirements:               []string{},
+		Pull: models.PullRequest{
+			Num:        1,
+			HeadCommit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			BaseRepo:   models.Repo{FullName: "runatlantis/atlantis"},
+		},
+	}
+
+	_, err := boltDB.UpdatePullWithResults(ctx.Pull, []command.ProjectResult{
+		plannedProjectResult(ctx.RepoRelDir, ctx.Workspace, ctx.ProjectName),
+	})
+	Ok(t, err)
+
+	res := runner.Apply(ctx)
+
+	Assert(t, res.Error != nil, "expected missing managed plan file to be rejected")
+	Assert(t, strings.Contains(res.Error.Error(), "plan file is missing"), "got: %s", res.Error)
+	mockApply.VerifyWasCalled(Never()).Run(Any[command.ProjectContext](), Any[[]string](), Any[string](), Any[map[string]string]())
 }


### PR DESCRIPTION
Fixes #6642.

### What broke

`ApplyPlanValidator` was introduced in #6605 and first released in **v0.46.0**, which matches the bisect reported in #6642 (0.43.0 fine, 0.46.0 broken).

`doApply` validates the plan for **every** project before any apply step executes:

```go
// server/events/project_command_runner.go
if p.ApplyPlanValidator != nil {
    if err := p.ApplyPlanValidator.ValidateProjectPlan(ctx, absPath); err != nil {
        return "", "", "", err
    }
}
```

The path it validates is the Atlantis convention artifact, derived from `runtime.GetPlanFilename`:

```go
func GetPlanFilename(workspace string, projName string) string {
	if projName == "" { return fmt.Sprintf("%s.tfplan", workspace) }
	...
}
```

A workflow whose `plan` and `apply` are built entirely from custom `run` steps writes its plan wherever its commands choose — `atlantis.tfplan` in the reported case. That project has no `<workspace>.tfplan`, so apply failed with:

```
plan file is missing for dir "." workspace "default" project ""; run `atlantis plan`
```

The same assumption broke a **second** path immediately below: when `ExpectedPlanHash` was empty, `doApply` called `hashFile` on that same nonexistent convention path to pin it for the rest of the command.

Note the sibling call inside the built-in `apply` step case is correct — it only runs for managed applies. The bug is that the `doApply` call fires for everyone.

### The fix

Derive whether Atlantis owns the plan artifact from the **workflow shape**. Atlantis owns it when the workflow uses the built-in `plan` step (Atlantis writes the file) or the built-in `apply` step (Atlantis reads it):

```go
func requiresAtlantisManagedPlanFile(workflow valid.Workflow) bool {
	return hasAtlantisManagedPlanStep(workflow.Plan.Steps) || hasAtlantisManagedApplyStep(workflow.Apply.Steps)
}
```

Workflows built only from custom `run` steps manage their own plan file, so Atlantis no longer requires, hashes, or removes one for them.

**Durable plan state is still validated for every project.** `ValidateProjectPlan` is split so custom-plan-path workflows go through the new `ValidateProjectPlanStatus`, which still enforces recorded plan status, apply eligibility, and head/base identity — it simply does not touch an artifact on disk.

**Artifact removal on rejection is unchanged for managed workflows.** The status failures that discarded the plan file before still do; stale command head errors still leave it in place so a concurrent replica's plan is not deleted, and `errStaleCommandHead` remains unwrapped so the `errors.Is` short-circuit in `apply_command_runner` keeps working.

The gate **fails closed** — the steps actually being executed are authoritative, so a `ProjectContext` built outside the builder (targeted apply, API paths, tests) still validates the plan file when a built-in apply step will read it:

```go
func requiresManagedPlanFileForApply(ctx command.ProjectContext) bool {
	return ctx.RequiresAtlantisManagedPlanFile || hasAtlantisManagedApplyStep(ctx.Steps)
}
```

An earlier revision of this branch gated only on the context field; the existing `TestProjectCommandRunner_ApplyRejectsPlanDeletedAfterBuilderValidation` caught that a directly-constructed context defaulted to `false` and skipped validation. Hence the fail-closed form.

### Tests

- `TestDefaultProjectCommandRunner_ApplyCustomPlanPathWorkflow` — reproduces #6642. Fails on `main` with the exact reported error; passes here.
- `TestDefaultProjectCommandRunner_ApplyManagedPlanFileStillRequired` — guards against over-permitting: a workflow using the built-in `apply` step with a missing convention plan file is still rejected.

### Verification

```
go build ./...                    clean
go vet ./server/... ./cmd/...     clean
gofmt -l server/                  clean
go test -race ./server/events/    ok, 0 failures (matches main baseline)
```

The `-race` result was compared against a `main` worktree run under identical scope.

### Review note

`project_command_context_builder.go` shows ~132 changed lines, but that is gofmt struct-literal realignment around a single added field. Please review it with `git diff -w`, which reduces it to the one real edit plus the new predicates.

### Scope

Deliberately minimal and backportable to 0.46.x — no dependency on plan generations, publication claims, or S3 changes.

This extracts the #6642 regression fix from #6657, which bundles it with a much larger durable-plan-state effort (plan generations, a publication claim, S3 digest binding, validated snapshots, a recovery CLI). That work is worth pursuing separately; this PR is only the regression.

Two follow-ups intentionally left out:

1. `rejectProjectPlan` **deletes** the plan file when validation fails. That is aggressive independent of this bug and predates it, so it is not touched here.
2. `TestBuildProjectCmdCtx` compares whole `ProjectContext` values, so adding any field produces a multi-hundred-megabyte failure diff that reads as a hung test rather than a failure. Worth making that comparison field-scoped before more fields land.
