### PR TITLE
docs: translate the blog and contributor pages too

### DIFF
--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -16,6 +16,8 @@ on:
     paths:
       - 'runatlantis.io/docs/**/*.md'
       - 'runatlantis.io/guide/**/*.md'
+      - 'runatlantis.io/blog/**/*.md'
+      - 'runatlantis.io/contributing/**/*.md'
       - 'runatlantis.io/*.md'
       - 'i18n.json'
       - 'scripts/localize-links.mjs'
@@ -66,7 +68,13 @@ jobs:
         run: |
           rm -rf .lingo-src
           mkdir -p .lingo-src/en
-          cp -r runatlantis.io/docs runatlantis.io/guide .lingo-src/en/
+          # Markdown only. The blog keeps its images and Terraform samples in
+          # per-post directories; those are not translated, and the link
+          # localizer already points a translated post back at the English
+          # copy of its assets.
+          rsync -a --include='*/' --include='*.md' --exclude='*' --prune-empty-dirs \
+            runatlantis.io/docs runatlantis.io/guide runatlantis.io/blog runatlantis.io/contributing \
+            .lingo-src/en/
           cp runatlantis.io/*.md .lingo-src/en/
 
           # Stage the translations already on the branch too. Without them the

--- a/TRANSLATIONS.md
+++ b/TRANSLATIONS.md
@@ -11,6 +11,11 @@ ships (see `--language` and `server/i18n/locales/`).
 
 `.github/workflows/translate-docs.yml` runs when English docs change on `main`:
 
+The pages under `docs/`, `guide/`, `blog/`, `contributing/` and the top-level
+pages are all translated. Images, Terraform samples and other assets are not
+copied into a locale; a translated page links back to the English copy of its
+assets.
+
 1. Stages a throwaway copy of the English pages under `.lingo-src/en/`. The
    translator finds sources by substituting the source locale into a `[locale]`
    path, and staging keeps the real English tree exactly where it is.

--- a/runatlantis.io/.vitepress/sidebars.ts
+++ b/runatlantis.io/.vitepress/sidebars.ts
@@ -202,8 +202,9 @@ const localizeSidebar = (
     ...(item.items ? { items: localizeSidebar(item.items, locale, labels) } : {}),
   }));
 
-// Section labels only. Blog post titles are left in English on purpose: the
-// posts themselves are not translated.
+// Every entry the sidebar renders. Blog post titles reuse the wording already
+// used for the same posts in runatlantis.io/es/blog.md, so a reader sees one
+// title for a post rather than two.
 const esLabels: Record<string, string> = {
   "Guide": "Guía",
   "Test Drive": "Prueba rápida",
@@ -250,6 +251,19 @@ const esLabels: Record<string, string> = {
   "Events Controller": "Controlador de eventos",
   "Glossary": "Glosario",
   "Blog": "Blog",
+  "Atlantis on Google Cloud Run": "Atlantis en Google Cloud Run",
+  "Integrating Atlantis with OpenTofu": "Integrar Atlantis con OpenTofu",
+  "Atlantis User Survey Results": "Resultados de la encuesta de usuarios de Atlantis",
+  "4 Reasons To Try HashiCorp's (New) Free Terraform Remote State Storage":
+    "4 razones para probar el nuevo almacenamiento gratuito de estado remoto de Terraform de HashiCorp",
+  "I'm Joining HashiCorp!": "\u00a1Me uno a HashiCorp!",
+  "Putting The Dev Into DevOps: Why Your Developers Should Write Terraform Too":
+    "Llevar el Dev a DevOps: por qu\u00e9 tus desarrolladores tambi\u00e9n deber\u00edan escribir Terraform",
+  "Atlantis 0.4.4 Now Supports Bitbucket": "Atlantis 0.4.4 ahora es compatible con Bitbucket",
+  "Terraform And The Dangers Of Applying Locally": "Terraform y los peligros de aplicar localmente",
+  "Hosting Our Static Site over SSL with S3, ACM, CloudFront and Terraform":
+    "Alojar nuestro sitio est\u00e1tico sobre SSL con S3, ACM, CloudFront y Terraform",
+  "Introducing Atlantis": "Presentando Atlantis",
 };
 
 const es: SidebarItem[] = localizeSidebar(en, "es", esLabels);

--- a/scripts/check-translation-integrity.mjs
+++ b/scripts/check-translation-integrity.mjs
@@ -23,6 +23,8 @@ const SITE_DIR = 'runatlantis.io';
 const TRANSLATED_DIRS = [
   { dir: 'docs', recursive: true },
   { dir: 'guide', recursive: true },
+  { dir: 'blog', recursive: true },
+  { dir: 'contributing', recursive: true },
   { dir: '.', recursive: false },
 ];
 


### PR DESCRIPTION
## Why

`es/blog.md` and `es/contributing.md` are translated, but everything they link to is not: the ten blog posts and the two contributor sub-pages were left out of the pipeline by #6767. A Spanish reader gets a Spanish blog index whose every entry, in the page and in the sidebar, is English.

## Changes

- `blog/` and `contributing/` added to the workflow's `paths` filter and to what the translator stages.
- Staging now copies **markdown only**. The blog keeps images, GIFs and Terraform samples in per-post directories; those must not be duplicated into a locale, and `localize-links.mjs` already points a translated post back at the English copy of its assets.
- Both directories added to `TRANSLATED_DIRS` so the integrity checker covers them.
- Spanish blog post titles added to the sidebar label map, reusing the wording already used for the same posts in `es/blog.md` so a post does not carry two different Spanish titles.

The translated pages themselves arrive from the next workflow run. `i18n.lock` has no entry for these twelve, so only they are sent to the provider; the existing forty-two stay cached.

## Verification

Staged English copies of both trees into `es/` and ran the whole chain locally:

- staging rsync yields 54 markdown files, 0 non-markdown
- `check-translation-integrity.mjs` — 54 files, no problems
- markdownlint — 54 files, 0 errors
- `npm run website:build` — clean
- a post's image rewrote to `../../../blog/2025/.../runatlantis-cloud-run-arch.drawio.png` and resolved in the build
- built `es/blog.html`: 59 links into `/es/`, 0 into English `/blog/` or `/contributing/`
- sidebar renders "Atlantis en Google Cloud Run", "Integrar Atlantis con OpenTofu", "Presentando Atlantis"

Those staged copies were reverted before committing; this PR is configuration only.

## Note

Merging this triggers `translate-docs` (the workflow file is in its own path filter). The resulting bot PR needs "Approve and run" once, since `github-actions[bot]` is still a first-time contributor under the repo's Actions approval policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129NKpLrXRu218sN77mVdLL