### PR TITLE
docs(adr): define when an ADR is required and how to propose changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,3 +27,8 @@
 - Use `closes #123`, if this PR closes a GitHub issue `#123`
 -->
 
+## architecture decision record
+
+- [ ] I checked the [ADR criteria](https://github.com/runatlantis/atlantis/blob/main/docs/adr/README.md#when-is-an-adr-required).
+
+**ADR:** <!-- Link the ADR, write "This PR", or "Not required". -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,8 @@
 **Key Info:** ~35MB repo, server + CLI app, E2E tests with Playwright, integration tests with Terraform
 
 > **AI Usage Policy:** Before contributing with AI assistance, read the [AI_USAGE_POLICY.md](AI_USAGE_POLICY.md).
+>
+> **Change proposals:** Before implementing user-visible or architectural changes, follow [the issue and ADR process](docs/adr/README.md#which-process-should-i-use).
 
 ## Build & Test (Always from repo root)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@
 
 - [Reporting Issues](#reporting-issues)
 - [Reporting Security Issues](#reporting-security-issues)
+- [Proposing Changes](#proposing-changes)
 - [Creating a Pull Request](#creating-a-pull-request)
   - [Resolving Comments](#resolving-comments)
 - [Developing](#developing)
@@ -19,6 +20,10 @@
 
 # Reporting Security Issues
 We take security issues seriously. Please report a security vulnerability to the maintainers using [private vulnerability reporting](https://github.com/runatlantis/atlantis/security/advisories/new).
+
+# Proposing Changes
+
+Before starting a large change, check whether it needs an [issue or ADR](docs/adr/README.md#which-process-should-i-use).
 
 # Creating a Pull Request
 * Fork the [Atlantis repo](https://github.com/runatlantis/atlantis)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,58 @@
+# Architecture Decision Records
+
+Architecture Decision Records (ADRs) preserve important design choices and their tradeoffs. Atlantis adopted them in [ADR 0001](0001-record-architecture-decisions.md).
+
+## Index
+
+| ADR | Title | Status |
+| --- | --- | --- |
+| [0001](0001-record-architecture-decisions.md) | Record architecture decisions | Accepted |
+| [0002](0002-api-enhancement-drift-detection.md) | API enhancement and drift detection | Proposed |
+
+Update this table when adding or changing an ADR.
+
+## Which process should I use?
+
+| Change | Process |
+| --- | --- |
+| Bug fixes, docs, tests, CI, dependency updates, and behavior-preserving refactors | Open a pull request. |
+| New user-visible behavior, flags, or commands | Agree on the change in an issue, then open a pull request. |
+| A change matching the criteria below | Open an issue, submit an ADR, then implement it after the ADR is accepted. |
+
+The decision matters more than the diff size.
+
+## When is an ADR required?
+
+Write an ADR when a change:
+
+- changes persisted data, migrations, or on-disk layout;
+- makes a breaking change to an API, config schema, server flag, default, or webhook contract;
+- changes concurrency or locking behavior;
+- adds a required runtime service, plugin, or extension point;
+- changes authentication, authorization, secret handling, command execution, or webhook validation;
+- is irreversible or reverses an accepted ADR.
+
+An ADR is not required for bug fixes, additive optional fields, default-off features, performance work with unchanged behavior, refactors, tests, docs, tooling, CI, or dependency updates.
+
+If unsure, open an issue before starting a large implementation.
+
+## Submit an ADR
+
+1. Agree on the problem in an issue.
+2. Copy [template.md](template.md) to `docs/adr/NNNN-short-title.md`.
+3. Use the next number across merged ADRs and open ADR pull requests. Renumber if another ADR merges first.
+4. Open a pull request with status `Proposed` and update the index above.
+
+Keep the ADR focused on one decision. Put implementation details in the issue or implementation pull request.
+
+## Statuses
+
+- **Proposed:** under discussion.
+- **Accepted:** approved by the project.
+- **Rejected:** considered and declined.
+- **Superseded by NNNN:** replaced by a later ADR.
+- **Deprecated:** no longer applies.
+
+Merge accepted and rejected ADRs so both decisions remain discoverable. Do not rewrite them later; supersede them with a new ADR.
+
+ADRs follow normal pull request review rules. Link accepted ADRs from their implementation pull requests.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -7,7 +7,7 @@ Architecture Decision Records (ADRs) preserve important design choices and their
 | ADR | Title | Status |
 | --- | --- | --- |
 | [0001](0001-record-architecture-decisions.md) | Record architecture decisions | Accepted |
-| [0002](0002-api-enhancement-drift-detection.md) | API enhancement and drift detection | Proposed |
+| [0002](0002-api-enhancement-drift-detection.md) | API Enhancement and Drift Detection | Proposed |
 
 Update this table when adding or changing an ADR.
 

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,21 @@
+# NNNN. Short title
+
+Date: YYYY-MM-DD
+
+## Status
+
+Proposed
+
+<!-- Proposed, Accepted, Rejected, Superseded by NNNN, or Deprecated. -->
+
+## Context
+
+Describe the problem, constraints, and relevant issue. Include only what a future reader needs to understand the decision.
+
+## Decision
+
+State what the project will do. Briefly note any serious alternatives and why they were rejected.
+
+## Consequences
+
+State the benefits and tradeoffs. Call out migrations, compatibility breaks, or an ADR this decision supersedes.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,4 +1,4 @@
-# NNNN. Short title
+# N. Short title
 
 Date: YYYY-MM-DD
 
@@ -6,7 +6,7 @@ Date: YYYY-MM-DD
 
 Proposed
 
-<!-- Proposed, Accepted, Rejected, Superseded by NNNN, or Deprecated. -->
+<!-- Proposed, Accepted, Rejected, Superseded by [NNNN](NNNN-short-title.md), or Deprecated. -->
 
 ## Context
 


### PR DESCRIPTION
## what

- Defines when a change can go directly to a PR, needs an issue first, or requires an ADR.
- Adds concise ADR criteria, statuses, submission steps, and a template.
- Links the process from `CONTRIBUTING.md` and `AGENTS.md`, with an ADR checkbox in the PR template.

## why

ADR 0001 adopted ADRs, but Atlantis never documented when to use one or how it is accepted. The process is hard to find, ADR 0002 remains `Proposed`, and duplicate numbering has already occurred.

## tests

- [x] `markdownlint-cli2` reports no errors in the changed documentation.
- [x] The `CONTRIBUTING.md` TOC check is idempotent.

## references

- ADR 0001 (#3405)
- ADR 0002 (#6590)

## architecture decision record

- [x] I checked the ADR criteria.

**ADR:** Not required
