### PR TITLE
fix: unify GitLab HeadCommit source between autoplan and comment commands

### DIFF
--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -153,6 +153,26 @@ func (c *DefaultCommandRunner) RunAutoplanCommand(baseRepo models.Repo, headRepo
 
 	log := c.buildLogger(baseRepo.FullName, pull.Num)
 	defer c.logPanics(baseRepo, pull.Num, log)
+
+	// GitLab merge request webhooks populate HeadCommit from the webhook
+	// payload (event.ObjectAttributes.LastCommit.ID), while comment-triggered
+	// commands (e.g. atlantis apply -p <project>) always refetch the MR via
+	// the API and use mr.SHA instead (see getGitlabData). These two GitLab
+	// fields can diverge even without a genuine new push. Since PullStatus is
+	// keyed by HeadCommit (see BoltDB.UpdatePullWithResults), a divergence
+	// here can make Atlantis think a later apply belongs to a "new" pull and
+	// silently forget about sibling projects that still need applying - which
+	// can in turn make automerge fire early. Refetch via the API here so
+	// autoplan uses the same HeadCommit source as every subsequent
+	// comment-triggered command for this pull.
+	if baseRepo.VCSHost.Type == models.Gitlab {
+		if freshPull, err := c.getGitlabData(log, baseRepo, pull.Num); err == nil {
+			pull = freshPull
+		} else {
+			log.Warn("unable to refresh GitLab merge request data for autoplan, using webhook payload: %s", err)
+		}
+	}
+
 	status, err := c.PullStatusFetcher.GetPullStatus(pull)
 
 	if err != nil {

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/runatlantis/atlantis/server/events/models/testdata"
 	vcsmocks "github.com/runatlantis/atlantis/server/events/vcs/mocks"
 	. "github.com/runatlantis/atlantis/testing"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
 	"go.uber.org/mock/gomock"
 )
 
@@ -2210,6 +2211,77 @@ func TestRunAutoplanCommand_DeletePlans(t *testing.T) {
 	testdata.Pull.BaseRepo = testdata.GithubRepo
 	ch.RunAutoplanCommand(testdata.GithubRepo, testdata.GithubRepo, testdata.Pull, testdata.User)
 	pendingPlanFinder.VerifyWasCalledOnce().Find(tmp)
+}
+
+// TestRunAutoplanCommand_GitlabRefetchesHeadCommitFromAPI guards against the
+// autoplan/apply automerge bug: GitLab merge_request webhooks carry
+// event.ObjectAttributes.LastCommit.ID as HeadCommit, but every
+// comment-triggered command (including `atlantis apply -p <project>`)
+// refetches the MR via the API and uses mr.SHA instead. If autoplan stored
+// PullStatus under the webhook's HeadCommit, a later apply's refetch would
+// see a HeadCommit mismatch and BoltDB.UpdatePullWithResults would treat the
+// pull as out of date - discarding every other project's tracked status,
+// which could make AutoMerger.automerge think all projects were applied and
+// merge the MR early. Autoplan must therefore store PullStatus under the
+// same API-sourced HeadCommit that comment-triggered commands will later use.
+func TestRunAutoplanCommand_GitlabRefetchesHeadCommitFromAPI(t *testing.T) {
+	setup(t)
+	tmp := t.TempDir()
+	boltDB, err := boltdb.New(tmp)
+	t.Cleanup(func() {
+		boltDB.Close()
+	})
+	Ok(t, err)
+	dbUpdater.Database = boltDB
+
+	webhookPull := testdata.Pull
+	webhookPull.BaseRepo = testdata.GitlabRepo
+	webhookPull.HeadCommit = "webhook-sha"
+
+	apiPull := webhookPull
+	apiPull.HeadCommit = "api-sha"
+
+	var mr gitlab.MergeRequest
+	When(gitlabGetter.GetMergeRequest(Any[logging.SimpleLogging](), Eq(testdata.GitlabRepo.FullName), Eq(webhookPull.Num))).ThenReturn(&mr, nil)
+	When(eventParsing.ParseGitlabMergeRequest(Eq(&mr), Eq(testdata.GitlabRepo))).ThenReturn(apiPull)
+	When(projectCommandBuilder.BuildAutoplanCommands(Any[*command.Context]())).ThenReturn([]command.ProjectContext{}, nil)
+	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(tmp, nil)
+
+	ch.RunAutoplanCommand(testdata.GitlabRepo, testdata.GitlabRepo, webhookPull, testdata.User)
+
+	pullStatus, err := dbUpdater.Database.GetPullStatus(apiPull)
+	Ok(t, err)
+	Assert(t, pullStatus != nil, "expected PullStatus to be stored under the API-sourced HeadCommit")
+	Equals(t, "api-sha", pullStatus.Pull.HeadCommit)
+}
+
+// TestRunAutoplanCommand_GitlabRefetchFailsFallsBackToWebhookPull ensures a
+// transient GitLab API error while refreshing the MR doesn't abort autoplan -
+// it should fail open and continue with the webhook-derived pull.
+func TestRunAutoplanCommand_GitlabRefetchFailsFallsBackToWebhookPull(t *testing.T) {
+	setup(t)
+	tmp := t.TempDir()
+	boltDB, err := boltdb.New(tmp)
+	t.Cleanup(func() {
+		boltDB.Close()
+	})
+	Ok(t, err)
+	dbUpdater.Database = boltDB
+
+	webhookPull := testdata.Pull
+	webhookPull.BaseRepo = testdata.GitlabRepo
+	webhookPull.HeadCommit = "webhook-sha"
+
+	When(gitlabGetter.GetMergeRequest(Any[logging.SimpleLogging](), Eq(testdata.GitlabRepo.FullName), Eq(webhookPull.Num))).ThenReturn(nil, errors.New("gitlab api unavailable"))
+	When(projectCommandBuilder.BuildAutoplanCommands(Any[*command.Context]())).ThenReturn([]command.ProjectContext{}, nil)
+	When(workingDir.GetPullDir(Any[models.Repo](), Any[models.PullRequest]())).ThenReturn(tmp, nil)
+
+	ch.RunAutoplanCommand(testdata.GitlabRepo, testdata.GitlabRepo, webhookPull, testdata.User)
+
+	pullStatus, err := dbUpdater.Database.GetPullStatus(webhookPull)
+	Ok(t, err)
+	Assert(t, pullStatus != nil, "expected PullStatus to fall back to the webhook-derived HeadCommit")
+	Equals(t, "webhook-sha", pullStatus.Pull.HeadCommit)
 }
 
 func TestRunAutoplan_NoProjectsWritesCurrentEmptyPullStatus(t *testing.T) {


### PR DESCRIPTION
### What

Fixes #6809.

For GitLab, `models.PullRequest.HeadCommit` was populated from two different upstream fields depending on how the pull was fetched:

- Webhook-driven autoplan (`merge_request` event): `event.ObjectAttributes.LastCommit.ID` (the webhook payload).
- Comment-triggered commands (`atlantis plan`, `atlantis apply -p <project>`, etc.): `mr.SHA`, via a live API refetch (`getGitlabData`).

These two GitLab-sourced values for "current head commit" can diverge even without a genuine new push. Since `PullStatus` (BoltDB/Redis) is keyed by `HeadCommit` (`pullStatusOutdatedForPull`), that divergence makes `UpdatePullWithResults` treat a later `atlantis apply -p <project>` as belonging to a "new" pull, and rebuild `PullStatus.Projects` from **only that command's results** — silently dropping every sibling project's tracked status. `AutoMerger.automerge` then sees only the just-applied project marked `Applied` and merges the MR early, even though sibling projects were never applied. The same divergence can also surface as a spurious "stale head" rejection of an otherwise successful, non-stale targeted apply.

### How

`RunAutoplanCommand` now refetches the GitLab MR via the same API call comment-triggered commands already use (`getGitlabData`) before touching `PullStatus`, so every GitLab-derived `HeadCommit` for a given pull comes from one consistent source (`mr.SHA`). Falls back to the webhook-derived pull (with a warning logged) if the refetch errors, so a transient GitLab API issue can't block autoplan.

### Testing

- Added `TestRunAutoplanCommand_GitlabRefetchesHeadCommitFromAPI` — verifies autoplan stores `PullStatus` under the API-sourced `HeadCommit`, matching what a later comment-triggered command will use.
- Added `TestRunAutoplanCommand_GitlabRefetchFailsFallsBackToWebhookPull` — verifies autoplan falls back gracefully to the webhook-derived pull if the API refetch fails.
- `go build ./...` and `go test ./server/...` pass (one pre-existing, unrelated failure locally due to a missing `conftest` binary needed by a policy-check e2e test).
