### PR TITLE
fix(docker): update Alpine curl pin to restore builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -194,7 +194,7 @@ COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 # renovate: datasource=repology depName=alpine_3_23/ca-certificates versioning=loose
 ENV CA_CERTIFICATES_VERSION="20260611-r0"
 # renovate: datasource=repology depName=alpine_3_23/curl versioning=loose
-ENV CURL_VERSION="8.20.0-r0"
+ENV CURL_VERSION="8.22.0-r0"
 # renovate: datasource=repology depName=alpine_3_23/git versioning=loose
 ENV GIT_VERSION="2.52.0-r0"
 # renovate: datasource=repology depName=alpine_3_23/unzip versioning=loose


### PR DESCRIPTION
## Summary

Update the Alpine curl pin from `8.20.0-r0` to `8.22.0-r0`. Alpine 3.23 now supplies the newer revision, so the old exact pin prevents the Atlantis image and Goss image-test jobs from installing their runtime packages.

This is a one-line Dockerfile change shared by all Alpine image architectures.

## References

- [Failing image job on #6847](https://github.com/runatlantis/atlantis/actions/runs/34077477609/job/101606362084?pr=6847)
- [Alpine 3.23 curl package](https://pkgs.alpinelinux.org/package/v3.23/main/aarch64/curl)
