### PR TITLE
fix: restore plans from the external store when the pull dir has none

### DIFF
--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -339,6 +339,49 @@ func (p *DefaultProjectCommandBuilder) restorePullDir(pullDir string, r models.R
 
 // withDefaultWorkspace appends DefaultWorkspace to workspaces if it isn't
 // already present, preserving the original order.
+// restorePlansFromStore re-clones the workspaces that have plans in the
+// external store and restores those plans into the pull directory, returning
+// that directory. It returns os.ErrNotExist when the store cannot restore or
+// holds nothing for this pull.
+func (p *DefaultProjectCommandBuilder) restorePlansFromStore(ctx *command.Context) (string, error) {
+	// Probe capability first to avoid pointless I/O on stores that don't
+	// support restore (e.g. LocalPlanStore).
+	if errors.Is(p.PlanStore.RestorePlans("", "", "", 0), runtime.ErrRestoreNotSupported) {
+		return "", os.ErrNotExist
+	}
+	workspaces, err := p.PlanStore.ListWorkspaces(ctx.Pull.BaseRepo.Owner, ctx.Pull.BaseRepo.Name, ctx.Pull.Num)
+	if err != nil {
+		return "", fmt.Errorf("listing workspaces from external store: %w", err)
+	}
+	// No workspaces in the store means there's nothing to restore.
+	if len(workspaces) == 0 {
+		return "", os.ErrNotExist
+	}
+	// Clone every workspace before restoring; this ensures each workspace
+	// dir has a .git so PendingPlanFinder's `git ls-files --others` works,
+	// and that Clone does not fall through to forceClone (os.RemoveAll) and
+	// wipe the just-restored plans. The default workspace is always cloned
+	// because it is read as the source of truth for atlantis.yaml, even when
+	// it holds no plans.
+	for _, workspace := range withDefaultWorkspace(workspaces) {
+		if _, cloneErr := p.WorkingDir.Clone(ctx.Log, ctx.HeadRepo, ctx.Pull, workspace); cloneErr != nil {
+			return "", fmt.Errorf("cloning workspace %q for apply: %w", workspace, cloneErr)
+		}
+	}
+	pullDir, err := p.WorkingDir.GetPullDir(ctx.Pull.BaseRepo, ctx.Pull)
+	if err != nil {
+		return "", err
+	}
+	restoreDir, err := p.restorePullDir(pullDir, ctx.Pull.BaseRepo, ctx.Pull)
+	if err != nil {
+		return "", err
+	}
+	if err := p.PlanStore.RestorePlans(restoreDir, ctx.Pull.BaseRepo.Owner, ctx.Pull.BaseRepo.Name, ctx.Pull.Num); err != nil {
+		return "", fmt.Errorf("restoring plans from external store: %w", err)
+	}
+	return pullDir, nil
+}
+
 func withDefaultWorkspace(workspaces []string) []string {
 	if slices.Contains(workspaces, DefaultWorkspace) {
 		return workspaces
@@ -1246,48 +1289,42 @@ func (p *DefaultProjectCommandBuilder) buildAllProjectCommandsByPlan(ctx *comman
 			return nil, err
 		}
 		// Working dir is gone (e.g. container restart with emptyDir). Try to
-		// recover via the plan store. We must clone each workspace that has
-		// stored plans BEFORE restoring, otherwise Clone falls through to
-		// forceClone (os.RemoveAll) and wipes the just-restored plans.
+		// recover via the plan store.
 		ctx.Log.Info("pull directory missing, attempting to restore plans")
-		// Probe capability first to avoid pointless I/O on stores that don't
-		// support restore (e.g. LocalPlanStore).
-		if errors.Is(p.PlanStore.RestorePlans("", "", "", 0), runtime.ErrRestoreNotSupported) {
-			return nil, os.ErrNotExist
-		}
-		workspaces, listErr := p.PlanStore.ListWorkspaces(ctx.Pull.BaseRepo.Owner, ctx.Pull.BaseRepo.Name, ctx.Pull.Num)
-		if listErr != nil {
-			return nil, fmt.Errorf("listing workspaces from external store: %w", listErr)
-		}
-		// No workspaces in the store means there's nothing to restore.
-		if len(workspaces) == 0 {
-			return nil, os.ErrNotExist
-		}
-		// Clone every workspace before restoring; this ensures each workspace
-		// dir has a .git so PendingPlanFinder's `git ls-files --others` works.
-		// The default workspace is always cloned because it is read below as
-		// the source of truth for atlantis.yaml, even when it holds no plans.
-		for _, workspace := range withDefaultWorkspace(workspaces) {
-			if _, cloneErr := p.WorkingDir.Clone(ctx.Log, ctx.HeadRepo, ctx.Pull, workspace); cloneErr != nil {
-				return nil, fmt.Errorf("cloning workspace %q for apply: %w", workspace, cloneErr)
-			}
-		}
-		pullDir, err = p.WorkingDir.GetPullDir(ctx.Pull.BaseRepo, ctx.Pull)
+		pullDir, err = p.restorePlansFromStore(ctx)
 		if err != nil {
 			return nil, err
-		}
-		restoreDir, err := p.restorePullDir(pullDir, ctx.Pull.BaseRepo, ctx.Pull)
-		if err != nil {
-			return nil, err
-		}
-		if restoreErr := p.PlanStore.RestorePlans(restoreDir, ctx.Pull.BaseRepo.Owner, ctx.Pull.BaseRepo.Name, ctx.Pull.Num); restoreErr != nil {
-			return nil, fmt.Errorf("restoring plans from external store: %w", restoreErr)
 		}
 	}
 
 	plans, err := p.PendingPlanFinder.Find(pullDir)
 	if err != nil {
 		return nil, err
+	}
+
+	// The pull directory can exist on this replica without holding any plans:
+	// an earlier event may have created it, or the plans may have been removed
+	// while the authoritative copy still lives in the external store. That is
+	// the common case with more than one replica, where the apply can land on
+	// a different replica than the plan did. Restore and look again before
+	// giving up, otherwise the apply fails with "plan file is missing" even
+	// though the plan is in the store.
+	if len(plans) == 0 {
+		ctx.Log.Info("no plans found in pull directory, attempting to restore plans")
+		restoredDir, restoreErr := p.restorePlansFromStore(ctx)
+		if restoreErr != nil {
+			// Nothing to restore. Keep the empty plan list so the caller
+			// reports the usual "plan file is missing" error.
+			if !errors.Is(restoreErr, os.ErrNotExist) {
+				return nil, restoreErr
+			}
+		} else {
+			pullDir = restoredDir
+			plans, err = p.PendingPlanFinder.Find(pullDir)
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	// use the default repository workspace because it is the only one guaranteed to have an atlantis.yaml,

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -5777,6 +5777,110 @@ func TestDefaultProjectCommandBuilder_ExternalPlanStoreRecovery(t *testing.T) {
 	Equals(t, 1, len(ctxs))
 }
 
+// Test that plans are restored from the external store when the pull directory
+// exists on this replica but holds no plan files. With more than one replica
+// the apply can land on a replica that has a working dir for the pull (created
+// by an earlier event) but no plan in it, while the plan itself is in the
+// store.
+func TestDefaultProjectCommandBuilder_ExternalPlanStoreRecoveryPullDirWithoutPlans(t *testing.T) {
+	RegisterMockTestingT(t)
+
+	// The pull dir exists and is a git repo, but has no .tfplan in it.
+	tmpDir := DirStructure(t, map[string]any{
+		"default": map[string]any{
+			"project1": map[string]any{
+				"main.tf": nil,
+			},
+		},
+	})
+	runCmd(t, filepath.Join(tmpDir, "default"), "git", "init")
+
+	workingDir := mocks.NewMockWorkingDir()
+	When(workingDir.GetPullDir(
+		Any[models.Repo](),
+		Any[models.PullRequest]())).
+		ThenReturn(tmpDir, nil)
+
+	When(workingDir.Clone(
+		Any[logging.SimpleLogging](),
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Any[string]())).
+		ThenReturn(tmpDir, nil)
+
+	When(workingDir.GetWorkingDir(
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Any[string]())).
+		ThenReturn(tmpDir, nil)
+
+	logger := logging.NewNoopLogger(t)
+	userConfig := defaultUserConfig
+	globalCfgArgs := valid.GlobalCfgArgs{}
+	scope := metricstest.NewLoggingScope(t, logger, "atlantis")
+	terraformClient := tfclientmocks.NewMockClient()
+
+	restoreCalled := false
+	planStore := &mockExternalPlanStore{
+		workspaces: []string{"default"},
+		restoreFn: func(pullDir, owner, repo string, pullNum int) error {
+			restoreCalled = true
+			// Restoring drops the plan back into the workspace dir.
+			return os.WriteFile(
+				filepath.Join(pullDir, "default", "project1", "default.tfplan"),
+				[]byte("plan"), 0600)
+		},
+	}
+
+	builder := events.NewProjectCommandBuilder(
+		false,
+		&config.ParserValidator{},
+		&events.DefaultProjectFinder{},
+		nil,
+		workingDir,
+		events.NewDefaultWorkingDirLocker(),
+		valid.NewGlobalCfgFromArgs(globalCfgArgs),
+		&events.DefaultPendingPlanFinder{},
+		&events.CommentParser{ExecutableName: "atlantis"},
+		userConfig.SkipCloneNoChanges,
+		userConfig.EnableRegExpCmd,
+		userConfig.EnableAutoMerge,
+		userConfig.EnableParallelPlan,
+		userConfig.EnableParallelApply,
+		userConfig.AutoDetectModuleFiles,
+		userConfig.AutoplanFileList,
+		userConfig.RestrictFileList,
+		userConfig.DefaultTFDistribution,
+		userConfig.SilenceNoProjects,
+		userConfig.IncludeGitUntrackedFiles,
+		userConfig.AutoDiscoverMode,
+		scope,
+		terraformClient,
+		planStore,
+	)
+
+	ctxs, err := builder.BuildApplyCommands(
+		&command.Context{
+			Log:   logger,
+			Scope: scope,
+			PullStatus: &models.PullStatus{
+				Projects: []models.ProjectStatus{
+					{
+						RepoRelDir: "project1",
+						Workspace:  "default",
+						Status:     models.PlannedPlanStatus,
+					},
+				},
+			},
+		},
+		&events.CommentCommand{
+			Name: command.Apply,
+		})
+	Ok(t, err)
+	Assert(t, restoreCalled, "expected RestorePlans to be called")
+	Equals(t, 1, len(ctxs))
+}
+
 // mockExternalPlanStore satisfies the runtime.PlanStore interface for testing
 // the external plan store recovery path.
 type mockExternalPlanStore struct {


### PR DESCRIPTION
## what

- `buildAllProjectCommandsByPlan` now also tries the external plan store when the pull directory exists but `PendingPlanFinder` finds no plans in it, not only when the directory is missing entirely.
- The restore path (capability probe, workspace listing, cloning each workspace, `RestorePlans`) moves into `restorePlansFromStore` and is shared by both cases.

## why

- Restore was reachable only from the `os.IsNotExist` branch. If the directory was present but empty of plans, apply failed with `plan file is missing for dir "..." workspace "..." with status "planned"; run atlantis plan`, even though the plan was in the store and `PullStatus` said `planned`.
- With more than one replica the apply can land on a replica that never held the plan but does have a working dir for that PR, created by an earlier event. It also happens after `deletePlansAndPlanLocks` removes the `.tfplan` of an autoplan that failed for an unrelated reason, leaving the directory behind.
- When the store genuinely has nothing (`os.ErrNotExist`), the empty plan list is kept so the existing "plan file is missing" error is still what the user sees. Stores that cannot restore, such as `LocalPlanStore`, are skipped by the capability probe as before, so this is a no-op without `--enable-external-stores`.

## tests

- [x] Added `TestDefaultProjectCommandBuilder_ExternalPlanStoreRecoveryPullDirWithoutPlans`: the pull dir exists as a git repo with no `.tfplan`, and `RestorePlans` writes the plan back. Without the change the test fails with the exact error from the issue — `plan file is missing for dir "project1" workspace "default" project "" with status "planned"` — and passes with it.
- [x] `go build ./...` and `go test ./server/events/...` pass on darwin/arm64. The existing recovery tests, including the ones covering clone-before-restore ordering for non-default workspaces, are unchanged and still pass.

## references

- closes #6806