### PR TITLE
fix: release project locks per project during drift detection

### DIFF
--- a/server/controllers/api_controller.go
+++ b/server/controllers/api_controller.go
@@ -2178,16 +2178,17 @@ func (a *APIController) DetectDrift(w http.ResponseWriter, r *http.Request) {
 			BaseRepo:                 baseRepo,
 			HardenedNonPRRefCheckout: true,
 		},
-		Scope:                     a.Scope,
-		Log:                       a.Logger,
-		API:                       true,
-		SkipPRModifiedFiles:       true,
-		SuppressVCSStatus:         true,
-		SuppressJobOutput:         true,
-		RunPolicyChecks:           true,
-		FailOnTeamAllowlistDenied: true,
-		ExactProjectNameMatching:  true,
-		SortByExecutionOrder:      true,
+		Scope:                        a.Scope,
+		Log:                          a.Logger,
+		API:                          true,
+		SkipPRModifiedFiles:          true,
+		SuppressVCSStatus:            true,
+		SuppressJobOutput:            true,
+		RunPolicyChecks:              true,
+		FailOnTeamAllowlistDenied:    true,
+		ExactProjectNameMatching:     true,
+		SortByExecutionOrder:         true,
+		ReleaseProjectLocksAfterPlan: true,
 	}
 
 	// Setup working directory
@@ -2211,6 +2212,11 @@ func (a *APIController) DetectDrift(w http.ResponseWriter, r *http.Request) {
 	}
 	ctx.PreWorkflowHooksAlreadyRun = true
 
+	// Registered before apiPlan runs so a mid-sweep error still cleans up any
+	// locks already acquired on the synthetic pull. Safe to call with no
+	// locks held.
+	defer a.Locker.UnlockByPull(ctx.HeadRepo.FullName, ctx.Pull.Num) // nolint: errcheck
+
 	result, err := a.apiPlan(apiRequest, ctx)
 	if err != nil {
 		if errors.Is(err, events.ErrTeamAllowlistDenied) {
@@ -2220,7 +2226,6 @@ func (a *APIController) DetectDrift(w http.ResponseWriter, r *http.Request) {
 		responder.InternalError(w, r, err)
 		return
 	}
-	defer a.Locker.UnlockByPull(ctx.HeadRepo.FullName, ctx.Pull.Num) // nolint: errcheck
 
 	// Process results and store drift data
 	detectionResult := models.NewDriftDetectionResult(request.Repository)

--- a/server/events/command/context.go
+++ b/server/events/command/context.go
@@ -108,4 +108,11 @@ type Context struct {
 	// cloned repo config before falling back to VCS content. This is used after
 	// pre-workflow hooks may have generated or updated atlantis.yaml.
 	PreferLocalRepoCfgForTargetedIgnore bool
+
+	// ReleaseProjectLocksAfterPlan makes each project's plan release its
+	// project lock as soon as the plan finishes rather than holding it until
+	// the whole command finishes. Drift detection uses this because it plans
+	// many projects under one synthetic pull and would otherwise hold every
+	// already-planned project locked for the duration of the whole run.
+	ReleaseProjectLocksAfterPlan bool
 }

--- a/server/events/command/project_context.go
+++ b/server/events/command/project_context.go
@@ -198,6 +198,12 @@ type ProjectContext struct {
 	// FailOnMissingDependencies makes apply dependency validation fail when a
 	// configured dependency is not present in PullStatus.
 	FailOnMissingDependencies bool
+
+	// ReleaseLockAfterPlan is set for API drift-detection plans, whose plan
+	// files are never consumed by a later apply (remediation re-plans
+	// instead), so the project lock is released as soon as the plan finishes
+	// instead of being held until the whole detection run responds.
+	ReleaseLockAfterPlan bool
 }
 
 // SetProjectScopeTags adds ProjectContext tags to a new returned scope.

--- a/server/events/project_command_context_builder.go
+++ b/server/events/project_command_context_builder.go
@@ -340,6 +340,7 @@ func newProjectCommandContext(ctx *command.Context,
 		SuppressJobOutput:               ctx.SuppressJobOutput,
 		SuppressApplyWebhooks:           ctx.SuppressApplyWebhooks,
 		FailOnMissingDependencies:       ctx.FailOnMissingDependencies,
+		ReleaseLockAfterPlan:            ctx.ReleaseProjectLocksAfterPlan,
 	}
 }
 

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -869,6 +869,13 @@ func (p *DefaultProjectCommandRunner) doPlan(ctx command.ProjectContext) (*model
 		return nil, "", errorWithStepOutput(err, outputs)
 	}
 
+	if ctx.ReleaseLockAfterPlan {
+		if unlockErr := lockAttempt.UnlockFn(); unlockErr != nil {
+			ctx.Log.Err("error unlocking state after drift plan: %v", unlockErr)
+		}
+		ctx.Log.Debug("released lock after drift plan")
+	}
+
 	return &models.PlanSuccess{
 		LockURL:         p.LockURLGenerator.GenerateLockURL(lockAttempt.LockKey),
 		TerraformOutput: strings.Join(outputs, "\n"),

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -125,6 +125,77 @@ func TestDefaultProjectCommandRunner_Plan(t *testing.T) {
 	}
 }
 
+// Test that doPlan releases the project lock right after a successful plan
+// when ReleaseLockAfterPlan is set (drift detection), and leaves the lock
+// held for a regular plan where it is unset.
+func TestDefaultProjectCommandRunner_PlanReleaseLockAfterPlan(t *testing.T) {
+	cases := []struct {
+		name                 string
+		releaseLockAfterPlan bool
+		expUnlockCalled      bool
+	}{
+		{
+			name:                 "releases lock when set",
+			releaseLockAfterPlan: true,
+			expUnlockCalled:      true,
+		},
+		{
+			name:                 "keeps lock when unset",
+			releaseLockAfterPlan: false,
+			expUnlockCalled:      false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			RegisterMockTestingT(t)
+			mockPlan := mocks.NewMockStepRunner()
+			mockWorkingDir := mocks.NewMockWorkingDir()
+			mockLocker := mocks.NewMockProjectLocker()
+			mockCommandRequirementHandler := mocks.NewMockCommandRequirementHandler()
+
+			runner := events.DefaultProjectCommandRunner{
+				Locker:                    mockLocker,
+				LockURLGenerator:          mockURLGenerator{},
+				PlanStepRunner:            mockPlan,
+				WorkingDir:                mockWorkingDir,
+				WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+				CommandRequirementHandler: mockCommandRequirementHandler,
+			}
+
+			repoDir := t.TempDir()
+			When(mockWorkingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](),
+				Any[string]())).ThenReturn(repoDir, nil)
+			When(mockWorkingDir.GitReadLock(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).ThenReturn(func() {})
+
+			unlockCalled := false
+			When(mockLocker.TryLock(Any[logging.SimpleLogging](), Any[models.PullRequest](), Any[models.User](), Any[string](),
+				Any[models.Project](), AnyBool())).ThenReturn(&events.TryLockResponse{
+				LockAcquired: true,
+				LockKey:      "lock-key",
+				UnlockFn: func() error {
+					unlockCalled = true
+					return nil
+				},
+			}, nil)
+
+			ctx := command.ProjectContext{
+				Log:                  logging.NewNoopLogger(t),
+				Steps:                []valid.Step{{StepName: "plan"}},
+				Workspace:            "default",
+				RepoRelDir:           ".",
+				ReleaseLockAfterPlan: c.releaseLockAfterPlan,
+			}
+			When(mockPlan.Run(ctx, nil, repoDir, map[string]string{})).ThenReturn("plan", nil)
+
+			res := runner.Plan(ctx)
+
+			Assert(t, res.PlanSuccess != nil, "exp plan success")
+			Equals(t, c.expUnlockCalled, unlockCalled)
+		})
+	}
+}
+
 func TestDefaultProjectCommandRunner_ProjectLockJobURL(t *testing.T) {
 	const jobURL = "https://atlantis.example.com/jobs/job-id"
 	tests := []struct {


### PR DESCRIPTION
## what

- Full drift detection now releases each project's lock right after that project's plan finishes. It no longer holds every already-planned project's lock until the whole detection run responds.
- The `UnlockByPull` safety net call in [`DetectDrift`](https://github.com/runatlantis/atlantis/blob/078d0a82081e8a2b1645268c5f5bfec578246fa9/server/controllers/api_controller.go#L2082) now runs before the plan loop starts, so it still fires when the sweep errors out partway through.

## why

- `POST /api/drift/detect` plans every project in a repo under one synthetic pull number. Each project's plan acquires the normal project lock inside [`doPlan`](https://github.com/runatlantis/atlantis/blob/078d0a82081e8a2b1645268c5f5bfec578246fa9/server/events/project_command_runner.go#L797).
- Those locks were only released by a `defer` call after the entire sweep finished. One slow project blocked real PR plans on every other already-planned project for the whole run.
- The unlock defer was also registered only after the plan call returned. An error partway through the sweep, for example a missing policy check runner, left every lock already acquired on that synthetic pull stuck forever.
- Drift detection plans are never applied. Remediation re-plans instead of reading the stored plan files, so releasing the lock right after the plan finishes is safe. Apply and policy check each re-acquire the project lock on their own, so they still work if a real PR grabs the lock in between. The one behavior change: a policy check running later in the same sweep can now report a lock failure for a project a real PR is actively working on, instead of blocking that PR.

## tests

- [x] Added [`TestDefaultProjectCommandRunner_PlanReleaseLockAfterPlan`](https://github.com/olegglushak-megaport/atlantis/blob/2a02408e5c3af22f28bc7890ab858e4cd8517ab1/server/events/project_command_runner_test.go#L131), which checks that `doPlan` releases the lock on success when `ReleaseLockAfterPlan` is set, and keeps it when unset.
- [x] Ran `go build ./...` and `go test ./server/events/... ./server/controllers/...`. One pre-existing failure, `TestGitHubWorkflowWithPolicyCheck`, is unrelated to this change. It fails the same way on `main` because `conftest` is not installed locally.

## references

No linked issue.
