### PR TITLE
feat: add --silence-closed-pr-errors to suppress closed PR error comments

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -138,6 +138,7 @@ const (
 	RepoAllowlistFlag                = "repo-allowlist"
 	SilenceNoProjectsFlag            = "silence-no-projects"
 	SilenceForkPRErrorsFlag          = "silence-fork-pr-errors"
+	SilenceClosedPRErrorsFlag        = "silence-closed-pr-errors"
 	SilenceVCSStatusNoPlans          = "silence-vcs-status-no-plans"
 	SilenceVCSStatusNoProjectsFlag   = "silence-vcs-status-no-projects"
 	SilenceAllowlistErrorsFlag       = "silence-allowlist-errors"
@@ -642,6 +643,10 @@ var boolFlags = map[string]boolFlag{
 	},
 	SilenceForkPRErrorsFlag: {
 		description:  "Silences the posting of fork pull requests not allowed error comments.",
+		defaultValue: false,
+	},
+	SilenceClosedPRErrorsFlag: {
+		description:  "Silences the posting of closed pull requests not allowed error comments.",
 		defaultValue: false,
 	},
 	SilenceVCSStatusNoPlans: {

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -1497,6 +1497,19 @@ ATLANTIS_SILENCE_FORK_PR_ERRORS=true
 Normally, if Atlantis receives a pull request webhook from a fork and --allow-fork-prs is not set,
 it will comment back with an error. This flag disables that commenting.
 
+### `--silence-closed-pr-errors`
+
+```bash
+atlantis server --silence-closed-pr-errors
+# or
+ATLANTIS_SILENCE_CLOSED_PR_ERRORS=true
+```
+
+Normally, if Atlantis receives a command on a closed pull request, it will comment back with an error.
+This flag disables that commenting. This is useful when several Atlantis servers watch the same
+repository, so that a single command on a closed pull request does not produce one error comment per
+server.
+
 ### `--silence-no-projects` <Badge text="v0.17.0" type="info"/>
 
 ```bash

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -129,6 +129,10 @@ type DefaultCommandRunner struct {
 	// this in our error message back to the user on a forked PR so they know
 	// how to disable error comment
 	SilenceForkPRErrorsFlag string
+	// SilenceClosedPRErrors controls whether to post the "commands can't be run
+	// on closed pull requests" error comment. Useful for multi-server setups
+	// where several Atlantis servers watch one repo and would each comment.
+	SilenceClosedPRErrors bool
 	// SilenceVCSStatusNoProjects is whether to set commit status if no projects are found
 	SilenceVCSStatusNoProjects     bool
 	CommentCommandRunnerByCmd      map[command.Name]CommentCommandRunner `validate:"required"`
@@ -697,7 +701,7 @@ func (c *DefaultCommandRunner) validateCtxAndComment(ctx *command.Context, comma
 
 	if ctx.Pull.State != models.OpenPullState && commandName != command.Unlock {
 		ctx.Log.Info("command was run on closed pull request")
-		if shouldComment {
+		if shouldComment && !c.SilenceClosedPRErrors {
 			if err := c.VCSClient.CreateComment(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull.Num, "Atlantis commands can't be run on closed pull requests", ""); err != nil {
 				ctx.Log.Err("unable to comment: %s", err)
 			}

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -445,6 +445,20 @@ func TestRunCommentCommand_ForkPRDisabled_SilenceEnabled(t *testing.T) {
 		Any[logging.SimpleLogging](), Any[models.Repo](), Any[int](), Any[string](), Any[string]())
 }
 
+func TestRunCommentCommand_ClosedPRDisabled_SilenceEnabled(t *testing.T) {
+	t.Log("if a command is run on a closed pull request and we are silencing errors do not comment with error")
+	vcsClient := setup(t)
+	ch.SilenceClosedPRErrors = true
+	var pull github.PullRequest
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.ClosedPullState}
+	When(githubGetter.GetPullRequest(Any[logging.SimpleLogging](), Eq(testdata.GithubRepo), Eq(testdata.Pull.Num))).ThenReturn(&pull, nil)
+	When(eventParsing.ParseGithubPull(Any[logging.SimpleLogging](), Eq(&pull))).ThenReturn(modelPull, modelPull.BaseRepo, testdata.GithubRepo, nil)
+
+	ch.RunCommentCommand(testdata.GithubRepo, nil, nil, testdata.User, testdata.Pull.Num, &events.CommentCommand{Name: command.Plan})
+	vcsClient.VerifyWasCalled(Never()).CreateComment(
+		Any[logging.SimpleLogging](), Any[models.Repo](), Any[int](), Any[string](), Any[string]())
+}
+
 func TestRunCommentCommandPlan_NoProjects_SilenceEnabled(t *testing.T) {
 	t.Log("if a plan command is run on a pull request and SilenceNoProjects is enabled and we are silencing all comments if the modified files don't have a matching project")
 	vcsClient := setup(t)

--- a/server/server.go
+++ b/server/server.go
@@ -1030,6 +1030,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		AllowForkPRsFlag:               config.AllowForkPRsFlag,
 		SilenceForkPRErrors:            userConfig.SilenceForkPRErrors,
 		SilenceForkPRErrorsFlag:        config.SilenceForkPRErrorsFlag,
+		SilenceClosedPRErrors:          userConfig.SilenceClosedPRErrors,
 		SilenceVCSStatusNoProjects:     userConfig.SilenceVCSStatusNoProjects,
 		DisableAutoplan:                userConfig.DisableAutoplan,
 		DisableAutoplanLabel:           userConfig.DisableAutoplanLabel,

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -117,8 +117,9 @@ type UserConfig struct {
 	RepoAllowlist                   string `mapstructure:"repo-allowlist"`
 
 	// SilenceNoProjects is whether Atlantis should respond to a PR if no projects are found.
-	SilenceNoProjects   bool `mapstructure:"silence-no-projects"`
-	SilenceForkPRErrors bool `mapstructure:"silence-fork-pr-errors"`
+	SilenceNoProjects     bool `mapstructure:"silence-no-projects"`
+	SilenceForkPRErrors   bool `mapstructure:"silence-fork-pr-errors"`
+	SilenceClosedPRErrors bool `mapstructure:"silence-closed-pr-errors"`
 	// SilenceVCSStatusNoPlans is whether autoplan should set commit status if no plans
 	// are found.
 	SilenceVCSStatusNoPlans bool `mapstructure:"silence-vcs-status-no-plans"`


### PR DESCRIPTION
Resolves #6782.

## what

Add a `--silence-closed-pr-errors` server flag (env `ATLANTIS_SILENCE_CLOSED_PR_ERRORS`, default false) that suppresses the "Atlantis commands can't be run on closed pull requests" comment. It mirrors the existing `--silence-fork-pr-errors` flag, which already does this for the fork pull request error comment.

## why

When several Atlantis servers watch one repository, a command on a closed PR makes every server post that error comment. With N servers that is N comments and N emails per watcher for a single stray comment. The fork pull request error already had a silence flag; the closed pull request error did not.

The command still returns early on a closed PR, so this only silences the comment. Closed PRs still cannot run commands.

## tests

Added `TestRunCommentCommand_ClosedPRDisabled_SilenceEnabled`, mirroring the fork silence test: with the flag set, no comment is posted on a closed PR. The existing default-behavior cases still assert a comment is posted when the flag is off.

## docs

Added the flag to `runatlantis.io/docs/server-configuration.md`.