### PR TITLE
feat: publish alpine-slim and debian-slim images without Terraform or OpenTofu

### DIFF
--- a/.github/workflows/atlantis-image.yml
+++ b/.github/workflows/atlantis-image.yml
@@ -50,6 +50,7 @@ jobs:
               - '.dockerignore'
               - 'docker-entrypoint.sh'
               - 'goss.yaml'
+              - 'goss-slim.yaml'
               - 'scripts/download-release.sh'
               - '.github/workflows/atlantis-image.yml'
               - 'cmd/**'
@@ -70,7 +71,9 @@ jobs:
       attestations: write
     strategy:
       matrix:
-        image_type: [alpine, debian]
+        # The -slim variants carry no Terraform or OpenTofu binaries; Atlantis
+        # downloads the version it needs at runtime. See the Dockerfile.
+        image_type: [alpine, debian, alpine-slim, debian-slim]
     runs-on: ubuntu-24.04
     env:
       # Set docker repo to either the fork or the main repo where the branch exists
@@ -116,6 +119,7 @@ jobs:
     # release tag also has the image type appended i.e. latest-alpine
     # if it's v0.10.0 and alpine, it will do v0.10.0, v0.10.0-alpine, latest, latest-alpine
     # if it's v0.10.0 and debian, it will do v0.10.0-debian, latest-debian
+    # the slim variants only ever get the suffixed form, i.e. v0.10.0-alpine-slim, latest-debian-slim
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
@@ -216,7 +220,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        image_type: [alpine, debian]
+        image_type: [alpine, debian, alpine-slim, debian-slim]
         platform: [linux/arm64/v8, linux/amd64, linux/arm/v7]
     env:
       # Set docker repo to either the fork or the main repo where the branch exists
@@ -252,6 +256,10 @@ jobs:
           version: "v0.4.7"
 
       - name: Execute Goss tests
+        env:
+          # The slim images have their own test file asserting the Terraform
+          # and OpenTofu binaries are absent.
+          GOSS_FILE: ${{ endsWith(matrix.image_type, '-slim') && 'goss-slim.yaml' || 'goss.yaml' }}
         run: |
           dgoss run --rm ${{ env.DOCKER_REPO }}:goss-test bash -c 'while true; do sleep 1; done;'
 
@@ -263,7 +271,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        image_type: [alpine, debian]
+        image_type: [alpine, debian, alpine-slim, debian-slim]
     runs-on: ubuntu-24.04
     steps:
       - name: Harden Runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -206,7 +206,7 @@ COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 # renovate: datasource=repology depName=alpine_3_23/ca-certificates versioning=loose
 ENV CA_CERTIFICATES_VERSION="20260611-r0"
 # renovate: datasource=repology depName=alpine_3_23/curl versioning=loose
-ENV CURL_VERSION="8.20.0-r0"
+ENV CURL_VERSION="8.22.0-r0"
 # renovate: datasource=repology depName=alpine_3_23/git versioning=loose
 ENV GIT_VERSION="2.52.0-r0"
 # renovate: datasource=repology depName=alpine_3_23/unzip versioning=loose

--- a/Dockerfile
+++ b/Dockerfile
@@ -142,6 +142,13 @@ RUN case ${TARGETPLATFORM} in \
     mv git-lfs /usr/bin/git-lfs && \
     git-lfs --version
 
+# Terraform and OpenTofu live in their own stage so the slim targets never
+# download them. The full targets copy from tf-deps; the slim targets do not.
+FROM deps AS tf-deps
+
+ARG TARGETPLATFORM
+WORKDIR /tmp/build
+
 # install terraform binaries
 ARG DEFAULT_TERRAFORM_VERSION
 ENV DEFAULT_TERRAFORM_VERSION=${DEFAULT_TERRAFORM_VERSION}
@@ -165,8 +172,16 @@ RUN ./download-release.sh \
         "${DEFAULT_OPENTOFU_VERSION}"
 
 # Stage 2 - Alpine
-# Creating the individual distro builds using targets
-FROM alpine:${ALPINE_TAG} AS alpine
+# Creating the individual distro builds using targets.
+#
+# Each distro has a runtime stage with everything except the Terraform and
+# OpenTofu binaries, and two final targets built on it:
+#   <distro>-slim  no Terraform or OpenTofu. Atlantis downloads the version it
+#                  needs at runtime (see --tf-download), so this image carries
+#                  none of the advisories filed against bundled binaries.
+#   <distro>       the runtime stage plus the bundled binaries. This is the
+#                  image that has always been published.
+FROM alpine:${ALPINE_TAG} AS alpine-runtime
 
 ARG ATLANTIS_PORT=4141
 
@@ -183,9 +198,6 @@ RUN addgroup --gid 1000 atlantis && \
 
 # copy atlantis binary
 COPY --from=builder /app/atlantis /usr/local/bin/atlantis
-# copy terraform binaries
-COPY --from=deps /usr/local/bin/terraform/terraform* /usr/local/bin/
-COPY --from=deps /usr/local/bin/tofu/tofu* /usr/local/bin/
 # copy dependencies
 COPY --from=deps /usr/local/bin/conftest /usr/local/bin/conftest
 COPY --from=deps /usr/bin/git-lfs /usr/bin/git-lfs
@@ -256,8 +268,23 @@ USER atlantis
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["server"]
 
+FROM alpine-runtime AS alpine-slim
+
+# With no terraform on PATH, Atlantis needs to be told a default version so it
+# can download it on first use. Set the same version the full image bundles.
+# OpenTofu users override this together with ATLANTIS_TF_DISTRIBUTION.
+ARG DEFAULT_TERRAFORM_VERSION
+ENV ATLANTIS_DEFAULT_TF_VERSION=${DEFAULT_TERRAFORM_VERSION}
+
+FROM alpine-runtime AS alpine
+
+# copy terraform binaries. These come out of release zip files, which carry no
+# file capabilities, so the capability strip in alpine-runtime still holds.
+COPY --from=tf-deps /usr/local/bin/terraform/terraform* /usr/local/bin/
+COPY --from=tf-deps /usr/local/bin/tofu/tofu* /usr/local/bin/
+
 # Stage 2 - Debian
-FROM debian-base AS debian
+FROM debian-base AS debian-runtime
 
 ARG ATLANTIS_PORT=4141
 
@@ -268,9 +295,6 @@ HEALTHCHECK --interval=5m --timeout=3s \
 
 # copy atlantis binary
 COPY --from=builder /app/atlantis /usr/local/bin/atlantis
-# copy terraform binaries
-COPY --from=deps /usr/local/bin/terraform/terraform* /usr/local/bin/
-COPY --from=deps /usr/local/bin/tofu/tofu* /usr/local/bin/
 # copy dependencies
 COPY --from=deps /usr/local/bin/conftest /usr/local/bin/conftest
 COPY --from=deps /usr/bin/git-lfs /usr/bin/git-lfs
@@ -311,3 +335,16 @@ RUN fcap_scan_dirs="/bin /sbin /usr /opt /lib /lib64" && \
 USER atlantis
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["server"]
+
+FROM debian-runtime AS debian-slim
+
+# See alpine-slim.
+ARG DEFAULT_TERRAFORM_VERSION
+ENV ATLANTIS_DEFAULT_TF_VERSION=${DEFAULT_TERRAFORM_VERSION}
+
+FROM debian-runtime AS debian
+
+# copy terraform binaries. See the alpine target for why this is safe to do
+# after the capability strip.
+COPY --from=tf-deps /usr/local/bin/terraform/terraform* /usr/local/bin/
+COPY --from=tf-deps /usr/local/bin/tofu/tofu* /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -270,11 +270,13 @@ CMD ["server"]
 
 FROM alpine-runtime AS alpine-slim
 
-# With no terraform on PATH, Atlantis needs to be told a default version so it
-# can download it on first use. Set the same version the full image bundles.
-# OpenTofu users override this together with ATLANTIS_TF_DISTRIBUTION.
-ARG DEFAULT_TERRAFORM_VERSION
-ENV ATLANTIS_DEFAULT_TF_VERSION=${DEFAULT_TERRAFORM_VERSION}
+# Nothing to add. With no terraform on PATH, Atlantis refuses to start until
+# --default-tf-version is set (flag, ATLANTIS_DEFAULT_TF_VERSION, or the
+# server config file) and then downloads that version on first use.
+#
+# Deliberately no ENV ATLANTIS_DEFAULT_TF_VERSION here: environment variables
+# take precedence over the server config file, so a version baked into the
+# image would silently override a version pinned in that file.
 
 FROM alpine-runtime AS alpine
 
@@ -338,9 +340,7 @@ CMD ["server"]
 
 FROM debian-runtime AS debian-slim
 
-# See alpine-slim.
-ARG DEFAULT_TERRAFORM_VERSION
-ENV ATLANTIS_DEFAULT_TF_VERSION=${DEFAULT_TERRAFORM_VERSION}
+# Nothing to add. See alpine-slim for why no default Terraform version is set.
 
 FROM debian-runtime AS debian
 

--- a/goss-slim.yaml
+++ b/goss-slim.yaml
@@ -36,13 +36,20 @@ command:
     exec: "tofu version"
     exit-status: 127
 
-  # ensure a default Terraform version is set so Atlantis can start and
-  # download it on first use
-  default-tf-version-set:
+  # ensure no default Terraform version is baked into the image: an env var
+  # would override a version pinned in the server config file
+  default-tf-version-unset:
     exec: "printenv ATLANTIS_DEFAULT_TF_VERSION"
-    exit-status: 0
-    stdout:
-      - "/^[0-9]+\\.[0-9]+\\.[0-9]+$/"
+    exit-status: 1
+
+  # ensure the server refuses to start, with a message that says what to set,
+  # rather than failing later in a less obvious way
+  server-fails-fast-without-tf-version:
+    exec: "atlantis server --gh-user=u --gh-token=t --repo-allowlist='github.com/*'"
+    exit-status: 1
+    stderr:
+      - "terraform not found in"
+      - "Set --default-tf-version"
 
 file:
   /usr/local/bin/terraform:

--- a/goss-slim.yaml
+++ b/goss-slim.yaml
@@ -1,0 +1,51 @@
+# Goss tests for the *-slim image targets.
+# See: https://github.com/goss-org/goss/blob/master/docs/gossfile.md
+#
+# The slim images ship without Terraform and OpenTofu. Everything else the full
+# image carries must still be there, and the two binaries must be absent.
+
+command:
+  # ensure atlantis is available
+  atlantis-available:
+    exec: "atlantis version"
+    exit-status: 0
+    stdout: []
+    stderr: []
+
+  # ensure conftest is available
+  conftest-available:
+    exec: "conftest -v"
+    exit-status: 0
+    stdout: []
+    stderr: []
+
+  # ensure git-lfs is available
+  git-lfs-available:
+    exec: "git-lfs -v"
+    exit-status: 0
+    stdout: []
+    stderr: []
+
+  # ensure terraform is NOT on PATH (127 is "command not found" from sh)
+  terraform-absent:
+    exec: "terraform version"
+    exit-status: 127
+
+  # ensure tofu is NOT on PATH
+  tofu-absent:
+    exec: "tofu version"
+    exit-status: 127
+
+  # ensure a default Terraform version is set so Atlantis can start and
+  # download it on first use
+  default-tf-version-set:
+    exec: "printenv ATLANTIS_DEFAULT_TF_VERSION"
+    exit-status: 0
+    stdout:
+      - "/^[0-9]+\\.[0-9]+\\.[0-9]+$/"
+
+file:
+  /usr/local/bin/terraform:
+    exists: false
+  /usr/local/bin/tofu:
+    exists: false

--- a/runatlantis.io/docs/deployment.md
+++ b/runatlantis.io/docs/deployment.md
@@ -641,11 +641,11 @@ Every release is published in four variants. The unsuffixed tag (for example `v0
 
 The full images bundle the last few Terraform minor releases and the current OpenTofu release, and `terraform` on `PATH` points at the newest of them.
 
-The slim images ship without either binary, so vulnerability scanners do not report advisories against Terraform or OpenTofu versions you may not even use. Everything else (`conftest`, `git-lfs`, `git`, `curl`, `dumb-init`) is the same as the full image. Atlantis downloads the Terraform version it needs on first use, so the slim image needs to know which version that is:
+The slim images ship without either binary, so vulnerability scanners do not report advisories against Terraform or OpenTofu versions you may not even use. Everything else (`conftest`, `git-lfs`, `git`, `curl`, `dumb-init`) is the same as the full image. Atlantis downloads the Terraform version it needs on first use, so the slim image needs to be told which version that is:
 
-* `ATLANTIS_DEFAULT_TF_VERSION` is preset in the slim image to the same version the full image bundles. Override it to pin a different version.
+* Set [`--default-tf-version`](server-configuration.md#default-tf-version) as a flag, as `ATLANTIS_DEFAULT_TF_VERSION`, or in the server config file. Without it the server refuses to start with `terraform not found in $PATH`. The slim image deliberately sets no default of its own, because an environment variable baked into the image would take precedence over a version pinned in your config file.
 * Per-project `terraform_version` in `atlantis.yaml` and `--tf-download-url` work as usual.
-* For OpenTofu, set `ATLANTIS_TF_DISTRIBUTION=opentofu` and `ATLANTIS_DEFAULT_TF_VERSION` to an OpenTofu version. The preset value is a Terraform version and will not exist as an OpenTofu release.
+* For OpenTofu, set `ATLANTIS_TF_DISTRIBUTION=opentofu` and give an OpenTofu version as the default.
 * If outbound downloads are not allowed from your Atlantis host (`--tf-download=false`), mount or copy the binaries you need into the image instead. See [Customization](#customization) below.
 
 #### Customization

--- a/runatlantis.io/docs/deployment.md
+++ b/runatlantis.io/docs/deployment.md
@@ -628,6 +628,26 @@ After it is deployed, see [Next Steps](#next-steps).
 
 Atlantis has an [official](https://ghcr.io/runatlantis/atlantis) Docker image: `ghcr.io/runatlantis/atlantis`.
 
+#### Image variants
+
+Every release is published in four variants. The unsuffixed tag (for example `v0.47.1` or `latest`) is the Alpine image.
+
+| Tag suffix     | Base   | Bundled Terraform and OpenTofu |
+|----------------|--------|--------------------------------|
+| `-alpine`      | Alpine | yes                            |
+| `-debian`      | Debian | yes                            |
+| `-alpine-slim` | Alpine | no                             |
+| `-debian-slim` | Debian | no                             |
+
+The full images bundle the last few Terraform minor releases and the current OpenTofu release, and `terraform` on `PATH` points at the newest of them.
+
+The slim images ship without either binary, so vulnerability scanners do not report advisories against Terraform or OpenTofu versions you may not even use. Everything else (`conftest`, `git-lfs`, `git`, `curl`, `dumb-init`) is the same as the full image. Atlantis downloads the Terraform version it needs on first use, so the slim image needs to know which version that is:
+
+* `ATLANTIS_DEFAULT_TF_VERSION` is preset in the slim image to the same version the full image bundles. Override it to pin a different version.
+* Per-project `terraform_version` in `atlantis.yaml` and `--tf-download-url` work as usual.
+* For OpenTofu, set `ATLANTIS_TF_DISTRIBUTION=opentofu` and `ATLANTIS_DEFAULT_TF_VERSION` to an OpenTofu version. The preset value is a Terraform version and will not exist as an OpenTofu release.
+* If outbound downloads are not allowed from your Atlantis host (`--tf-download=false`), mount or copy the binaries you need into the image instead. See [Customization](#customization) below.
+
 #### Customization
 
 If you need to modify the Docker image that we provide, for instance to add the terragrunt binary, you can do something like this:


### PR DESCRIPTION
## what

Adds two image variants, `alpine-slim` and `debian-slim`, that ship without the bundled Terraform and OpenTofu binaries. Published alongside the existing images with tags suffixed `-alpine-slim` and `-debian-slim` (for example `v0.48.0-alpine-slim`, `latest-debian-slim`, `dev-alpine-slim`). The unsuffixed tags (`latest`, `v0.48.0`) still point at the full Alpine image, so nothing changes for anyone not opting in.

## why

The full images bundle four Terraform releases and one OpenTofu release. Every advisory filed against any of those binaries shows up in a scan of the Atlantis image, whether or not the operator uses that version. Operators who pin their own Terraform version, download at runtime, or use OpenTofu carry that scanner noise for nothing, and today the only way out is to build a custom image.

## how

**Dockerfile.** The Terraform and OpenTofu download moves from `deps` into its own `tf-deps` stage, so a slim build never fetches them. Each distro now has a runtime stage (`alpine-runtime`, `debian-runtime`) with everything except the two binaries, and two final targets on top of it:

- `alpine` / `debian`: the runtime stage plus `COPY --from=tf-deps` of the binaries. Same content as the images published today.
- `alpine-slim` / `debian-slim`: the runtime stage and nothing else.

The slim image deliberately bakes in no `ATLANTIS_DEFAULT_TF_VERSION`. An earlier revision of this PR did, so `docker run ...-slim server` worked out of the box, but viper gives environment variables precedence over the server config file, so a version baked into the image would silently override a `default-tf-version` pinned in that file (thanks @GenPage). Instead the operator sets `--default-tf-version` by flag, env, or config file; without it `NewClientWithDefaultVersion` refuses to start with `terraform not found in $PATH. Set --default-tf-version ...`, which says exactly what to do. Reproduced locally with the binary and an empty `PATH`: exit 1, message on stderr.

The binaries are copied in after the file-capability strip in the runtime stage. They come from release zip files, which carry no capabilities, so the strip's guarantee holds; there is a comment at the copy explaining this.

**Workflow.** `image_type` matrix gains the two slim entries in `build`, `test` and `skip-build`. `docker/metadata-action` already derives the suffix from `matrix.image_type`, and every unsuffixed tag is gated on `matrix.image_type == 'alpine'`, so the slim images only ever get suffixed tags. The Goss step picks `goss-slim.yaml` for slim types via `GOSS_FILE`, which `dgoss` honours.

**goss-slim.yaml.** Same checks as `goss.yaml` for `atlantis`, `conftest` and `git-lfs`, plus: `terraform version` and `tofu version` exit 127, `/usr/local/bin/terraform` and `/usr/local/bin/tofu` do not exist, `ATLANTIS_DEFAULT_TF_VERSION` is not set in the image, and `atlantis server` without a default version exits 1 with the `terraform not found` message on stderr.

**Docs.** New "Image variants" section in `deployment.md` with the four tags, what is and is not in the slim image, and how to point it at Terraform, OpenTofu, or a mounted binary when downloads are blocked.

## tests

Verified locally: workflow and goss YAML parse, `markdownlint-cli2` clean on `deployment.md`. Docker Desktop on my machine is stuck behind a privileged-helper prompt, so I could not build the images locally; this PR relies on the `atlantis-image` workflow, which builds all four targets on three platforms and runs Goss against each, to validate the Dockerfile. hadolint runs in that workflow as well.

CI on this PR: all four `Build Image` jobs pass (hadolint included), and all twelve `Test Image With Goss` jobs pass, so the full images still carry terraform and tofu after the restructure and the slim images verifiably do not, on amd64, arm64 and arm/v7.

One unrelated pin moved while this PR was open: Alpine 3.23 replaced `curl` 8.20.0-r0 with 8.22.0-r0 and stopped serving the old package, which broke the uncached arm64 build. Bumped `CURL_VERSION` here so the PR is green; `main` carries the same pin and will need the same bump (Renovate should pick it up). Every other Alpine and Debian pin was checked against the current indexes and is unchanged.

Build time for the workflow roughly doubles in matrix size, but the slim and full targets share every layer up to the final `COPY`, so with the GHA cache the added cost is mostly the extra Goss runs.

One drawback #6574 calls out and this PR does not remove: a slim image has no bundled fallback if the Terraform release host is unreachable or a signing key expires. That is the trade the operator makes by choosing the slim tag, and the docs say to mount or copy a binary in when downloads are not an option.

## references

- closes #6574 (publish `-slim` variants with neither Terraform nor OpenTofu)
- relates to #5366 (asks for per-distribution slim images; this PR ships the binary-free variant and leaves per-distribution variants for a follow-up if there is demand)

## architecture decision record

- [x] I checked the [ADR criteria](https://github.com/runatlantis/atlantis/blob/main/docs/adr/README.md#when-is-an-adr-required).

**ADR:** Not required. New image targets on the existing Dockerfile and workflow; no change to how components interact.
