### PR TITLE
fix: align golang image pins with the go directive in go.mod

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,7 @@ jobs:
 
       - run: make test-all
       - run: make check-fmt
+      - run: make check-go-toolchain
 
       ###########################################################
       # Notifying #contributors about test failure on main branch

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG ALPINE_TAG=3.23.5@sha256:fd791d74b68913cbb027c6546007b3f0d3bc45125f797758156952bc2d6daf40
 ARG DEBIAN_TAG=13.5-slim@sha256:28de0877c2189802884ccd20f15ee41c203573bd87bb6b883f5f46362d24c5c2
 # renovate: datasource=docker depName=golang versioning=docker
-ARG GOLANG_TAG=1.26.5-alpine3.24@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2
+ARG GOLANG_TAG=1.26.6-alpine3.24@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83
 
 # renovate: datasource=github-releases depName=hashicorp/terraform versioning=hashicorp
 ARG DEFAULT_TERRAFORM_VERSION=1.14.9

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,10 @@ lint: ## Run linter locally
 check-fmt: ## Fail if not formatted
 	./scripts/fmt.sh
 
+.PHONY: check-go-toolchain
+check-go-toolchain: ## Fail if the golang image pins drift from go.mod
+	./scripts/verify-go-toolchain.sh
+
 .PHONY: end-to-end-deps
 end-to-end-deps: ## Install e2e dependencies
 	./scripts/e2e-deps.sh

--- a/scripts/verify-go-toolchain.sh
+++ b/scripts/verify-go-toolchain.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Verify that the Go toolchain used to build the container images matches the
+# version required by go.mod.
+#
+# The `go` directive in go.mod is maintained by Renovate's gomod manager, while
+# the golang base images are pinned separately. When the two drift, the image
+# build fails with "go.mod requires go >= X (running go Y; GOTOOLCHAIN=local)",
+# and only when the Docker layer cache misses, which can be many commits after
+# the drift was introduced.
+set -euo pipefail
+
+fail=0
+
+required="$(awk '/^go [0-9]/ {print $2; exit}' go.mod)"
+if [[ -z "${required}" ]]; then
+  echo "could not read the go directive from go.mod" >&2
+  exit 1
+fi
+
+check() {
+  local file="$1" found="$2"
+  if [[ -z "${found}" ]]; then
+    echo "FAIL ${file}: could not find a golang version to check" >&2
+    fail=1
+  elif [[ "${found}" != "${required}" ]]; then
+    echo "FAIL ${file}: pins go ${found}, but go.mod requires ${required}" >&2
+    fail=1
+  else
+    echo "ok   ${file}: go ${found}"
+  fi
+}
+
+# Dockerfile: ARG GOLANG_TAG=<version>-alpine<x.y>@sha256:...
+check Dockerfile \
+  "$(sed -n 's/^ARG GOLANG_TAG=\([0-9][0-9.]*\)-alpine.*/\1/p' Dockerfile | head -1)"
+
+# testing/Dockerfile: FROM golang:<version>@sha256:...
+check testing/Dockerfile \
+  "$(sed -n 's/^FROM golang:\([0-9][0-9.]*\)[@ ].*/\1/p' testing/Dockerfile | head -1)"
+
+# The nested modules must not require a newer toolchain than the images provide.
+for mod in e2e/go.mod .github/scripts/update_top_issues_ranking/go.mod; do
+  [[ -f "${mod}" ]] || continue
+  nested="$(awk '/^go [0-9]/ {print $2; exit}' "${mod}")"
+  if [[ "${nested}" != "${required}" ]]; then
+    echo "FAIL ${mod}: requires go ${nested}, but go.mod requires ${required}" >&2
+    fail=1
+  else
+    echo "ok   ${mod}: go ${nested}"
+  fi
+done
+
+if [[ "${fail}" -ne 0 ]]; then
+  echo >&2
+  echo "Go toolchain pins are out of sync. Update the golang image pins to ${required}." >&2
+  exit 1
+fi

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647
+FROM golang:1.26.6@sha256:0d1d3a794be25f809dd2cb3160d8c73276c4056a9f8242a138e908ddeee7b6b6
 
 RUN apt-get update && apt-get --no-install-recommends -y install unzip \
     && apt-get clean \


### PR DESCRIPTION
## Problem

The image build is failing on `main`:

```
go: go.mod requires go >= 1.26.6 (running go 1.26.5; GOTOOLCHAIN=local)
ERROR: failed to solve: process "/bin/bash -o pipefail -c go mod graph | awk '{if ($1 !~ \"@\") print $2}' | xargs go get" did not complete successfully: exit code: 123
```

#6787 bumped the `go` directive to 1.26.6, but the golang base images stayed on 1.26.5. `GOTOOLCHAIN=local` stops the builder from fetching a newer toolchain, so the dependency layer fails and the build with it.

The drift landed before the failure appeared. Builds in between kept passing because the `COPY go.mod go.sum` layer was served from the buildx cache; the first commit to change enough Go files missed the cache and exposed it.

## Changes

- `Dockerfile`: `GOLANG_TAG` → `1.26.6-alpine3.24@sha256:3889b425…`
- `testing/Dockerfile`: `FROM golang:1.26.6@sha256:0d1d3a79…`

`testing/Dockerfile` was on 1.26.5 too. That is the image the tester workflow runs `make test-all` inside, so it would have hit the same wall as soon as its cache missed.

Both digests were read from the registry for the corresponding tags rather than hand-written.

## Guard

`scripts/verify-go-toolchain.sh`, exposed as `make check-go-toolchain` and run in the tester workflow. It compares the `go` directive in `go.mod` against:

- the `GOLANG_TAG` pin in `Dockerfile`
- the `FROM golang:` pin in `testing/Dockerfile`
- the `go` directive in `e2e/go.mod` and `.github/scripts/update_top_issues_ranking/go.mod`

Behaviour, checked both ways:

```
$ ./scripts/verify-go-toolchain.sh        # with the drift restored
FAIL Dockerfile: pins go 1.26.5, but go.mod requires 1.26.6
FAIL testing/Dockerfile: pins go 1.26.5, but go.mod requires 1.26.6
Go toolchain pins are out of sync. Update the golang image pins to 1.26.6.
exit=1

$ ./scripts/verify-go-toolchain.sh        # after this change
ok   Dockerfile: go 1.26.6
ok   testing/Dockerfile: go 1.26.6
ok   e2e/go.mod: go 1.26.6
ok   .github/scripts/update_top_issues_ranking/go.mod: go 1.26.6
exit=0
```

The check is the part that matters more than the bump. This particular drift survived two releases because layer caching kept hiding it, and the next Go patch release can reintroduce it the same way.

## Why Renovate did not keep these in step

Renovate maintained the `Dockerfile` pin until recently, alongside the `go` directive, under `groupName: 'go'` — for example #6488 and #5943 both moved `go.mod` and `Dockerfile` line 6 together.

It stopped after #6668, which changed the tag form and the matching package rule in the same commit:

```diff
-ARG GOLANG_TAG=1.26.4-alpine@sha256:3ad5730…
+ARG GOLANG_TAG=1.26.5-alpine3.24@sha256:0178a64…

-"allowedVersions": "/-alpine$/"
+"allowedVersions": "/-alpine3\\.24$/"
```

`allowedVersions` is now anchored to one specific Alpine minor. I have not changed the Renovate configuration here, because I cannot run Renovate against this repository to confirm which rule is filtering the candidates, and guessing at a config change would leave the same silent-drift failure mode in place while looking fixed. The check above fails loudly either way; a follow-up can narrow down the Renovate side with a debug run.

One related note for whoever picks that up: the two `customManagers` for Dockerfiles only match ARG names ending in `_VERSION`, so renaming `GOLANG_TAG` to `GOLANG_VERSION` would move this pin from the built-in dockerfile manager into a custom manager whose `extractVersionTemplate` (`^v(?<version>\d+\.\d+\.\d+)`) does not match docker tags such as `1.26.6-alpine3.24`. That rename would need the template fixed at the same time.

## Testing

- `make check-go-toolchain` passes, and fails as shown above when the pins are reverted.
- Go 1.26.6 and the `golang:1.26.6-alpine3.24` and `golang:1.26.6` images are published; digests taken from the registry.
- No Go source changes.
