### PR TITLE
fix: prevent concurrent PR commands across Redis-backed replicas

### DIFF
--- a/server/core/redis/pull_lease.go
+++ b/server/core/redis/pull_lease.go
@@ -1,0 +1,99 @@
+// Copyright 2026 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package redis
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+const acquirePullLeaseScript = "" +
+	"local current = redis.call(\"GET\", KEYS[1])\n" +
+	"if current then\n" +
+	"  return {0, current}\n" +
+	"end\n" +
+	"redis.call(\"SET\", KEYS[1], ARGV[1], \"PX\", ARGV[2])\n" +
+	"return {1, ARGV[1]}\n"
+
+const renewPullLeaseScript = "" +
+	"if redis.call(\"GET\", KEYS[1]) ~= ARGV[1] then\n" +
+	"  return 0\n" +
+	"end\n" +
+	"redis.call(\"PEXPIRE\", KEYS[1], ARGV[2])\n" +
+	"return 1\n"
+
+const releasePullLeaseScript = "" +
+	"if redis.call(\"GET\", KEYS[1]) ~= ARGV[1] then\n" +
+	"  return 0\n" +
+	"end\n" +
+	"redis.call(\"DEL\", KEYS[1])\n" +
+	"return 1\n"
+
+// TryAcquirePullLease atomically acquires a renewable lease for a pull request.
+// When another process owns the lease, it returns that process's serialized
+// value so callers can preserve the existing working-directory lock error.
+func (r *RedisDB) TryAcquirePullLease(ctx context.Context, repoFullName string, pullNum int, value string, ttl time.Duration) (bool, string, error) {
+	result, err := r.client.Eval(
+		ctx,
+		acquirePullLeaseScript,
+		[]string{pullLeaseKey(repoFullName, pullNum)},
+		value,
+		ttl.Milliseconds(),
+	).Result()
+	if err != nil {
+		return false, "", fmt.Errorf("acquiring pull lease: %w", err)
+	}
+
+	values, ok := result.([]any)
+	if !ok || len(values) != 2 {
+		return false, "", fmt.Errorf("unexpected pull lease result type %T", result)
+	}
+	acquired, ok := values[0].(int64)
+	if !ok {
+		return false, "", fmt.Errorf("unexpected pull lease acquired result type %T", values[0])
+	}
+	current, ok := values[1].(string)
+	if !ok {
+		return false, "", fmt.Errorf("unexpected pull lease value result type %T", values[1])
+	}
+	return acquired == 1, current, nil
+}
+
+// RenewPullLease extends a lease only while value remains its exact owner.
+func (r *RedisDB) RenewPullLease(ctx context.Context, repoFullName string, pullNum int, value string, ttl time.Duration) (bool, error) {
+	result, err := r.client.Eval(
+		ctx,
+		renewPullLeaseScript,
+		[]string{pullLeaseKey(repoFullName, pullNum)},
+		value,
+		ttl.Milliseconds(),
+	).Int64()
+	if err != nil {
+		return false, fmt.Errorf("renewing pull lease: %w", err)
+	}
+	return result == 1, nil
+}
+
+// ReleasePullLease removes a lease only while value remains its exact owner.
+func (r *RedisDB) ReleasePullLease(ctx context.Context, repoFullName string, pullNum int, value string) (bool, error) {
+	result, err := r.client.Eval(
+		ctx,
+		releasePullLeaseScript,
+		[]string{pullLeaseKey(repoFullName, pullNum)},
+		value,
+	).Int64()
+	if err != nil {
+		return false, fmt.Errorf("releasing pull lease: %w", err)
+	}
+	return result == 1, nil
+}
+
+func pullLeaseKey(repoFullName string, pullNum int) string {
+	key := fmt.Sprintf("%s\x00%d", repoFullName, pullNum)
+	hash := sha256.Sum256([]byte(key))
+	return "working-dir-lock/pull/" + hex.EncodeToString(hash[:])
+}

--- a/server/core/redis/pull_lease_test.go
+++ b/server/core/redis/pull_lease_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package redis_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+)
+
+func TestPullLeaseLifecycle(t *testing.T) {
+	s := miniredis.RunT(t)
+	r := newTestRedis(s)
+	ctx := context.Background()
+
+	acquired, current, err := r.TryAcquirePullLease(ctx, "owner/repo", 12, "owner-a", time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !acquired || current != "owner-a" {
+		t.Fatalf("expected owner-a to acquire lease, acquired=%v current=%q", acquired, current)
+	}
+
+	acquired, current, err = r.TryAcquirePullLease(ctx, "owner/repo", 12, "owner-b", time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if acquired || current != "owner-a" {
+		t.Fatalf("expected owner-a to retain lease, acquired=%v current=%q", acquired, current)
+	}
+
+	released, err := r.ReleasePullLease(ctx, "owner/repo", 12, "owner-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if released {
+		t.Fatal("expected a non-owner release to leave the lease intact")
+	}
+
+	renewed, err := r.RenewPullLease(ctx, "owner/repo", 12, "owner-a", 2*time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !renewed {
+		t.Fatal("expected owner-a to renew its lease")
+	}
+
+	released, err = r.ReleasePullLease(ctx, "owner/repo", 12, "owner-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !released {
+		t.Fatal("expected owner-a to release its lease")
+	}
+
+	acquired, _, err = r.TryAcquirePullLease(ctx, "owner/repo", 12, "owner-b", time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !acquired {
+		t.Fatal("expected owner-b to acquire the released lease")
+	}
+}
+
+func TestPullLeaseExpiresAfterOwnerStopsRenewing(t *testing.T) {
+	s := miniredis.RunT(t)
+	r := newTestRedis(s)
+	ctx := context.Background()
+
+	acquired, _, err := r.TryAcquirePullLease(ctx, "owner/repo", 12, "owner-a", time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !acquired {
+		t.Fatal("expected owner-a to acquire lease")
+	}
+
+	s.FastForward(time.Minute + time.Second)
+
+	acquired, _, err = r.TryAcquirePullLease(ctx, "owner/repo", 12, "owner-b", time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !acquired {
+		t.Fatal("expected owner-b to acquire the expired lease")
+	}
+}
+
+func TestPullLeaseDoesNotPolluteProjectLockListing(t *testing.T) {
+	s := miniredis.RunT(t)
+	r := newTestRedis(s)
+
+	acquired, _, err := r.TryAcquirePullLease(context.Background(), "owner/repo", 12, "owner-a", time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !acquired {
+		t.Fatal("expected lease acquisition")
+	}
+
+	locks, err := r.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(locks) != 0 {
+		t.Fatalf("expected no project locks, got %d", len(locks))
+	}
+}

--- a/server/core/redis/redis.go
+++ b/server/core/redis/redis.go
@@ -106,20 +106,22 @@ func NewWithConfig(cfg Config) (*RedisDB, error) {
 			return nil, errors.New("redis cluster addresses provided but all are empty")
 		}
 		rdb = redis.NewClusterClient(&redis.ClusterOptions{
-			Addrs:     addrs,
-			Username:  cfg.Username,
-			Password:  cfg.Password,
-			TLSConfig: tlsConfig,
+			Addrs:                 addrs,
+			Username:              cfg.Username,
+			Password:              cfg.Password,
+			TLSConfig:             tlsConfig,
+			ContextTimeoutEnabled: true,
 		})
 		connDesc = fmt.Sprintf("cluster nodes %s", strings.Join(addrs, ", "))
 	default:
 		address := fmt.Sprintf("%s:%d", cfg.Hostname, cfg.Port)
 		rdb = redis.NewClient(&redis.Options{
-			Addr:      address,
-			Username:  cfg.Username,
-			Password:  cfg.Password,
-			DB:        cfg.DB,
-			TLSConfig: tlsConfig,
+			Addr:                  address,
+			Username:              cfg.Username,
+			Password:              cfg.Password,
+			DB:                    cfg.DB,
+			TLSConfig:             tlsConfig,
+			ContextTimeoutEnabled: true,
 		})
 		connDesc = address
 	}

--- a/server/events/leased_working_dir_locker.go
+++ b/server/events/leased_working_dir_locker.go
@@ -1,0 +1,225 @@
+// Copyright 2026 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package events
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/logging"
+)
+
+const pullLeaseOperationTimeout = 5 * time.Second
+
+type pullLeaseStore interface {
+	TryAcquirePullLease(context.Context, string, int, string, time.Duration) (bool, string, error)
+	RenewPullLease(context.Context, string, int, string, time.Duration) (bool, error)
+	ReleasePullLease(context.Context, string, int, string) (bool, error)
+}
+
+type pullLeaseValue struct {
+	Token string `json:"token"`
+	workingDirLock
+}
+
+type heldPullLease struct {
+	value string
+	ctx   context.Context
+	stop  context.CancelFunc
+	done  chan struct{}
+	once  sync.Once
+}
+
+// LeasedWorkingDirLocker adds cross-process pull-level exclusion to an
+// existing WorkingDirLocker while leaving its project-level parallelism intact.
+type LeasedWorkingDirLocker struct {
+	local            WorkingDirLocker
+	store            pullLeaseStore
+	logger           logging.SimpleLogging
+	ttl              time.Duration
+	leaseLossHandler func(error)
+
+	mutex sync.Mutex
+	held  map[string]*heldPullLease
+}
+
+func NewLeasedWorkingDirLocker(local WorkingDirLocker, store pullLeaseStore, logger logging.SimpleLogging, ttl time.Duration) *LeasedWorkingDirLocker {
+	return &LeasedWorkingDirLocker{
+		local:  local,
+		store:  store,
+		logger: logger,
+		ttl:    ttl,
+		held:   make(map[string]*heldPullLease),
+		leaseLossHandler: func(err error) {
+			// Atlantis cannot cancel an in-flight command yet. Continuing after
+			// lease loss could corrupt a shared working directory, so fail-stop
+			// the process before another replica can acquire the lease.
+			panic(err)
+		},
+	}
+}
+
+func (l *LeasedWorkingDirLocker) TryLockPull(repoFullName string, pullNum int, cmdName command.Name, metadata WorkingDirLockMetadata) (func(), error) {
+	unlockLocal, err := l.local.TryLockPull(repoFullName, pullNum, cmdName, metadata)
+	if err != nil {
+		return func() {}, err
+	}
+
+	record := pullLeaseValue{
+		Token: uuid.NewString(),
+		workingDirLock: workingDirLock{
+			Command:                cmdName,
+			WorkingDirLockMetadata: metadata,
+		},
+	}
+	serialized, err := json.Marshal(record)
+	if err != nil {
+		unlockLocal()
+		return func() {}, fmt.Errorf("serializing pull lease: %w", err)
+	}
+
+	acquiredAt := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), pullLeaseOperationTimeout)
+	acquired, current, err := l.store.TryAcquirePullLease(ctx, repoFullName, pullNum, string(serialized), l.ttl)
+	cancel()
+	if err != nil {
+		unlockLocal()
+		return func() {}, err
+	}
+	if !acquired {
+		unlockLocal()
+		var owner pullLeaseValue
+		if err := json.Unmarshal([]byte(current), &owner); err != nil {
+			return func() {}, fmt.Errorf("pull request %d is currently locked by another Atlantis process", pullNum)
+		}
+		return func() {}, newRemotePullLockError(pullNum, cmdName, owner.workingDirLock)
+	}
+
+	key := l.pullKey(repoFullName, pullNum)
+	renewalCtx, stopRenewal := context.WithCancel(context.Background())
+	lease := &heldPullLease{
+		value: string(serialized),
+		ctx:   renewalCtx,
+		stop:  stopRenewal,
+		done:  make(chan struct{}),
+	}
+	l.mutex.Lock()
+	l.held[key] = lease
+	l.mutex.Unlock()
+	go l.renew(repoFullName, pullNum, lease, acquiredAt.Add(l.ttl))
+
+	return func() {
+		lease.once.Do(func() {
+			lease.stop()
+			<-lease.done
+
+			ctx, cancel := context.WithTimeout(context.Background(), pullLeaseOperationTimeout)
+			released, err := l.store.ReleasePullLease(ctx, repoFullName, pullNum, lease.value)
+			cancel()
+			if err != nil {
+				l.logger.Err("releasing working directory lease for pull request %d: %s", pullNum, err)
+			} else if !released {
+				l.logger.Warn("working directory lease for pull request %d was no longer owned by this process", pullNum)
+			}
+
+			l.mutex.Lock()
+			if l.held[key] == lease {
+				delete(l.held, key)
+			}
+			l.mutex.Unlock()
+			unlockLocal()
+		})
+	}, nil
+}
+
+func (l *LeasedWorkingDirLocker) TryLock(repoFullName string, pullNum int, workspace string, path string, projectName string, cmdName command.Name, metadata WorkingDirLockMetadata) (func(), error) {
+	return l.local.TryLock(repoFullName, pullNum, workspace, path, projectName, cmdName, metadata)
+}
+
+func (l *LeasedWorkingDirLocker) HasCommandLock(repoFullName string, pullNum int, cmdName command.Name) bool {
+	return l.local.HasCommandLock(repoFullName, pullNum, cmdName)
+}
+
+func (l *LeasedWorkingDirLocker) UnlockByPull(repoFullName string, pullNum int) {
+	l.local.UnlockByPull(repoFullName, pullNum)
+}
+
+func (l *LeasedWorkingDirLocker) renew(repoFullName string, pullNum int, lease *heldPullLease, expiresAt time.Time) {
+	defer close(lease.done)
+
+	renewInterval := l.ttl / 3
+	retryInterval := l.ttl / 12
+	safetyMargin := l.ttl / 6
+	timer := time.NewTimer(renewInterval)
+	defer timer.Stop()
+	retrying := false
+
+	for {
+		select {
+		case <-lease.ctx.Done():
+			return
+		case <-timer.C:
+			failStopAt := expiresAt.Add(-safetyMargin)
+			if !time.Now().Before(failStopAt) {
+				if lease.ctx.Err() != nil {
+					return
+				}
+				l.leaseLossHandler(fmt.Errorf("unable to confirm ownership of working directory lease for %s pull request %d before expiry", repoFullName, pullNum))
+				return
+			}
+			startedAt := time.Now()
+			operationDeadline := startedAt.Add(pullLeaseOperationTimeout)
+			if failStopAt.Before(operationDeadline) {
+				operationDeadline = failStopAt
+			}
+			ctx, cancel := context.WithDeadline(lease.ctx, operationDeadline)
+			renewed, err := l.store.RenewPullLease(ctx, repoFullName, pullNum, lease.value, l.ttl)
+			cancel()
+			if lease.ctx.Err() != nil {
+				return
+			}
+			if err == nil && renewed {
+				if retrying {
+					l.logger.Info("Renewed working directory lease for %s pull request %d after a transient Redis error", repoFullName, pullNum)
+				}
+				expiresAt = startedAt.Add(l.ttl)
+				retrying = false
+				timer.Reset(renewInterval)
+				continue
+			}
+
+			if err == nil {
+				l.leaseLossHandler(fmt.Errorf("working directory lease for %s pull request %d is no longer owned by this process", repoFullName, pullNum))
+				return
+			}
+
+			if !retrying {
+				l.logger.Warn("Unable to renew working directory lease for %s pull request %d; retrying before the lease expires: %s", repoFullName, pullNum, err)
+				retrying = true
+			}
+			if !time.Now().Before(failStopAt) {
+				l.leaseLossHandler(fmt.Errorf("unable to confirm ownership of working directory lease for %s pull request %d before expiry: %w", repoFullName, pullNum, err))
+				return
+			}
+			timer.Reset(min(retryInterval, time.Until(failStopAt)))
+		}
+	}
+}
+
+func (l *LeasedWorkingDirLocker) pullKey(repoFullName string, pullNum int) string {
+	return fmt.Sprintf("%d:%s/%d", len(repoFullName), repoFullName, pullNum)
+}
+
+func newRemotePullLockError(pullNum int, cmdName command.Name, currentLock workingDirLock) error {
+	return &workingDirLockError{
+		message: fmt.Sprintf("cannot run %q: pull request %d is currently locked by %q%s.\n"+
+			"Wait until the previous command is complete and try again", cmdName, pullNum, currentLock.Command, formatCommitSuffix(currentLock)),
+		metadata: currentLock.WorkingDirLockMetadata,
+	}
+}

--- a/server/events/leased_working_dir_locker_internal_test.go
+++ b/server/events/leased_working_dir_locker_internal_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package events
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/logging"
+)
+
+type renewalFailureStore struct {
+	mutex       sync.Mutex
+	renewCalls  int
+	releaseCall chan struct{}
+	renew       func(context.Context) (bool, error)
+}
+
+func (s *renewalFailureStore) TryAcquirePullLease(context.Context, string, int, string, time.Duration) (bool, string, error) {
+	return true, "", nil
+}
+
+func (s *renewalFailureStore) RenewPullLease(ctx context.Context, _ string, _ int, _ string, _ time.Duration) (bool, error) {
+	s.mutex.Lock()
+	s.renewCalls++
+	s.mutex.Unlock()
+	if s.renew != nil {
+		return s.renew(ctx)
+	}
+	return false, errors.New("redis unavailable")
+}
+
+func (s *renewalFailureStore) ReleasePullLease(context.Context, string, int, string) (bool, error) {
+	close(s.releaseCall)
+	return true, nil
+}
+
+func TestLeasedWorkingDirLockerFailsBeforeUnconfirmedLeaseExpires(t *testing.T) {
+	store := &renewalFailureStore{releaseCall: make(chan struct{})}
+	ttl := 300 * time.Millisecond
+	locker := NewLeasedWorkingDirLocker(
+		NewDefaultWorkingDirLocker(),
+		store,
+		logging.NewNoopLogger(t),
+		ttl,
+	)
+	leaseLost := make(chan error, 1)
+	locker.leaseLossHandler = func(err error) {
+		leaseLost <- err
+	}
+
+	unlock, err := locker.TryLockPull("owner/repo", 1, command.Plan, WorkingDirLockMetadata{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlock()
+
+	startedAt := time.Now()
+	select {
+	case err := <-leaseLost:
+		if !strings.Contains(err.Error(), "before expiry") {
+			t.Fatalf("expected expiry error, got %q", err)
+		}
+		if time.Since(startedAt) >= ttl {
+			t.Fatalf("lease loss handler ran after the lease could expire")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for lease loss handler")
+	}
+
+	store.mutex.Lock()
+	renewCalls := store.renewCalls
+	store.mutex.Unlock()
+	if renewCalls < 2 {
+		t.Fatalf("expected renewal retries, got %d call(s)", renewCalls)
+	}
+}
+
+func TestLeasedWorkingDirLockerDoesNotFailStopAfterUnlock(t *testing.T) {
+	renewStarted := make(chan struct{})
+	store := &renewalFailureStore{
+		releaseCall: make(chan struct{}),
+		renew: func(ctx context.Context) (bool, error) {
+			close(renewStarted)
+			<-ctx.Done()
+			return false, ctx.Err()
+		},
+	}
+	locker := NewLeasedWorkingDirLocker(
+		NewDefaultWorkingDirLocker(),
+		store,
+		logging.NewNoopLogger(t),
+		300*time.Millisecond,
+	)
+	leaseLost := make(chan error, 1)
+	locker.leaseLossHandler = func(err error) {
+		leaseLost <- err
+	}
+
+	unlock, err := locker.TryLockPull("owner/repo", 1, command.Plan, WorkingDirLockMetadata{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-renewStarted
+	unlock()
+
+	select {
+	case err := <-leaseLost:
+		t.Fatalf("unexpected lease loss after unlock: %v", err)
+	default:
+	}
+	select {
+	case <-store.releaseCall:
+	default:
+		t.Fatal("expected unlock to release the lease")
+	}
+}

--- a/server/events/leased_working_dir_locker_test.go
+++ b/server/events/leased_working_dir_locker_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package events_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	redislib "github.com/redis/go-redis/v9"
+	atlantisredis "github.com/runatlantis/atlantis/server/core/redis"
+	"github.com/runatlantis/atlantis/server/events"
+	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/logging"
+)
+
+func TestLeasedWorkingDirLockerCoordinatesProcesses(t *testing.T) {
+	s := miniredis.RunT(t)
+	clientA := redislib.NewClient(&redislib.Options{Addr: s.Addr()})
+	clientB := redislib.NewClient(&redislib.Options{Addr: s.Addr()})
+	t.Cleanup(func() {
+		_ = clientA.Close()
+		_ = clientB.Close()
+	})
+	storeA, err := atlantisredis.NewWithClient(clientA, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	storeB, err := atlantisredis.NewWithClient(clientB, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lockerA := events.NewLeasedWorkingDirLocker(events.NewDefaultWorkingDirLocker(), storeA, logging.NewNoopLogger(t), time.Minute)
+	lockerB := events.NewLeasedWorkingDirLocker(events.NewDefaultWorkingDirLocker(), storeB, logging.NewNoopLogger(t), time.Minute)
+	metadata := events.WorkingDirLockMetadata{
+		HeadCommit: "0123456789abcdef0123456789abcdef01234567",
+		CommitURL:  "https://github.com/owner/repo/commit/0123456789abcdef0123456789abcdef01234567",
+	}
+
+	unlockA, err := lockerA.TryLockPull("owner/repo", 12, command.Plan, metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = lockerB.TryLockPull("owner/repo", 12, command.Apply, events.WorkingDirLockMetadata{})
+	if err == nil {
+		t.Fatal("expected the second process to be rejected")
+	}
+	if !strings.Contains(err.Error(), `currently locked by "plan" for commit 0123456`) {
+		t.Fatalf("unexpected contention error: %s", err)
+	}
+
+	unlockA()
+
+	unlockB, err := lockerB.TryLockPull("owner/repo", 12, command.Apply, events.WorkingDirLockMetadata{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	unlockB()
+}
+
+func TestLeasedWorkingDirLockerKeepsProjectLocksLocal(t *testing.T) {
+	s := miniredis.RunT(t)
+	client := redislib.NewClient(&redislib.Options{Addr: s.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	store, err := atlantisredis.NewWithClient(client, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	local := events.NewDefaultWorkingDirLocker()
+	locker := events.NewLeasedWorkingDirLocker(local, store, logging.NewNoopLogger(t), time.Minute)
+
+	unlock, err := locker.TryLock("owner/repo", 12, "default", "project-a", "a", command.Plan, events.WorkingDirLockMetadata{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlock()
+
+	if !locker.HasCommandLock("owner/repo", 12, command.Plan) {
+		t.Fatal("expected project-level lock behavior to remain unchanged")
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -493,6 +493,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	var lockingClient locking.Locker
 	var applyLockingClient locking.ApplyLocker
 	var database db.Database
+	var redisDatabase *redis.RedisDB
 
 	switch dbtype := userConfig.LockingDBType; dbtype {
 	case "redis":
@@ -512,7 +513,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		default:
 			logger.Info("Utilizing Redis DB in single-node mode, host: %s, port: %d", userConfig.RedisHost, userConfig.RedisPort)
 		}
-		database, err = redis.NewWithConfig(redis.Config{
+		redisDatabase, err = redis.NewWithConfig(redis.Config{
 			Hostname:           userConfig.RedisHost,
 			Port:               userConfig.RedisPort,
 			Password:           userConfig.RedisPassword,
@@ -525,6 +526,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		if err != nil {
 			return nil, err
 		}
+		database = redisDatabase
 	case "boltdb":
 		logger.Info("Utilizing BoltDB")
 		database, err = boltdb.New(userConfig.DataDir)
@@ -543,7 +545,10 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	disableGlobalApplyLock := userConfig.DisableGlobalApplyLock
 
 	applyLockingClient = locking.NewApplyClient(database, disableApply, disableGlobalApplyLock)
-	workingDirLocker := events.NewDefaultWorkingDirLocker()
+	var workingDirLocker events.WorkingDirLocker = events.NewDefaultWorkingDirLocker()
+	if redisDatabase != nil {
+		workingDirLocker = events.NewLeasedWorkingDirLocker(workingDirLocker, redisDatabase, logger, 30*time.Second)
+	}
 
 	var workingDir events.WorkingDir = &events.FileWorkspace{
 		DataDir:           userConfig.DataDir,


### PR DESCRIPTION
## what

When Redis locking is configured, this adds a renewable Redis lease around the existing pull-level working directory lock.

The lease:

• is acquired atomically before a pull-level command starts;
• is renewed while the command is running;
• can only be renewed or released by its owner;
• expires when a replica dies, allowing another replica to recover the work;
• preserves the existing lock error and commit metadata shown to users.

Project-level working directory locks remain local, so Atlantis can still run independent projects in parallel as it does today. Non-Redis deployments are unchanged.

If Redis ownership is lost and cannot be confirmed before the lease expires, Atlantis fail-stops the replica. Continuing after expiry would allow another replica to acquire the lease while the original command is still modifying the shared checkout. Atlantis does not currently expose a way to cancel only the command holding the lease, so stopping the process is the safest failure mode.

This intentionally does not add pod-to-pod routing, a work queue, or any deployment topology requirements

## why

Atlantis currently uses an in-memory `WorkingDirLocker` to prevent multiple commands from modifying the same pull request checkout concurrently. That works within a single Atlantis process, but not when multiple replicas share the same working directory.

In that configuration, two requests for the same PR can reach different replicas and both operate on the shared checkout. We encountered this while investigating overlapping plans that left the generated provider lockfile with an incompatible provider selection:

```text
Error: Failed to resolve provider packages

Could not resolve provider datadog/datadog: locked provider
registry.opentofu.org/datadog/datadog 4.19.0 does not match configured
version constraint >= 3.5.0, >= 3.21.0, ~> 3.54; must use tofu init -upgrade
to allow selection of new versions
```

The repository lockfile had a compatible provider version, but the lockfile in Atlantis's shared working directory had been regenerated with a conflicting version.

This change extends the existing pull-level locking behavior across replicas while preserving the current execution model.




## tests

✓ Tested contention between independent locker instances sharing Redis.
✓ Tested lease acquisition, renewal, owner-safe release, and expiration.
✓ Tested retry and fail-stop behavior when lease renewal fails.
✓ Tested clean shutdown while a renewal is in flight.
✓ Tested lock owner and commit metadata in contention errors.
✓ Tested that lease keys do not appear as existing Redis project locks.
✓ Ran the Redis, events, and server package test suites.
✓ Ran the lease tests with the Go race detector.


## references

Related: #6750 proposes assigning each pull request to one Atlantis replica and forwarding requests between replicas. This PR solves a smaller problem: preventing two replicas from using the same shared working directory at the same time. It uses Redis for coordination and does not require replicas to send requests directly to each other