### PR TITLE
fix(runtime): preserve workflow hook status read errors

### DIFF
--- a/server/core/runtime/post_workflow_hook_runner.go
+++ b/server/core/runtime/post_workflow_hook_runner.go
@@ -78,7 +78,7 @@ func (wh DefaultPostWorkflowHookRunner) Run(ctx models.WorkflowHookCommandContex
 		var customStatusErr error
 		customStatusOut, customStatusErr = os.ReadFile(outputFilePath)
 		if customStatusErr != nil {
-			err = fmt.Errorf("%s: running '%s' in '%s': \n%s", err, shell+" "+shellArgs+" "+command, path, out)
+			err = fmt.Errorf("reading workflow hook status file %q after running %q in %q: %w\n%s", outputFilePath, shell+" "+shellArgs+" "+command, path, customStatusErr, out)
 			ctx.Log.Debug("error: %s", err)
 			return string(out), "", err
 		}

--- a/server/core/runtime/pre_workflow_hook_runner.go
+++ b/server/core/runtime/pre_workflow_hook_runner.go
@@ -77,7 +77,7 @@ func (wh DefaultPreWorkflowHookRunner) Run(ctx models.WorkflowHookCommandContext
 		var customStatusErr error
 		customStatusOut, customStatusErr = os.ReadFile(outputFilePath)
 		if customStatusErr != nil {
-			err = fmt.Errorf("%s: running %q in %q: \n%s", err, shell+" "+shellArgs+" "+command, path, out)
+			err = fmt.Errorf("reading workflow hook status file %q after running %q in %q: %w\n%s", outputFilePath, shell+" "+shellArgs+" "+command, path, customStatusErr, out)
 			ctx.Log.Debug("error: %s", err)
 			return string(out), "", err
 		}

--- a/server/core/runtime/workflow_hook_status_test.go
+++ b/server/core/runtime/workflow_hook_status_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/core/runtime"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/logging"
+	. "github.com/runatlantis/atlantis/testing"
+)
+
+func TestWorkflowHookRunner_StatusReadError(t *testing.T) {
+	runners := []struct {
+		name string
+		run  func(models.WorkflowHookCommandContext, string, string, string, string) (string, string, error)
+	}{
+		{"pre", (runtime.DefaultPreWorkflowHookRunner{}).Run},
+		{"post", (runtime.DefaultPostWorkflowHookRunner{}).Run},
+	}
+	for _, runner := range runners {
+		t.Run(runner.name, func(t *testing.T) {
+			dir := t.TempDir()
+			statusPath := filepath.Join(dir, "OUTPUT_STATUS_FILE")
+			// A directory passes Stat but cannot be read as a status file.
+			Ok(t, os.Mkdir(statusPath, 0700))
+			ctx := models.WorkflowHookCommandContext{Log: logging.NewNoopLogger(t), SuppressJobOutput: true}
+
+			output, description, err := runner.run(ctx, "printf 'hook output'", "sh", "-c", dir)
+
+			Equals(t, "hook output", output)
+			Equals(t, "", description)
+			pathErr, ok := errors.AsType[*os.PathError](err)
+			Assert(t, ok, "expected status file error cause, got %v", err)
+			Equals(t, statusPath, pathErr.Path)
+			Equals(t, "read", pathErr.Op)
+			ErrContains(t, "sh -c printf 'hook output'", err)
+			ErrContains(t, "\nhook output", err)
+			Assert(t, strings.Contains(err.Error(), "reading workflow hook status file"), "missing status file context: %v", err)
+		})
+	}
+}


### PR DESCRIPTION
## What

Preserve status-file read errors from pre- and post-workflow hooks.

## Why

The old diagnostic formatted a nil Stat error and discarded the actual read failure.

## Testing

Both regression cases fail before the fix; the runtime package passes with coverage.
