### PR TITLE
fix: reclone when the base branch changed before merging again

### DIFF
--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -222,7 +222,19 @@ func (w *FileWorkspace) MergeAgain(
 	}
 	c := wrappedGitContext{cloneDir, headRepo, p}
 
-	if !w.recheckDiverged(logger, p, headRepo, cloneDir) {
+	// A base branch the checkout does not have means the pull request was
+	// retargeted onto a branch that was never fetched, e.g. a user changed the
+	// target branch by hand. recheckDiverged compares the working tree against
+	// its *old* base branch, so when that branch still exists and has not moved
+	// it reports no divergence and we would leave the checkout merged into the
+	// wrong base. Detect the missing ref up front so that case refreshes too.
+	// git show-ref only reads, so the read lock is enough here; mergeAgain
+	// repeats the check under the write lock before acting on it.
+	gitReadUnlockFn := w.gitReadLock(cloneDir)
+	baseRefMissing := !w.remoteHasBranch(logger, c, p.BaseBranch)
+	gitReadUnlockFn()
+
+	if !baseRefMissing && !w.recheckDiverged(logger, p, headRepo, cloneDir) {
 		return false, nil
 	}
 
@@ -820,6 +832,10 @@ func (w *FileWorkspace) mergeAgain(logger logging.SimpleLogging, c wrappedGitCon
 	// tree". Re-clone instead, the same way Clone does when it notices the base
 	// branch changed. This discards existing plans, but that is unavoidable:
 	// the checkout cannot be updated to a base branch it never fetched.
+	//
+	// MergeAgain performs this check too, to decide whether to refresh at all.
+	// It is repeated here under the write lock so a concurrent re-clone between
+	// the two cannot leave us resetting to a ref that is missing.
 	if !w.remoteHasBranch(logger, c, c.pr.BaseBranch) {
 		logger.Info("base branch %q is not in the checkout, must reclone", c.pr.BaseBranch)
 		return w.forceClone(logger, c)

--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -812,6 +812,19 @@ func nonPRTargetRef(p models.PullRequest) string {
 // There is a new upstream update that we need, and we want to update to it
 // without deleting any existing plans
 func (w *FileWorkspace) mergeAgain(logger logging.SimpleLogging, c wrappedGitContext) error {
+	// The base branch can change after the checkout was created, e.g. when a
+	// stacked pull request is retargeted because its original base branch was
+	// merged and deleted. forceClone clones with --single-branch, so the
+	// checkout only has a remote-tracking ref for the *old* base branch and the
+	// reset below would fail with "unknown revision or path not in the working
+	// tree". Re-clone instead, the same way Clone does when it notices the base
+	// branch changed. This discards existing plans, but that is unavoidable:
+	// the checkout cannot be updated to a base branch it never fetched.
+	if !w.remoteHasBranch(logger, c, c.pr.BaseBranch) {
+		logger.Info("base branch %q is not in the checkout, must reclone", c.pr.BaseBranch)
+		return w.forceClone(logger, c)
+	}
+
 	// Reset branch as if it was cloned again
 	if err := w.wrappedGit(logger, c, "reset", "--hard", fmt.Sprintf("refs/remotes/origin/%s", c.pr.BaseBranch)); err != nil {
 		return err

--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -138,8 +138,18 @@ func (w *FileWorkspace) Clone(logger logging.SimpleLogging, headRepo models.Repo
 	if _, err := os.Stat(cloneDir); err == nil {
 		gitReadUnlockFn := w.gitReadLock(cloneDir)
 		isUpToDate, err := w.isBranchAtTargetRef(logger, c, p.HeadCommit)
+		// The head commit being current is not enough: the pull request may have
+		// been retargeted onto a base branch this checkout never fetched, which
+		// leaves the working tree merged into the old base. Callers that use the
+		// checkout without going through MergeAgain — pre-workflow hooks and
+		// project discovery among them — would otherwise run against it. Fall
+		// through to the slow path, where attemptReuseCloneDir re-clones.
+		// Only meaningful for the merge strategy: branch-strategy clones track
+		// the head branch and synthetic API refs (Num < 0) are checked out
+		// detached, so neither has a base remote-tracking branch to find.
+		baseRefOK := !w.CheckoutMerge || p.Num <= 0 || w.remoteHasBranch(logger, c, p.BaseBranch)
 		gitReadUnlockFn()
-		if err == nil && isUpToDate {
+		if err == nil && isUpToDate && baseRefOK {
 			logger.Info("repo is at correct commit %q so will not re-clone (fast path)", p.HeadCommit)
 			return cloneDir, nil
 		}
@@ -174,6 +184,22 @@ func (w *FileWorkspace) attemptReuseCloneDir(logger logging.SimpleLogging, c wra
 	}
 	logger.Debug("clone directory '%s' already exists, checking if it's at the right commit", cloneDir)
 
+	// A missing base remote-tracking branch means the checkout cannot serve this
+	// pull request: it was cloned with --single-branch against a base branch the
+	// pull request no longer targets. Only meaningful for the merge strategy;
+	// branch-strategy clones track the head branch and never have this ref.
+	baseBranchMissing := w.CheckoutMerge && !w.remoteHasBranch(logger, c, c.pr.BaseBranch)
+
+	// For a pull request this has to be decided before the commit check: the
+	// working tree can be at the right head commit and still be merged into the
+	// old base, which the commit check alone would happily accept. Synthetic API
+	// refs (Num < 0) are checked out detached and have no base branch to track,
+	// so they keep the original ordering below.
+	if baseBranchMissing && c.pr.Num > 0 {
+		logger.Info("repo appears to have changed base branch, must reclone")
+		return false, nil
+	}
+
 	isUpToDate, err := w.isBranchAtTargetRef(logger, c, c.pr.HeadCommit)
 	if err != nil {
 		return false, err
@@ -182,7 +208,7 @@ func (w *FileWorkspace) attemptReuseCloneDir(logger logging.SimpleLogging, c wra
 		logger.Info("repo is at correct commit %q so will not re-clone", c.pr.HeadCommit)
 		return true, nil
 	}
-	if w.CheckoutMerge && !w.remoteHasBranch(logger, c, c.pr.BaseBranch) {
+	if baseBranchMissing {
 		logger.Info("repo appears to have changed base branch, must reclone")
 		return false, nil
 	}
@@ -822,7 +848,13 @@ func nonPRTargetRef(p models.PullRequest) string {
 }
 
 // There is a new upstream update that we need, and we want to update to it
-// without deleting any existing plans
+// without deleting any existing plans.
+//
+// One exception: if the pull request was retargeted onto a base branch this
+// checkout never fetched, the working tree cannot be updated in place and is
+// re-cloned instead, which does delete its plans. Callers must not rely on plan
+// preservation in that case. Those plans were made against a different base
+// branch, so they no longer describe what would be applied.
 func (w *FileWorkspace) mergeAgain(logger logging.SimpleLogging, c wrappedGitContext) error {
 	// The base branch can change after the checkout was created, e.g. when a
 	// stacked pull request is retargeted because its original base branch was

--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -1296,6 +1296,82 @@ func TestMergeAgain_BaseBranchRetargetedAfterParentMerged(t *testing.T) {
 	Equals(t, childHeadCommit, actCommit)
 }
 
+// TestMergeAgain_RetargetedWhileOldBaseStillExists covers retargeting a pull
+// request onto a different branch while its original base branch still exists
+// and has not advanced, e.g. a user changed the target branch by hand. The
+// checkout was cloned with --single-branch against the old base, so it has no
+// ref for the new one, and the head commit is unchanged so Clone reuses the
+// directory. Comparing against the old base reports no divergence, so without
+// an explicit base-ref check the working tree would silently stay merged into
+// the wrong base and the plan would run against it.
+func TestMergeAgain_RetargetedWhileOldBaseStillExists(t *testing.T) {
+	repoDir := initRepo(t)
+
+	// The branch the pull request originally targeted.
+	runCmd(t, repoDir, "git", "checkout", "-b", "old-base")
+	runCmd(t, repoDir, "touch", "old-base-file.txt")
+	runCmd(t, repoDir, "git", "add", "old-base-file.txt")
+	runCmd(t, repoDir, "git", "commit", "-m", "old base change")
+
+	// The pull request itself, branched off the old base.
+	runCmd(t, repoDir, "git", "checkout", "-b", "pr-branch")
+	runCmd(t, repoDir, "touch", "pr-file.txt")
+	runCmd(t, repoDir, "git", "add", "pr-file.txt")
+	runCmd(t, repoDir, "git", "commit", "-m", "pr change")
+	prHeadCommit := strings.TrimSpace(runCmd(t, repoDir, "git", "rev-parse", "HEAD"))
+
+	// Give main a commit of its own so it is distinguishable from the old base.
+	runCmd(t, repoDir, "git", "checkout", "main")
+	runCmd(t, repoDir, "touch", "main-only.txt")
+	runCmd(t, repoDir, "git", "add", "main-only.txt")
+	runCmd(t, repoDir, "git", "commit", "-m", "main only change")
+
+	// Atlantis checks the pull request out merged into the old base.
+	workspaceDir := filepath.Join(repoDir, "repos", "1", "default")
+	runCmd(t, repoDir, "mkdir", "-p", filepath.Join("repos", "1", "default"))
+	runCmd(t, workspaceDir, "git", "clone", "--branch", "old-base", "--single-branch", repoDir, ".")
+	runCmd(t, workspaceDir, "git", "remote", "add", "source", repoDir)
+	runCmd(t, workspaceDir, "git", "fetch", "source", "+refs/heads/pr-branch")
+	runCmd(t, workspaceDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
+	runCmd(t, workspaceDir, "git", "config", "--local", "user.name", "atlantisbot")
+	runCmd(t, workspaceDir, "git", "config", "--local", "commit.gpgsign", "false")
+	runCmd(t, workspaceDir, "git", "merge", "-q", "--no-ff", "-m", "atlantis-merge", "FETCH_HEAD")
+
+	// The old base is deliberately left in place and unchanged: this is what
+	// makes the divergence check report that there is nothing to do.
+	logger := logging.NewNoopLogger(t)
+	wd := &events.FileWorkspace{
+		DataDir:             repoDir,
+		CheckoutMerge:       true,
+		CheckoutDepth:       50,
+		GpgNoSigningEnabled: true,
+	}
+	pullRequest := models.PullRequest{
+		Num:        1,
+		BaseRepo:   models.Repo{CloneURL: repoDir},
+		HeadBranch: "pr-branch",
+		BaseBranch: "main",
+		HeadCommit: prHeadCommit,
+	}
+
+	_, err := wd.Clone(logger, models.Repo{CloneURL: repoDir}, pullRequest, "default")
+	Ok(t, err)
+
+	mergedAgain, err := wd.MergeAgain(logger, models.Repo{CloneURL: repoDir}, pullRequest, "default")
+	Ok(t, err)
+	Assert(t, mergedAgain == true, "expected the working tree to be refreshed after the retarget")
+
+	// The checkout must be the pull request merged into the new base branch.
+	// old-base-file.txt is deliberately not asserted against: the pull request
+	// branched off the old base, so that commit is part of its own history and
+	// legitimately survives the merge.
+	assert.FileExists(t, filepath.Join(workspaceDir, "main-only.txt"), "new base branch content should be present")
+	assert.FileExists(t, filepath.Join(workspaceDir, "pr-file.txt"))
+
+	actCommit := strings.TrimSpace(runCmd(t, workspaceDir, "git", "rev-parse", "HEAD^2"))
+	Equals(t, prHeadCommit, actCommit)
+}
+
 func TestHasDiverged_MasterHasDiverged(t *testing.T) {
 	// Initialize the git repo.
 	repoDir := initRepo(t)

--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -1207,6 +1208,92 @@ func TestMergeAgain_ConcurrentDiverged(t *testing.T) {
 	// the upstream merge was applied to disk.
 	assert.FileExists(t, filepath.Join(workspaceDir, "base-update.txt"))
 	assert.FileExists(t, filepath.Join(workspaceDir, "pr-file.txt"))
+}
+
+// TestMergeAgain_BaseBranchRetargetedAfterParentMerged verifies that a stacked
+// pull request recovers when its base branch is replaced after the checkout was
+// created. This happens whenever the parent of a stacked PR merges: the forge
+// deletes the parent branch and retargets the child onto the repo's main branch.
+// The existing checkout was cloned with --single-branch against the parent
+// branch, so it has no refs/remotes/origin/<new base> to reset to, and the head
+// commit is unchanged so Clone reuses the directory. MergeAgain must re-clone
+// rather than fail with "unknown revision or path not in the working tree".
+func TestMergeAgain_BaseBranchRetargetedAfterParentMerged(t *testing.T) {
+	// Use the repo dir as both the "remote" and the Atlantis DataDir — same
+	// pattern as TestMergeAgain_ConcurrentDiverged.
+	repoDir := initRepo(t)
+
+	// Parent PR: branch off main.
+	runCmd(t, repoDir, "git", "checkout", "-b", "parent-pr")
+	runCmd(t, repoDir, "touch", "parent-file.txt")
+	runCmd(t, repoDir, "git", "add", "parent-file.txt")
+	runCmd(t, repoDir, "git", "commit", "-m", "parent change")
+
+	// Child PR: stacked on the parent branch, so its base branch is parent-pr.
+	runCmd(t, repoDir, "git", "checkout", "-b", "child-pr")
+	runCmd(t, repoDir, "touch", "child-file.txt")
+	runCmd(t, repoDir, "git", "add", "child-file.txt")
+	runCmd(t, repoDir, "git", "commit", "-m", "child change")
+	childHeadCommit := strings.TrimSpace(runCmd(t, repoDir, "git", "rev-parse", "HEAD"))
+
+	// Atlantis checks out the child PR merged into its base, parent-pr. This is
+	// what forceClone does for the merge checkout strategy, and it leaves
+	// refs/remotes/origin/parent-pr as the only remote-tracking branch.
+	runCmd(t, repoDir, "git", "checkout", "main")
+	workspaceDir := filepath.Join(repoDir, "repos", "1", "default")
+	runCmd(t, repoDir, "mkdir", "-p", filepath.Join("repos", "1", "default"))
+	runCmd(t, workspaceDir, "git", "clone", "--branch", "parent-pr", "--single-branch", repoDir, ".")
+	runCmd(t, workspaceDir, "git", "remote", "add", "source", repoDir)
+	runCmd(t, workspaceDir, "git", "fetch", "source", "+refs/heads/child-pr")
+	runCmd(t, workspaceDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
+	runCmd(t, workspaceDir, "git", "config", "--local", "user.name", "atlantisbot")
+	runCmd(t, workspaceDir, "git", "config", "--local", "commit.gpgsign", "false")
+	runCmd(t, workspaceDir, "git", "merge", "-q", "--no-ff", "-m", "atlantis-merge", "FETCH_HEAD")
+
+	// Sanity check the precondition: the checkout knows the old base branch and
+	// not the new one.
+	runCmd(t, workspaceDir, "git", "show-ref", "--verify", "refs/remotes/origin/parent-pr")
+	_, err := exec.Command("git", "-C", workspaceDir, "show-ref", "--verify", "refs/remotes/origin/main").CombinedOutput() // nolint: gosec
+	Assert(t, err != nil, "precondition: refs/remotes/origin/main should not exist in the checkout")
+
+	// The parent PR merges into main and its branch is deleted, so the forge
+	// retargets the child PR onto main. The child's head commit is unchanged.
+	runCmd(t, repoDir, "git", "checkout", "main")
+	runCmd(t, repoDir, "git", "merge", "--no-ff", "-m", "merge parent-pr", "parent-pr")
+	runCmd(t, repoDir, "git", "branch", "-D", "parent-pr")
+
+	logger := logging.NewNoopLogger(t)
+	wd := &events.FileWorkspace{
+		DataDir:             repoDir,
+		CheckoutMerge:       true,
+		CheckoutDepth:       50,
+		GpgNoSigningEnabled: true,
+	}
+	pullRequest := models.PullRequest{
+		Num:        1,
+		BaseRepo:   models.Repo{CloneURL: repoDir},
+		HeadBranch: "child-pr",
+		BaseBranch: "main",
+		HeadCommit: childHeadCommit,
+	}
+
+	// Clone reuses the existing directory because the head commit is unchanged,
+	// so it is MergeAgain that has to notice the base branch is unusable.
+	_, err = wd.Clone(logger, models.Repo{CloneURL: repoDir}, pullRequest, "default")
+	Ok(t, err)
+
+	mergedAgain, err := wd.MergeAgain(logger, models.Repo{CloneURL: repoDir}, pullRequest, "default")
+	Ok(t, err)
+	Assert(t, mergedAgain == true, "expected the working tree to be refreshed after the base branch changed")
+
+	// The checkout must now be the child PR merged into the new base branch.
+	assert.FileExists(t, filepath.Join(workspaceDir, "child-file.txt"))
+	assert.FileExists(t, filepath.Join(workspaceDir, "parent-file.txt"))
+	runCmd(t, workspaceDir, "git", "show-ref", "--verify", "refs/remotes/origin/main")
+
+	// HEAD^2 is the PR head, which is how Atlantis verifies a merge checkout.
+	actCommit := strings.TrimSpace(runCmd(t, workspaceDir, "git", "rev-parse", "HEAD^2"))
+	Equals(t, childHeadCommit, actCommit)
 }
 
 func TestHasDiverged_MasterHasDiverged(t *testing.T) {

--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -1277,11 +1277,10 @@ func TestMergeAgain_BaseBranchRetargetedAfterParentMerged(t *testing.T) {
 		HeadCommit: childHeadCommit,
 	}
 
-	// Clone reuses the existing directory because the head commit is unchanged,
-	// so it is MergeAgain that has to notice the base branch is unusable.
-	_, err = wd.Clone(logger, models.Repo{CloneURL: repoDir}, pullRequest, "default")
-	Ok(t, err)
-
+	// MergeAgain is exercised directly here, without a preceding Clone. Clone
+	// also repairs this now (see TestClone_RetargetedBaseBranchWithUnchangedHead),
+	// so going through it would leave nothing for MergeAgain to do and this guard
+	// would not be covered.
 	mergedAgain, err := wd.MergeAgain(logger, models.Repo{CloneURL: repoDir}, pullRequest, "default")
 	Ok(t, err)
 	Assert(t, mergedAgain == true, "expected the working tree to be refreshed after the base branch changed")
@@ -1354,9 +1353,8 @@ func TestMergeAgain_RetargetedWhileOldBaseStillExists(t *testing.T) {
 		HeadCommit: prHeadCommit,
 	}
 
-	_, err := wd.Clone(logger, models.Repo{CloneURL: repoDir}, pullRequest, "default")
-	Ok(t, err)
-
+	// As above, MergeAgain is exercised directly so that its own handling of the
+	// retarget is covered rather than Clone's.
 	mergedAgain, err := wd.MergeAgain(logger, models.Repo{CloneURL: repoDir}, pullRequest, "default")
 	Ok(t, err)
 	Assert(t, mergedAgain == true, "expected the working tree to be refreshed after the retarget")
@@ -1369,6 +1367,65 @@ func TestMergeAgain_RetargetedWhileOldBaseStillExists(t *testing.T) {
 	assert.FileExists(t, filepath.Join(workspaceDir, "pr-file.txt"))
 
 	actCommit := strings.TrimSpace(runCmd(t, workspaceDir, "git", "rev-parse", "HEAD^2"))
+	Equals(t, prHeadCommit, actCommit)
+}
+
+// TestClone_RetargetedBaseBranchWithUnchangedHead covers the callers that use a
+// checkout without ever calling MergeAgain — pre-workflow hooks and project
+// discovery among them. Clone's reuse checks are driven by the head commit, so
+// a pull request retargeted onto a branch the checkout never fetched would be
+// reused as-is and those callers would run against the old base branch.
+func TestClone_RetargetedBaseBranchWithUnchangedHead(t *testing.T) {
+	repoDir := initRepo(t)
+
+	runCmd(t, repoDir, "git", "checkout", "-b", "old-base")
+	runCmd(t, repoDir, "touch", "old-base-file.txt")
+	runCmd(t, repoDir, "git", "add", "old-base-file.txt")
+	runCmd(t, repoDir, "git", "commit", "-m", "old base change")
+
+	runCmd(t, repoDir, "git", "checkout", "-b", "pr-branch")
+	runCmd(t, repoDir, "touch", "pr-file.txt")
+	runCmd(t, repoDir, "git", "add", "pr-file.txt")
+	runCmd(t, repoDir, "git", "commit", "-m", "pr change")
+	prHeadCommit := strings.TrimSpace(runCmd(t, repoDir, "git", "rev-parse", "HEAD"))
+
+	runCmd(t, repoDir, "git", "checkout", "main")
+	runCmd(t, repoDir, "touch", "main-only.txt")
+	runCmd(t, repoDir, "git", "add", "main-only.txt")
+	runCmd(t, repoDir, "git", "commit", "-m", "main only change")
+
+	workspaceDir := filepath.Join(repoDir, "repos", "1", "default")
+	runCmd(t, repoDir, "mkdir", "-p", filepath.Join("repos", "1", "default"))
+	runCmd(t, workspaceDir, "git", "clone", "--branch", "old-base", "--single-branch", repoDir, ".")
+	runCmd(t, workspaceDir, "git", "remote", "add", "source", repoDir)
+	runCmd(t, workspaceDir, "git", "fetch", "source", "+refs/heads/pr-branch")
+	runCmd(t, workspaceDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
+	runCmd(t, workspaceDir, "git", "config", "--local", "user.name", "atlantisbot")
+	runCmd(t, workspaceDir, "git", "config", "--local", "commit.gpgsign", "false")
+	runCmd(t, workspaceDir, "git", "merge", "-q", "--no-ff", "-m", "atlantis-merge", "FETCH_HEAD")
+
+	logger := logging.NewNoopLogger(t)
+	wd := &events.FileWorkspace{
+		DataDir:             repoDir,
+		CheckoutMerge:       true,
+		CheckoutDepth:       50,
+		GpgNoSigningEnabled: true,
+	}
+
+	// Clone only, with the head commit unchanged: no MergeAgain to fall back on.
+	cloneDir, err := wd.Clone(logger, models.Repo{CloneURL: repoDir}, models.PullRequest{
+		Num:        1,
+		BaseRepo:   models.Repo{CloneURL: repoDir},
+		HeadBranch: "pr-branch",
+		BaseBranch: "main",
+		HeadCommit: prHeadCommit,
+	}, "default")
+	Ok(t, err)
+
+	assert.FileExists(t, filepath.Join(cloneDir, "main-only.txt"), "new base branch content should be present")
+	assert.FileExists(t, filepath.Join(cloneDir, "pr-file.txt"))
+
+	actCommit := strings.TrimSpace(runCmd(t, cloneDir, "git", "rev-parse", "HEAD^2"))
 	Equals(t, prHeadCommit, actCommit)
 }
 


### PR DESCRIPTION
## what

- `mergeAgain` now checks that the checkout actually has a remote-tracking ref for the pull request's base branch, and re-clones when it does not, instead of running `git reset --hard` against a ref that cannot exist.
- `MergeAgain` performs the same check before its divergence early-return, so a pull request retargeted onto a branch the checkout never fetched is refreshed even when the old base branch still exists and the divergence check reports nothing to do.
- `Clone` validates the base branch too, in its fast path and before the head-commit comparison in `attemptReuseCloneDir`, so callers that use a checkout without going through `MergeAgain` — pre-workflow hooks, post-workflow hooks, project discovery — do not run against the old base either.

## why

- A pull request's base branch can change after its working directory was created. The common case is a stacked pull request: the parent merges, the forge deletes the parent branch and retargets the child onto the repo's main branch. (GitLab does this automatically and posts *"deleted the `<branch>` branch. This merge request now targets the `main` branch"*; GitHub retargets on base-branch deletion too, and either forge lets a user retarget by hand.)
- `forceClone` clones with `--single-branch`, so the checkout's only remote-tracking branch is the base branch the PR had at clone time. After a retarget, `mergeAgain`'s reset refers to a ref that was never fetched:

  ```
  running git reset --hard refs/remotes/origin/main: fatal: ambiguous argument 'refs/remotes/origin/main': unknown revision or path not in the working tree.
  Use '--' to separate paths from revisions, like this:
  'git <command> [<revision>...] -- [<file>...]'
  : exit status 128
  ```

- The existing `remoteHasBranch` guard added in #6177 does not cover this. It lives in `attemptReuseCloneDir`, which is only reached when the head commit changed. In this scenario the head commit is unchanged, so `Clone` returns via its fast path (`repo is at correct commit ... (fast path)`) and never consults the guard. `recheckDiverged` then fails its `git remote update` because the old base branch is gone from the remote, returns `true` per its documented "assume divergence for safety" behaviour, and `mergeAgain` runs and fails.
- The failure is not self-healing: every subsequent plan takes the same fast path and fails identically, so the working directory stays broken until an operator deletes it. We hit this in production and had to `rm -rf` the directory by hand to recover.
- A second, quieter variant of the same root cause was raised in review and confirmed: if the pull request is retargeted while its **original base branch still exists and has not advanced** (e.g. a user changes the target branch by hand), `recheckDiverged` compares the working tree against the *old* base, finds no divergence, and `MergeAgain` returns before the guard is reached. The checkout stays merged into the old base and the plan runs against the wrong branch with no error at all. That is worse than the hard failure above, because nothing surfaces it. The check therefore also runs in `MergeAgain` before the early return.
- A third variant, also raised in review and confirmed: only `project_command_runner.go` calls `MergeAgain` after `Clone`. The other ~10 `Clone` call sites use the checkout directly, and `Clone`'s reuse checks are driven by the head commit, so after a retarget they ran against the old base. `attemptReuseCloneDir` compounded this by returning on `isUpToDate` before its existing `remoteHasBranch` check, so the base-branch decision is now made first.
- All the new checks are gated on `CheckoutMerge` **and** `Num > 0`. Branch-strategy clones track the head branch and synthetic API refs are checked out detached, so neither has a base remote-tracking branch; without the gate every such checkout would re-clone on every operation.
- The fix mirrors what `Clone` already does when it detects a base branch change, so the two paths now behave consistently. Re-cloning discards existing plans for that PR, which is unavoidable here — the checkout cannot be updated to a base branch it never fetched — and matches the existing behaviour asserted by `TestClone_ReCloneOnBaseChangeForMergeStrategy`.

## tests

- [x] Added `TestMergeAgain_BaseBranchRetargetedAfterParentMerged`, which builds a real stacked-PR checkout (child cloned against `parent-pr` with `--single-branch`), merges and deletes the parent, retargets the child onto `main` without changing its head commit, and asserts the working tree recovers.
- [x] Added `TestMergeAgain_RetargetedWhileOldBaseStillExists` for the review finding: the old base branch is left in place and unchanged, so the divergence check reports nothing to do, and the test asserts the checkout is still rebased onto the new base.
- [x] Added `TestClone_RetargetedBaseBranchWithUnchangedHead`, which calls `Clone` only — no `MergeAgain` — and asserts the checkout ends up on the new base branch.
- [x] The three tests pin the three changes independently: reverting any one of the checks fails exactly one test. The two `MergeAgain` tests exercise that method directly, since `Clone` now repairs the checkout before it would be reached.
- [x] `TestClone_DoNotReCloneOnBaseChangeForBranchStrategy` and the `TestClone_SyntheticNonPRRefs*` tests confirm the branch-strategy and non-PR paths are unaffected.
- [x] Verified the test reproduces the bug: on `main` without the fix it fails with the exact production error (`fatal: ambiguous argument 'refs/remotes/origin/main'`), preceded by the `(fast path)` log line. With the fix it passes.
- [x] `go test ./server/events/ -run 'TestClone|TestMergeAgain|TestHasDiverged|TestGetDivergedFiles'` passes.
- [x] Full `go test ./server/events/` shows an identical set of failures before and after this change (15 pre-existing failures in `TestValidateNonPRAPIRef*` / `TestProjectCommandRunner_NonPR*`, all `fatal: not in a git directory` in my local environment), so this change introduces no regressions.
- [x] `gofmt` and `go vet` clean.

## references

- closes #6872
- Related: #6146 and #6177, which added `remoteHasBranch` to the `Clone` path. This PR covers the `MergeAgain` path, which runs even when `Clone` legitimately reuses the working directory.

## architecture decision record

- [x] I checked the [ADR criteria](https://github.com/runatlantis/atlantis/blob/main/docs/adr/README.md#when-is-an-adr-required).

**ADR:** Not required — bug fix, no user-visible or architectural change.

---

Per [AI_USAGE_POLICY.md](https://github.com/runatlantis/atlantis/blob/main/AI_USAGE_POLICY.md): this change was written with AI assistance, disclosed in the commit trailer. I have reviewed it, verified the failure mode against a live Atlantis deployment, and take responsibility for its correctness. Issue #6872 is not yet triaged by a maintainer — happy to hold this PR until the issue is accepted, or to adjust the approach if you would prefer the guard live somewhere else (e.g. in `MergeAgain` before the lock, or in `Clone`'s fast path).
