### PR TITLE
ci: lint every translated page and fold serializer-split image links

### DIFF
--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -133,13 +133,27 @@ jobs:
         # a blank line. Both are mechanical to repair.
         run: |
           locales="$(node -e "process.stdout.write(require('./i18n.json').locale.targets.join(' '))")"
+
+          # The translator's markdown serializer writes a link whose only
+          # content is an image as five lines: "[", blank, the image, blank,
+          # "](url)". That trips MD034 and renders a stray bracket. Fold it
+          # back onto one line, which is how the English source writes it.
+          for locale in $locales; do
+            find "runatlantis.io/${locale}" -name '*.md' -print0 \
+              | xargs -0 perl -0pi -e 's/\[\n\n(!\[[^\]]*\]\([^)]*\))\n\n\]\(/[$1](/g'
+          done
+
           node scripts/align-tables.mjs $locales
-          globs=""
-          for locale in $locales; do globs="$globs runatlantis.io/${locale}/**/*.md"; done
+
+          # Quoted so markdownlint-cli2 expands `**` itself. Unquoted, bash
+          # treats `**` as `*` and the top-level <locale>/*.md pages are
+          # never linted.
+          globs=()
+          for locale in $locales; do globs+=("runatlantis.io/${locale}/**/*.md"); done
           # `--fix` exits non-zero when findings remain. Those are caught by
           # the integrity step below, which quarantines the page instead of
           # failing the run.
-          npx --yes markdownlint-cli2@0.20.0 --fix --config .markdownlint.yaml $globs || true
+          npx --yes markdownlint-cli2@0.20.0 --fix --config .markdownlint.yaml "${globs[@]}" || true
 
       - name: Upload translated output
         # Kept even when the integrity check fails: when a page trips a check,
@@ -167,13 +181,13 @@ jobs:
         # split across lines).
         run: |
           locales="$(node -e "process.stdout.write(require('./i18n.json').locale.targets.join(' '))")"
-          globs=""
-          for locale in $locales; do globs="$globs runatlantis.io/${locale}/**/*.md"; done
+          globs=()
+          for locale in $locales; do globs+=("runatlantis.io/${locale}/**/*.md"); done
 
           run_checks() {
             local ok=0
             node scripts/check-translation-integrity.mjs $locales > /tmp/integrity.txt 2>&1 || ok=1
-            npx --yes markdownlint-cli2@0.20.0 --config .markdownlint.yaml $globs > /tmp/lint.txt 2>&1 || ok=1
+            npx --yes markdownlint-cli2@0.20.0 --config .markdownlint.yaml "${globs[@]}" > /tmp/lint.txt 2>&1 || ok=1
             cat /tmp/integrity.txt /tmp/lint.txt
             return $ok
           }


### PR DESCRIPTION
## Result of the first incremental run

[34313617937](https://github.com/runatlantis/atlantis/actions/runs/34313617937) after #6864: **0 pages processed, 42 from the lock, 83 s**. Incremental translation works.

It still opened #6865 (closed). The only diff was `es/guide.md`: lingo's markdown serializer writes a link whose sole content is an image as five lines (`[`, blank, image, blank, `](url)`). That is a bare-URL lint finding and renders a stray bracket. The same thing I hand-joined in #6863, so it will recur on every run.

The lint step in the workflow did not catch it: the globs were unquoted, bash without globstar reads `**` as `*`, and the run linted 37 files, never the top-level `es/*.md` pages.

## Changes

- Fold `[\n\n![..](..)\n\n](url)` back onto one line before linting, per locale. Regex tested against the exact text from #6865.
- Pass markdownlint globs quoted, as a bash array, in both the fix step and the check step so markdownlint-cli2 expands `**` itself. Locally that lints all 42 files with 0 findings.

## Expected next run on main

"No translation changes." Nothing to translate, and `es/guide.md` on main already matches the folded form.

Also noticed: Website Check on the bot's PR sat at `action_required`. Bot-authored PRs need a manual workflow approval under the repo's Actions settings, or the translation PRs will never show CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129NKpLrXRu218sN77mVdLL