### PR TITLE
Remove draftplan locking for policy check

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -162,7 +162,7 @@ const (
 	DefaultADHostname                   = "dev.azure.com"
 	DefaultAutoDiscoverMode             = "auto"
 	DefaultAutoplanFileList             = "**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl,**/.terraform.lock.hcl"
-	DefaultAllowCommands                = "version,plan,apply,unlock,approve_policies,cancel"
+	DefaultAllowCommands                = "version,draftplan,plan,apply,unlock,approve_policies,cancel"
 	DefaultBlockedExtraArgs             = "-chdir,--chdir,-plugin-dir,--plugin-dir"
 	DefaultCheckoutStrategy             = CheckoutStrategyBranch
 	DefaultCheckoutDepth                = 0

--- a/runatlantis.io/docs/repo-level-atlantis-yaml.md
+++ b/runatlantis.io/docs/repo-level-atlantis-yaml.md
@@ -75,6 +75,7 @@ projects:
   repo_locks: # Available since v0.17.0
     mode: on_plan
   custom_policy_check: false # Available since v0.17.0
+  draft_plan_policy_check: false # Skip policy checks triggered by draftplan
   autoplan: # Available since v0.1.0
     when_modified: ["*.tf", "../modules/**/*.tf", ".terraform.lock.hcl"]
     enabled: true

--- a/runatlantis.io/docs/repo-level-atlantis-yaml.md
+++ b/runatlantis.io/docs/repo-level-atlantis-yaml.md
@@ -75,7 +75,7 @@ projects:
   repo_locks: # Available since v0.17.0
     mode: on_plan
   custom_policy_check: false # Available since v0.17.0
-  draft_plan_policy_check: false # Skip policy checks triggered by draftplan
+  draft_plan_policy_check: true # Enable policy checks for draftplan
   autoplan: # Available since v0.1.0
     when_modified: ["*.tf", "../modules/**/*.tf", ".terraform.lock.hcl"]
     enabled: true

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1652,6 +1652,7 @@ func setupE2E(t *testing.T, repoDir string, opt setupOption) (events_controllers
 
 	commentCommandRunnerByCmd := map[command.Name]events.CommentCommandRunner{
 		command.Plan:            planCommandRunner,
+		command.DraftPlan:       planCommandRunner,
 		command.Apply:           applyCommandRunner,
 		command.ApprovePolicies: approvePoliciesCommandRunner,
 		command.Unlock:          unlockCommandRunner,

--- a/server/core/boltdb/boltdb.go
+++ b/server/core/boltdb/boltdb.go
@@ -571,7 +571,6 @@ func (b *BoltDB) projectResultToProject(p command.ProjectResult) models.ProjectS
 		Workspace:    p.Workspace,
 		RepoRelDir:   p.RepoRelDir,
 		ProjectName:  p.ProjectName,
-		IsDraftPlan:  p.Command == command.DraftPlan || (p.PolicyCheckResults != nil && p.PolicyCheckResults.IsDraftPlan),
 		PolicyStatus: p.PolicyStatus(),
 		Status:       p.PlanStatus(),
 	}

--- a/server/core/boltdb/boltdb.go
+++ b/server/core/boltdb/boltdb.go
@@ -571,6 +571,7 @@ func (b *BoltDB) projectResultToProject(p command.ProjectResult) models.ProjectS
 		Workspace:    p.Workspace,
 		RepoRelDir:   p.RepoRelDir,
 		ProjectName:  p.ProjectName,
+		IsDraftPlan:  p.Command == command.DraftPlan || (p.PolicyCheckResults != nil && p.PolicyCheckResults.IsDraftPlan),
 		PolicyStatus: p.PolicyStatus(),
 		Status:       p.PlanStatus(),
 	}

--- a/server/core/config/parser_validator_test.go
+++ b/server/core/config/parser_validator_test.go
@@ -1317,7 +1317,7 @@ func TestParseGlobalCfg(t *testing.T) {
 			input: `repos:
 - id: /.*/
   allowed_overrides: [invalid]`,
-			expErr: "repos: (0: (allowed_overrides: \"invalid\" is not a valid override, only \"plan_requirements\", \"apply_requirements\", \"import_requirements\", \"workflow\", \"delete_source_branch_on_merge\", \"repo_locking\", \"repo_locks\", \"policy_check\", \"custom_policy_check\", and \"silence_pr_comments\" are supported.).).",
+			expErr: "repos: (0: (allowed_overrides: \"invalid\" is not a valid override, only \"plan_requirements\", \"apply_requirements\", \"import_requirements\", \"workflow\", \"delete_source_branch_on_merge\", \"repo_locking\", \"repo_locks\", \"policy_check\", \"draft_plan_policy_check\", \"custom_policy_check\", and \"silence_pr_comments\" are supported.).).",
 		},
 		"invalid plan_requirement": {
 			input: `repos:

--- a/server/core/config/raw/global_cfg.go
+++ b/server/core/config/raw/global_cfg.go
@@ -226,8 +226,8 @@ func (r Repo) Validate() error {
 	overridesValid := func(value any) error {
 		overrides := value.([]string)
 		for _, o := range overrides {
-			if o != valid.PlanRequirementsKey && o != valid.ApplyRequirementsKey && o != valid.ImportRequirementsKey && o != valid.WorkflowKey && o != valid.DeleteSourceBranchOnMergeKey && o != valid.RepoLockingKey && o != valid.RepoLocksKey && o != valid.PolicyCheckKey && o != valid.CustomPolicyCheckKey && o != valid.SilencePRCommentsKey {
-				return fmt.Errorf("%q is not a valid override, only %q, %q, %q, %q, %q, %q, %q, %q, %q, and %q are supported", o, valid.PlanRequirementsKey, valid.ApplyRequirementsKey, valid.ImportRequirementsKey, valid.WorkflowKey, valid.DeleteSourceBranchOnMergeKey, valid.RepoLockingKey, valid.RepoLocksKey, valid.PolicyCheckKey, valid.CustomPolicyCheckKey, valid.SilencePRCommentsKey)
+			if o != valid.PlanRequirementsKey && o != valid.ApplyRequirementsKey && o != valid.ImportRequirementsKey && o != valid.WorkflowKey && o != valid.DeleteSourceBranchOnMergeKey && o != valid.RepoLockingKey && o != valid.RepoLocksKey && o != valid.PolicyCheckKey && o != valid.DraftPlanPolicyCheckKey && o != valid.CustomPolicyCheckKey && o != valid.SilencePRCommentsKey {
+				return fmt.Errorf("%q is not a valid override, only %q, %q, %q, %q, %q, %q, %q, %q, %q, %q, and %q are supported", o, valid.PlanRequirementsKey, valid.ApplyRequirementsKey, valid.ImportRequirementsKey, valid.WorkflowKey, valid.DeleteSourceBranchOnMergeKey, valid.RepoLockingKey, valid.RepoLocksKey, valid.PolicyCheckKey, valid.DraftPlanPolicyCheckKey, valid.CustomPolicyCheckKey, valid.SilencePRCommentsKey)
 			}
 		}
 		return nil

--- a/server/core/config/raw/project.go
+++ b/server/core/config/raw/project.go
@@ -42,6 +42,7 @@ type Project struct {
 	RepoLocks                 *RepoLocks `yaml:"repo_locks,omitempty"`
 	ExecutionOrderGroup       *int       `yaml:"execution_order_group,omitempty"`
 	PolicyCheck               *bool      `yaml:"policy_check,omitempty"`
+	DraftPlanPolicyCheck      *bool      `yaml:"draft_plan_policy_check,omitempty"`
 	CustomPolicyCheck         *bool      `yaml:"custom_policy_check,omitempty"`
 	SilencePRComments         []string   `yaml:"silence_pr_comments,omitempty"`
 }
@@ -181,6 +182,9 @@ func (p Project) ToValid() valid.Project {
 
 	if p.PolicyCheck != nil {
 		v.PolicyCheck = p.PolicyCheck
+	}
+	if p.DraftPlanPolicyCheck != nil {
+		v.DraftPlanPolicyCheck = p.DraftPlanPolicyCheck
 	}
 
 	if p.CustomPolicyCheck != nil {

--- a/server/core/config/valid/global_cfg.go
+++ b/server/core/config/valid/global_cfg.go
@@ -28,6 +28,7 @@ const DeleteSourceBranchOnMergeKey = "delete_source_branch_on_merge"
 const RepoLockingKey = "repo_locking"
 const RepoLocksKey = "repo_locks"
 const PolicyCheckKey = "policy_check"
+const DraftPlanPolicyCheckKey = "draft_plan_policy_check"
 const CustomPolicyCheckKey = "custom_policy_check"
 const AutoDiscoverKey = "autodiscover"
 const SilencePRCommentsKey = "silence_pr_comments"
@@ -90,6 +91,7 @@ type Repo struct {
 	RepoLocking               *bool
 	RepoLocks                 *RepoLocks
 	PolicyCheck               *bool
+	DraftPlanPolicyCheck      *bool
 	CustomPolicyCheck         *bool
 	AutoDiscover              *AutoDiscover
 	SilencePRComments         []string
@@ -117,6 +119,7 @@ type MergedProjectCfg struct {
 	ExecutionOrderGroup       int
 	RepoLocks                 RepoLocks
 	PolicyCheck               bool
+	DraftPlanPolicyCheck      bool
 	CustomPolicyCheck         bool
 	SilencePRComments         []string
 }
@@ -227,7 +230,7 @@ func NewGlobalCfgFromArgs(args GlobalCfgArgs) GlobalCfg {
 	customPolicyCheck := false
 	var silencePRComments []string
 	if args.AllowAllRepoSettings {
-		allowedOverrides = []string{PlanRequirementsKey, ApplyRequirementsKey, ImportRequirementsKey, WorkflowKey, DeleteSourceBranchOnMergeKey, RepoLockingKey, RepoLocksKey, PolicyCheckKey, SilencePRCommentsKey}
+		allowedOverrides = []string{PlanRequirementsKey, ApplyRequirementsKey, ImportRequirementsKey, WorkflowKey, DeleteSourceBranchOnMergeKey, RepoLockingKey, RepoLocksKey, PolicyCheckKey, DraftPlanPolicyCheckKey, SilencePRCommentsKey}
 		allowCustomWorkflows = true
 	}
 
@@ -291,6 +294,7 @@ func (r Repo) IDString() string {
 func (g GlobalCfg) MergeProjectCfg(log logging.SimpleLogging, repoID string, proj Project, rCfg RepoCfg) MergedProjectCfg {
 	log.Debug("MergeProjectCfg started")
 	planReqs, applyReqs, importReqs, workflow, allowedOverrides, allowCustomWorkflows, deleteSourceBranchOnMerge, repoLocks, policyCheck, customPolicyCheck, _, silencePRComments := g.getMatchingCfg(log, repoID)
+	draftPlanPolicyCheck := false
 	// If repos are allowed to override certain keys then override them.
 	for _, key := range allowedOverrides {
 		switch key {
@@ -378,6 +382,11 @@ func (g GlobalCfg) MergeProjectCfg(log logging.SimpleLogging, repoID string, pro
 				log.Debug("overriding server-defined %s with repo settings: [%t]", PolicyCheckKey, *proj.PolicyCheck)
 				policyCheck = *proj.PolicyCheck
 			}
+		case DraftPlanPolicyCheckKey:
+			if proj.DraftPlanPolicyCheck != nil {
+				log.Debug("overriding default %s with repo settings: [%t]", DraftPlanPolicyCheckKey, *proj.DraftPlanPolicyCheck)
+				draftPlanPolicyCheck = *proj.DraftPlanPolicyCheck
+			}
 		case CustomPolicyCheckKey:
 			if proj.CustomPolicyCheck != nil {
 				log.Debug("overriding server-defined %s with repo settings: [%t]", CustomPolicyCheckKey, *proj.CustomPolicyCheck)
@@ -426,6 +435,7 @@ func (g GlobalCfg) MergeProjectCfg(log logging.SimpleLogging, repoID string, pro
 		ExecutionOrderGroup:       proj.ExecutionOrderGroup,
 		RepoLocks:                 repoLocks,
 		PolicyCheck:               policyCheck,
+		DraftPlanPolicyCheck:      draftPlanPolicyCheck,
 		CustomPolicyCheck:         customPolicyCheck,
 		SilencePRComments:         silencePRComments,
 	}
@@ -512,6 +522,9 @@ func (g GlobalCfg) ValidateRepoCfg(rCfg RepoCfg, repoID string) error {
 		}
 		if p.RepoLocks != nil && !utils.SlicesContains(allowedOverrides, RepoLocksKey) {
 			return fmt.Errorf("repo config not allowed to set '%s' key: server-side config needs '%s: [%s]'", RepoLocksKey, AllowedOverridesKey, RepoLocksKey)
+		}
+		if p.DraftPlanPolicyCheck != nil && !utils.SlicesContains(allowedOverrides, DraftPlanPolicyCheckKey) {
+			return fmt.Errorf("repo config not allowed to set '%s' key: server-side config needs '%s: [%s]'", DraftPlanPolicyCheckKey, AllowedOverridesKey, DraftPlanPolicyCheckKey)
 		}
 		if p.CustomPolicyCheck != nil && !utils.SlicesContains(allowedOverrides, CustomPolicyCheckKey) {
 			return fmt.Errorf("repo config not allowed to set '%s' key: server-side config needs '%s: [%s]'", CustomPolicyCheckKey, AllowedOverridesKey, CustomPolicyCheckKey)

--- a/server/core/config/valid/global_cfg_test.go
+++ b/server/core/config/valid/global_cfg_test.go
@@ -133,7 +133,7 @@ func TestNewGlobalCfg(t *testing.T) {
 
 			if c.allowAllRepoSettings {
 				exp.Repos[0].AllowCustomWorkflows = Bool(true)
-				exp.Repos[0].AllowedOverrides = []string{"plan_requirements", "apply_requirements", "import_requirements", "workflow", "delete_source_branch_on_merge", "repo_locking", "repo_locks", "policy_check", "silence_pr_comments"}
+				exp.Repos[0].AllowedOverrides = []string{"plan_requirements", "apply_requirements", "import_requirements", "workflow", "delete_source_branch_on_merge", "repo_locking", "repo_locks", "policy_check", "draft_plan_policy_check", "silence_pr_comments"}
 			}
 			if c.policyCheckEnabled {
 				exp.Repos[0].ApplyRequirements = append(exp.Repos[0].ApplyRequirements, "policies_passed")
@@ -645,6 +645,7 @@ policies:
 				global = valid.NewGlobalCfgFromArgs(globalCfgArgs)
 			}
 
+			c.exp.DraftPlanPolicyCheck = false
 			Equals(t,
 				c.exp,
 				global.MergeProjectCfg(logging.NewNoopLogger(t), c.repoID, c.proj, valid.RepoCfg{}))
@@ -1078,6 +1079,7 @@ repos:
 			}
 
 			global.PolicySets = emptyPolicySets
+			c.exp.DraftPlanPolicyCheck = false
 			Equals(t, c.exp, global.MergeProjectCfg(logging.NewNoopLogger(t), c.repoID, c.proj, valid.RepoCfg{Workflows: c.repoWorkflows}))
 		})
 	}
@@ -1476,6 +1478,7 @@ repos:
 			Ok(t, err)
 
 			global.PolicySets = emptyPolicySets
+			c.exp.DraftPlanPolicyCheck = false
 			Equals(t, c.exp, global.MergeProjectCfg(logging.NewNoopLogger(t), c.repoID, c.proj, valid.RepoCfg{Workflows: c.repoWorkflows}))
 		})
 	}

--- a/server/core/config/valid/repo_cfg.go
+++ b/server/core/config/valid/repo_cfg.go
@@ -186,6 +186,7 @@ type Project struct {
 	RepoLocks                 *RepoLocks
 	ExecutionOrderGroup       int
 	PolicyCheck               *bool
+	DraftPlanPolicyCheck      *bool
 	CustomPolicyCheck         *bool
 	SilencePRComments         []string
 }

--- a/server/core/redis/redis.go
+++ b/server/core/redis/redis.go
@@ -470,6 +470,7 @@ func (r *RedisDB) projectResultToProject(p command.ProjectResult) models.Project
 		Workspace:    p.Workspace,
 		RepoRelDir:   p.RepoRelDir,
 		ProjectName:  p.ProjectName,
+		IsDraftPlan:  p.Command == command.DraftPlan || (p.PolicyCheckResults != nil && p.PolicyCheckResults.IsDraftPlan),
 		PolicyStatus: p.PolicyStatus(),
 		Status:       p.PlanStatus(),
 	}

--- a/server/core/redis/redis.go
+++ b/server/core/redis/redis.go
@@ -470,7 +470,6 @@ func (r *RedisDB) projectResultToProject(p command.ProjectResult) models.Project
 		Workspace:    p.Workspace,
 		RepoRelDir:   p.RepoRelDir,
 		ProjectName:  p.ProjectName,
-		IsDraftPlan:  p.Command == command.DraftPlan || (p.PolicyCheckResults != nil && p.PolicyCheckResults.IsDraftPlan),
 		PolicyStatus: p.PolicyStatus(),
 		Status:       p.PlanStatus(),
 	}

--- a/server/core/runtime/apply_step_runner.go
+++ b/server/core/runtime/apply_step_runner.go
@@ -33,7 +33,8 @@ func (a *ApplyStepRunner) Run(ctx command.ProjectContext, extraArgs []string, pa
 		return "", errors.New("cannot run apply with -target because we are applying an already generated plan. Instead, run -target with atlantis plan")
 	}
 
-	planPath := filepath.Join(path, GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	// isDraft is always false here: apply must never resolve to a draftplan's file.
+	planPath := filepath.Join(path, GetPlanFilename(ctx.Workspace, ctx.ProjectName, false))
 	contents, err := os.ReadFile(planPath)
 	if os.IsNotExist(err) {
 		return "", fmt.Errorf("no plan found at path %q and workspace %q–did you run plan?", ctx.RepoRelDir, ctx.Workspace)

--- a/server/core/runtime/import_step_runner.go
+++ b/server/core/runtime/import_step_runner.go
@@ -44,7 +44,8 @@ func (p *importStepRunner) Run(ctx command.ProjectContext, extraArgs []string, p
 	out, err := p.terraformExecutor.RunCommandWithVersion(ctx, filepath.Clean(path), importCmd, envs, tfDistribution, tfVersion, ctx.Workspace)
 
 	// If the import was successful and a plan file exists, delete the plan.
-	planPath := filepath.Join(path, GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	// isDraft is always false here: import must never resolve to a draftplan's file.
+	planPath := filepath.Join(path, GetPlanFilename(ctx.Workspace, ctx.ProjectName, false))
 	if err == nil {
 		if _, planPathErr := os.Stat(planPath); !os.IsNotExist(planPathErr) {
 			ctx.Log.Info("import successful, deleting planfile")

--- a/server/core/runtime/plan_step_runner.go
+++ b/server/core/runtime/plan_step_runner.go
@@ -97,23 +97,23 @@ func (p *planStepRunner) remotePlan(ctx command.ProjectContext, extraArgs []stri
 		return output, err
 	}
 
-	if ctx.CommandName != command.DraftPlan {
-		// If using remote ops, we create our own "fake" planfile with the
-		// text output of the plan. We do this for two reasons:
-		// 1) Atlantis relies on there being a planfile on disk to detect which
-		// projects have outstanding plans.
-		// 2) Remote ops don't support the -out parameter so we can't save the
-		// plan. To ensure that what gets applied is the plan we printed to the PR,
-		// during the apply phase, we diff the output we stored in the fake
-		// planfile with the pending apply output.
-		planOutput := StripRefreshingFromPlanOutput(output, tfVersion)
+	// If using remote ops, we create our own "fake" planfile with the
+	// text output of the plan. We do this for three reasons:
+	// 1) Atlantis relies on there being a planfile on disk to detect which
+	// projects have outstanding plans.
+	// 2) Remote ops don't support the -out parameter so we can't save the
+	// plan. To ensure that what gets applied is the plan we printed to the PR,
+	// during the apply phase, we diff the output we stored in the fake
+	// planfile with the pending apply output.
+	// 3) The show/policy_check steps need a planfile on disk to run
+	// "terraform show" against, including for draftplan.
+	planOutput := StripRefreshingFromPlanOutput(output, tfVersion)
 
-		// We also prepend our own remote ops header to the file so during apply we
-		// know this is a remote apply.
-		err = os.WriteFile(planFile, []byte(remoteOpsHeader+planOutput), 0600)
-		if err != nil {
-			return output, fmt.Errorf("unable to create planfile for remote ops: %w", err)
-		}
+	// We also prepend our own remote ops header to the file so during apply we
+	// know this is a remote apply.
+	err = os.WriteFile(planFile, []byte(remoteOpsHeader+planOutput), 0600)
+	if err != nil {
+		return output, fmt.Errorf("unable to create planfile for remote ops: %w", err)
 	}
 
 	return p.fmtPlanOutput(output, tfVersion), nil
@@ -136,7 +136,7 @@ func (p *planStepRunner) buildPlanCmd(ctx command.ProjectContext, extraArgs []st
 	// have spaces in its repo owner names.
 	baseCommand := []string{"plan", "-input=false", "-refresh", "-out", fmt.Sprintf("%q", planFile)}
 	if ctx.CommandName == command.DraftPlan {
-		baseCommand = []string{"plan", "-input=false", "-refresh=false", "-lock=false"}
+		baseCommand = []string{"plan", "-input=false", "-refresh=false", "-lock=false", "-out", fmt.Sprintf("%q", planFile)}
 	}
 
 	argList := [][]string{

--- a/server/core/runtime/plan_step_runner.go
+++ b/server/core/runtime/plan_step_runner.go
@@ -82,8 +82,12 @@ func (p *planStepRunner) isRemoteOpsErr(output string, err error) bool {
 // remotePlan runs a terraform plan command compatible with TFE remote
 // operations.
 func (p *planStepRunner) remotePlan(ctx command.ProjectContext, extraArgs []string, path string, tfDistribution terraform.Distribution, tfVersion *version.Version, planFile string, envs map[string]string) (string, error) {
+	baseCommand := []string{"plan", "-input=false", "-refresh", "-no-color"}
+	if ctx.CommandName == command.DraftPlan {
+		baseCommand = []string{"plan", "-input=false", "-no-color", "-refresh=false", "-lock=false"}
+	}
 	argList := [][]string{
-		{"plan", "-input=false", "-refresh", "-no-color"},
+		baseCommand,
 		extraArgs,
 		ctx.EscapedCommentArgs,
 	}
@@ -93,21 +97,23 @@ func (p *planStepRunner) remotePlan(ctx command.ProjectContext, extraArgs []stri
 		return output, err
 	}
 
-	// If using remote ops, we create our own "fake" planfile with the
-	// text output of the plan. We do this for two reasons:
-	// 1) Atlantis relies on there being a planfile on disk to detect which
-	// projects have outstanding plans.
-	// 2) Remote ops don't support the -out parameter so we can't save the
-	// plan. To ensure that what gets applied is the plan we printed to the PR,
-	// during the apply phase, we diff the output we stored in the fake
-	// planfile with the pending apply output.
-	planOutput := StripRefreshingFromPlanOutput(output, tfVersion)
+	if ctx.CommandName != command.DraftPlan {
+		// If using remote ops, we create our own "fake" planfile with the
+		// text output of the plan. We do this for two reasons:
+		// 1) Atlantis relies on there being a planfile on disk to detect which
+		// projects have outstanding plans.
+		// 2) Remote ops don't support the -out parameter so we can't save the
+		// plan. To ensure that what gets applied is the plan we printed to the PR,
+		// during the apply phase, we diff the output we stored in the fake
+		// planfile with the pending apply output.
+		planOutput := StripRefreshingFromPlanOutput(output, tfVersion)
 
-	// We also prepend our own remote ops header to the file so during apply we
-	// know this is a remote apply.
-	err = os.WriteFile(planFile, []byte(remoteOpsHeader+planOutput), 0600)
-	if err != nil {
-		return output, fmt.Errorf("unable to create planfile for remote ops: %w", err)
+		// We also prepend our own remote ops header to the file so during apply we
+		// know this is a remote apply.
+		err = os.WriteFile(planFile, []byte(remoteOpsHeader+planOutput), 0600)
+		if err != nil {
+			return output, fmt.Errorf("unable to create planfile for remote ops: %w", err)
+		}
 	}
 
 	return p.fmtPlanOutput(output, tfVersion), nil
@@ -126,10 +132,15 @@ func (p *planStepRunner) buildPlanCmd(ctx command.ProjectContext, extraArgs []st
 		envFileArgs = []string{"-var-file", envFile}
 	}
 
+	// NOTE: we need to quote the plan filename because Bitbucket Server can
+	// have spaces in its repo owner names.
+	baseCommand := []string{"plan", "-input=false", "-refresh", "-out", fmt.Sprintf("%q", planFile)}
+	if ctx.CommandName == command.DraftPlan {
+		baseCommand = []string{"plan", "-input=false", "-refresh=false", "-lock=false"}
+	}
+
 	argList := [][]string{
-		// NOTE: we need to quote the plan filename because Bitbucket Server can
-		// have spaces in its repo owner names.
-		{"plan", "-input=false", "-refresh", "-out", fmt.Sprintf("%q", planFile)},
+		baseCommand,
 		tfVars,
 		extraArgs,
 		ctx.EscapedCommentArgs,
@@ -208,7 +219,7 @@ func (p *planStepRunner) runRemotePlan(
 
 	// updateStatusF will update the commit status and log any error.
 	updateStatusF := func(status models.CommitStatus, url string) {
-		if err := p.CommitStatusUpdater.UpdateProject(ctx, command.Plan, status, url, nil); err != nil {
+		if err := p.CommitStatusUpdater.UpdateProject(ctx, ctx.CommandName, status, url, nil); err != nil {
 			ctx.Log.Err("unable to update status: %s", err)
 		}
 	}

--- a/server/core/runtime/plan_step_runner.go
+++ b/server/core/runtime/plan_step_runner.go
@@ -57,7 +57,7 @@ func (p *planStepRunner) Run(ctx command.ProjectContext, extraArgs []string, pat
 		tfVersion = ctx.TerraformVersion
 	}
 
-	planFile := filepath.Join(path, GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	planFile := filepath.Join(path, PlanFilenameForContext(ctx))
 	planCmd := p.buildPlanCmd(ctx, extraArgs, path, tfVersion, planFile)
 	output, err := p.TerraformExecutor.RunCommandWithVersion(ctx, filepath.Clean(path), planCmd, envs, tfDistribution, tfVersion, ctx.Workspace)
 	if p.isRemoteOpsErr(output, err) {
@@ -99,8 +99,10 @@ func (p *planStepRunner) remotePlan(ctx command.ProjectContext, extraArgs []stri
 
 	// If using remote ops, we create our own "fake" planfile with the
 	// text output of the plan. We do this for three reasons:
-	// 1) Atlantis relies on there being a planfile on disk to detect which
-	// projects have outstanding plans.
+	// 1) For a real plan, Atlantis relies on there being a planfile on disk
+	// (PendingPlanFinder's ".tfplan" scan) to detect which projects have
+	// outstanding plans. A draftplan's planfile uses a different extension
+	// (see PlanFilenameForContext) and is deliberately invisible to that scan.
 	// 2) Remote ops don't support the -out parameter so we can't save the
 	// plan. To ensure that what gets applied is the plan we printed to the PR,
 	// during the apply phase, we diff the output we stored in the fake

--- a/server/core/runtime/plan_step_runner.go
+++ b/server/core/runtime/plan_step_runner.go
@@ -57,7 +57,7 @@ func (p *planStepRunner) Run(ctx command.ProjectContext, extraArgs []string, pat
 		tfVersion = ctx.TerraformVersion
 	}
 
-	planFile := filepath.Join(path, PlanFilenameForContext(ctx))
+	planFile := filepath.Join(path, GetPlanFilename(ctx.Workspace, ctx.ProjectName, ctx.IsDraft()))
 	planCmd := p.buildPlanCmd(ctx, extraArgs, path, tfVersion, planFile)
 	output, err := p.TerraformExecutor.RunCommandWithVersion(ctx, filepath.Clean(path), planCmd, envs, tfDistribution, tfVersion, ctx.Workspace)
 	if p.isRemoteOpsErr(output, err) {
@@ -97,16 +97,16 @@ func (p *planStepRunner) remotePlan(ctx command.ProjectContext, extraArgs []stri
 		return output, err
 	}
 
-	// If using remote ops, we create our own "fake" planfile with the
-	// text output of the plan. We do this for three reasons:
+	// If using remote ops, terraform doesn't write a planfile itself since
+	// -out isn't supported, so we write the plan's text output to the
+	// planfile path ourselves (below). We do this for three reasons:
 	// 1) For a real plan, Atlantis relies on there being a planfile on disk
 	// (PendingPlanFinder's ".tfplan" scan) to detect which projects have
-	// outstanding plans. A draftplan's planfile uses a different extension
-	// (see PlanFilenameForContext) and is deliberately invisible to that scan.
-	// 2) Remote ops don't support the -out parameter so we can't save the
-	// plan. To ensure that what gets applied is the plan we printed to the PR,
-	// during the apply phase, we diff the output we stored in the fake
-	// planfile with the pending apply output.
+	// outstanding plans. Draftplan planfiles use a different extension so
+	// they're never picked up by that scan.
+	// 2) To ensure that what gets applied is the plan we printed to the PR,
+	// during the apply phase we diff the output stored here against the
+	// pending apply output.
 	// 3) The show/policy_check steps need a planfile on disk to run
 	// "terraform show" against, including for draftplan.
 	planOutput := StripRefreshingFromPlanOutput(output, tfVersion)

--- a/server/core/runtime/plan_step_runner_test.go
+++ b/server/core/runtime/plan_step_runner_test.go
@@ -494,6 +494,138 @@ Plan: 0 to add, 0 to change, 1 to destroy.`), "expect plan success")
 	}
 }
 
+func TestRun_RemoteOps_DraftPlan(t *testing.T) {
+	// Even for remote ops, draftplan must leave a (fake) planfile on disk so
+	// that show/policy_check have something to read, unlike before when
+	// draftplan skipped writing it entirely.
+	logger := logging.NewNoopLogger(t)
+	ctx := command.ProjectContext{
+		Log:                logger,
+		CommandName:        command.DraftPlan,
+		Workspace:          "default",
+		RepoRelDir:         ".",
+		User:               models.User{Username: "username"},
+		EscapedCommentArgs: []string{"comment", "args"},
+		Pull: models.PullRequest{
+			Num: 2,
+		},
+		BaseRepo: models.Repo{
+			FullName: "owner/repo",
+			Owner:    "owner",
+			Name:     "repo",
+		},
+	}
+	RegisterMockTestingT(t)
+	terraform := tfclientmocks.NewMockClient()
+	commitStatusUpdater := runtimemocks.NewMockStatusUpdater()
+	mockDownloader := mocks.NewMockDownloader()
+	tfDistribution := tf.NewDistributionTerraformWithDownloader(mockDownloader)
+	tfVersion, _ := version.NewVersion("1.1.0")
+	asyncTf := &remotePlanMock{}
+	s := runtime.NewPlanStepRunner(terraform, tfDistribution, tfVersion, commitStatusUpdater, asyncTf)
+	absProjectPath := t.TempDir()
+
+	When(terraform.RunCommandWithVersion(
+		ctx,
+		absProjectPath,
+		[]string{"workspace", "show"},
+		map[string]string(nil),
+		tfDistribution,
+		tfVersion,
+		"default")).ThenReturn("default\n", nil)
+
+	expPlanArgs := []string{"plan",
+		"-input=false",
+		"-refresh=false",
+		"-lock=false",
+		"-out",
+		fmt.Sprintf("%q", filepath.Join(absProjectPath, "default.tfplan")),
+		"extra",
+		"args",
+		"comment",
+		"args",
+	}
+
+	// note: the trailing whitespace after the blank "│" line is intentional
+	// and must match remoteOpsErr110 in plan_step_runner.go exactly.
+	remoteOpsErr := strings.Join([]string{
+		"╷",
+		"│ Error: Saving a generated plan is currently not supported",
+		"│ ",
+		"│ Terraform Cloud does not support saving the generated execution plan",
+		"│ locally at this time.",
+		"╵",
+		"",
+	}, "\n")
+	planErr := errors.New("exit status 1: err")
+	planOutput := "\n" + remoteOpsErr
+	asyncTf.LinesToSend = remotePlanOutput
+	When(terraform.RunCommandWithVersion(ctx, absProjectPath, expPlanArgs, map[string]string(nil), tfDistribution, tfVersion, "default")).
+		ThenReturn(planOutput, planErr)
+
+	_, err := s.Run(ctx, []string{"extra", "args"}, absProjectPath, map[string]string(nil))
+	Ok(t, err)
+
+	expRemotePlanArgs := []string{"plan", "-input=false", "-no-color", "-refresh=false", "-lock=false", "extra", "args", "comment", "args"}
+	Equals(t, expRemotePlanArgs, asyncTf.CalledArgs)
+
+	// Verify that the fake plan file still gets written for draftplan.
+	bytes, err := os.ReadFile(filepath.Join(absProjectPath, "default.tfplan"))
+	Ok(t, err)
+	Assert(t, strings.HasPrefix(string(bytes), "Atlantis: this plan was created by remote ops"), "expect remote plan")
+}
+
+func TestRun_DraftPlan(t *testing.T) {
+	// DraftPlan should skip refresh and locking but still write a planfile
+	// via -out so that show/policy_check have something to read.
+	RegisterMockTestingT(t)
+	terraform := tfclientmocks.NewMockClient()
+	commitStatusUpdater := runtimemocks.NewMockStatusUpdater()
+	asyncTfExec := runtimemocks.NewMockAsyncTFExec()
+
+	mockDownloader := mocks.NewMockDownloader()
+	tfDistribution := tf.NewDistributionTerraformWithDownloader(mockDownloader)
+	tfVersion, _ := version.NewVersion("1.0.0")
+	logger := logging.NewNoopLogger(t)
+	s := runtime.NewPlanStepRunner(terraform, tfDistribution, tfVersion, commitStatusUpdater, asyncTfExec)
+	tmpDir := t.TempDir()
+
+	expPlanArgs := []string{"plan",
+		"-input=false",
+		"-refresh=false",
+		"-lock=false",
+		"-out",
+		fmt.Sprintf("%q", filepath.Join(tmpDir, "workspace.tfplan")),
+		"extra",
+		"args",
+		"comment",
+		"args",
+	}
+	ctx := command.ProjectContext{
+		Log:                logger,
+		CommandName:        command.DraftPlan,
+		Workspace:          "workspace",
+		RepoRelDir:         ".",
+		User:               models.User{Username: "username"},
+		EscapedCommentArgs: []string{"comment", "args"},
+		Pull: models.PullRequest{
+			Num: 2,
+		},
+		BaseRepo: models.Repo{
+			FullName: "owner/repo",
+			Owner:    "owner",
+			Name:     "repo",
+		},
+	}
+	When(terraform.RunCommandWithVersion(ctx, tmpDir, expPlanArgs, map[string]string(nil), tfDistribution, tfVersion, "workspace")).ThenReturn("output", nil)
+
+	output, err := s.Run(ctx, []string{"extra", "args"}, tmpDir, map[string]string(nil))
+	Ok(t, err)
+
+	terraform.VerifyWasCalledOnce().RunCommandWithVersion(ctx, tmpDir, expPlanArgs, map[string]string(nil), tfDistribution, tfVersion, "workspace")
+	Equals(t, "output", output)
+}
+
 // Test striping output method
 func TestStripRefreshingFromPlanOutput(t *testing.T) {
 	tfVersion0135, _ := version.NewVersion("0.13.5")

--- a/server/core/runtime/plan_step_runner_test.go
+++ b/server/core/runtime/plan_step_runner_test.go
@@ -390,6 +390,7 @@ locally at this time.
 			// Now that mocking is set up, we're ready to run the plan.
 			ctx := command.ProjectContext{
 				Log:                logger,
+				CommandName:        command.Plan,
 				Workspace:          "default",
 				RepoRelDir:         ".",
 				User:               models.User{Username: "username"},

--- a/server/core/runtime/plan_step_runner_test.go
+++ b/server/core/runtime/plan_step_runner_test.go
@@ -539,7 +539,7 @@ func TestRun_RemoteOps_DraftPlan(t *testing.T) {
 		"-refresh=false",
 		"-lock=false",
 		"-out",
-		fmt.Sprintf("%q", filepath.Join(absProjectPath, "default.tfplan")),
+		fmt.Sprintf("%q", filepath.Join(absProjectPath, "default.draftplan")),
 		"extra",
 		"args",
 		"comment",
@@ -569,8 +569,9 @@ func TestRun_RemoteOps_DraftPlan(t *testing.T) {
 	expRemotePlanArgs := []string{"plan", "-input=false", "-no-color", "-refresh=false", "-lock=false", "extra", "args", "comment", "args"}
 	Equals(t, expRemotePlanArgs, asyncTf.CalledArgs)
 
-	// Verify that the fake plan file still gets written for draftplan.
-	bytes, err := os.ReadFile(filepath.Join(absProjectPath, "default.tfplan"))
+	// Verify that the fake plan file still gets written for draftplan, at
+	// its own path distinct from a real plan's.
+	bytes, err := os.ReadFile(filepath.Join(absProjectPath, "default.draftplan"))
 	Ok(t, err)
 	Assert(t, strings.HasPrefix(string(bytes), "Atlantis: this plan was created by remote ops"), "expect remote plan")
 }
@@ -595,7 +596,7 @@ func TestRun_DraftPlan(t *testing.T) {
 		"-refresh=false",
 		"-lock=false",
 		"-out",
-		fmt.Sprintf("%q", filepath.Join(tmpDir, "workspace.tfplan")),
+		fmt.Sprintf("%q", filepath.Join(tmpDir, "workspace.draftplan")),
 		"extra",
 		"args",
 		"comment",

--- a/server/core/runtime/plan_step_runner_test.go
+++ b/server/core/runtime/plan_step_runner_test.go
@@ -481,7 +481,8 @@ Plan: 0 to add, 0 to change, 1 to destroy.`), "expect plan success")
 			expRemotePlanArgs := []string{"plan", "-input=false", "-refresh", "-no-color", "extra", "args", "comment", "args"}
 			Equals(t, expRemotePlanArgs, asyncTf.CalledArgs)
 
-			// Verify that the fake plan file we write has the correct contents.
+			// Verify that the planfile we write ourselves (since remote ops
+			// doesn't support -out) has the correct contents.
 			bytes, err := os.ReadFile(filepath.Join(absProjectPath, "default.tfplan"))
 			Ok(t, err)
 			Assert(t, strings.HasPrefix(string(bytes), "Atlantis: this plan was created by remote ops"), "expect remote plan")
@@ -495,9 +496,9 @@ Plan: 0 to add, 0 to change, 1 to destroy.`), "expect plan success")
 }
 
 func TestRun_RemoteOps_DraftPlan(t *testing.T) {
-	// Even for remote ops, draftplan must leave a (fake) planfile on disk so
-	// that show/policy_check have something to read, unlike before when
-	// draftplan skipped writing it entirely.
+	// Even for remote ops, draftplan must leave a planfile on disk so that
+	// show/policy_check have something to read, unlike before when draftplan
+	// skipped writing it entirely.
 	logger := logging.NewNoopLogger(t)
 	ctx := command.ProjectContext{
 		Log:                logger,
@@ -569,8 +570,8 @@ func TestRun_RemoteOps_DraftPlan(t *testing.T) {
 	expRemotePlanArgs := []string{"plan", "-input=false", "-no-color", "-refresh=false", "-lock=false", "extra", "args", "comment", "args"}
 	Equals(t, expRemotePlanArgs, asyncTf.CalledArgs)
 
-	// Verify that the fake plan file still gets written for draftplan, at
-	// its own path distinct from a real plan's.
+	// Verify that the planfile still gets written for draftplan, at its own
+	// path distinct from a real plan's.
 	bytes, err := os.ReadFile(filepath.Join(absProjectPath, "default.draftplan"))
 	Ok(t, err)
 	Assert(t, strings.HasPrefix(string(bytes), "Atlantis: this plan was created by remote ops"), "expect remote plan")

--- a/server/core/runtime/plan_type_step_runner_delegate.go
+++ b/server/core/runtime/plan_type_step_runner_delegate.go
@@ -35,7 +35,7 @@ func (p *planTypeStepRunnerDelegate) isRemotePlan(planFile string) (bool, error)
 }
 
 func (p *planTypeStepRunnerDelegate) Run(ctx command.ProjectContext, extraArgs []string, path string, envs map[string]string) (string, error) {
-	planFile := filepath.Join(path, PlanFilenameForContext(ctx))
+	planFile := filepath.Join(path, GetPlanFilename(ctx.Workspace, ctx.ProjectName, ctx.IsDraft()))
 	remotePlan, err := p.isRemotePlan(planFile)
 
 	if err != nil {

--- a/server/core/runtime/plan_type_step_runner_delegate.go
+++ b/server/core/runtime/plan_type_step_runner_delegate.go
@@ -35,7 +35,7 @@ func (p *planTypeStepRunnerDelegate) isRemotePlan(planFile string) (bool, error)
 }
 
 func (p *planTypeStepRunnerDelegate) Run(ctx command.ProjectContext, extraArgs []string, path string, envs map[string]string) (string, error) {
-	planFile := filepath.Join(path, GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	planFile := filepath.Join(path, PlanFilenameForContext(ctx))
 	remotePlan, err := p.isRemotePlan(planFile)
 
 	if err != nil {

--- a/server/core/runtime/policy/conftest_client.go
+++ b/server/core/runtime/policy/conftest_client.go
@@ -260,7 +260,13 @@ func (c *ConfTestExecutorWorkflow) Run(ctx command.ProjectContext, executablePat
 }
 
 func (c *ConfTestExecutorWorkflow) sanitizeOutput(inputFile string, output string) string {
-	return strings.ReplaceAll(output, inputFile, "<redacted plan file>")
+	// Redact the real path everywhere it appears first, regardless of
+	// context, so it can never leak through unredacted. Then drop the
+	// "<redacted plan file> - " segment specifically from conftest's
+	// "LEVEL - <file> - <namespace> - <message>" violation lines, since
+	// once redacted it's a constant, uninformative placeholder there.
+	redacted := strings.ReplaceAll(output, inputFile, "<redacted plan file>")
+	return strings.ReplaceAll(redacted, "<redacted plan file> - ", "")
 }
 
 func (c *ConfTestExecutorWorkflow) EnsureExecutorVersion(log logging.SimpleLogging, v *version.Version) (string, error) {

--- a/server/core/runtime/policy/conftest_client.go
+++ b/server/core/runtime/policy/conftest_client.go
@@ -260,13 +260,7 @@ func (c *ConfTestExecutorWorkflow) Run(ctx command.ProjectContext, executablePat
 }
 
 func (c *ConfTestExecutorWorkflow) sanitizeOutput(inputFile string, output string) string {
-	// Redact the real path everywhere it appears first, regardless of
-	// context, so it can never leak through unredacted. Then drop the
-	// "<redacted plan file> - " segment specifically from conftest's
-	// "LEVEL - <file> - <namespace> - <message>" violation lines, since
-	// once redacted it's a constant, uninformative placeholder there.
-	redacted := strings.ReplaceAll(output, inputFile, "<redacted plan file>")
-	return strings.ReplaceAll(redacted, "<redacted plan file> - ", "")
+	return strings.ReplaceAll(output, inputFile, "<redacted plan file>")
 }
 
 func (c *ConfTestExecutorWorkflow) EnsureExecutorVersion(log logging.SimpleLogging, v *version.Version) (string, error) {

--- a/server/core/runtime/policy/conftest_client_test.go
+++ b/server/core/runtime/policy/conftest_client_test.go
@@ -283,7 +283,7 @@ func TestRun(t *testing.T) {
 
 		expectedOutputPolicy1 := fmt.Sprintf("FAIL - %s - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions", filepath.Join(workdir, "testproj-default.json"))
 		expectedOutputPolicy2 := "Success"
-		expectedResult := `[{"PolicySetName":"policy1","PolicyOutput":"FAIL - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions","Passed":false,"ReqApprovals":0,"CurApprovals":0},{"PolicySetName":"policy2","PolicyOutput":"Success","Passed":true,"ReqApprovals":0,"CurApprovals":0}]`
+		expectedResult := `[{"PolicySetName":"policy1","PolicyOutput":"FAIL - <redacted plan file> - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions","Passed":false,"ReqApprovals":0,"CurApprovals":0},{"PolicySetName":"policy2","PolicyOutput":"Success","Passed":true,"ReqApprovals":0,"CurApprovals":0}]`
 
 		expectedArgsPolicy1 := []string{executablePath, "test", "-p", localPolicySetPath1, filepath.Join(workdir, "testproj-default.json"), "--no-color"}
 		expectedArgsPolicy2 := []string{executablePath, "test", "-p", localPolicySetPath2, filepath.Join(workdir, "testproj-default.json"), "--no-color"}
@@ -305,7 +305,7 @@ func TestRun(t *testing.T) {
 		var extraArgs []string
 
 		expectedOutput := fmt.Sprintf("FAIL - %s - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions", filepath.Join(workdir, "testproj-default.json"))
-		expectedResult := `[{"PolicySetName":"policy1","PolicyOutput":"FAIL - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions","Passed":false,"ReqApprovals":0,"CurApprovals":0},{"PolicySetName":"policy2","PolicyOutput":"FAIL - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions","Passed":false,"ReqApprovals":0,"CurApprovals":0}]`
+		expectedResult := `[{"PolicySetName":"policy1","PolicyOutput":"FAIL - <redacted plan file> - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions","Passed":false,"ReqApprovals":0,"CurApprovals":0},{"PolicySetName":"policy2","PolicyOutput":"FAIL - <redacted plan file> - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions","Passed":false,"ReqApprovals":0,"CurApprovals":0}]`
 
 		expectedArgsPolicy1 := []string{executablePath, "test", "-p", localPolicySetPath1, filepath.Join(workdir, "testproj-default.json"), "--no-color"}
 		expectedArgsPolicy2 := []string{executablePath, "test", "-p", localPolicySetPath2, filepath.Join(workdir, "testproj-default.json"), "--no-color"}
@@ -349,29 +349,5 @@ func TestRun(t *testing.T) {
 		Equals(t, result, expectedResult)
 		Assert(t, err != nil, "error is expected")
 
-	})
-}
-
-func TestSanitizeOutput(t *testing.T) {
-	subject := &ConfTestExecutorWorkflow{}
-	inputFile := "/some/workdir/testproj-default.json"
-
-	t.Run("drops the redacted plan file segment from violation lines", func(t *testing.T) {
-		output := fmt.Sprintf(
-			"WARN - %s - terraform.analysis - allowed_copy_scope must be set to \"AAD\" for module.foo\n"+
-				"WARN - %s - terraform.analysis - infrastructure_encryption_enabled must be set to true. false is not allowed for module.foo",
-			inputFile, inputFile,
-		)
-		expected := "WARN - terraform.analysis - allowed_copy_scope must be set to \"AAD\" for module.foo\n" +
-			"WARN - terraform.analysis - infrastructure_encryption_enabled must be set to true. false is not allowed for module.foo"
-
-		Equals(t, expected, subject.sanitizeOutput(inputFile, output))
-	})
-
-	t.Run("still redacts the path when it's not followed by ' - '", func(t *testing.T) {
-		output := fmt.Sprintf("unable to open file: %s", inputFile)
-		expected := "unable to open file: <redacted plan file>"
-
-		Equals(t, expected, subject.sanitizeOutput(inputFile, output))
 	})
 }

--- a/server/core/runtime/policy/conftest_client_test.go
+++ b/server/core/runtime/policy/conftest_client_test.go
@@ -283,7 +283,7 @@ func TestRun(t *testing.T) {
 
 		expectedOutputPolicy1 := fmt.Sprintf("FAIL - %s - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions", filepath.Join(workdir, "testproj-default.json"))
 		expectedOutputPolicy2 := "Success"
-		expectedResult := `[{"PolicySetName":"policy1","PolicyOutput":"FAIL - <redacted plan file> - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions","Passed":false,"ReqApprovals":0,"CurApprovals":0},{"PolicySetName":"policy2","PolicyOutput":"Success","Passed":true,"ReqApprovals":0,"CurApprovals":0}]`
+		expectedResult := `[{"PolicySetName":"policy1","PolicyOutput":"FAIL - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions","Passed":false,"ReqApprovals":0,"CurApprovals":0},{"PolicySetName":"policy2","PolicyOutput":"Success","Passed":true,"ReqApprovals":0,"CurApprovals":0}]`
 
 		expectedArgsPolicy1 := []string{executablePath, "test", "-p", localPolicySetPath1, filepath.Join(workdir, "testproj-default.json"), "--no-color"}
 		expectedArgsPolicy2 := []string{executablePath, "test", "-p", localPolicySetPath2, filepath.Join(workdir, "testproj-default.json"), "--no-color"}
@@ -305,7 +305,7 @@ func TestRun(t *testing.T) {
 		var extraArgs []string
 
 		expectedOutput := fmt.Sprintf("FAIL - %s - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions", filepath.Join(workdir, "testproj-default.json"))
-		expectedResult := `[{"PolicySetName":"policy1","PolicyOutput":"FAIL - <redacted plan file> - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions","Passed":false,"ReqApprovals":0,"CurApprovals":0},{"PolicySetName":"policy2","PolicyOutput":"FAIL - <redacted plan file> - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions","Passed":false,"ReqApprovals":0,"CurApprovals":0}]`
+		expectedResult := `[{"PolicySetName":"policy1","PolicyOutput":"FAIL - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions","Passed":false,"ReqApprovals":0,"CurApprovals":0},{"PolicySetName":"policy2","PolicyOutput":"FAIL - failure\n1 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions","Passed":false,"ReqApprovals":0,"CurApprovals":0}]`
 
 		expectedArgsPolicy1 := []string{executablePath, "test", "-p", localPolicySetPath1, filepath.Join(workdir, "testproj-default.json"), "--no-color"}
 		expectedArgsPolicy2 := []string{executablePath, "test", "-p", localPolicySetPath2, filepath.Join(workdir, "testproj-default.json"), "--no-color"}
@@ -349,5 +349,29 @@ func TestRun(t *testing.T) {
 		Equals(t, result, expectedResult)
 		Assert(t, err != nil, "error is expected")
 
+	})
+}
+
+func TestSanitizeOutput(t *testing.T) {
+	subject := &ConfTestExecutorWorkflow{}
+	inputFile := "/some/workdir/testproj-default.json"
+
+	t.Run("drops the redacted plan file segment from violation lines", func(t *testing.T) {
+		output := fmt.Sprintf(
+			"WARN - %s - terraform.analysis - allowed_copy_scope must be set to \"AAD\" for module.foo\n"+
+				"WARN - %s - terraform.analysis - infrastructure_encryption_enabled must be set to true. false is not allowed for module.foo",
+			inputFile, inputFile,
+		)
+		expected := "WARN - terraform.analysis - allowed_copy_scope must be set to \"AAD\" for module.foo\n" +
+			"WARN - terraform.analysis - infrastructure_encryption_enabled must be set to true. false is not allowed for module.foo"
+
+		Equals(t, expected, subject.sanitizeOutput(inputFile, output))
+	})
+
+	t.Run("still redacts the path when it's not followed by ' - '", func(t *testing.T) {
+		output := fmt.Sprintf("unable to open file: %s", inputFile)
+		expected := "unable to open file: <redacted plan file>"
+
+		Equals(t, expected, subject.sanitizeOutput(inputFile, output))
 	})
 }

--- a/server/core/runtime/run_step_runner.go
+++ b/server/core/runtime/run_step_runner.go
@@ -69,7 +69,7 @@ func (r *RunStepRunner) Run(
 		"HEAD_REPO_NAME":                  ctx.HeadRepo.Name,
 		"HEAD_REPO_OWNER":                 ctx.HeadRepo.Owner,
 		"PATH":                            fmt.Sprintf("%s:%s", os.Getenv("PATH"), r.TerraformBinDir),
-		"PLANFILE":                        filepath.Join(path, GetPlanFilename(ctx.Workspace, ctx.ProjectName)),
+		"PLANFILE":                        filepath.Join(path, PlanFilenameForContext(ctx)),
 		"SHOWFILE":                        filepath.Join(path, ctx.GetShowResultFileName()),
 		"POLICYCHECKFILE":                 filepath.Join(path, ctx.GetPolicyCheckResultFileName()),
 		"PROJECT_NAME":                    ctx.ProjectName,

--- a/server/core/runtime/run_step_runner.go
+++ b/server/core/runtime/run_step_runner.go
@@ -69,7 +69,7 @@ func (r *RunStepRunner) Run(
 		"HEAD_REPO_NAME":                  ctx.HeadRepo.Name,
 		"HEAD_REPO_OWNER":                 ctx.HeadRepo.Owner,
 		"PATH":                            fmt.Sprintf("%s:%s", os.Getenv("PATH"), r.TerraformBinDir),
-		"PLANFILE":                        filepath.Join(path, PlanFilenameForContext(ctx)),
+		"PLANFILE":                        filepath.Join(path, GetPlanFilename(ctx.Workspace, ctx.ProjectName, ctx.IsDraft())),
 		"SHOWFILE":                        filepath.Join(path, ctx.GetShowResultFileName()),
 		"POLICYCHECKFILE":                 filepath.Join(path, ctx.GetPolicyCheckResultFileName()),
 		"PROJECT_NAME":                    ctx.ProjectName,

--- a/server/core/runtime/runtime.go
+++ b/server/core/runtime/runtime.go
@@ -99,6 +99,34 @@ func GetPlanFilename(workspace string, projName string) string {
 	return fmt.Sprintf("%s-%s.tfplan", projName, workspace)
 }
 
+// GetDraftPlanFilename returns the filename (not the path) of the generated tf
+// plan for a draftplan preview. It intentionally uses a different extension
+// (not .tfplan) so a draftplan's plan file is always distinct from a real
+// plan's: apply/import/state_rm/unlock resolve paths via GetPlanFilename and
+// so can never find or act on a draftplan's file, and PendingPlanFinder's
+// ".tfplan" extension scan (used by unlock and to clear stale plans before a
+// new plan) naturally skips it too.
+func GetDraftPlanFilename(workspace string, projName string) string {
+	if projName == "" {
+		return fmt.Sprintf("%s.draftplan", workspace)
+	}
+	projName = strings.ReplaceAll(projName, "/", planfileSlashReplace)
+	return fmt.Sprintf("%s-%s.draftplan", projName, workspace)
+}
+
+// PlanFilenameForContext returns GetDraftPlanFilename's result for a
+// draftplan or the policy_check/show steps that follow one (ctx.IsDraftPlan
+// is what carries that across, since ctx.CommandName is PolicyCheck, not
+// DraftPlan, for those steps), and GetPlanFilename's otherwise. Steps that
+// must never resolve to a draftplan's file (apply, import, state_rm) should
+// keep calling GetPlanFilename directly instead of this.
+func PlanFilenameForContext(ctx command.ProjectContext) string {
+	if ctx.CommandName == command.DraftPlan || ctx.IsDraftPlan {
+		return GetDraftPlanFilename(ctx.Workspace, ctx.ProjectName)
+	}
+	return GetPlanFilename(ctx.Workspace, ctx.ProjectName)
+}
+
 // isRemotePlan returns true if planContents are from a plan that was generated
 // using TFE remote operations.
 func IsRemotePlan(planContents []byte) bool {

--- a/server/core/runtime/runtime.go
+++ b/server/core/runtime/runtime.go
@@ -89,42 +89,19 @@ func MustConstraint(constraint string) version.Constraints {
 	return c
 }
 
-// GetPlanFilename returns the filename (not the path) of the generated tf plan
-// given a workspace and project name.
-func GetPlanFilename(workspace string, projName string) string {
+// GetPlanFilename returns the filename (not the path) of the generated tf
+// plan given a workspace, project name, and whether this is a draftplan.
+// Draftplans use extension .draftplan, and real plans use .tfplan.
+func GetPlanFilename(workspace string, projName string, isDraft bool) string {
+	ext := "tfplan"
+	if isDraft {
+		ext = "draftplan"
+	}
 	if projName == "" {
-		return fmt.Sprintf("%s.tfplan", workspace)
+		return fmt.Sprintf("%s.%s", workspace, ext)
 	}
 	projName = strings.ReplaceAll(projName, "/", planfileSlashReplace)
-	return fmt.Sprintf("%s-%s.tfplan", projName, workspace)
-}
-
-// GetDraftPlanFilename returns the filename (not the path) of the generated tf
-// plan for a draftplan preview. It intentionally uses a different extension
-// (not .tfplan) so a draftplan's plan file is always distinct from a real
-// plan's: apply/import/state_rm/unlock resolve paths via GetPlanFilename and
-// so can never find or act on a draftplan's file, and PendingPlanFinder's
-// ".tfplan" extension scan (used by unlock and to clear stale plans before a
-// new plan) naturally skips it too.
-func GetDraftPlanFilename(workspace string, projName string) string {
-	if projName == "" {
-		return fmt.Sprintf("%s.draftplan", workspace)
-	}
-	projName = strings.ReplaceAll(projName, "/", planfileSlashReplace)
-	return fmt.Sprintf("%s-%s.draftplan", projName, workspace)
-}
-
-// PlanFilenameForContext returns GetDraftPlanFilename's result for a
-// draftplan or the policy_check/show steps that follow one (ctx.IsDraftPlan
-// is what carries that across, since ctx.CommandName is PolicyCheck, not
-// DraftPlan, for those steps), and GetPlanFilename's otherwise. Steps that
-// must never resolve to a draftplan's file (apply, import, state_rm) should
-// keep calling GetPlanFilename directly instead of this.
-func PlanFilenameForContext(ctx command.ProjectContext) string {
-	if ctx.CommandName == command.DraftPlan || ctx.IsDraftPlan {
-		return GetDraftPlanFilename(ctx.Workspace, ctx.ProjectName)
-	}
-	return GetPlanFilename(ctx.Workspace, ctx.ProjectName)
+	return fmt.Sprintf("%s-%s.%s", projName, workspace, ext)
 }
 
 // isRemotePlan returns true if planContents are from a plan that was generated

--- a/server/core/runtime/runtime_test.go
+++ b/server/core/runtime/runtime_test.go
@@ -15,31 +15,37 @@ func TestGetPlanFilename(t *testing.T) {
 	cases := []struct {
 		workspace   string
 		projectName string
+		isDraft     bool
 		exp         string
 	}{
 		{
 			"workspace",
 			"",
+			false,
 			"workspace.tfplan",
 		},
 		{
 			"workspace",
 			"project",
+			false,
 			"project-workspace.tfplan",
 		},
 		{
 			"workspace",
 			"project/with/slash",
+			false,
 			"project::with::slash-workspace.tfplan",
 		},
 		{
 			"workspace",
 			"project with space",
+			false,
 			"project with space-workspace.tfplan",
 		},
 		{
 			"workspace😀",
 			"project😀",
+			false,
 			"project😀-workspace😀.tfplan",
 		},
 		// Previously we replaced invalid chars with -'s, however we now
@@ -49,13 +55,28 @@ func TestGetPlanFilename(t *testing.T) {
 		{
 			"default",
 			`all.invalid.chars \/"*?<>`,
+			false,
 			"all.invalid.chars \\::\"*?<>-default.tfplan",
+		},
+		// isDraft uses a different extension so a draftplan's file is never
+		// mistaken for (or resolved by callers looking for) a real plan's.
+		{
+			"workspace",
+			"",
+			true,
+			"workspace.draftplan",
+		},
+		{
+			"workspace",
+			"project",
+			true,
+			"project-workspace.draftplan",
 		},
 	}
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			Equals(t, c.exp, runtime.GetPlanFilename(c.workspace, c.projectName))
+			Equals(t, c.exp, runtime.GetPlanFilename(c.workspace, c.projectName, c.isDraft))
 		})
 	}
 }

--- a/server/core/runtime/show_step_runner.go
+++ b/server/core/runtime/show_step_runner.go
@@ -43,7 +43,7 @@ func (p *showStepRunner) Run(ctx command.ProjectContext, _ []string, path string
 		tfVersion = ctx.TerraformVersion
 	}
 
-	planFile := filepath.Join(path, PlanFilenameForContext(ctx))
+	planFile := filepath.Join(path, GetPlanFilename(ctx.Workspace, ctx.ProjectName, ctx.IsDraft()))
 	showResultFile := filepath.Join(path, ctx.GetShowResultFileName())
 
 	output, err := p.terraformExecutor.RunCommandWithVersion(

--- a/server/core/runtime/show_step_runner.go
+++ b/server/core/runtime/show_step_runner.go
@@ -43,7 +43,7 @@ func (p *showStepRunner) Run(ctx command.ProjectContext, _ []string, path string
 		tfVersion = ctx.TerraformVersion
 	}
 
-	planFile := filepath.Join(path, GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	planFile := filepath.Join(path, PlanFilenameForContext(ctx))
 	showResultFile := filepath.Join(path, ctx.GetShowResultFileName())
 
 	output, err := p.terraformExecutor.RunCommandWithVersion(

--- a/server/core/runtime/state_rm_step_runner.go
+++ b/server/core/runtime/state_rm_step_runner.go
@@ -44,7 +44,7 @@ func (p *stateRmStepRunner) Run(ctx command.ProjectContext, extraArgs []string, 
 	out, err := p.terraformExecutor.RunCommandWithVersion(ctx, filepath.Clean(path), stateRmCmd, envs, tfDistribution, tfVersion, ctx.Workspace)
 
 	// If the state rm was successful and a plan file exists, delete the plan.
-	planPath := filepath.Join(path, GetPlanFilename(ctx.Workspace, ctx.ProjectName))
+	planPath := filepath.Join(path, GetPlanFilename(ctx.Workspace, ctx.ProjectName, false))
 	if err == nil {
 		if _, planPathErr := os.Stat(planPath); !os.IsNotExist(planPathErr) {
 			ctx.Log.Info("state rm successful, deleting planfile")

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -196,8 +196,7 @@ func (a *ApplyCommandRunner) updateCommitStatus(ctx *command.Context, pullStatus
 	var numErrored int
 	status := models.SuccessCommitStatus
 
-	// A draftplan with no changes has nothing to apply, same as a real
-	// plan with no changes, so it counts toward success here too.
+	// A no-changes draftplan has nothing to apply either, so count it too.
 	numSuccess = pullStatus.StatusCount(models.AppliedPlanStatus) + pullStatus.StatusCount(models.PlannedNoChangesPlanStatus) + pullStatus.StatusCount(models.DraftPlannedNoChangesPlanStatus)
 	numErrored = pullStatus.StatusCount(models.ErroredApplyStatus)
 

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -196,7 +196,9 @@ func (a *ApplyCommandRunner) updateCommitStatus(ctx *command.Context, pullStatus
 	var numErrored int
 	status := models.SuccessCommitStatus
 
-	numSuccess = pullStatus.StatusCount(models.AppliedPlanStatus) + pullStatus.StatusCount(models.PlannedNoChangesPlanStatus)
+	// A draftplan with no changes has nothing to apply, same as a real
+	// plan with no changes, so it counts toward success here too.
+	numSuccess = pullStatus.StatusCount(models.AppliedPlanStatus) + pullStatus.StatusCount(models.PlannedNoChangesPlanStatus) + pullStatus.StatusCount(models.DraftPlannedNoChangesPlanStatus)
 	numErrored = pullStatus.StatusCount(models.ErroredApplyStatus)
 
 	if numErrored > 0 {

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -196,7 +196,6 @@ func (a *ApplyCommandRunner) updateCommitStatus(ctx *command.Context, pullStatus
 	var numErrored int
 	status := models.SuccessCommitStatus
 
-	// A no-changes draftplan has nothing to apply either, so count it too.
 	numSuccess = pullStatus.StatusCount(models.AppliedPlanStatus) + pullStatus.StatusCount(models.PlannedNoChangesPlanStatus) + pullStatus.StatusCount(models.DraftPlannedNoChangesPlanStatus)
 	numErrored = pullStatus.StatusCount(models.ErroredApplyStatus)
 

--- a/server/events/command/name.go
+++ b/server/events/command/name.go
@@ -35,6 +35,8 @@ const (
 	State
 	// Cancel is a command to cancel running plan or apply operations
 	Cancel
+	// DraftPlan is a light-weight plan that cannot be applied
+	DraftPlan
 	// Adding more? Don't forget to update String() below
 )
 
@@ -53,6 +55,7 @@ var AllCommentCommands = []Name{
 	ApprovePolicies,
 	Import,
 	State,
+	DraftPlan,
 }
 
 // TitleString returns the string representation in title form.
@@ -82,6 +85,8 @@ func (c Name) String() string {
 		return "state"
 	case Cancel:
 		return "cancel"
+	case DraftPlan:
+		return "draftplan"
 	}
 	return ""
 }
@@ -145,6 +150,8 @@ func ParseCommandName(name string) (Name, error) {
 		return Apply, nil
 	case "plan":
 		return Plan, nil
+	case "draftplan":
+		return DraftPlan, nil
 	case "unlock":
 		return Unlock, nil
 	case "policy_check":

--- a/server/events/command/project_context.go
+++ b/server/events/command/project_context.go
@@ -78,6 +78,9 @@ type ProjectContext struct {
 	PullReqStatus models.PullReqStatus
 	// CurrentProjectPlanStatus is the status of the current project prior to this command.
 	ProjectPlanStatus models.ProjectPlanStatus
+	// IsDraftPlan is true if this stage was triggered by a draftplan command
+	// (or the policy_check that followed one) rather than a full plan.
+	IsDraftPlan bool
 	//PullStatus is the status of the current pull request prior to this command.
 	PullStatus *models.PullStatus
 	// ProjectPolicyStatus is the status of policy sets of the current project prior to this command.

--- a/server/events/command/project_context.go
+++ b/server/events/command/project_context.go
@@ -181,6 +181,14 @@ func (p ProjectContext) GetPolicyCheckResultFileName() string {
 	return fmt.Sprintf("%s-%s-policyout.json", projName, p.Workspace)
 }
 
+// IsDraft returns true if this stage is part of a draftplan: either the
+// draftplan command itself, or a policy_check/show stage that followed one
+// (those run with CommandName PolicyCheck, not DraftPlan, so IsDraftPlan is
+// what carries the signal forward for them).
+func (p ProjectContext) IsDraft() bool {
+	return p.CommandName == DraftPlan || p.IsDraftPlan
+}
+
 // Gets a unique identifier for the current pull request as a single string
 func (p ProjectContext) PullInfo() string {
 	normalizedOwner := strings.ReplaceAll(p.BaseRepo.Owner, "/", "-")

--- a/server/events/command/project_result.go
+++ b/server/events/command/project_result.go
@@ -61,7 +61,7 @@ func (p ProjectResult) PolicyStatus() []models.PolicySetStatus {
 func (p ProjectResult) PlanStatus() models.ProjectPlanStatus {
 	switch p.Command {
 
-	case Plan, DraftPlan:
+	case Plan:
 		if p.Error != nil {
 			return models.ErroredPlanStatus
 		} else if p.Failure != "" {
@@ -70,6 +70,15 @@ func (p ProjectResult) PlanStatus() models.ProjectPlanStatus {
 			return models.PlannedNoChangesPlanStatus
 		}
 		return models.PlannedPlanStatus
+	case DraftPlan:
+		if p.Error != nil {
+			return models.ErroredPlanStatus
+		} else if p.Failure != "" {
+			return models.ErroredPlanStatus
+		} else if p.PlanSuccess.NoChanges() {
+			return models.DraftPlannedNoChangesPlanStatus
+		}
+		return models.DraftPlannedPlanStatus
 	case PolicyCheck, ApprovePolicies:
 		if p.Error != nil {
 			return models.ErroredPolicyCheckStatus

--- a/server/events/command/project_result.go
+++ b/server/events/command/project_result.go
@@ -61,7 +61,7 @@ func (p ProjectResult) PolicyStatus() []models.PolicySetStatus {
 func (p ProjectResult) PlanStatus() models.ProjectPlanStatus {
 	switch p.Command {
 
-	case Plan:
+	case Plan, DraftPlan:
 		if p.Error != nil {
 			return models.ErroredPlanStatus
 		} else if p.Failure != "" {

--- a/server/events/command/project_result_test.go
+++ b/server/events/command/project_result_test.go
@@ -111,6 +111,35 @@ func TestProjectResult_PlanStatus(t *testing.T) {
 		},
 		{
 			p: command.ProjectResult{
+				Command: command.DraftPlan,
+				ProjectCommandOutput: command.ProjectCommandOutput{
+					Error: errors.New("err"),
+				},
+			},
+			expStatus: models.ErroredPlanStatus,
+		},
+		{
+			p: command.ProjectResult{
+				Command: command.DraftPlan,
+				ProjectCommandOutput: command.ProjectCommandOutput{
+					PlanSuccess: &models.PlanSuccess{},
+				},
+			},
+			expStatus: models.DraftPlannedPlanStatus,
+		},
+		{
+			p: command.ProjectResult{
+				Command: command.DraftPlan,
+				ProjectCommandOutput: command.ProjectCommandOutput{
+					PlanSuccess: &models.PlanSuccess{
+						TerraformOutput: "No changes. Infrastructure is up-to-date.",
+					},
+				},
+			},
+			expStatus: models.DraftPlannedNoChangesPlanStatus,
+		},
+		{
+			p: command.ProjectResult{
 				Command: command.Apply,
 				ProjectCommandOutput: command.ProjectCommandOutput{
 					Error: errors.New("err"),

--- a/server/events/command_requirement_handler.go
+++ b/server/events/command_requirement_handler.go
@@ -80,7 +80,9 @@ func (a *DefaultCommandRequirementHandler) validateCommandRequirement(repoDir st
 			diverged, err := a.hasUndivergedImpact(repoDir, ctx)
 			if err != nil {
 				ctx.Log.Warn("evaluating undiverged requirement has failed, falling back to full divergence check: %s", err)
-				diverged = a.WorkingDir.HasDiverged(ctx.Log, repoDir, ctx.RepoRelDir, nil, ctx.Pull)
+				// Here it doesn't matter if diverged check has errored. If `true` is returned,
+				// diverged path will be followed which will ask the user to rebase
+				diverged, _ = a.WorkingDir.HasDiverged(ctx.Log, repoDir, ctx.RepoRelDir, nil, ctx.Pull)
 			}
 			if diverged {
 				return fmt.Sprintf("Default branch must be rebased onto pull request before running %s.", cmd), nil
@@ -93,7 +95,7 @@ func (a *DefaultCommandRequirementHandler) validateCommandRequirement(repoDir st
 
 func (a *DefaultCommandRequirementHandler) hasUndivergedImpact(repoDir string, ctx command.ProjectContext) (bool, error) {
 	if a.ProjectImpactResolver == nil {
-		return a.WorkingDir.HasDiverged(ctx.Log, repoDir, ctx.RepoRelDir, ctx.AutoplanWhenModified, ctx.Pull), nil
+		return a.WorkingDir.HasDiverged(ctx.Log, repoDir, ctx.RepoRelDir, ctx.AutoplanWhenModified, ctx.Pull)
 	}
 
 	handled, impacted, err := a.ProjectImpactResolver.HasUndivergedImpact(ctx, repoDir, a.WorkingDir)
@@ -101,7 +103,7 @@ func (a *DefaultCommandRequirementHandler) hasUndivergedImpact(repoDir string, c
 		return false, err
 	}
 	if !handled {
-		return a.WorkingDir.HasDiverged(ctx.Log, repoDir, ctx.RepoRelDir, ctx.AutoplanWhenModified, ctx.Pull), nil
+		return a.WorkingDir.HasDiverged(ctx.Log, repoDir, ctx.RepoRelDir, ctx.AutoplanWhenModified, ctx.Pull)
 	}
 	return impacted, nil
 }

--- a/server/events/command_requirement_handler.go
+++ b/server/events/command_requirement_handler.go
@@ -48,6 +48,13 @@ func (a *DefaultCommandRequirementHandler) ValidatePlanProject(repoDir string, c
 }
 
 func (a *DefaultCommandRequirementHandler) ValidateApplyProject(repoDir string, ctx command.ProjectContext) (failure string, err error) {
+	// A draftplan is an unlocked, unrefreshed preview and must never be
+	// applied. Its plan status is distinct from a real plan's, so this
+	// check can't be bypassed by configuring apply_requirements.
+	if ctx.ProjectPlanStatus == models.DraftPlannedPlanStatus || ctx.ProjectPlanStatus == models.DraftPlannedNoChangesPlanStatus {
+		return "This project's most recent plan was a draftplan preview, which is not locked and may not reflect the latest state. Run 'atlantis plan' to generate an applyable plan before running apply.", nil
+	}
+
 	return a.validateCommandRequirement(repoDir, ctx, command.Apply, ctx.ApplyRequirements)
 }
 

--- a/server/events/command_requirement_handler.go
+++ b/server/events/command_requirement_handler.go
@@ -48,12 +48,6 @@ func (a *DefaultCommandRequirementHandler) ValidatePlanProject(repoDir string, c
 }
 
 func (a *DefaultCommandRequirementHandler) ValidateApplyProject(repoDir string, ctx command.ProjectContext) (failure string, err error) {
-	// Blocks apply for a project whose last plan was a draftplan preview.
-	// Checked before apply_requirements so it can't be bypassed by config.
-	if ctx.IsDraftPlan || ctx.ProjectPlanStatus == models.DraftPlannedPlanStatus || ctx.ProjectPlanStatus == models.DraftPlannedNoChangesPlanStatus {
-		return "This project's most recent plan was a draftplan preview, which is not locked and may not reflect the latest state. Run 'atlantis plan' to generate an applyable plan before running apply.", nil
-	}
-
 	return a.validateCommandRequirement(repoDir, ctx, command.Apply, ctx.ApplyRequirements)
 }
 

--- a/server/events/command_requirement_handler.go
+++ b/server/events/command_requirement_handler.go
@@ -50,7 +50,7 @@ func (a *DefaultCommandRequirementHandler) ValidatePlanProject(repoDir string, c
 func (a *DefaultCommandRequirementHandler) ValidateApplyProject(repoDir string, ctx command.ProjectContext) (failure string, err error) {
 	// Blocks apply for a project whose last plan was a draftplan preview.
 	// Checked before apply_requirements so it can't be bypassed by config.
-	if ctx.ProjectPlanStatus == models.DraftPlannedPlanStatus || ctx.ProjectPlanStatus == models.DraftPlannedNoChangesPlanStatus {
+	if ctx.IsDraftPlan || ctx.ProjectPlanStatus == models.DraftPlannedPlanStatus || ctx.ProjectPlanStatus == models.DraftPlannedNoChangesPlanStatus {
 		return "This project's most recent plan was a draftplan preview, which is not locked and may not reflect the latest state. Run 'atlantis plan' to generate an applyable plan before running apply.", nil
 	}
 

--- a/server/events/command_requirement_handler.go
+++ b/server/events/command_requirement_handler.go
@@ -48,9 +48,13 @@ func (a *DefaultCommandRequirementHandler) ValidatePlanProject(repoDir string, c
 }
 
 func (a *DefaultCommandRequirementHandler) ValidateApplyProject(repoDir string, ctx command.ProjectContext) (failure string, err error) {
-	// A draftplan is an unlocked, unrefreshed preview and must never be
-	// applied. Its plan status is distinct from a real plan's, so this
-	// check can't be bypassed by configuring apply_requirements.
+	// Blocks apply while the project's last recorded status is still a
+	// draftplan (an unlocked, unrefreshed preview). This only covers the
+	// window before a policy_check has run against it: once policy_check
+	// runs, it overwrites the recorded status, and apply is gated by the
+	// normal apply_requirements (mergeable/approved/policies-passed) tied
+	// to a subsequent real plan instead. Runs before the requirements loop
+	// so it can't be disabled by apply_requirements config.
 	if ctx.ProjectPlanStatus == models.DraftPlannedPlanStatus || ctx.ProjectPlanStatus == models.DraftPlannedNoChangesPlanStatus {
 		return "This project's most recent plan was a draftplan preview, which is not locked and may not reflect the latest state. Run 'atlantis plan' to generate an applyable plan before running apply.", nil
 	}

--- a/server/events/command_requirement_handler.go
+++ b/server/events/command_requirement_handler.go
@@ -48,13 +48,8 @@ func (a *DefaultCommandRequirementHandler) ValidatePlanProject(repoDir string, c
 }
 
 func (a *DefaultCommandRequirementHandler) ValidateApplyProject(repoDir string, ctx command.ProjectContext) (failure string, err error) {
-	// Blocks apply while the project's last recorded status is still a
-	// draftplan (an unlocked, unrefreshed preview). This only covers the
-	// window before a policy_check has run against it: once policy_check
-	// runs, it overwrites the recorded status, and apply is gated by the
-	// normal apply_requirements (mergeable/approved/policies-passed) tied
-	// to a subsequent real plan instead. Runs before the requirements loop
-	// so it can't be disabled by apply_requirements config.
+	// Blocks apply for a project whose last plan was a draftplan preview.
+	// Checked before apply_requirements so it can't be bypassed by config.
 	if ctx.ProjectPlanStatus == models.DraftPlannedPlanStatus || ctx.ProjectPlanStatus == models.DraftPlannedNoChangesPlanStatus {
 		return "This project's most recent plan was a draftplan preview, which is not locked and may not reflect the latest state. Run 'atlantis plan' to generate an applyable plan before running apply.", nil
 	}

--- a/server/events/command_requirement_handler_test.go
+++ b/server/events/command_requirement_handler_test.go
@@ -50,7 +50,7 @@ func TestAggregateApplyRequirements_ValidatePlanProject(t *testing.T) {
 				ProjectPlanStatus: models.PassedPolicyCheckStatus,
 			},
 			setup: func(workingDir *mocks.MockWorkingDir) {
-				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(false)
+				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(false, nil)
 			},
 			wantErr: assert.NoError,
 		},
@@ -96,7 +96,7 @@ func TestAggregateApplyRequirements_ValidatePlanProject(t *testing.T) {
 				PlanRequirements: []string{raw.UnDivergedRequirement},
 			},
 			setup: func(workingDir *mocks.MockWorkingDir) {
-				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(true)
+				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(true, nil)
 			},
 			wantFailure: "Default branch must be rebased onto pull request before running plan.",
 			wantErr:     assert.NoError,
@@ -150,7 +150,7 @@ func TestAggregateApplyRequirements_ValidateApplyProject(t *testing.T) {
 				ProjectPlanStatus: models.PassedPolicyCheckStatus,
 			},
 			setup: func(workingDir *mocks.MockWorkingDir) {
-				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(false)
+				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(false, nil)
 			},
 			wantErr: assert.NoError,
 		},
@@ -206,7 +206,7 @@ func TestAggregateApplyRequirements_ValidateApplyProject(t *testing.T) {
 				ApplyRequirements: []string{raw.UnDivergedRequirement},
 			},
 			setup: func(workingDir *mocks.MockWorkingDir) {
-				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(true)
+				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(true, nil)
 			},
 			wantFailure: "Default branch must be rebased onto pull request before running apply.",
 			wantErr:     assert.NoError,
@@ -385,7 +385,7 @@ func TestAggregateApplyRequirements_ValidateImportProject(t *testing.T) {
 				ProjectPlanStatus: models.PassedPolicyCheckStatus,
 			},
 			setup: func(workingDir *mocks.MockWorkingDir) {
-				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(false)
+				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(false, nil)
 			},
 			wantErr: assert.NoError,
 		},
@@ -417,7 +417,7 @@ func TestAggregateApplyRequirements_ValidateImportProject(t *testing.T) {
 				ImportRequirements: []string{raw.UnDivergedRequirement},
 			},
 			setup: func(workingDir *mocks.MockWorkingDir) {
-				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(true)
+				When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Any[string](), Any[string](), Any[[]string](), Any[models.PullRequest]())).ThenReturn(true, nil)
 			},
 			wantFailure: "Default branch must be rebased onto pull request before running import.",
 			wantErr:     assert.NoError,

--- a/server/events/command_requirement_handler_test.go
+++ b/server/events/command_requirement_handler_test.go
@@ -211,6 +211,29 @@ func TestAggregateApplyRequirements_ValidateApplyProject(t *testing.T) {
 			wantFailure: "Default branch must be rebased onto pull request before running apply.",
 			wantErr:     assert.NoError,
 		},
+		{
+			name: "fail by draft planned with changes, even with no apply requirements configured",
+			ctx: command.ProjectContext{
+				ProjectPlanStatus: models.DraftPlannedPlanStatus,
+			},
+			wantFailure: "This project's most recent plan was a draftplan preview, which is not locked and may not reflect the latest state. Run 'atlantis plan' to generate an applyable plan before running apply.",
+			wantErr:     assert.NoError,
+		},
+		{
+			name: "fail by draft planned with no changes",
+			ctx: command.ProjectContext{
+				ProjectPlanStatus: models.DraftPlannedNoChangesPlanStatus,
+			},
+			wantFailure: "This project's most recent plan was a draftplan preview, which is not locked and may not reflect the latest state. Run 'atlantis plan' to generate an applyable plan before running apply.",
+			wantErr:     assert.NoError,
+		},
+		{
+			name: "pass when a real plan followed the draft plan",
+			ctx: command.ProjectContext{
+				ProjectPlanStatus: models.PlannedPlanStatus,
+			},
+			wantErr: assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/server/events/command_requirement_handler_test.go
+++ b/server/events/command_requirement_handler_test.go
@@ -234,6 +234,15 @@ func TestAggregateApplyRequirements_ValidateApplyProject(t *testing.T) {
 			},
 			wantErr: assert.NoError,
 		},
+		{
+			name: "fail when draft marker survives policy check",
+			ctx: command.ProjectContext{
+				IsDraftPlan:       true,
+				ProjectPlanStatus: models.PassedPolicyCheckStatus,
+			},
+			wantFailure: "This project's most recent plan was a draftplan preview, which is not locked and may not reflect the latest state. Run 'atlantis plan' to generate an applyable plan before running apply.",
+			wantErr:     assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/server/events/command_requirement_handler_test.go
+++ b/server/events/command_requirement_handler_test.go
@@ -211,38 +211,6 @@ func TestAggregateApplyRequirements_ValidateApplyProject(t *testing.T) {
 			wantFailure: "Default branch must be rebased onto pull request before running apply.",
 			wantErr:     assert.NoError,
 		},
-		{
-			name: "fail by draft planned with changes, even with no apply requirements configured",
-			ctx: command.ProjectContext{
-				ProjectPlanStatus: models.DraftPlannedPlanStatus,
-			},
-			wantFailure: "This project's most recent plan was a draftplan preview, which is not locked and may not reflect the latest state. Run 'atlantis plan' to generate an applyable plan before running apply.",
-			wantErr:     assert.NoError,
-		},
-		{
-			name: "fail by draft planned with no changes",
-			ctx: command.ProjectContext{
-				ProjectPlanStatus: models.DraftPlannedNoChangesPlanStatus,
-			},
-			wantFailure: "This project's most recent plan was a draftplan preview, which is not locked and may not reflect the latest state. Run 'atlantis plan' to generate an applyable plan before running apply.",
-			wantErr:     assert.NoError,
-		},
-		{
-			name: "pass when a real plan followed the draft plan",
-			ctx: command.ProjectContext{
-				ProjectPlanStatus: models.PlannedPlanStatus,
-			},
-			wantErr: assert.NoError,
-		},
-		{
-			name: "fail when draft marker survives policy check",
-			ctx: command.ProjectContext{
-				IsDraftPlan:       true,
-				ProjectPlanStatus: models.PassedPolicyCheckStatus,
-			},
-			wantFailure: "This project's most recent plan was a draftplan preview, which is not locked and may not reflect the latest state. Run 'atlantis plan' to generate an applyable plan before running apply.",
-			wantErr:     assert.NoError,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/server/events/command_runner_internal_test.go
+++ b/server/events/command_runner_internal_test.go
@@ -157,7 +157,7 @@ func TestPlanUpdatePlanCommitStatus(t *testing.T) {
 			cr := &PlanCommandRunner{
 				commitStatusUpdater: csu,
 			}
-			cr.updateCommitStatus(&command.Context{}, c.pullStatus, command.Plan)
+			cr.updateCommitStatus(&command.Context{}, c.pullStatus, c.cmd)
 			Equals(t, models.Repo{}, csu.CalledRepo)
 			Equals(t, models.PullRequest{}, csu.CalledPull)
 			Equals(t, c.expStatus, csu.CalledStatus)

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -228,6 +228,7 @@ func setup(t *testing.T, options ...func(testConfig *TestConfig)) *vcsmocks.Mock
 
 	commentCommandRunnerByCmd := map[command.Name]events.CommentCommandRunner{
 		command.Plan:            planCommandRunner,
+		command.DraftPlan:       planCommandRunner,
 		command.Apply:           applyCommandRunner,
 		command.ApprovePolicies: approvePoliciesCommandRunner,
 		command.Unlock:          unlockCommandRunner,

--- a/server/events/comment_parser.go
+++ b/server/events/comment_parser.go
@@ -255,6 +255,14 @@ func (e *CommentParser) Parse(rawComment string, vcsHost models.VCSHostType) Com
 		flagSet.StringVarP(&dir, dirFlagLong, dirFlagShort, "", "Which directory to run plan in relative to root of repo, ex. 'child/dir'.")
 		flagSet.StringVarP(&project, projectFlagLong, projectFlagShort, "", "Which project to run plan for. Refers to the name of the project configured in a repo config file. Cannot be used at same time as workspace or dir flags.")
 		flagSet.BoolVarP(&verbose, verboseFlagLong, verboseFlagShort, false, "Append Atlantis log to comment.")
+	case command.DraftPlan.String():
+		name = command.DraftPlan
+		flagSet = pflag.NewFlagSet(command.Plan.String(), pflag.ContinueOnError)
+		flagSet.SetOutput(io.Discard)
+		flagSet.StringVarP(&workspace, workspaceFlagLong, workspaceFlagShort, "", "Switch to this Terraform workspace before planning.")
+		flagSet.StringVarP(&dir, dirFlagLong, dirFlagShort, "", "Which directory to run plan in relative to root of repo, ex. 'child/dir'.")
+		flagSet.StringVarP(&project, projectFlagLong, projectFlagShort, "", "Which project to run plan for. Refers to the name of the project configured in a repo config file. Cannot be used at same time as workspace or dir flags.")
+		flagSet.BoolVarP(&verbose, verboseFlagLong, verboseFlagShort, false, "Append Atlantis log to comment.")
 	case command.Apply.String():
 		name = command.Apply
 		flagSet = pflag.NewFlagSet(command.Apply.String(), pflag.ContinueOnError)
@@ -570,6 +578,7 @@ func (e *CommentParser) HelpComment() string {
 	if err := tmpl.Execute(buf, struct {
 		ExecutableName       string
 		AllowVersion         bool
+		AllowDraftPlan       bool
 		AllowPlan            bool
 		AllowApply           bool
 		AllowUnlock          bool
@@ -579,6 +588,7 @@ func (e *CommentParser) HelpComment() string {
 	}{
 		ExecutableName:       e.ExecutableName,
 		AllowVersion:         e.isAllowedCommand(command.Version.String()),
+		AllowDraftPlan:       e.isAllowedCommand(command.DraftPlan.String()),
 		AllowPlan:            e.isAllowedCommand(command.Plan.String()),
 		AllowApply:           e.isAllowedCommand(command.Apply.String()),
 		AllowUnlock:          e.isAllowedCommand(command.Unlock.String()),
@@ -618,6 +628,12 @@ Examples:
 Commands:
 {{- if .AllowPlan }}
   plan     Runs 'terraform plan' for the changes in this pull request.
+           To plan a specific project, use the -d, -w and -p flags.
+{{- end }}
+{{- if .AllowDraftPlan }}
+  draftplan
+           Runs plan in draft mode. Runs quickly without locks or
+           refreshing, plan is only added to PR comments. Cannot be applied.
            To plan a specific project, use the -d, -w and -p flags.
 {{- end }}
 {{- if .AllowApply }}

--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -198,6 +198,31 @@ func TestParse_UnusedArguments(t *testing.T) {
 			"arg arg2",
 		},
 		{
+			command.DraftPlan,
+			"-d . arg",
+			"arg",
+		},
+		{
+			command.DraftPlan,
+			"arg -d .",
+			"arg",
+		},
+		{
+			command.DraftPlan,
+			"arg",
+			"arg",
+		},
+		{
+			command.DraftPlan,
+			"arg arg2",
+			"arg arg2",
+		},
+		{
+			command.DraftPlan,
+			"-d . arg -w kjj arg2",
+			"arg arg2",
+		},
+		{
 			command.Apply,
 			"-d . arg",
 			"arg",
@@ -241,6 +266,8 @@ func TestParse_UnusedArguments(t *testing.T) {
 			switch c.Command {
 			case command.Plan:
 				usage = PlanUsage
+			case command.DraftPlan:
+				usage = DraftPlanUsage
 			case command.Apply:
 				usage = ApplyUsage
 			case command.ApprovePolicies:
@@ -298,13 +325,14 @@ func TestParse_InvalidCommand(t *testing.T) {
 			command.Unlock,
 			command.Apply,
 			command.Plan,
+			command.DraftPlan,
 			command.Apply, // duplicate command is filtered
 		},
 		nil,
 	)
 	for _, c := range comments {
 		r := cp.Parse(c, models.Github)
-		exp := fmt.Sprintf("```\nError: unknown command %q.\nRun 'atlantis --help' for usage.\nAvailable commands(--allow-commands): version, plan, apply, unlock\n```", strings.Fields(c)[1])
+		exp := fmt.Sprintf("```\nError: unknown command %q.\nRun 'atlantis --help' for usage.\nAvailable commands(--allow-commands): version, plan, apply, unlock, draftplan\n```", strings.Fields(c)[1])
 		Equals(t, exp, r.CommentResponse)
 	}
 }
@@ -350,6 +378,10 @@ func TestParse_InvalidFlags(t *testing.T) {
 		},
 		{
 			"atlantis plan --abc",
+			"Error: unknown flag: --abc",
+		},
+		{
+			"atlantis draftplan --abc",
 			"Error: unknown flag: --abc",
 		},
 		{
@@ -1071,6 +1103,10 @@ Examples:
 Commands:
   plan     Runs 'terraform plan' for the changes in this pull request.
            To plan a specific project, use the -d, -w and -p flags.
+  draftplan
+           Runs plan in draft mode. Runs quickly without locks or
+           refreshing, plan is only added to PR comments. Cannot be applied.
+           To plan a specific project, use the -d, -w and -p flags.
   apply    Runs 'terraform apply' on all unapplied plans from this pull request.
            To only apply a specific plan, use the -d, -w and -p flags.
   unlock   Removes all atlantis locks and discards all plans for this PR.
@@ -1207,6 +1243,15 @@ func TestParse_VCSUsername(t *testing.T) {
 }
 
 var PlanUsage = `Usage of plan:
+  -d, --dir string         Which directory to run plan in relative to root of repo,
+                           ex. 'child/dir'.
+  -p, --project string     Which project to run plan for. Refers to the name of the
+                           project configured in a repo config file. Cannot be used
+                           at same time as workspace or dir flags.
+      --verbose            Append Atlantis log to comment.
+  -w, --workspace string   Switch to this Terraform workspace before planning.
+`
+var DraftPlanUsage = `Usage of draftplan:
   -d, --dir string         Which directory to run plan in relative to root of repo,
                            ex. 'child/dir'.
   -p, --project string     Which project to run plan for. Refers to the name of the

--- a/server/events/commit_status_updater.go
+++ b/server/events/commit_status_updater.go
@@ -68,6 +68,8 @@ func (d *DefaultCommitStatusUpdater) UpdateCombinedCount(logger logging.SimpleLo
 		cmdVerb = "policies checked"
 	case command.Apply:
 		cmdVerb = "applied"
+	case command.DraftPlan:
+		cmdVerb = "draftplanned"
 	}
 
 	return d.Client.UpdateStatus(logger, repo, pull, status, src, fmt.Sprintf("%d/%d projects %s successfully.", numSuccess, numTotal, cmdVerb), "")

--- a/server/events/instrumented_project_command_builder.go
+++ b/server/events/instrumented_project_command_builder.go
@@ -36,7 +36,7 @@ func (b *InstrumentedProjectCommandBuilder) BuildAutoplanCommands(ctx *command.C
 
 func (b *InstrumentedProjectCommandBuilder) BuildPlanCommands(ctx *command.Context, comment *CommentCommand) ([]command.ProjectContext, error) {
 	return b.buildAndEmitStats(
-		"plan",
+		comment.Name.String(),
 		func() ([]command.ProjectContext, error) {
 			return b.ProjectCommandBuilder.BuildPlanCommands(ctx, comment)
 		},

--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -20,6 +20,7 @@ import (
 
 var (
 	planCommandTitle            = command.Plan.TitleString()
+	draftplanCommandTitle       = command.DraftPlan.TitleString()
 	applyCommandTitle           = command.Apply.TitleString()
 	policyCheckCommandTitle     = command.PolicyCheck.TitleString()
 	approvePoliciesCommandTitle = command.ApprovePolicies.TitleString()
@@ -236,11 +237,20 @@ func (m *MarkdownRenderer) renderProjectResults(ctx *command.Context, results []
 				EnableDiffMarkdownFormat: common.EnableDiffMarkdownFormat,
 				PlanStats:                result.PlanSuccess.Stats(),
 			}
-			if m.shouldUseWrappedTmpl(vcsHost, result.PlanSuccess.TerraformOutput) {
-				data.PlanSummary = result.PlanSuccess.Summary()
-				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("planSuccessWrapped"), data)
+			if common.Command == draftplanCommandTitle {
+				if m.shouldUseWrappedTmpl(vcsHost, result.PlanSuccess.TerraformOutput) {
+					data.PlanSummary = result.PlanSuccess.Summary()
+					resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("draftplanSuccessWrapped"), data)
+				} else {
+					resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("draftplanSuccessUnwrapped"), data)
+				}
 			} else {
-				resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("planSuccessUnwrapped"), data)
+				if m.shouldUseWrappedTmpl(vcsHost, result.PlanSuccess.TerraformOutput) {
+					data.PlanSummary = result.PlanSuccess.Summary()
+					resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("planSuccessWrapped"), data)
+				} else {
+					resultData.Rendered = m.renderTemplateTrimSpace(templates.Lookup("planSuccessUnwrapped"), data)
+				}
 			}
 			resultData.NoChanges = result.PlanSuccess.NoChanges()
 			if result.PlanSuccess.NoChanges() {
@@ -341,8 +351,12 @@ func (m *MarkdownRenderer) renderProjectResults(ctx *command.Context, results []
 	switch {
 	case len(resultsTmplData) == 1 && common.Command == planCommandTitle && numPlanSuccesses > 0:
 		tmpl = templates.Lookup("singleProjectPlanSuccess")
+	case len(resultsTmplData) == 1 && common.Command == draftplanCommandTitle && numPlanSuccesses > 0:
+		tmpl = templates.Lookup("singleProjectDraftPlanSuccess")
 	case len(resultsTmplData) == 1 && common.Command == planCommandTitle && numPlanSuccesses == 0:
 		tmpl = templates.Lookup("singleProjectPlanUnsuccessful")
+	case len(resultsTmplData) == 1 && common.Command == draftplanCommandTitle && numPlanSuccesses == 0:
+		tmpl = templates.Lookup("singleProjectDraftPlanUnsuccessful")
 	case len(resultsTmplData) == 1 && common.Command == policyCheckCommandTitle && numPolicyCheckSuccesses > 0:
 		tmpl = templates.Lookup("singleProjectPlanSuccess")
 	case len(resultsTmplData) == 1 && common.Command == policyCheckCommandTitle && numPolicyCheckSuccesses == 0:
@@ -364,6 +378,8 @@ func (m *MarkdownRenderer) renderProjectResults(ctx *command.Context, results []
 		}
 	case common.Command == planCommandTitle:
 		tmpl = templates.Lookup("multiProjectPlan")
+	case common.Command == draftplanCommandTitle:
+		tmpl = templates.Lookup("multiProjectDraftPlan")
 	case common.Command == policyCheckCommandTitle:
 		if numPolicyCheckSuccesses == len(results) {
 			tmpl = templates.Lookup("multiProjectPolicy")

--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -67,12 +67,6 @@ type commonData struct {
 	HideUnchangedPlanComments bool
 	QuietPolicyChecks         bool
 	VcsRequestType            string
-	// IsDraftPolicyCheck is true if this is a policy_check comment for a
-	// draftplan. Named distinctly from models.PolicyCheckResults.IsDraftPlan
-	// (rather than reusing that name here) because policyCheckResultsData
-	// embeds both commonData and models.PolicyCheckResults - reusing the
-	// name would make .IsDraftPlan an ambiguous selector in templates.
-	IsDraftPolicyCheck bool
 }
 
 // errData is data about an error response.
@@ -212,19 +206,6 @@ func (m *MarkdownRenderer) Render(ctx *command.Context, res command.Result, cmd 
 
 func (m *MarkdownRenderer) renderProjectResults(ctx *command.Context, results []command.ProjectResult, common commonData) string {
 	vcsHost := ctx.Pull.BaseRepo.VCSHost.Type
-
-	// A policy_check comment's results are always all-draft or all-real:
-	// they come from a single atlantis plan/draftplan invocation's
-	// policyCheckCmds, which are never a mix of the two. So it's safe to
-	// derive this once from the first result rather than per-project.
-	if common.Command == policyCheckCommandTitle {
-		for _, result := range results {
-			if result.PolicyCheckResults != nil {
-				common.IsDraftPolicyCheck = result.PolicyCheckResults.IsDraftPlan
-				break
-			}
-		}
-	}
 
 	var resultsTmplData []projectResultTmplData
 	numPlanSuccesses := 0

--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -67,12 +67,7 @@ type commonData struct {
 	HideUnchangedPlanComments bool
 	QuietPolicyChecks         bool
 	VcsRequestType            string
-	// IsDraftPolicyCheck is true if this is a policy_check comment for a
-	// draftplan. Named distinctly from models.PolicyCheckResults.IsDraftPlan
-	// (rather than reusing that name here) because policyCheckResultsData
-	// embeds both commonData and models.PolicyCheckResults - reusing the
-	// name would make .IsDraftPlan an ambiguous selector in templates.
-	IsDraftPolicyCheck bool
+	IsDraftPolicyCheck        bool
 }
 
 // errData is data about an error response.
@@ -213,10 +208,7 @@ func (m *MarkdownRenderer) Render(ctx *command.Context, res command.Result, cmd 
 func (m *MarkdownRenderer) renderProjectResults(ctx *command.Context, results []command.ProjectResult, common commonData) string {
 	vcsHost := ctx.Pull.BaseRepo.VCSHost.Type
 
-	// A policy_check comment's results are always all-draft or all-real:
-	// they come from a single atlantis plan/draftplan invocation's
-	// policyCheckCmds, which are never a mix of the two. So it's safe to
-	// derive this once from the first result rather than per-project.
+	// Check if policy check is being run for a draftplan
 	if common.Command == policyCheckCommandTitle {
 		for _, result := range results {
 			if result.PolicyCheckResults != nil {

--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -67,6 +67,12 @@ type commonData struct {
 	HideUnchangedPlanComments bool
 	QuietPolicyChecks         bool
 	VcsRequestType            string
+	// IsDraftPolicyCheck is true if this is a policy_check comment for a
+	// draftplan. Named distinctly from models.PolicyCheckResults.IsDraftPlan
+	// (rather than reusing that name here) because policyCheckResultsData
+	// embeds both commonData and models.PolicyCheckResults - reusing the
+	// name would make .IsDraftPlan an ambiguous selector in templates.
+	IsDraftPolicyCheck bool
 }
 
 // errData is data about an error response.
@@ -206,6 +212,19 @@ func (m *MarkdownRenderer) Render(ctx *command.Context, res command.Result, cmd 
 
 func (m *MarkdownRenderer) renderProjectResults(ctx *command.Context, results []command.ProjectResult, common commonData) string {
 	vcsHost := ctx.Pull.BaseRepo.VCSHost.Type
+
+	// A policy_check comment's results are always all-draft or all-real:
+	// they come from a single atlantis plan/draftplan invocation's
+	// policyCheckCmds, which are never a mix of the two. So it's safe to
+	// derive this once from the first result rather than per-project.
+	if common.Command == policyCheckCommandTitle {
+		for _, result := range results {
+			if result.PolicyCheckResults != nil {
+				common.IsDraftPolicyCheck = result.PolicyCheckResults.IsDraftPlan
+				break
+			}
+		}
+	}
 
 	var resultsTmplData []projectResultTmplData
 	numPlanSuccesses := 0

--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -1292,6 +1292,145 @@ $$$
 	}
 }
 
+func TestRenderProjectResults_DraftPlanPolicyCheck(t *testing.T) {
+	cases := []struct {
+		Description    string
+		ProjectResults []command.ProjectResult
+		Expected       string
+	}{
+		{
+			"draftplan policy check cleared shows no apply/replan CTA",
+			[]command.ProjectResult{
+				{
+					ProjectCommandOutput: command.ProjectCommandOutput{
+						PolicyCheckResults: &models.PolicyCheckResults{
+							PolicySetResults: []models.PolicySetResult{
+								{
+									PolicySetName: "policy1",
+									PolicyOutput:  "2 tests, 2 passed, 0 warnings, 0 failure, 0 exceptions",
+									Passed:        true,
+									ReqApprovals:  1,
+								},
+							},
+							LockURL:     "lock-url",
+							RePlanCmd:   "atlantis plan -d path -w workspace",
+							ApplyCmd:    "atlantis apply -d path -w workspace",
+							IsDraftPlan: true,
+						},
+					},
+					Workspace:   "workspace",
+					RepoRelDir:  "path",
+					ProjectName: "projectname",
+				},
+			},
+			`
+Ran Policy Check for project: $projectname$ dir: $path$ workspace: $workspace$
+
+#### Policy Set: $policy1$
+$$$diff
+2 tests, 2 passed, 0 warnings, 0 failure, 0 exceptions
+$$$
+
+
+* :warning: This is a draftplan preview: it is not locked and may not reflect the latest state. Run ` + "`atlantis plan`" + ` to generate an applyable plan.
+
+---
+* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
+  $$$shell
+  atlantis apply
+  $$$
+* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
+  $$$shell
+  atlantis unlock
+  $$$
+`,
+		},
+		{
+			"draftplan policy check with violations shows approval status but no apply CTA",
+			[]command.ProjectResult{
+				{
+					ProjectCommandOutput: command.ProjectCommandOutput{
+						PolicyCheckResults: &models.PolicyCheckResults{
+							PolicySetResults: []models.PolicySetResult{
+								{
+									PolicySetName: "policy1",
+									PolicyOutput:  "FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibited.",
+									Passed:        false,
+									ReqApprovals:  1,
+								},
+							},
+							LockURL:            "lock-url",
+							RePlanCmd:          "atlantis plan -d path -w workspace",
+							ApplyCmd:           "atlantis apply -d path -w workspace",
+							ApprovePoliciesCmd: "atlantis approve_policies -d path -w workspace",
+							IsDraftPlan:        true,
+						},
+					},
+					Workspace:   "workspace",
+					RepoRelDir:  "path",
+					ProjectName: "projectname",
+				},
+			},
+			`
+Ran Policy Check for project: $projectname$ dir: $path$ workspace: $workspace$
+
+#### Policy Set: $policy1$
+$$$diff
+FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibited.
+$$$
+
+
+#### Policy Approval Status:
+$$$
+policy set: policy1: requires: 1 approval(s), have: 0.
+$$$
+* :warning: This is a draftplan preview: it is not locked and may not reflect the latest state. Run ` + "`atlantis plan`" + ` to generate an applyable plan.
+
+---
+* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
+  $$$shell
+  atlantis apply
+  $$$
+* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
+  $$$shell
+  atlantis unlock
+  $$$
+`,
+		},
+	}
+
+	r := events.NewMarkdownRenderer(
+		false,      // gitlabSupportsCommonMark
+		false,      // disableApplyAll
+		false,      // disableApply
+		false,      // disableMarkdownFolding
+		false,      // disableRepoLocking
+		false,      // enableDiffMarkdownFormat
+		"",         // markdownTemplateOverridesDir
+		"atlantis", // executableName
+		false,      // hideUnchangedPlanComments
+		false,      // quietPolicyChecks
+	)
+	ctx := &command.Context{
+		Log: logging.NewNoopLogger(t),
+		Pull: models.PullRequest{
+			BaseRepo: models.Repo{
+				VCSHost: models.VCSHost{
+					Type: models.Github,
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.Description, func(t *testing.T) {
+			res := command.Result{ProjectResults: c.ProjectResults}
+			cmd := &events.CommentCommand{Name: command.PolicyCheck}
+			s := r.Render(ctx, res, cmd)
+			Equals(t, normalize(c.Expected), normalize(s))
+		})
+	}
+}
+
 func TestRenderProjectResultsWithQuietPolicyChecks(t *testing.T) {
 	cases := []struct {
 		Description    string

--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -1330,6 +1330,16 @@ Ran Policy Check for project: $projectname$ dir: $path$ workspace: $workspace$
 $$$diff
 2 tests, 2 passed, 0 warnings, 0 failure, 0 exceptions
 $$$
+
+---
+* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
+  $$$shell
+  atlantis apply
+  $$$
+* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
+  $$$shell
+  atlantis unlock
+  $$$
 `,
 		},
 		{
@@ -1371,6 +1381,16 @@ $$$
 $$$
 policy set: policy1: requires: 1 approval(s), have: 0.
 $$$
+
+---
+* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
+  $$$shell
+  atlantis apply
+  $$$
+* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
+  $$$shell
+  atlantis unlock
+  $$$
 `,
 		},
 	}
@@ -1403,100 +1423,6 @@ $$$
 			cmd := &events.CommentCommand{Name: command.PolicyCheck}
 			s := r.Render(ctx, res, cmd)
 			Equals(t, normalize(c.Expected), normalize(s))
-		})
-	}
-}
-
-// Test that the multi-project policy_check footer ("apply all"/"approve
-// all"/"unlock" CTAs) is also suppressed for a draftplan, same as the
-// single-project templates.
-func TestRenderProjectResults_DraftPlanPolicyCheck_MultiProject(t *testing.T) {
-	draftProjectResult := func(name string, passed bool) command.ProjectResult {
-		policyOutput := "2 tests, 2 passed, 0 warnings, 0 failure, 0 exceptions"
-		if !passed {
-			policyOutput = "FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibited."
-		}
-		return command.ProjectResult{
-			ProjectCommandOutput: command.ProjectCommandOutput{
-				PolicyCheckResults: &models.PolicyCheckResults{
-					PolicySetResults: []models.PolicySetResult{
-						{
-							PolicySetName: "policy1",
-							PolicyOutput:  policyOutput,
-							Passed:        passed,
-							ReqApprovals:  1,
-						},
-					},
-					LockURL:            "lock-url",
-					RePlanCmd:          "atlantis plan -d " + name + " -w workspace",
-					ApplyCmd:           "atlantis apply -d " + name + " -w workspace",
-					ApprovePoliciesCmd: "atlantis approve_policies -d " + name + " -w workspace",
-					IsDraftPlan:        true,
-				},
-			},
-			Workspace:   "workspace",
-			RepoRelDir:  name,
-			ProjectName: name,
-		}
-	}
-
-	cases := []struct {
-		Description    string
-		ProjectResults []command.ProjectResult
-	}{
-		{
-			"all projects cleared",
-			[]command.ProjectResult{
-				draftProjectResult("project1", true),
-				draftProjectResult("project2", true),
-			},
-		},
-		{
-			"one project has violations",
-			[]command.ProjectResult{
-				draftProjectResult("project1", true),
-				draftProjectResult("project2", false),
-			},
-		},
-	}
-
-	r := events.NewMarkdownRenderer(
-		false,      // gitlabSupportsCommonMark
-		false,      // disableApplyAll
-		false,      // disableApply
-		false,      // disableMarkdownFolding
-		false,      // disableRepoLocking
-		false,      // enableDiffMarkdownFormat
-		"",         // markdownTemplateOverridesDir
-		"atlantis", // executableName
-		false,      // hideUnchangedPlanComments
-		false,      // quietPolicyChecks
-	)
-	ctx := &command.Context{
-		Log: logging.NewNoopLogger(t),
-		Pull: models.PullRequest{
-			BaseRepo: models.Repo{
-				VCSHost: models.VCSHost{
-					Type: models.Github,
-				},
-			},
-		},
-	}
-	for _, c := range cases {
-		t.Run(c.Description, func(t *testing.T) {
-			res := command.Result{ProjectResults: c.ProjectResults}
-			cmd := &events.CommentCommand{Name: command.PolicyCheck}
-			s := r.Render(ctx, res, cmd)
-			for _, forbidden := range []string{
-				"apply all unapplied plans",
-				"approve all unapplied plans",
-				"delete all plans and locks",
-				"atlantis apply",
-				"atlantis approve_policies",
-				"atlantis unlock",
-			} {
-				Assert(t, !strings.Contains(s, forbidden), "expected rendered comment not to contain %q, got:\n%s", forbidden, s)
-			}
 		})
 	}
 }

--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -1330,16 +1330,6 @@ Ran Policy Check for project: $projectname$ dir: $path$ workspace: $workspace$
 $$$diff
 2 tests, 2 passed, 0 warnings, 0 failure, 0 exceptions
 $$$
-
----
-* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
-  $$$shell
-  atlantis apply
-  $$$
-* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
-  $$$shell
-  atlantis unlock
-  $$$
 `,
 		},
 		{
@@ -1381,16 +1371,6 @@ $$$
 $$$
 policy set: policy1: requires: 1 approval(s), have: 0.
 $$$
-
----
-* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
-  $$$shell
-  atlantis apply
-  $$$
-* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
-  $$$shell
-  atlantis unlock
-  $$$
 `,
 		},
 	}
@@ -1423,6 +1403,100 @@ $$$
 			cmd := &events.CommentCommand{Name: command.PolicyCheck}
 			s := r.Render(ctx, res, cmd)
 			Equals(t, normalize(c.Expected), normalize(s))
+		})
+	}
+}
+
+// Test that the multi-project policy_check footer ("apply all"/"approve
+// all"/"unlock" CTAs) is also suppressed for a draftplan, same as the
+// single-project templates.
+func TestRenderProjectResults_DraftPlanPolicyCheck_MultiProject(t *testing.T) {
+	draftProjectResult := func(name string, passed bool) command.ProjectResult {
+		policyOutput := "2 tests, 2 passed, 0 warnings, 0 failure, 0 exceptions"
+		if !passed {
+			policyOutput = "FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibited."
+		}
+		return command.ProjectResult{
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PolicyCheckResults: &models.PolicyCheckResults{
+					PolicySetResults: []models.PolicySetResult{
+						{
+							PolicySetName: "policy1",
+							PolicyOutput:  policyOutput,
+							Passed:        passed,
+							ReqApprovals:  1,
+						},
+					},
+					LockURL:            "lock-url",
+					RePlanCmd:          "atlantis plan -d " + name + " -w workspace",
+					ApplyCmd:           "atlantis apply -d " + name + " -w workspace",
+					ApprovePoliciesCmd: "atlantis approve_policies -d " + name + " -w workspace",
+					IsDraftPlan:        true,
+				},
+			},
+			Workspace:   "workspace",
+			RepoRelDir:  name,
+			ProjectName: name,
+		}
+	}
+
+	cases := []struct {
+		Description    string
+		ProjectResults []command.ProjectResult
+	}{
+		{
+			"all projects cleared",
+			[]command.ProjectResult{
+				draftProjectResult("project1", true),
+				draftProjectResult("project2", true),
+			},
+		},
+		{
+			"one project has violations",
+			[]command.ProjectResult{
+				draftProjectResult("project1", true),
+				draftProjectResult("project2", false),
+			},
+		},
+	}
+
+	r := events.NewMarkdownRenderer(
+		false,      // gitlabSupportsCommonMark
+		false,      // disableApplyAll
+		false,      // disableApply
+		false,      // disableMarkdownFolding
+		false,      // disableRepoLocking
+		false,      // enableDiffMarkdownFormat
+		"",         // markdownTemplateOverridesDir
+		"atlantis", // executableName
+		false,      // hideUnchangedPlanComments
+		false,      // quietPolicyChecks
+	)
+	ctx := &command.Context{
+		Log: logging.NewNoopLogger(t),
+		Pull: models.PullRequest{
+			BaseRepo: models.Repo{
+				VCSHost: models.VCSHost{
+					Type: models.Github,
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.Description, func(t *testing.T) {
+			res := command.Result{ProjectResults: c.ProjectResults}
+			cmd := &events.CommentCommand{Name: command.PolicyCheck}
+			s := r.Render(ctx, res, cmd)
+			for _, forbidden := range []string{
+				"apply all unapplied plans",
+				"approve all unapplied plans",
+				"delete all plans and locks",
+				"atlantis apply",
+				"atlantis approve_policies",
+				"atlantis unlock",
+			} {
+				Assert(t, !strings.Contains(s, forbidden), "expected rendered comment not to contain %q, got:\n%s", forbidden, s)
+			}
 		})
 	}
 }

--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -1408,8 +1408,7 @@ $$$
 }
 
 // Test that the multi-project policy_check footer ("apply all"/"approve
-// all"/"unlock" CTAs) is also suppressed for a draftplan, same as the
-// single-project templates.
+// all"/"unlock" CTAs) is suppressed for a draftplan
 func TestRenderProjectResults_DraftPlanPolicyCheck_MultiProject(t *testing.T) {
 	draftProjectResult := func(name string, passed bool) command.ProjectResult {
 		policyOutput := "2 tests, 2 passed, 0 warnings, 0 failure, 0 exceptions"

--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -1330,19 +1330,6 @@ Ran Policy Check for project: $projectname$ dir: $path$ workspace: $workspace$
 $$$diff
 2 tests, 2 passed, 0 warnings, 0 failure, 0 exceptions
 $$$
-
-
-* :warning: This is a draftplan preview: it is not locked and may not reflect the latest state. Run ` + "`atlantis plan`" + ` to generate an applyable plan.
-
----
-* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
-  $$$shell
-  atlantis apply
-  $$$
-* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
-  $$$shell
-  atlantis unlock
-  $$$
 `,
 		},
 		{
@@ -1384,17 +1371,6 @@ $$$
 $$$
 policy set: policy1: requires: 1 approval(s), have: 0.
 $$$
-* :warning: This is a draftplan preview: it is not locked and may not reflect the latest state. Run ` + "`atlantis plan`" + ` to generate an applyable plan.
-
----
-* :fast_forward: To **apply** all unapplied plans from this Pull Request, comment:
-  $$$shell
-  atlantis apply
-  $$$
-* :put_litter_in_its_place: To **delete** all plans and locks from this Pull Request, comment:
-  $$$shell
-  atlantis unlock
-  $$$
 `,
 		},
 	}
@@ -1427,6 +1403,100 @@ $$$
 			cmd := &events.CommentCommand{Name: command.PolicyCheck}
 			s := r.Render(ctx, res, cmd)
 			Equals(t, normalize(c.Expected), normalize(s))
+		})
+	}
+}
+
+// Test that the multi-project policy_check footer ("apply all"/"approve
+// all"/"unlock" CTAs) is also suppressed for a draftplan, same as the
+// single-project templates.
+func TestRenderProjectResults_DraftPlanPolicyCheck_MultiProject(t *testing.T) {
+	draftProjectResult := func(name string, passed bool) command.ProjectResult {
+		policyOutput := "2 tests, 2 passed, 0 warnings, 0 failure, 0 exceptions"
+		if !passed {
+			policyOutput = "FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibited."
+		}
+		return command.ProjectResult{
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PolicyCheckResults: &models.PolicyCheckResults{
+					PolicySetResults: []models.PolicySetResult{
+						{
+							PolicySetName: "policy1",
+							PolicyOutput:  policyOutput,
+							Passed:        passed,
+							ReqApprovals:  1,
+						},
+					},
+					LockURL:            "lock-url",
+					RePlanCmd:          "atlantis plan -d " + name + " -w workspace",
+					ApplyCmd:           "atlantis apply -d " + name + " -w workspace",
+					ApprovePoliciesCmd: "atlantis approve_policies -d " + name + " -w workspace",
+					IsDraftPlan:        true,
+				},
+			},
+			Workspace:   "workspace",
+			RepoRelDir:  name,
+			ProjectName: name,
+		}
+	}
+
+	cases := []struct {
+		Description    string
+		ProjectResults []command.ProjectResult
+	}{
+		{
+			"all projects cleared",
+			[]command.ProjectResult{
+				draftProjectResult("project1", true),
+				draftProjectResult("project2", true),
+			},
+		},
+		{
+			"one project has violations",
+			[]command.ProjectResult{
+				draftProjectResult("project1", true),
+				draftProjectResult("project2", false),
+			},
+		},
+	}
+
+	r := events.NewMarkdownRenderer(
+		false,      // gitlabSupportsCommonMark
+		false,      // disableApplyAll
+		false,      // disableApply
+		false,      // disableMarkdownFolding
+		false,      // disableRepoLocking
+		false,      // enableDiffMarkdownFormat
+		"",         // markdownTemplateOverridesDir
+		"atlantis", // executableName
+		false,      // hideUnchangedPlanComments
+		false,      // quietPolicyChecks
+	)
+	ctx := &command.Context{
+		Log: logging.NewNoopLogger(t),
+		Pull: models.PullRequest{
+			BaseRepo: models.Repo{
+				VCSHost: models.VCSHost{
+					Type: models.Github,
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.Description, func(t *testing.T) {
+			res := command.Result{ProjectResults: c.ProjectResults}
+			cmd := &events.CommentCommand{Name: command.PolicyCheck}
+			s := r.Render(ctx, res, cmd)
+			for _, forbidden := range []string{
+				"apply all unapplied plans",
+				"approve all unapplied plans",
+				"delete all plans and locks",
+				"atlantis apply",
+				"atlantis approve_policies",
+				"atlantis unlock",
+			} {
+				Assert(t, !strings.Contains(s, forbidden), "expected rendered comment not to contain %q, got:\n%s", forbidden, s)
+			}
 		})
 	}
 }

--- a/server/events/mock_workingdir_test.go
+++ b/server/events/mock_workingdir_test.go
@@ -181,19 +181,23 @@ func (mock *MockWorkingDir) GitReadLock(r models.Repo, p models.PullRequest, wor
 	return _ret0
 }
 
-func (mock *MockWorkingDir) HasDiverged(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) bool {
+func (mock *MockWorkingDir) HasDiverged(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) (bool, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockWorkingDir().")
 	}
 	_params := []pegomock.Param{logger, cloneDir, projectPath, autoplanWhenModified, pullRequest}
-	_result := pegomock.GetGenericMockFrom(mock).Invoke("HasDiverged", _params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem()})
+	_result := pegomock.GetGenericMockFrom(mock).Invoke("HasDiverged", _params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
 	var _ret0 bool
+	var _ret1 error
 	if len(_result) != 0 {
 		if _result[0] != nil {
 			_ret0 = _result[0].(bool)
 		}
+		if _result[1] != nil {
+			_ret1 = _result[1].(error)
+		}
 	}
-	return _ret0
+	return _ret0, _ret1
 }
 
 func (mock *MockWorkingDir) MergeAgain(logger logging.SimpleLogging, headRepo models.Repo, p models.PullRequest, workspace string) (bool, error) {

--- a/server/events/mocks/mock_working_dir.go
+++ b/server/events/mocks/mock_working_dir.go
@@ -181,19 +181,23 @@ func (mock *MockWorkingDir) GitReadLock(r models.Repo, p models.PullRequest, wor
 	return _ret0
 }
 
-func (mock *MockWorkingDir) HasDiverged(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) bool {
+func (mock *MockWorkingDir) HasDiverged(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) (bool, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockWorkingDir().")
 	}
 	_params := []pegomock.Param{logger, cloneDir, projectPath, autoplanWhenModified, pullRequest}
-	_result := pegomock.GetGenericMockFrom(mock).Invoke("HasDiverged", _params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem()})
+	_result := pegomock.GetGenericMockFrom(mock).Invoke("HasDiverged", _params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
 	var _ret0 bool
+	var _ret1 error
 	if len(_result) != 0 {
 		if _result[0] != nil {
 			_ret0 = _result[0].(bool)
 		}
+		if _result[1] != nil {
+			_ret1 = _result[1].(error)
+		}
 	}
-	return _ret0
+	return _ret0, _ret1
 }
 
 func (mock *MockWorkingDir) MergeAgain(logger logging.SimpleLogging, headRepo models.Repo, p models.PullRequest, workspace string) (bool, error) {

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -485,6 +485,9 @@ type PolicyCheckResults struct {
 	// branch we're merging into has been updated since we cloned and merged
 	// it.
 	HasDiverged bool
+	// IsDraftPlan is true if this policy check ran against a draftplan
+	// preview rather than a full plan, in which case ApplyCmd is not usable.
+	IsDraftPlan bool
 }
 
 // ImportSuccess is the result of a successful import run.
@@ -615,6 +618,14 @@ const (
 	// PassedPolicyCheckStatus means that there was an unapplied plan that was
 	// discarded due to a project being unlocked
 	PassedPolicyCheckStatus
+	// DraftPlannedPlanStatus means that a draftplan has been successfully
+	// generated with changes. Unlike PlannedPlanStatus, this plan was not
+	// taken under a lock or against refreshed state, so it cannot be applied.
+	DraftPlannedPlanStatus
+	// DraftPlannedNoChangesPlanStatus means that a draftplan has been
+	// successfully generated with "No changes". Like DraftPlannedPlanStatus,
+	// this cannot be applied.
+	DraftPlannedNoChangesPlanStatus
 )
 
 // String returns a string representation of the status.
@@ -636,6 +647,10 @@ func (p ProjectPlanStatus) String() string {
 		return "policy_check_errored"
 	case PassedPolicyCheckStatus:
 		return "policy_check_passed"
+	case DraftPlannedPlanStatus:
+		return "draft_planned"
+	case DraftPlannedNoChangesPlanStatus:
+		return "draft_planned_no_changes"
 	default:
 		panic("missing String() impl for ProjectPlanStatus")
 	}

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -583,8 +583,6 @@ type ProjectStatus struct {
 	Workspace   string
 	RepoRelDir  string
 	ProjectName string
-	// IsDraftPlan is true when the latest plan for this project was a draftplan.
-	IsDraftPlan bool
 	// PolicySetApprovals tracks the approval status of every PolicySet for a Project.
 	PolicyStatus []PolicySetStatus
 	// Status is the status of where this project is at in the planning cycle.

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -583,6 +583,8 @@ type ProjectStatus struct {
 	Workspace   string
 	RepoRelDir  string
 	ProjectName string
+	// IsDraftPlan is true when the latest plan for this project was a draftplan.
+	IsDraftPlan bool
 	// PolicySetApprovals tracks the approval status of every PolicySet for a Project.
 	PolicyStatus []PolicySetStatus
 	// Status is the status of where this project is at in the planning cycle.

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -309,11 +309,13 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 
 	// Runs policy checks step after all plans are successful.
 	// This step does not approve any policies that require approval.
-	if cmd.Name == command.Plan && len(result.ProjectResults) > 0 &&
+	// Draftplan also runs policy checks so that violations are visible
+	// before a real, locked plan is ever generated.
+	if (cmd.Name == command.Plan || cmd.Name == command.DraftPlan) && len(result.ProjectResults) > 0 &&
 		(!result.HasErrors() && !result.PlansDeleted) {
 		ctx.Log.Info("Running policy check for '%s'", cmd.CommandName())
 		p.policyCheckCommandRunner.Run(ctx, policyCheckCmds)
-	} else if len(projectCmds) == 0 && cmd.Name == command.Plan && !cmd.IsForSpecificProject() {
+	} else if len(projectCmds) == 0 && (cmd.Name == command.Plan || cmd.Name == command.DraftPlan) && !cmd.IsForSpecificProject() {
 		// If there were no projects modified, we set successful commit statuses
 		// with 0/0 projects planned/policy_checked/applied successfully because some users require
 		// the Atlantis status to be passing for all pull requests.

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -205,7 +205,7 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 		ctx.Log.Warn("unable to get pull request status: %s. Continuing with mergeable and approved assumed false", err)
 	}
 
-	if p.DiscardApprovalOnPlan {
+	if cmd.Name != command.DraftPlan && p.DiscardApprovalOnPlan {
 		if err = p.pullUpdater.VCSClient.DiscardReviews(ctx.Log, baseRepo, pull); err != nil {
 			ctx.Log.Err("failed to remove approvals: %s", err)
 		}
@@ -213,7 +213,7 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 
 	projectCmds, err := p.prjCmdBuilder.BuildPlanCommands(ctx, cmd)
 	if err != nil {
-		if statusErr := p.commitStatusUpdater.UpdateCombined(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, command.Plan); statusErr != nil {
+		if statusErr := p.commitStatusUpdater.UpdateCombined(ctx.Log, ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, cmd.Name); statusErr != nil {
 			ctx.Log.Warn("unable to update commit status: %s", statusErr)
 		}
 		p.pullUpdater.updatePull(ctx, cmd, command.Result{Error: err})
@@ -233,27 +233,29 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 				if pullStatus == nil {
 					// default to 0/0
 					ctx.Log.Debug("setting VCS status to 0/0 success as no previous state was found")
-					if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.Plan, 0, 0); err != nil {
+					if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, cmd.Name, 0, 0); err != nil {
 						ctx.Log.Warn("unable to update commit status: %s", err)
 					}
 					return
 				}
 				ctx.Log.Debug("resetting VCS status")
-				p.updateCommitStatus(ctx, *pullStatus, command.Plan)
+				p.updateCommitStatus(ctx, *pullStatus, cmd.Name)
 			} else {
 				// With a generic plan, we set successful commit statuses
 				// with 0/0 projects planned successfully because some users require
 				// the Atlantis status to be passing for all pull requests.
 				// Does not apply to skipped runs for specific projects
 				ctx.Log.Debug("setting VCS status to success with no projects found")
-				if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.Plan, 0, 0); err != nil {
+				if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, cmd.Name, 0, 0); err != nil {
 					ctx.Log.Warn("unable to update commit status: %s", err)
 				}
-				if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.PolicyCheck, 0, 0); err != nil {
-					ctx.Log.Warn("unable to update commit status: %s", err)
-				}
-				if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.Apply, 0, 0); err != nil {
-					ctx.Log.Warn("unable to update commit status: %s", err)
+				if cmd.Name == command.Plan {
+					if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.PolicyCheck, 0, 0); err != nil {
+						ctx.Log.Warn("unable to update commit status: %s", err)
+					}
+					if err := p.commitStatusUpdater.UpdateCombinedCount(ctx.Log, baseRepo, pull, models.SuccessCommitStatus, command.Apply, 0, 0); err != nil {
+						ctx.Log.Warn("unable to update commit status: %s", err)
+					}
 				}
 			}
 		} else {
@@ -267,7 +269,7 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 
 	// if the plan is generic, new plans will be generated based on changes
 	// discard previous plans that might not be relevant anymore
-	if !cmd.IsForSpecificProject() {
+	if cmd.Name != command.DraftPlan && !cmd.IsForSpecificProject() {
 		ctx.Log.Debug("deleting previous plans and locks")
 		p.deletePlans(ctx)
 		_, err := p.lockingLocker.UnlockByPull(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num)
@@ -279,7 +281,7 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 	result := runProjectCmdsWithCancellationTracker(ctx, projectCmds, p.cancellationTracker, p.parallelPoolSize, p.isParallelEnabled(projectCmds), p.prjCmdRunner.Plan)
 	ctx.CommandHasErrors = result.HasErrors()
 
-	if p.autoMerger.automergeEnabled(projectCmds) && result.HasErrors() {
+	if cmd.Name != command.DraftPlan && p.autoMerger.automergeEnabled(projectCmds) && result.HasErrors() {
 		ctx.Log.Info("deleting plans because there were errors and automerge requires all plans succeed")
 		p.deletePlans(ctx)
 		_, err := p.lockingLocker.UnlockByPull(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num)
@@ -300,16 +302,18 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 		return
 	}
 
-	p.updateCommitStatus(ctx, pullStatus, command.Plan)
-	p.updateCommitStatus(ctx, pullStatus, command.Apply)
+	p.updateCommitStatus(ctx, pullStatus, cmd.Name)
+	if cmd.Name == command.Plan {
+		p.updateCommitStatus(ctx, pullStatus, command.Apply)
+	}
 
 	// Runs policy checks step after all plans are successful.
 	// This step does not approve any policies that require approval.
-	if len(result.ProjectResults) > 0 &&
+	if cmd.Name == command.Plan && len(result.ProjectResults) > 0 &&
 		(!result.HasErrors() && !result.PlansDeleted) {
 		ctx.Log.Info("Running policy check for '%s'", cmd.CommandName())
 		p.policyCheckCommandRunner.Run(ctx, policyCheckCmds)
-	} else if len(projectCmds) == 0 && !cmd.IsForSpecificProject() {
+	} else if len(projectCmds) == 0 && cmd.Name == command.Plan && !cmd.IsForSpecificProject() {
 		// If there were no projects modified, we set successful commit statuses
 		// with 0/0 projects planned/policy_checked/applied successfully because some users require
 		// the Atlantis status to be passing for all pull requests.
@@ -334,7 +338,7 @@ func (p *PlanCommandRunner) updateCommitStatus(ctx *command.Context, pullStatus 
 	status := models.SuccessCommitStatus
 
 	switch commandName {
-	case command.Plan:
+	case command.Plan, command.DraftPlan:
 		numErrored = pullStatus.StatusCount(models.ErroredPlanStatus)
 		// We consider anything that isn't a plan error as a plan success.
 		// For example, if there is an apply error, that means that at least a
@@ -402,7 +406,7 @@ func (p *PlanCommandRunner) partitionProjectCmds(
 ) {
 	for _, cmd := range cmds {
 		switch cmd.CommandName {
-		case command.Plan:
+		case command.Plan, command.DraftPlan:
 			projectCmds = append(projectCmds, cmd)
 		case command.PolicyCheck:
 			policyCheckCmds = append(policyCheckCmds, cmd)

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -309,8 +309,7 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *CommentCommand) {
 
 	// Runs policy checks step after all plans are successful.
 	// This step does not approve any policies that require approval.
-	// Draftplan also runs policy checks so that violations are visible
-	// before a real, locked plan is ever generated.
+	// Draftplan runs the same policy check step as Plan.
 	if (cmd.Name == command.Plan || cmd.Name == command.DraftPlan) && len(result.ProjectResults) > 0 &&
 		(!result.HasErrors() && !result.PlansDeleted) {
 		ctx.Log.Info("Running policy check for '%s'", cmd.CommandName())
@@ -351,7 +350,9 @@ func (p *PlanCommandRunner) updateCommitStatus(ctx *command.Context, pullStatus 
 			status = models.FailedCommitStatus
 		}
 	case command.Apply:
-		numSuccess = pullStatus.StatusCount(models.AppliedPlanStatus) + pullStatus.StatusCount(models.PlannedNoChangesPlanStatus)
+		// A draftplan with no changes has nothing to apply, same as a real
+		// plan with no changes, so it counts toward success here too.
+		numSuccess = pullStatus.StatusCount(models.AppliedPlanStatus) + pullStatus.StatusCount(models.PlannedNoChangesPlanStatus) + pullStatus.StatusCount(models.DraftPlannedNoChangesPlanStatus)
 		numErrored = pullStatus.StatusCount(models.ErroredApplyStatus)
 
 		if numErrored > 0 {

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -350,7 +350,6 @@ func (p *PlanCommandRunner) updateCommitStatus(ctx *command.Context, pullStatus 
 			status = models.FailedCommitStatus
 		}
 	case command.Apply:
-		// A no-changes draftplan has nothing to apply either, so count it too.
 		numSuccess = pullStatus.StatusCount(models.AppliedPlanStatus) + pullStatus.StatusCount(models.PlannedNoChangesPlanStatus) + pullStatus.StatusCount(models.DraftPlannedNoChangesPlanStatus)
 		numErrored = pullStatus.StatusCount(models.ErroredApplyStatus)
 

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -350,8 +350,7 @@ func (p *PlanCommandRunner) updateCommitStatus(ctx *command.Context, pullStatus 
 			status = models.FailedCommitStatus
 		}
 	case command.Apply:
-		// A draftplan with no changes has nothing to apply, same as a real
-		// plan with no changes, so it counts toward success here too.
+		// A no-changes draftplan has nothing to apply either, so count it too.
 		numSuccess = pullStatus.StatusCount(models.AppliedPlanStatus) + pullStatus.StatusCount(models.PlannedNoChangesPlanStatus) + pullStatus.StatusCount(models.DraftPlannedNoChangesPlanStatus)
 		numErrored = pullStatus.StatusCount(models.ErroredApplyStatus)
 

--- a/server/events/plan_command_runner_test.go
+++ b/server/events/plan_command_runner_test.go
@@ -165,6 +165,47 @@ func TestPlanCommandRunner_IsSilenced(t *testing.T) {
 	}
 }
 
+func TestPlanCommandRunner_DraftPlanTriggersPolicyCheck(t *testing.T) {
+	RegisterMockTestingT(t)
+	setup(t)
+
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num}
+	cmd := &events.CommentCommand{Name: command.DraftPlan}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     modelPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+
+	When(projectCommandBuilder.BuildPlanCommands(ctx, cmd)).ThenReturn([]command.ProjectContext{
+		{CommandName: command.DraftPlan, RepoRelDir: "somedir", Workspace: "default"},
+		{CommandName: command.PolicyCheck, RepoRelDir: "somedir", Workspace: "default"},
+	}, nil)
+	When(projectCommandRunner.Plan(Any[command.ProjectContext]())).ThenReturn(command.ProjectCommandOutput{PlanSuccess: &models.PlanSuccess{}})
+	When(projectCommandRunner.PolicyCheck(Any[command.ProjectContext]())).ThenReturn(command.ProjectCommandOutput{
+		PolicyCheckResults: &models.PolicyCheckResults{},
+	})
+
+	planCommandRunner.Run(ctx, cmd)
+
+	// A draftplan should still run the policy_check step for its projects,
+	// same as a real plan would, so violations surface before a real,
+	// locked plan is ever generated.
+	projectCommandRunner.VerifyWasCalledOnce().PolicyCheck(Any[command.ProjectContext]())
+	commitUpdater.VerifyWasCalledOnce().UpdateCombinedCount(
+		Any[logging.SimpleLogging](),
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Eq[models.CommitStatus](models.SuccessCommitStatus),
+		Eq[command.Name](command.PolicyCheck),
+		Eq(1),
+		Eq(1),
+	)
+}
+
 func TestPlanCommandRunner_ExecutionOrder(t *testing.T) {
 	logger := logging.NewNoopLogger(t)
 	RegisterMockTestingT(t)

--- a/server/events/plan_command_runner_test.go
+++ b/server/events/plan_command_runner_test.go
@@ -192,8 +192,7 @@ func TestPlanCommandRunner_DraftPlanTriggersPolicyCheck(t *testing.T) {
 	planCommandRunner.Run(ctx, cmd)
 
 	// A draftplan should still run the policy_check step for its projects,
-	// same as a real plan would, so violations surface before a real,
-	// locked plan is ever generated.
+	// same as a real plan would.
 	projectCommandRunner.VerifyWasCalledOnce().PolicyCheck(Any[command.ProjectContext]())
 	commitUpdater.VerifyWasCalledOnce().UpdateCombinedCount(
 		Any[logging.SimpleLogging](),
@@ -203,6 +202,66 @@ func TestPlanCommandRunner_DraftPlanTriggersPolicyCheck(t *testing.T) {
 		Eq[command.Name](command.PolicyCheck),
 		Eq(1),
 		Eq(1),
+	)
+}
+
+func TestPlanCommandRunner_ApplyStatusCountsDraftPlanNoChanges(t *testing.T) {
+	RegisterMockTestingT(t)
+
+	tmp := t.TempDir()
+	database, err := boltdb.New(tmp)
+	t.Cleanup(func() {
+		database.Close()
+	})
+	Ok(t, err)
+
+	setup(t, func(tc *TestConfig) {
+		tc.database = database
+	})
+
+	modelPull := models.PullRequest{BaseRepo: testdata.GithubRepo, State: models.OpenPullState, Num: testdata.Pull.Num}
+	cmd := &events.CommentCommand{Name: command.Plan}
+	ctx := &command.Context{
+		User:     testdata.User,
+		Log:      logging.NewNoopLogger(t),
+		Scope:    metricstest.NewLoggingScope(t, logging.NewNoopLogger(t), "atlantis"),
+		Pull:     modelPull,
+		HeadRepo: testdata.GithubRepo,
+		Trigger:  command.CommentTrigger,
+	}
+
+	// "draftdir" only ever had a "no changes" draftplan; it will never get
+	// a real plan or apply, and shouldn't permanently block the PR's Apply
+	// status from going green.
+	_, err = database.UpdatePullWithResults(modelPull, []command.ProjectResult{
+		{
+			Command:    command.DraftPlan,
+			RepoRelDir: "draftdir",
+			Workspace:  "default",
+			ProjectCommandOutput: command.ProjectCommandOutput{
+				PlanSuccess: &models.PlanSuccess{TerraformOutput: "No changes. Infrastructure is up-to-date."},
+			},
+		},
+	})
+	Ok(t, err)
+
+	When(projectCommandBuilder.BuildPlanCommands(ctx, cmd)).ThenReturn([]command.ProjectContext{
+		{CommandName: command.Plan, RepoRelDir: "mydir", Workspace: "default"},
+	}, nil)
+	When(projectCommandRunner.Plan(Any[command.ProjectContext]())).ThenReturn(command.ProjectCommandOutput{
+		PlanSuccess: &models.PlanSuccess{TerraformOutput: "No changes. Infrastructure is up-to-date."},
+	})
+
+	planCommandRunner.Run(ctx, cmd)
+
+	commitUpdater.VerifyWasCalledOnce().UpdateCombinedCount(
+		Any[logging.SimpleLogging](),
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Eq[models.CommitStatus](models.SuccessCommitStatus),
+		Eq[command.Name](command.Apply),
+		Eq(2),
+		Eq(2),
 	)
 }
 

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -750,7 +750,7 @@ func (p *DefaultProjectCommandBuilder) buildProjectPlanCommand(ctx *command.Cont
 
 	return p.buildProjectCommandCtx(
 		ctx,
-		command.Plan,
+		cmd.Name,
 		"",
 		cmd.ProjectName,
 		cmd.Flags,

--- a/server/events/project_command_context_builder.go
+++ b/server/events/project_command_context_builder.go
@@ -103,7 +103,7 @@ func (cb *DefaultProjectCommandContextBuilder) BuildProjectContext(
 
 	var steps []valid.Step
 	switch cmdName {
-	case command.Plan:
+	case command.Plan, command.DraftPlan:
 		steps = prjCfg.Workflow.Plan.Steps
 	case command.Apply:
 		steps = prjCfg.Workflow.Apply.Steps

--- a/server/events/project_command_context_builder.go
+++ b/server/events/project_command_context_builder.go
@@ -151,6 +151,7 @@ func (cb *DefaultProjectCommandContextBuilder) BuildProjectContext(
 		ctx.PullRequestStatus,
 		ctx.PullStatus,
 		ctx.TeamAllowlistChecker,
+		cmdName == command.DraftPlan,
 	)
 
 	projectCmds = append(projectCmds, projectCmdContext)
@@ -201,7 +202,7 @@ func (cb *PolicyCheckProjectCommandContextBuilder) BuildProjectContext(
 		terraformClient,
 	)
 
-	if cmdName == command.Plan && prjCfg.PolicyCheck {
+	if (cmdName == command.Plan || cmdName == command.DraftPlan) && prjCfg.PolicyCheck {
 		ctx.Log.Debug("Building project command context for %s", command.PolicyCheck)
 		steps := prjCfg.Workflow.PolicyCheck.Steps
 
@@ -225,6 +226,7 @@ func (cb *PolicyCheckProjectCommandContextBuilder) BuildProjectContext(
 			ctx.PullRequestStatus,
 			ctx.PullStatus,
 			ctx.TeamAllowlistChecker,
+			cmdName == command.DraftPlan,
 		))
 	}
 
@@ -252,6 +254,7 @@ func newProjectCommandContext(ctx *command.Context,
 	pullReqStatus models.PullReqStatus,
 	pullStatus *models.PullStatus,
 	teamAllowlistChecker command.TeamAllowlistChecker,
+	isDraftPlan bool,
 ) command.ProjectContext {
 
 	var projectPlanStatus models.ProjectPlanStatus
@@ -321,6 +324,7 @@ func newProjectCommandContext(ctx *command.Context,
 		AbortOnExecutionOrderFail:  abortOnExecutionOrderFail,
 		SilencePRComments:          projCfg.SilencePRComments,
 		TeamAllowlistChecker:       teamAllowlistChecker,
+		IsDraftPlan:                isDraftPlan,
 	}
 }
 

--- a/server/events/project_command_context_builder.go
+++ b/server/events/project_command_context_builder.go
@@ -259,7 +259,6 @@ func newProjectCommandContext(ctx *command.Context,
 
 	var projectPlanStatus models.ProjectPlanStatus
 	var projectPolicyStatus []models.PolicySetStatus
-	projectIsDraftPlan := isDraftPlan
 
 	if ctx.PullStatus != nil {
 		for _, project := range ctx.PullStatus.Projects {
@@ -268,18 +267,12 @@ func newProjectCommandContext(ctx *command.Context,
 			if projCfg.Name == "" && project.RepoRelDir == projCfg.RepoRelDir {
 				projectPlanStatus = project.Status
 				projectPolicyStatus = project.PolicyStatus
-				if cmd == command.Apply {
-					projectIsDraftPlan = projectIsDraftPlan || project.IsDraftPlan
-				}
 				break
 			}
 
 			if projCfg.Name != "" && project.ProjectName == projCfg.Name {
 				projectPlanStatus = project.Status
 				projectPolicyStatus = project.PolicyStatus
-				if cmd == command.Apply {
-					projectIsDraftPlan = projectIsDraftPlan || project.IsDraftPlan
-				}
 				break
 			}
 		}
@@ -331,7 +324,7 @@ func newProjectCommandContext(ctx *command.Context,
 		AbortOnExecutionOrderFail:  abortOnExecutionOrderFail,
 		SilencePRComments:          projCfg.SilencePRComments,
 		TeamAllowlistChecker:       teamAllowlistChecker,
-		IsDraftPlan:                projectIsDraftPlan,
+		IsDraftPlan:                isDraftPlan,
 	}
 }
 

--- a/server/events/project_command_context_builder.go
+++ b/server/events/project_command_context_builder.go
@@ -202,7 +202,7 @@ func (cb *PolicyCheckProjectCommandContextBuilder) BuildProjectContext(
 		terraformClient,
 	)
 
-	if (cmdName == command.Plan || cmdName == command.DraftPlan) && prjCfg.PolicyCheck {
+	if (cmdName == command.Plan || (cmdName == command.DraftPlan && prjCfg.DraftPlanPolicyCheck)) && prjCfg.PolicyCheck {
 		ctx.Log.Debug("Building project command context for %s", command.PolicyCheck)
 		steps := prjCfg.Workflow.PolicyCheck.Steps
 
@@ -259,6 +259,7 @@ func newProjectCommandContext(ctx *command.Context,
 
 	var projectPlanStatus models.ProjectPlanStatus
 	var projectPolicyStatus []models.PolicySetStatus
+	projectIsDraftPlan := isDraftPlan
 
 	if ctx.PullStatus != nil {
 		for _, project := range ctx.PullStatus.Projects {
@@ -267,12 +268,18 @@ func newProjectCommandContext(ctx *command.Context,
 			if projCfg.Name == "" && project.RepoRelDir == projCfg.RepoRelDir {
 				projectPlanStatus = project.Status
 				projectPolicyStatus = project.PolicyStatus
+				if cmd == command.Apply {
+					projectIsDraftPlan = projectIsDraftPlan || project.IsDraftPlan
+				}
 				break
 			}
 
 			if projCfg.Name != "" && project.ProjectName == projCfg.Name {
 				projectPlanStatus = project.Status
 				projectPolicyStatus = project.PolicyStatus
+				if cmd == command.Apply {
+					projectIsDraftPlan = projectIsDraftPlan || project.IsDraftPlan
+				}
 				break
 			}
 		}
@@ -324,7 +331,7 @@ func newProjectCommandContext(ctx *command.Context,
 		AbortOnExecutionOrderFail:  abortOnExecutionOrderFail,
 		SilencePRComments:          projCfg.SilencePRComments,
 		TeamAllowlistChecker:       teamAllowlistChecker,
-		IsDraftPlan:                isDraftPlan,
+		IsDraftPlan:                projectIsDraftPlan,
 	}
 }
 

--- a/server/events/project_command_context_builder_test.go
+++ b/server/events/project_command_context_builder_test.go
@@ -129,3 +129,58 @@ func TestProjectCommandContextBuilder_PullStatus(t *testing.T) {
 		assert.True(t, result[0].AbortOnExecutionOrderFail)
 	})
 }
+
+func TestPolicyCheckProjectCommandContextBuilder_BuildProjectContext(t *testing.T) {
+	mockCommentBuilder := mocks.NewMockCommentBuilder()
+	subject := events.PolicyCheckProjectCommandContextBuilder{
+		CommentBuilder:               mockCommentBuilder,
+		ProjectCommandContextBuilder: &events.DefaultProjectCommandContextBuilder{CommentBuilder: mockCommentBuilder},
+	}
+
+	projCfg := valid.MergedProjectCfg{
+		RepoRelDir: "dir1",
+		Workspace:  "default",
+		Name:       "project1",
+		PolicyCheck: true,
+		Workflow: valid.Workflow{
+			Name: valid.DefaultWorkflowName,
+			Plan: valid.DefaultPlanStage,
+		},
+	}
+
+	commandCtx := &command.Context{
+		Log:        logging.NewNoopLogger(t),
+		PullStatus: &models.PullStatus{Projects: []models.ProjectStatus{}},
+	}
+
+	terraformClient := tfclientmocks.NewMockClient()
+
+	t.Run("plan with policy checks enabled builds a plan and a policy_check context", func(t *testing.T) {
+		result := subject.BuildProjectContext(commandCtx, command.Plan, "", projCfg, []string{}, "some/dir", false, false, false, false, false, terraformClient)
+
+		assert.Len(t, result, 2)
+		assert.Equal(t, command.Plan, result[0].CommandName)
+		assert.False(t, result[0].IsDraftPlan)
+		assert.Equal(t, command.PolicyCheck, result[1].CommandName)
+		assert.False(t, result[1].IsDraftPlan)
+	})
+
+	t.Run("draftplan with policy checks enabled also builds a policy_check context, marked as draft", func(t *testing.T) {
+		result := subject.BuildProjectContext(commandCtx, command.DraftPlan, "", projCfg, []string{}, "some/dir", false, false, false, false, false, terraformClient)
+
+		assert.Len(t, result, 2)
+		assert.Equal(t, command.DraftPlan, result[0].CommandName)
+		assert.True(t, result[0].IsDraftPlan)
+		assert.Equal(t, command.PolicyCheck, result[1].CommandName)
+		assert.True(t, result[1].IsDraftPlan)
+	})
+
+	t.Run("draftplan with policy checks disabled only builds the draftplan context", func(t *testing.T) {
+		disabledCfg := projCfg
+		disabledCfg.PolicyCheck = false
+		result := subject.BuildProjectContext(commandCtx, command.DraftPlan, "", disabledCfg, []string{}, "some/dir", false, false, false, false, false, terraformClient)
+
+		assert.Len(t, result, 1)
+		assert.Equal(t, command.DraftPlan, result[0].CommandName)
+	})
+}

--- a/server/events/project_command_context_builder_test.go
+++ b/server/events/project_command_context_builder_test.go
@@ -196,38 +196,4 @@ func TestPolicyCheckProjectCommandContextBuilder_BuildProjectContext(t *testing.
 		assert.Equal(t, command.DraftPlan, result[0].CommandName)
 	})
 
-	t.Run("persisted draftplan marker is propagated to apply context", func(t *testing.T) {
-		ctx := &command.Context{
-			Log: logging.NewNoopLogger(t),
-			PullStatus: &models.PullStatus{Projects: []models.ProjectStatus{
-				{
-					ProjectName: "project1",
-					RepoRelDir:  "dir1",
-					IsDraftPlan: true,
-				},
-			}},
-		}
-		result := subject.BuildProjectContext(ctx, command.Apply, "", projCfg, []string{}, "some/dir", false, false, false, false, false, terraformClient)
-
-		assert.Len(t, result, 1)
-		assert.True(t, result[0].IsDraftPlan)
-	})
-
-	t.Run("persisted draftplan marker does not affect a real plan", func(t *testing.T) {
-		ctx := &command.Context{
-			Log: logging.NewNoopLogger(t),
-			PullStatus: &models.PullStatus{Projects: []models.ProjectStatus{
-				{
-					ProjectName: "project1",
-					RepoRelDir:  "dir1",
-					IsDraftPlan: true,
-				},
-			}},
-		}
-		result := subject.BuildProjectContext(ctx, command.Plan, "", projCfg, []string{}, "some/dir", false, false, false, false, false, terraformClient)
-
-		assert.Len(t, result, 2)
-		assert.False(t, result[0].IsDraftPlan)
-		assert.False(t, result[1].IsDraftPlan)
-	})
 }

--- a/server/events/project_command_context_builder_test.go
+++ b/server/events/project_command_context_builder_test.go
@@ -36,6 +36,8 @@ func TestProjectCommandContextBuilder_PullStatus(t *testing.T) {
 			Name:  valid.DefaultWorkflowName,
 			Apply: valid.DefaultApplyStage,
 		},
+		PolicyCheck:          true,
+		DraftPlanPolicyCheck: true,
 	}
 
 	pullStatus := &models.PullStatus{
@@ -138,10 +140,11 @@ func TestPolicyCheckProjectCommandContextBuilder_BuildProjectContext(t *testing.
 	}
 
 	projCfg := valid.MergedProjectCfg{
-		RepoRelDir: "dir1",
-		Workspace:  "default",
-		Name:       "project1",
-		PolicyCheck: true,
+		RepoRelDir:           "dir1",
+		Workspace:            "default",
+		Name:                 "project1",
+		PolicyCheck:          true,
+		DraftPlanPolicyCheck: true,
 		Workflow: valid.Workflow{
 			Name: valid.DefaultWorkflowName,
 			Plan: valid.DefaultPlanStage,
@@ -182,5 +185,49 @@ func TestPolicyCheckProjectCommandContextBuilder_BuildProjectContext(t *testing.
 
 		assert.Len(t, result, 1)
 		assert.Equal(t, command.DraftPlan, result[0].CommandName)
+	})
+
+	t.Run("draftplan policy checks can be disabled independently", func(t *testing.T) {
+		disabledCfg := projCfg
+		disabledCfg.DraftPlanPolicyCheck = false
+		result := subject.BuildProjectContext(commandCtx, command.DraftPlan, "", disabledCfg, []string{}, "some/dir", false, false, false, false, false, terraformClient)
+
+		assert.Len(t, result, 1)
+		assert.Equal(t, command.DraftPlan, result[0].CommandName)
+	})
+
+	t.Run("persisted draftplan marker is propagated to apply context", func(t *testing.T) {
+		ctx := &command.Context{
+			Log: logging.NewNoopLogger(t),
+			PullStatus: &models.PullStatus{Projects: []models.ProjectStatus{
+				{
+					ProjectName: "project1",
+					RepoRelDir:  "dir1",
+					IsDraftPlan: true,
+				},
+			}},
+		}
+		result := subject.BuildProjectContext(ctx, command.Apply, "", projCfg, []string{}, "some/dir", false, false, false, false, false, terraformClient)
+
+		assert.Len(t, result, 1)
+		assert.True(t, result[0].IsDraftPlan)
+	})
+
+	t.Run("persisted draftplan marker does not affect a real plan", func(t *testing.T) {
+		ctx := &command.Context{
+			Log: logging.NewNoopLogger(t),
+			PullStatus: &models.PullStatus{Projects: []models.ProjectStatus{
+				{
+					ProjectName: "project1",
+					RepoRelDir:  "dir1",
+					IsDraftPlan: true,
+				},
+			}},
+		}
+		result := subject.BuildProjectContext(ctx, command.Plan, "", projCfg, []string{}, "some/dir", false, false, false, false, false, terraformClient)
+
+		assert.Len(t, result, 2)
+		assert.False(t, result[0].IsDraftPlan)
+		assert.False(t, result[1].IsDraftPlan)
 	})
 }

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -566,6 +566,7 @@ func (p *DefaultProjectCommandRunner) doPolicyCheck(ctx command.ProjectContext) 
 		RePlanCmd:          ctx.RePlanCmd,
 		ApplyCmd:           ctx.ApplyCmd,
 		ApprovePoliciesCmd: ctx.ApprovePoliciesCmd,
+		IsDraftPlan:        ctx.IsDraftPlan,
 	}
 
 	// Using this function instead of catching failed policy runs with errors, for cases when '--no-fail' is passed to conftest.

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -175,7 +175,7 @@ type ProjectOutputWrapper struct {
 }
 
 func (p *ProjectOutputWrapper) Plan(ctx command.ProjectContext) command.ProjectCommandOutput {
-	result := p.updateProjectPRStatus(command.Plan, ctx, p.ProjectCommandRunner.Plan)
+	result := p.updateProjectPRStatus(ctx.CommandName, ctx, p.ProjectCommandRunner.Plan)
 	p.JobMessageSender.Send(ctx, "", OperationComplete)
 	return result
 }
@@ -584,7 +584,8 @@ func (p *DefaultProjectCommandRunner) doPolicyCheck(ctx command.ProjectContext) 
 
 func (p *DefaultProjectCommandRunner) doPlan(ctx command.ProjectContext) (*models.PlanSuccess, string, error) {
 	// Acquire Atlantis lock for this repo/dir/workspace.
-	lockAttempt, err := p.Locker.TryLock(ctx.Log, ctx.Pull, ctx.User, ctx.Workspace, models.NewProject(ctx.Pull.BaseRepo.FullName, ctx.RepoRelDir, ctx.ProjectName), ctx.RepoLocksMode == valid.RepoLocksOnPlanMode)
+	useRealLock := ctx.RepoLocksMode == valid.RepoLocksOnPlanMode && ctx.CommandName != command.DraftPlan
+	lockAttempt, err := p.Locker.TryLock(ctx.Log, ctx.Pull, ctx.User, ctx.Workspace, models.NewProject(ctx.Pull.BaseRepo.FullName, ctx.RepoRelDir, ctx.ProjectName), useRealLock)
 	if err != nil {
 		return nil, "", fmt.Errorf("acquiring lock: %w", err)
 	}
@@ -832,7 +833,7 @@ func (p *DefaultProjectCommandRunner) runSteps(steps []valid.Step, ctx command.P
 		switch step.StepName {
 		case "init":
 			out, err = p.InitStepRunner.Run(ctx, step.ExtraArgs, absPath, envs)
-		case "plan":
+		case "plan", "draftplan":
 			out, err = p.PlanStepRunner.Run(ctx, step.ExtraArgs, absPath, envs)
 		case "show":
 			_, err = p.ShowStepRunner.Run(ctx, step.ExtraArgs, absPath, envs)

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -418,6 +418,8 @@ func (p *DefaultProjectCommandRunner) doPolicyCheck(ctx command.ProjectContext) 
 		return nil, "", fmt.Errorf("acquiring lock: %w", err)
 	}
 	if !lockAttempt.LockAcquired {
+		// Only false if we attempt to acquire the lock and we fail.
+		// So, for draftplans, when we skip lock acquisition, this will still be true.
 		return nil, lockAttempt.LockFailureReason, nil
 	}
 	if useLock {

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -409,7 +409,10 @@ func (p *DefaultProjectCommandRunner) doPolicyCheck(ctx command.ProjectContext) 
 	// we will attempt to capture the lock here but fail to get the working directory
 	// at which point we will unlock again to preserve functionality
 	// If we fail to capture the lock here (super unlikely) then we error out and the user is forced to replan
-	lockAttempt, err := p.Locker.TryLock(ctx.Log, ctx.Pull, ctx.User, ctx.Workspace, models.NewProject(ctx.Pull.BaseRepo.FullName, ctx.RepoRelDir, ctx.ProjectName), ctx.RepoLocksMode == valid.RepoLocksOnPlanMode)
+	// Skip the check to re-acquire a lock when running a draftplan.
+
+	useLock := ctx.RepoLocksMode == valid.RepoLocksOnPlanMode && !ctx.IsDraftPlan
+	lockAttempt, err := p.Locker.TryLock(ctx.Log, ctx.Pull, ctx.User, ctx.Workspace, models.NewProject(ctx.Pull.BaseRepo.FullName, ctx.RepoRelDir, ctx.ProjectName), useLock)
 
 	if err != nil {
 		return nil, "", fmt.Errorf("acquiring lock: %w", err)
@@ -417,7 +420,11 @@ func (p *DefaultProjectCommandRunner) doPolicyCheck(ctx command.ProjectContext) 
 	if !lockAttempt.LockAcquired {
 		return nil, lockAttempt.LockFailureReason, nil
 	}
-	ctx.Log.Debug("acquired lock for project.")
+	if useLock {
+		ctx.Log.Debug("acquired lock for project.")
+	} else {
+		ctx.Log.Debug("draftplan: skipped acquiring a real lock for project.")
+	}
 
 	// Acquire internal lock for the directory we're going to operate in.
 	// We should refactor this to keep the lock for the duration of plan and policy check since as of now
@@ -584,16 +591,23 @@ func (p *DefaultProjectCommandRunner) doPolicyCheck(ctx command.ProjectContext) 
 }
 
 func (p *DefaultProjectCommandRunner) doPlan(ctx command.ProjectContext) (*models.PlanSuccess, string, error) {
-	// Acquire Atlantis lock for this repo/dir/workspace.
-	useRealLock := ctx.RepoLocksMode == valid.RepoLocksOnPlanMode && ctx.CommandName != command.DraftPlan
-	lockAttempt, err := p.Locker.TryLock(ctx.Log, ctx.Pull, ctx.User, ctx.Workspace, models.NewProject(ctx.Pull.BaseRepo.FullName, ctx.RepoRelDir, ctx.ProjectName), useRealLock)
+	// Acquire Atlantis lock for this repo/dir/workspace. Draftplan never
+	// takes a real lock, so it uses a no-op locker that always trivially
+	// succeeds instead - useLock only controls which locker backs the
+	// lock, not whether TryLock succeeds.
+	useLock := ctx.RepoLocksMode == valid.RepoLocksOnPlanMode && ctx.CommandName != command.DraftPlan
+	lockAttempt, err := p.Locker.TryLock(ctx.Log, ctx.Pull, ctx.User, ctx.Workspace, models.NewProject(ctx.Pull.BaseRepo.FullName, ctx.RepoRelDir, ctx.ProjectName), useLock)
 	if err != nil {
 		return nil, "", fmt.Errorf("acquiring lock: %w", err)
 	}
 	if !lockAttempt.LockAcquired {
 		return nil, lockAttempt.LockFailureReason, nil
 	}
-	ctx.Log.Debug("acquired lock for project")
+	if useLock {
+		ctx.Log.Debug("acquired lock for project")
+	} else {
+		ctx.Log.Debug("draftplan: skipped acquiring a real lock for project")
+	}
 
 	// Acquire internal lock for the directory we're going to operate in.
 	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace, ctx.RepoRelDir, ctx.ProjectName, command.Plan)

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -593,10 +593,8 @@ func (p *DefaultProjectCommandRunner) doPolicyCheck(ctx command.ProjectContext) 
 }
 
 func (p *DefaultProjectCommandRunner) doPlan(ctx command.ProjectContext) (*models.PlanSuccess, string, error) {
-	// Acquire Atlantis lock for this repo/dir/workspace. Draftplan never
-	// takes a real lock, so it uses a no-op locker that always trivially
-	// succeeds instead - useLock only controls which locker backs the
-	// lock, not whether TryLock succeeds.
+	// Acquire Atlantis lock for this repo/dir/workspace.
+	// Draftplan acquires a real lock; it instead uses a no-op locker that always trivially succeeds.
 	useLock := ctx.RepoLocksMode == valid.RepoLocksOnPlanMode && ctx.CommandName != command.DraftPlan
 	lockAttempt, err := p.Locker.TryLock(ctx.Log, ctx.Pull, ctx.User, ctx.Workspace, models.NewProject(ctx.Pull.BaseRepo.FullName, ctx.RepoRelDir, ctx.ProjectName), useLock)
 	if err != nil {

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -207,8 +207,10 @@ func TestProjectOutputWrapper(t *testing.T) {
 
 			switch c.CommandName {
 			case command.Plan:
+				ctx.CommandName = command.Plan
 				runner.Plan(ctx)
 			case command.Apply:
+				ctx.CommandName = command.Apply
 				runner.Apply(ctx)
 			}
 

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -304,7 +304,7 @@ func TestDefaultProjectCommandRunner_ApplyDiverged(t *testing.T) {
 	}
 	tmp := t.TempDir()
 	When(mockWorkingDir.GetWorkingDir(ctx.BaseRepo, ctx.Pull, ctx.Workspace)).ThenReturn(tmp, nil)
-	When(mockWorkingDir.HasDiverged(ctx.Log, tmp, ctx.RepoRelDir, ctx.AutoplanWhenModified, ctx.Pull)).ThenReturn(true)
+	When(mockWorkingDir.HasDiverged(ctx.Log, tmp, ctx.RepoRelDir, ctx.AutoplanWhenModified, ctx.Pull)).ThenReturn(true, nil)
 
 	res := runner.Apply(ctx)
 	Equals(t, "Default branch must be rebased onto pull request before running apply.", res.Failure)

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -118,10 +118,6 @@ func TestDefaultProjectCommandRunner_Plan(t *testing.T) {
 }
 
 // Test that doPlan doesn't actually acquire the lock during draftplan.
-// The planfile-location half of "draftplan doesn't affect
-// the real plan process" is already covered with real filesystem checks by
-// TestRun_DraftPlan/TestRun_RemoteOps_DraftPlan in plan_step_runner_test.go;
-// this covers the lock half at the level a real caller invokes.
 func TestDefaultProjectCommandRunner_Plan_DraftPlanDoesNotTakeRealLock(t *testing.T) {
 	RegisterMockTestingT(t)
 

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -745,6 +745,86 @@ func (m mockURLGenerator) GenerateLockURL(lockID string) string {
 	return "https://" + lockID
 }
 
+// The policy_check step normally tries to re-acquire the lock to avoid some edge cases.
+// Ensure that it skips this step if it is being run as part of a draftplan.
+func TestDefaultProjectCommandRunner_PolicyCheck_DraftPlanDoesNotTakeRealLock(t *testing.T) {
+	RegisterMockTestingT(t)
+
+	cases := []struct {
+		description      string
+		isDraftPlan      bool
+		expectedRealLock bool
+	}{
+		{"real plan's policy check takes a real lock", false, true},
+		{"draftplan's policy check does not take a real lock", true, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			mockPolicyCheck := mocks.NewMockStepRunner()
+			mockWorkingDir := mocks.NewMockWorkingDir()
+			mockLocker := mocks.NewMockProjectLocker()
+
+			runner := events.DefaultProjectCommandRunner{
+				Locker:                mockLocker,
+				LockURLGenerator:      mockURLGenerator{},
+				PolicyCheckStepRunner: mockPolicyCheck,
+				WorkingDir:            mockWorkingDir,
+				WorkingDirLocker:      events.NewDefaultWorkingDirLocker(),
+			}
+
+			repoDir := t.TempDir()
+			When(mockWorkingDir.GetWorkingDir(
+				Any[models.Repo](),
+				Any[models.PullRequest](),
+				Any[string](),
+			)).ThenReturn(repoDir, nil)
+			When(mockWorkingDir.GitReadLock(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).ThenReturn(func() {})
+
+			When(mockLocker.TryLock(
+				Any[logging.SimpleLogging](),
+				Any[models.PullRequest](),
+				Any[models.User](),
+				Any[string](),
+				Any[models.Project](),
+				AnyBool(),
+			)).ThenReturn(&events.TryLockResponse{
+				LockAcquired: true,
+				LockKey:      "lock-key",
+			}, nil)
+
+			When(mockPolicyCheck.Run(
+				Any[command.ProjectContext](),
+				Any[[]string](),
+				Any[string](),
+				Any[map[string]string](),
+			)).ThenReturn("Policy check passed", nil)
+
+			ctx := command.ProjectContext{
+				Log:               logging.NewNoopLogger(t),
+				Workspace:         "default",
+				RepoRelDir:        ".",
+				IsDraftPlan:       c.isDraftPlan,
+				RepoLocksMode:     valid.RepoLocksOnPlanMode,
+				CustomPolicyCheck: true,
+				Steps:             []valid.Step{{StepName: "policy_check"}},
+			}
+
+			res := runner.PolicyCheck(ctx)
+			Assert(t, res.Error == nil, "not expecting error: %v", res.Error)
+
+			mockLocker.VerifyWasCalledOnce().TryLock(
+				Any[logging.SimpleLogging](),
+				Any[models.PullRequest](),
+				Any[models.User](),
+				Any[string](),
+				Any[models.Project](),
+				Eq(c.expectedRealLock),
+			)
+		})
+	}
+}
+
 // Test that custom policy checks use configured policy set names instead of defaulting to "Custom".
 // This is a regression test for https://github.com/runatlantis/atlantis/pull/5331
 // where custom policy sets defaulting to "Custom" allowed any user to approve policies.

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -117,6 +117,80 @@ func TestDefaultProjectCommandRunner_Plan(t *testing.T) {
 	}
 }
 
+// Test that doPlan doesn't actually acquire the lock during draftplan.
+// The planfile-location half of "draftplan doesn't affect
+// the real plan process" is already covered with real filesystem checks by
+// TestRun_DraftPlan/TestRun_RemoteOps_DraftPlan in plan_step_runner_test.go;
+// this covers the lock half at the level a real caller invokes.
+func TestDefaultProjectCommandRunner_Plan_DraftPlanDoesNotTakeRealLock(t *testing.T) {
+	RegisterMockTestingT(t)
+
+	cases := []struct {
+		description      string
+		commandName      command.Name
+		expectedRealLock bool
+	}{
+		{"real plan takes a real lock", command.Plan, true},
+		{"draftplan does not take a real lock", command.DraftPlan, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			mockPlan := mocks.NewMockStepRunner()
+			mockWorkingDir := mocks.NewMockWorkingDir()
+			mockLocker := mocks.NewMockProjectLocker()
+			mockCommandRequirementHandler := mocks.NewMockCommandRequirementHandler()
+
+			runner := events.DefaultProjectCommandRunner{
+				Locker:                    mockLocker,
+				LockURLGenerator:          mockURLGenerator{},
+				PlanStepRunner:            mockPlan,
+				WorkingDir:                mockWorkingDir,
+				WorkingDirLocker:          events.NewDefaultWorkingDirLocker(),
+				CommandRequirementHandler: mockCommandRequirementHandler,
+			}
+
+			repoDir := t.TempDir()
+			When(mockWorkingDir.Clone(Any[logging.SimpleLogging](), Any[models.Repo](), Any[models.PullRequest](),
+				Any[string]())).ThenReturn(repoDir, nil)
+			When(mockWorkingDir.GitReadLock(Any[models.Repo](), Any[models.PullRequest](), Any[string]())).ThenReturn(func() {})
+
+			When(mockLocker.TryLock(
+				Any[logging.SimpleLogging](),
+				Any[models.PullRequest](),
+				Any[models.User](),
+				Any[string](),
+				Any[models.Project](),
+				AnyBool(),
+			)).ThenReturn(&events.TryLockResponse{LockAcquired: true, LockKey: "lock-key"}, nil)
+
+			ctx := command.ProjectContext{
+				Log:           logging.NewNoopLogger(t),
+				CommandName:   c.commandName,
+				RepoLocksMode: valid.RepoLocksOnPlanMode,
+				Steps:         []valid.Step{{StepName: "plan"}},
+				Workspace:     "default",
+				RepoRelDir:    ".",
+			}
+
+			When(mockPlan.Run(ctx, nil, repoDir, map[string]string(nil))).ThenReturn("plan output", nil)
+
+			res := runner.Plan(ctx)
+			Assert(t, res.Error == nil, "not expecting error: %v", res.Error)
+			Assert(t, res.PlanSuccess != nil, "expecting plan success")
+
+			mockLocker.VerifyWasCalledOnce().TryLock(
+				Any[logging.SimpleLogging](),
+				Any[models.PullRequest](),
+				Any[models.User](),
+				Any[string](),
+				Any[models.Project](),
+				Eq(c.expectedRealLock),
+			)
+		})
+	}
+}
+
 func TestProjectOutputWrapper(t *testing.T) {
 	RegisterMockTestingT(t)
 	ctx := command.ProjectContext{

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -825,6 +825,64 @@ func TestDefaultProjectCommandRunner_PolicyCheck_DraftPlanDoesNotTakeRealLock(t 
 	}
 }
 
+// Test that when TryLock fails to acquire the lock (e.g. another pull
+// request already holds it), doPolicyCheck returns the failure reason
+// immediately and never proceeds to clone/run policy check steps.
+func TestDefaultProjectCommandRunner_PolicyCheck_LockAcquisitionFails(t *testing.T) {
+	RegisterMockTestingT(t)
+
+	mockPolicyCheck := mocks.NewMockStepRunner()
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockLocker := mocks.NewMockProjectLocker()
+
+	runner := events.DefaultProjectCommandRunner{
+		Locker:                mockLocker,
+		LockURLGenerator:      mockURLGenerator{},
+		PolicyCheckStepRunner: mockPolicyCheck,
+		WorkingDir:            mockWorkingDir,
+		WorkingDirLocker:      events.NewDefaultWorkingDirLocker(),
+	}
+
+	When(mockLocker.TryLock(
+		Any[logging.SimpleLogging](),
+		Any[models.PullRequest](),
+		Any[models.User](),
+		Any[string](),
+		Any[models.Project](),
+		AnyBool(),
+	)).ThenReturn(&events.TryLockResponse{
+		LockAcquired:      false,
+		LockFailureReason: "locked by another pull",
+	}, nil)
+
+	ctx := command.ProjectContext{
+		Log:               logging.NewNoopLogger(t),
+		Workspace:         "default",
+		RepoRelDir:        ".",
+		RepoLocksMode:     valid.RepoLocksOnPlanMode,
+		CustomPolicyCheck: true,
+		Steps:             []valid.Step{{StepName: "policy_check"}},
+	}
+
+	res := runner.PolicyCheck(ctx)
+
+	Assert(t, res.Error == nil, "not expecting error: %v", res.Error)
+	Assert(t, res.PolicyCheckResults == nil, "not expecting policy check results")
+	Equals(t, "locked by another pull", res.Failure)
+
+	mockPolicyCheck.VerifyWasCalled(Never()).Run(
+		Any[command.ProjectContext](),
+		Any[[]string](),
+		Any[string](),
+		Any[map[string]string](),
+	)
+	mockWorkingDir.VerifyWasCalled(Never()).GetWorkingDir(
+		Any[models.Repo](),
+		Any[models.PullRequest](),
+		Any[string](),
+	)
+}
+
 // Test that custom policy checks use configured policy set names instead of defaulting to "Custom".
 // This is a regression test for https://github.com/runatlantis/atlantis/pull/5331
 // where custom policy sets defaulting to "Custom" allowed any user to approve policies.

--- a/server/events/project_locker.go
+++ b/server/events/project_locker.go
@@ -80,12 +80,6 @@ func (p *DefaultProjectLocker) TryLock(log logging.SimpleLogging, pull models.Pu
 	return &TryLockResponse{
 		LockAcquired: true,
 		UnlockFn: func() error {
-			// Release through the same locker used to acquire (NoOpLocker
-			// if repoLocking is false). Lock keys don't include the pull
-			// number (see GenerateLockKey), so releasing through Locker
-			// when NoOpLocker was used to acquire could delete an
-			// unrelated lock on the same project/workspace held by a
-			// different pull request.
 			_, err := locker.Unlock(lockAttempt.LockKey)
 			return err
 		},

--- a/server/events/project_locker.go
+++ b/server/events/project_locker.go
@@ -80,7 +80,13 @@ func (p *DefaultProjectLocker) TryLock(log logging.SimpleLogging, pull models.Pu
 	return &TryLockResponse{
 		LockAcquired: true,
 		UnlockFn: func() error {
-			_, err := p.Locker.Unlock(lockAttempt.LockKey)
+			// Release through the same locker used to acquire (NoOpLocker
+			// if repoLocking is false). Lock keys don't include the pull
+			// number (see GenerateLockKey), so releasing through Locker
+			// when NoOpLocker was used to acquire could delete an
+			// unrelated lock on the same project/workspace held by a
+			// different pull request.
+			_, err := locker.Unlock(lockAttempt.LockKey)
 			return err
 		},
 		LockKey: lockAttempt.LockKey,

--- a/server/events/project_locker_test.go
+++ b/server/events/project_locker_test.go
@@ -200,6 +200,8 @@ func TestDefaultProjectLocker_RepoLocking(t *testing.T) {
 					},
 					nil,
 				)
+				// UnlockFn should release through Locker (repo locking is enabled).
+				locker.EXPECT().Unlock(lockKey).Return(nil, nil)
 				// noOpLocker has no EXPECT — gomock will fail if it's called
 			},
 		},
@@ -215,6 +217,11 @@ func TestDefaultProjectLocker_RepoLocking(t *testing.T) {
 					},
 					nil,
 				)
+				// UnlockFn should release through NoOpLocker, not Locker.
+				// Lock keys don't include the pull number, so releasing
+				// through Locker here could delete an unrelated lock on
+				// the same project/workspace held by another pull.
+				noOpLocker.EXPECT().Unlock(lockKey).Return(nil, nil)
 				// locker has no EXPECT — gomock will fail if it's called
 			},
 		},
@@ -234,6 +241,9 @@ func TestDefaultProjectLocker_RepoLocking(t *testing.T) {
 			res, err := locker.TryLock(logging.NewNoopLogger(t), expPull, expUser, expWorkspace, expProject, tt.repoLocking)
 			Ok(t, err)
 			Equals(t, true, res.LockAcquired)
+
+			unlockErr := res.UnlockFn()
+			Ok(t, unlockErr)
 		})
 	}
 }

--- a/server/events/templates/draftplan_success_unwrapped.tmpl
+++ b/server/events/templates/draftplan_success_unwrapped.tmpl
@@ -1,0 +1,7 @@
+{{ define "draftplanSuccessUnwrapped" -}}
+```diff
+{{ if .EnableDiffMarkdownFormat }}{{ .DiffMarkdownFormattedTerraformOutput }}{{ else }}{{ .TerraformOutput }}{{ end }}
+```
+
+{{ template "mergedAgain" . }}
+{{ end -}}

--- a/server/events/templates/draftplan_success_wrapped.tmpl
+++ b/server/events/templates/draftplan_success_wrapped.tmpl
@@ -1,0 +1,11 @@
+{{ define "draftplanSuccessWrapped" -}}
+<details><summary>Show Output</summary>
+
+```diff
+{{ if .EnableDiffMarkdownFormat }}{{ .DiffMarkdownFormattedTerraformOutput }}{{ else }}{{ .TerraformOutput }}{{ end }}
+```
+
+</details>
+{{ .PlanSummary -}}
+{{ template "mergedAgain" . -}}
+{{ end -}}

--- a/server/events/templates/multi_project_draftplan.tmpl
+++ b/server/events/templates/multi_project_draftplan.tmpl
@@ -1,0 +1,12 @@
+{{ define "multiProjectDraftPlan" -}}
+{{ template "multiProjectHeader" . }}
+{{ $disableApplyAll := .DisableApplyAll -}}
+{{ $hideUnchangedPlans := .HideUnchangedPlanComments -}}
+{{ range $i, $result := .Results -}}
+{{ if (and $hideUnchangedPlans $result.NoChanges) }}{{continue}}{{end -}}
+### {{ add $i 1 }}. {{ if $result.ProjectName }}project: `{{ $result.ProjectName }}` {{ end }}dir: `{{ $result.RepoRelDir }}` workspace: `{{ $result.Workspace }}`
+{{ $result.Rendered }}
+
+{{ end -}}
+{{- template "log" . -}}
+{{ end -}}

--- a/server/events/templates/multi_project_policy.tmpl
+++ b/server/events/templates/multi_project_policy.tmpl
@@ -14,7 +14,7 @@
 {{ end -}}
 {{ end -}}
 {{ if ne .DisableApplyAll true -}}
-{{ if and (gt (len .Results) 0) (not .PlansDeleted) -}}
+{{ if and (and (gt (len .Results) 0) (not .PlansDeleted)) (not .IsDraftPolicyCheck) -}}
 * :fast_forward: To **apply** all unapplied plans from this {{ .VcsRequestType }}, comment:
   ```shell
   {{ .ExecutableName }} apply

--- a/server/events/templates/multi_project_policy.tmpl
+++ b/server/events/templates/multi_project_policy.tmpl
@@ -14,7 +14,7 @@
 {{ end -}}
 {{ end -}}
 {{ if ne .DisableApplyAll true -}}
-{{ if and (and (gt (len .Results) 0) (not .PlansDeleted)) (not .IsDraftPolicyCheck) -}}
+{{ if and (gt (len .Results) 0) (not .PlansDeleted) -}}
 * :fast_forward: To **apply** all unapplied plans from this {{ .VcsRequestType }}, comment:
   ```shell
   {{ .ExecutableName }} apply

--- a/server/events/templates/multi_project_policy_unsuccessful.tmpl
+++ b/server/events/templates/multi_project_policy_unsuccessful.tmpl
@@ -12,7 +12,7 @@
 {{ end -}}
 {{ end -}}
 {{ if ne .DisableApplyAll true -}}
-{{ if and (and (gt (len .Results) 0) (not .PlansDeleted)) (not .IsDraftPolicyCheck) -}}
+{{ if and (gt (len .Results) 0) (not .PlansDeleted) -}}
 * :heavy_check_mark: To **approve** all unapplied plans from this {{ .VcsRequestType }}, comment:
   ```shell
   {{ .ExecutableName }} approve_policies

--- a/server/events/templates/multi_project_policy_unsuccessful.tmpl
+++ b/server/events/templates/multi_project_policy_unsuccessful.tmpl
@@ -12,7 +12,7 @@
 {{ end -}}
 {{ end -}}
 {{ if ne .DisableApplyAll true -}}
-{{ if and (gt (len .Results) 0) (not .PlansDeleted) -}}
+{{ if and (and (gt (len .Results) 0) (not .PlansDeleted)) (not .IsDraftPolicyCheck) -}}
 * :heavy_check_mark: To **approve** all unapplied plans from this {{ .VcsRequestType }}, comment:
   ```shell
   {{ .ExecutableName }} approve_policies

--- a/server/events/templates/policy_check_results_unwrapped.tmpl
+++ b/server/events/templates/policy_check_results_unwrapped.tmpl
@@ -12,6 +12,15 @@
 ```
 {{ end -}}
 {{- end }}
+{{- if .IsDraftPlan }}
+{{- if not .PolicyCleared }}
+#### Policy Approval Status:
+```
+{{ .PolicyApprovalSummary }}
+```
+{{- end }}
+* :warning: This is a draftplan preview: it is not locked and may not reflect the latest state. Run `atlantis plan` to generate an applyable plan.
+{{- else }}
 {{- if .PolicyCleared }}
 * :arrow_forward: To **apply** this plan, comment:
   ```shell
@@ -32,4 +41,5 @@
   ```shell
   {{ .RePlanCmd }}
   ```
+{{- end }}
 {{ end -}}

--- a/server/events/templates/policy_check_results_unwrapped.tmpl
+++ b/server/events/templates/policy_check_results_unwrapped.tmpl
@@ -19,7 +19,6 @@
 {{ .PolicyApprovalSummary }}
 ```
 {{- end }}
-* :warning: This is a draftplan preview: it is not locked and may not reflect the latest state. Run `atlantis plan` to generate an applyable plan.
 {{- else }}
 {{- if .PolicyCleared }}
 * :arrow_forward: To **apply** this plan, comment:

--- a/server/events/templates/policy_check_results_wrapped.tmpl
+++ b/server/events/templates/policy_check_results_wrapped.tmpl
@@ -15,6 +15,18 @@
 ```
 {{ end -}}
 {{- end }}
+{{- if .IsDraftPlan }}
+</details>
+
+{{- if not .PolicyCleared }}
+
+#### Policy Approval Status:
+```
+{{ .PolicyApprovalSummary }}
+```
+{{- end }}
+* :warning: This is a draftplan preview: it is not locked and may not reflect the latest state. Run `atlantis plan` to generate an applyable plan.
+{{- else }}
 {{- if .PolicyCleared }}
 * :arrow_forward: To **apply** this plan, comment:
   ```shell
@@ -37,6 +49,7 @@
   ```shell
   {{ .RePlanCmd }}
   ```
+{{- end }}
 {{- if eq .Command "Policy Check" }}
 
 {{- if ne .PolicyCheckSummary "" }}

--- a/server/events/templates/policy_check_results_wrapped.tmpl
+++ b/server/events/templates/policy_check_results_wrapped.tmpl
@@ -25,7 +25,6 @@
 {{ .PolicyApprovalSummary }}
 ```
 {{- end }}
-* :warning: This is a draftplan preview: it is not locked and may not reflect the latest state. Run `atlantis plan` to generate an applyable plan.
 {{- else }}
 {{- if .PolicyCleared }}
 * :arrow_forward: To **apply** this plan, comment:

--- a/server/events/templates/policy_check_results_wrapped.tmpl
+++ b/server/events/templates/policy_check_results_wrapped.tmpl
@@ -18,7 +18,7 @@
 {{- if .IsDraftPlan }}
 </details>
 
-{{- if not .PolicyCleared }}
+{{ if not .PolicyCleared }}
 
 #### Policy Approval Status:
 ```

--- a/server/events/templates/single_project_draftplan_success.tmpl
+++ b/server/events/templates/single_project_draftplan_success.tmpl
@@ -1,0 +1,7 @@
+{{ define "singleProjectDraftPlanSuccess" -}}
+{{ $result := index .Results 0 -}}
+Ran {{ .Command }} for {{ if $result.ProjectName }}project: `{{ $result.ProjectName }}` {{ end }}dir: `{{ $result.RepoRelDir }}` workspace: `{{ $result.Workspace }}`
+
+{{ $result.Rendered }}
+{{- template "log" . -}}
+{{ end -}}

--- a/server/events/templates/single_project_draftplan_unsuccessful.tmpl
+++ b/server/events/templates/single_project_draftplan_unsuccessful.tmpl
@@ -1,0 +1,7 @@
+{{ define "singleProjectDraftPlanUnsuccessful" -}}
+{{ $result := index .Results 0 -}}
+Ran {{ .Command }} for dir: `{{ $result.RepoRelDir }}` workspace: `{{ $result.Workspace }}`
+
+{{ $result.Rendered }}
+{{- template "log" . -}}
+{{ end -}}

--- a/server/events/templates/single_project_plan_success.tmpl
+++ b/server/events/templates/single_project_plan_success.tmpl
@@ -3,7 +3,7 @@
 Ran {{ .Command }} for {{ if $result.ProjectName }}project: `{{ $result.ProjectName }}` {{ end }}dir: `{{ $result.RepoRelDir }}` workspace: `{{ $result.Workspace }}`
 
 {{ $result.Rendered }}
-{{ if and (ne .DisableApplyAll true) (not .IsDraftPolicyCheck) }}
+{{ if ne .DisableApplyAll true }}
 ---
 * :fast_forward: To **apply** all unapplied plans from this {{ .VcsRequestType }}, comment:
   ```shell

--- a/server/events/templates/single_project_plan_success.tmpl
+++ b/server/events/templates/single_project_plan_success.tmpl
@@ -3,7 +3,7 @@
 Ran {{ .Command }} for {{ if $result.ProjectName }}project: `{{ $result.ProjectName }}` {{ end }}dir: `{{ $result.RepoRelDir }}` workspace: `{{ $result.Workspace }}`
 
 {{ $result.Rendered }}
-{{ if ne .DisableApplyAll true }}
+{{ if and (ne .DisableApplyAll true) (not .IsDraftPolicyCheck) }}
 ---
 * :fast_forward: To **apply** all unapplied plans from this {{ .VcsRequestType }}, comment:
   ```shell

--- a/server/events/templates/single_project_policy_unsuccessful.tmpl
+++ b/server/events/templates/single_project_policy_unsuccessful.tmpl
@@ -3,7 +3,7 @@
 Ran {{ .Command }} for {{ if $result.ProjectName }}project: `{{ $result.ProjectName }}` {{ end }}dir: `{{ $result.RepoRelDir }}` workspace: `{{ $result.Workspace }}`
 
 {{ $result.Rendered }}
-{{ if ne .DisableApplyAll true -}}
+{{ if and (ne .DisableApplyAll true) (not .IsDraftPolicyCheck) -}}
 ---
 * :heavy_check_mark: To **approve** all unapplied plans from this {{ .VcsRequestType }}, comment:
   ```shell

--- a/server/events/templates/single_project_policy_unsuccessful.tmpl
+++ b/server/events/templates/single_project_policy_unsuccessful.tmpl
@@ -3,7 +3,7 @@
 Ran {{ .Command }} for {{ if $result.ProjectName }}project: `{{ $result.ProjectName }}` {{ end }}dir: `{{ $result.RepoRelDir }}` workspace: `{{ $result.Workspace }}`
 
 {{ $result.Rendered }}
-{{ if and (ne .DisableApplyAll true) (not .IsDraftPolicyCheck) -}}
+{{ if ne .DisableApplyAll true -}}
 ---
 * :heavy_check_mark: To **approve** all unapplied plans from this {{ .VcsRequestType }}, comment:
   ```shell

--- a/server/events/undiverged_project_impact_test.go
+++ b/server/events/undiverged_project_impact_test.go
@@ -212,7 +212,7 @@ func TestDefaultCommandRequirementHandler_TargetedUndivergedFallsBackWhenGenerat
 	repoDir := autoDiscoveredRepo(t)
 	resolver := newTestUndivergedProjectImpactResolver("**/*.tf", defaultAutoplanFileList, "auto")
 	workingDir := NewMockWorkingDir()
-	When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Eq(repoDir), Eq("project1"), Eq([]string{"generated-only/**"}), Any[models.PullRequest]())).ThenReturn(true)
+	When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Eq(repoDir), Eq("project1"), Eq([]string{"generated-only/**"}), Any[models.PullRequest]())).ThenReturn(true, nil)
 
 	handler := &DefaultCommandRequirementHandler{
 		WorkingDir:            workingDir,
@@ -236,7 +236,7 @@ func TestDefaultCommandRequirementHandler_TargetedUndivergedFallsBackForEmptyCon
 	repoDir := configuredProjectRepoWithEmptyWhenModified(t)
 	resolver := newTestUndivergedProjectImpactResolver("**/*.tf", defaultAutoplanFileList, "auto")
 	workingDir := NewMockWorkingDir()
-	When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Eq(repoDir), Eq("project1"), Eq([]string{}), Any[models.PullRequest]())).ThenReturn(true)
+	When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Eq(repoDir), Eq("project1"), Eq([]string{}), Any[models.PullRequest]())).ThenReturn(true, nil)
 
 	handler := &DefaultCommandRequirementHandler{
 		WorkingDir:            workingDir,
@@ -258,8 +258,8 @@ func TestDefaultCommandRequirementHandler_TargetedUndivergedFallsBackToFullCheck
 
 	repoDir := configuredProjectRepo(t)
 	workingDir := NewMockWorkingDir()
-	When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Eq(repoDir), Eq("project1"), Eq([]string{"modules/database/**"}), Any[models.PullRequest]())).ThenReturn(true)
-	When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Eq(repoDir), Eq("project1"), Eq([]string(nil)), Any[models.PullRequest]())).ThenReturn(false)
+	When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Eq(repoDir), Eq("project1"), Eq([]string{"modules/database/**"}), Any[models.PullRequest]())).ThenReturn(true, nil)
+	When(workingDir.HasDiverged(Any[logging.SimpleLogging](), Eq(repoDir), Eq("project1"), Eq([]string(nil)), Any[models.PullRequest]())).ThenReturn(false, nil)
 
 	handler := &DefaultCommandRequirementHandler{
 		WorkingDir:            workingDir,

--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -257,7 +257,7 @@ func (w *FileWorkspace) recheckDiverged(logger logging.SimpleLogging, p models.P
 			"git", "remote", "set-url", prSourceRemote, headRepo.CloneURL,
 		},
 		{
-			"git", "remote", "update",
+			"git", "remote", "update", "--prune",
 		},
 	}
 
@@ -317,7 +317,7 @@ func (w *FileWorkspace) GetDivergedFiles(logger logging.SimpleLogging, cloneDir 
 // gitRefLock(cloneDir) and gitReadLock(cloneDir) (or the write lock).
 func (w *FileWorkspace) hasDiverged(logger logging.SimpleLogging, cloneDir string) (bool, error) {
 	logger.Debug("HasDiverged: running git fetch in %s", cloneDir)
-	cmd := exec.Command("git", "fetch")
+	cmd := exec.Command("git", "fetch", "--prune")
 	cmd.Dir = cloneDir
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -409,7 +409,7 @@ func divergedFilesCommandError(action string, err error, output []byte) error {
 
 func (w *FileWorkspace) getDivergedFiles(logger logging.SimpleLogging, cloneDir string, pullRequest models.PullRequest) ([]string, error) {
 	logger.Debug("GetDivergedFiles: running git fetch")
-	fetchCmd := exec.Command("git", "fetch")
+	fetchCmd := exec.Command("git", "fetch", "--prune")
 	fetchCmd.Dir = cloneDir
 	outputFetch, err := fetchCmd.CombinedOutput()
 	if err != nil {
@@ -454,7 +454,7 @@ func (w *FileWorkspace) remoteHasBranch(logger logging.SimpleLogging, c wrappedG
 func (w *FileWorkspace) updateToRef(logger logging.SimpleLogging, c wrappedGitContext, targetRef string) error {
 
 	// We use both `<prSourceRemote>` and `origin` remotes, update them both
-	if err := w.wrappedGit(logger, c, "fetch", "--all"); err != nil {
+	if err := w.wrappedGit(logger, c, "fetch", "--all", "--prune"); err != nil {
 		return err
 	}
 
@@ -632,7 +632,7 @@ func (w *FileWorkspace) mergeToBaseBranch(logger logging.SimpleLogging, c wrappe
 	if err := w.wrappedGit(logger, c, "merge-base", c.pr.BaseBranch, "FETCH_HEAD"); err != nil {
 		// git merge-base returning error means that we did not receive enough commits in shallow clone.
 		// Fall back to retrieving full repo history.
-		if err := w.wrappedGit(logger, c, "fetch", "--unshallow"); err != nil {
+		if err := w.wrappedGit(logger, c, "fetch", "--unshallow", "--prune"); err != nil {
 			return err
 		}
 

--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -46,7 +46,7 @@ type WorkingDir interface {
 	// When autoplanWhenModified patterns are provided, only divergence affecting
 	// files matching those patterns is considered. When patterns are empty,
 	// any divergence is reported.
-	HasDiverged(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) bool
+	HasDiverged(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) (bool, error)
 	// GetDivergedFiles returns the files changed on the base branch since the
 	// current checkout. When merge checkout is disabled there is no divergence
 	// check, so this returns no files and no error.
@@ -193,7 +193,11 @@ func (w *FileWorkspace) MergeAgain(
 
 	c := wrappedGitContext{cloneDir, headRepo, p}
 
-	if !w.recheckDiverged(logger, p, headRepo, cloneDir) {
+	diverged, err := w.recheckDiverged(logger, p, headRepo, cloneDir)
+	if err != nil {
+		return true, err
+	}
+	if !diverged {
 		recheckRequiredMap.Delete(cloneDir)
 		return false, nil
 	}
@@ -218,17 +222,17 @@ func (w *FileWorkspace) MergeAgain(
 // This matters in the case of the merge checkout strategy because after
 // cloning the repo and doing the merge, it's possible main was updated
 // and we have to perform a new merge.
-// If there are any errors we return true since we prefer to assume divergence
-// for safety.
+// If there are any errors we return (true, err) since we prefer to assume divergence
+// for safety and don't want plan against stale code. Plan will fail.
 // Acquires gitRefLock and gitReadLock internally to serialize git metadata operations.
 // Does NOT require the caller to hold the repo read or write lock.
-func (w *FileWorkspace) recheckDiverged(logger logging.SimpleLogging, p models.PullRequest, headRepo models.Repo, cloneDir string) bool {
+func (w *FileWorkspace) recheckDiverged(logger logging.SimpleLogging, p models.PullRequest, headRepo models.Repo, cloneDir string) (bool, error) {
 	if !w.CheckoutMerge {
 		// It only makes sense to warn that main has diverged if we're using
 		// the checkout merge strategy. If we're just checking out the branch,
 		// then it doesn't matter what's going on with main because we've
 		// decided to always run off the branch.
-		return false
+		return false, nil
 	}
 
 	// Hold the read and ref locks for the entire sequence: URL updates write .git/config,
@@ -263,19 +267,20 @@ func (w *FileWorkspace) recheckDiverged(logger logging.SimpleLogging, p models.P
 
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			logger.Warn("getting remote update failed: %s", string(output))
-			return true
+			cmdErr := fmt.Errorf("getting remote update failed: %w: %s", err, strings.TrimSpace(string(output)))
+			logger.Err(cmdErr.Error())
+			return true, cmdErr
 		}
 	}
 
 	return w.hasDiverged(logger, cloneDir)
 }
 
-func (w *FileWorkspace) HasDiverged(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) bool {
+func (w *FileWorkspace) HasDiverged(logger logging.SimpleLogging, cloneDir string, projectPath string, autoplanWhenModified []string, pullRequest models.PullRequest) (bool, error) {
 	logger.Debug("HasDiverged: starting divergence check in %s", cloneDir)
 	if !w.CheckoutMerge {
 		logger.Debug("HasDiverged: CheckoutMerge is false, skipping divergence check")
-		return false
+		return false, nil
 	}
 
 	// Hold repo read lock and ref lock for the full duration (fetch + status) so we don't race with
@@ -287,7 +292,7 @@ func (w *FileWorkspace) HasDiverged(logger logging.SimpleLogging, cloneDir strin
 	defer unlockGitRefLock()
 
 	if len(autoplanWhenModified) > 0 {
-		return w.hasDivergedForPatterns(logger, cloneDir, projectPath, autoplanWhenModified, pullRequest)
+		return w.hasDivergedForPatterns(logger, cloneDir, projectPath, autoplanWhenModified, pullRequest), nil
 	}
 	return w.hasDiverged(logger, cloneDir)
 }
@@ -310,14 +315,15 @@ func (w *FileWorkspace) GetDivergedFiles(logger logging.SimpleLogging, cloneDir 
 
 // hasDiverged runs fetch and git status to detect divergence. Caller must hold
 // gitRefLock(cloneDir) and gitReadLock(cloneDir) (or the write lock).
-func (w *FileWorkspace) hasDiverged(logger logging.SimpleLogging, cloneDir string) bool {
+func (w *FileWorkspace) hasDiverged(logger logging.SimpleLogging, cloneDir string) (bool, error) {
 	logger.Debug("HasDiverged: running git fetch in %s", cloneDir)
 	cmd := exec.Command("git", "fetch")
 	cmd.Dir = cloneDir
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		logger.Warn("HasDiverged: fetching repo has failed: %s", string(output))
-		return true
+		fetchErr := fmt.Errorf("HasDiverged: fetching repo has failed: %w: %s", err, strings.TrimSpace(string(output)))
+		logger.Err(fetchErr.Error())
+		return true, fetchErr
 	}
 	logger.Debug("HasDiverged: git fetch completed successfully")
 
@@ -327,12 +333,12 @@ func (w *FileWorkspace) hasDiverged(logger logging.SimpleLogging, cloneDir strin
 	outputStatusUno, err := statusUnoCmd.CombinedOutput()
 	if err != nil {
 		logger.Warn("getting repo status has failed: %s", string(outputStatusUno))
-		return true
+		return true, nil
 	}
 	logger.Debug("HasDiverged: git status output: %s", string(outputStatusUno))
 	hasDiverged := strings.Contains(string(outputStatusUno), "have diverged")
 	logger.Debug("HasDiverged: result=%t", hasDiverged)
-	return hasDiverged
+	return hasDiverged, nil
 }
 
 // hasDivergedForPatterns checks if the base branch has new commits that affect files

--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -719,7 +719,7 @@ func (w *FileWorkspace) SetCheckForUpstreamChanges() {
 }
 
 func (w *FileWorkspace) DeletePlan(logger logging.SimpleLogging, r models.Repo, p models.PullRequest, workspace string, projectPath string, projectName string) error {
-	planPath := filepath.Join(w.cloneDir(r, p, workspace), projectPath, runtime.GetPlanFilename(workspace, projectName))
+	planPath := filepath.Join(w.cloneDir(r, p, workspace), projectPath, runtime.GetPlanFilename(workspace, projectName, false))
 	logger.Info("Deleting plan: " + planPath)
 	return utils.RemoveIgnoreNonExistent(planPath)
 }

--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -755,6 +755,66 @@ func TestClone_MasterHasDiverged(t *testing.T) {
 	assert.FileExists(t, planFile, "Existing plan file should not have been deleted")
 }
 
+// TestMergeAgain_PrunesConflictingRefNames verifies that git remote update uses --prune.
+// Without --prune, if origin once had "feature/foo" (leaving refs/remotes/origin/feature/
+// as a directory on disk) and the remote then deletes that branch and creates "feature",
+// git remote update fails with "cannot lock ref 'refs/remotes/origin/feature': ... exists;
+// cannot create 'refs/remotes/origin/feature'". With --prune, the stale ref is removed
+// first and the update succeeds.
+func TestMergeAgain_PrunesConflictingRefNames(t *testing.T) {
+	repoDir := initRepo(t)
+
+	// Create feature/foo on remote so that cloning it will create
+	// refs/remotes/origin/feature/foo (i.e. the "feature/" directory on disk).
+	runCmd(t, repoDir, "git", "checkout", "-b", "feature/foo")
+	runCmd(t, repoDir, "touch", "foo.tf")
+	runCmd(t, repoDir, "git", "add", "foo.tf")
+	runCmd(t, repoDir, "git", "commit", "-m", "add feature/foo")
+	runCmd(t, repoDir, "git", "checkout", "main")
+
+	// Clone without --single-branch so all remote branches are fetched,
+	// which creates refs/remotes/origin/feature/foo in the workspace.
+	atlantisDir := repoDir + "/repos/0/default"
+	runCmd(t, repoDir, "mkdir", "-p", "repos/0/default")
+	runCmd(t, atlantisDir, "git", "clone", repoDir, ".")
+	runCmd(t, atlantisDir, "git", "remote", "add", "source", repoDir)
+	runCmd(t, atlantisDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
+	runCmd(t, atlantisDir, "git", "config", "--local", "user.name", "atlantisbot")
+	runCmd(t, atlantisDir, "git", "config", "--local", "commit.gpgsign", "false")
+
+	// Confirm the conflicting ref exists in the workspace.
+	remoteBranches := runCmd(t, atlantisDir, "git", "branch", "-r")
+	assert.Contains(t, remoteBranches, "origin/feature/foo")
+
+	// Delete feature/foo from remote and replace it with a flat "feature" branch.
+	// refs/remotes/origin/feature can't be a file while refs/remotes/origin/feature/
+	// is a directory, so git remote update (without --prune) would fail here.
+	runCmd(t, repoDir, "git", "branch", "-D", "feature/foo")
+	runCmd(t, repoDir, "git", "checkout", "-b", "feature")
+	runCmd(t, repoDir, "touch", "feature.tf")
+	runCmd(t, repoDir, "git", "add", "feature.tf")
+	runCmd(t, repoDir, "git", "commit", "-m", "add feature")
+	runCmd(t, repoDir, "git", "checkout", "main")
+
+	logger := logging.NewNoopLogger(t)
+	wd := &events.FileWorkspace{
+		DataDir:             repoDir,
+		CheckoutMerge:       true,
+		CheckoutDepth:       50,
+		GpgNoSigningEnabled: true,
+	}
+
+	// MergeAgain calls recheckDiverged which runs git remote update --prune.
+	// --prune removes refs/remotes/origin/feature/foo before fetching
+	// refs/remotes/origin/feature, avoiding the "cannot lock ref" failure.
+	_, err := wd.MergeAgain(logger, models.Repo{CloneURL: repoDir}, models.PullRequest{
+		BaseRepo:   models.Repo{CloneURL: repoDir},
+		HeadBranch: "main",
+		BaseBranch: "main",
+	}, "default")
+	Ok(t, err)
+}
+
 func TestHasDiverged_MasterHasDiverged(t *testing.T) {
 	// Initialize the git repo.
 	repoDir := initRepo(t)

--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -814,13 +814,15 @@ func TestHasDiverged_MasterHasDiverged(t *testing.T) {
 		CheckoutDepth:       50,
 		GpgNoSigningEnabled: true,
 	}
-	hasDiverged := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", nil, models.PullRequest{})
+	hasDiverged, err := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", nil, models.PullRequest{})
+	assert.NoError(t, err)
 	Equals(t, hasDiverged, true)
 
 	// Run it again but without the checkout merge strategy. It should return
 	// false.
 	wd.CheckoutMerge = false
-	hasDiverged = wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", nil, models.PullRequest{})
+	hasDiverged, err = wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", nil, models.PullRequest{})
+	assert.NoError(t, err)
 	Equals(t, hasDiverged, false)
 }
 
@@ -919,7 +921,8 @@ func TestHasDiverged_WithPatterns_CheckoutMergeDisabled(t *testing.T) {
 	}
 
 	// Should return false when CheckoutMerge is disabled.
-	hasDiverged := wd.HasDiverged(logger, firstPRDir, ".", []string{"project1/**"}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, firstPRDir, ".", []string{"project1/**"}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, false, hasDiverged)
 }
 
@@ -1006,7 +1009,8 @@ func TestHasDiverged_WithEmptyPatterns(t *testing.T) {
 	}
 
 	// With empty patterns, should fall back to regular HasDiverged which should return true.
-	hasDiverged := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, true, hasDiverged)
 }
 
@@ -1079,7 +1083,8 @@ func TestHasDiverged_PatternHasDiverged(t *testing.T) {
 	}
 
 	// Pattern matches files that have diverged (project1 was modified in first-pr and merged to main).
-	hasDiverged := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project1/**"}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project1/**"}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, true, hasDiverged)
 }
 
@@ -1140,7 +1145,8 @@ func TestHasDiverged_PatternHasNotDiverged(t *testing.T) {
 
 	// Pattern matches project1 files. Main's last commit for project1 is in second-pr's history (since it branched from main).
 	// So it has not diverged.
-	hasDiverged := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project1/**"}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project1/**"}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, false, hasDiverged)
 }
 
@@ -1201,7 +1207,8 @@ func TestHasDiverged_MultiplePatterns(t *testing.T) {
 
 	// Both patterns match files. Main's commits for these patterns are in feature-pr's history.
 	// So neither has diverged.
-	hasDiverged := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project2/**", "project3/**"}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project2/**", "project3/**"}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, false, hasDiverged)
 }
 
@@ -1245,7 +1252,8 @@ func TestHasDiverged_PatternMatchesNothing(t *testing.T) {
 	}
 
 	// Pattern matches no files (project2 doesn't exist), should not be considered diverged.
-	hasDiverged := wd.HasDiverged(logger, firstPRDir, ".", []string{"project2/**"}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, firstPRDir, ".", []string{"project2/**"}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, false, hasDiverged)
 }
 
@@ -1293,7 +1301,8 @@ func TestHasDiverged_BrandNewFiles(t *testing.T) {
 
 	// Pattern matches brand new files that main has never touched.
 	// Main hasn't "diverged" - we're just adding new content.
-	hasDiverged := wd.HasDiverged(logger, prDir, ".", []string{"project1/**"}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, prDir, ".", []string{"project1/**"}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, false, hasDiverged)
 }
 
@@ -1356,7 +1365,8 @@ func TestHasDiverged_FilesDeletedFromMain(t *testing.T) {
 
 	// Pattern matches project1 which has been deleted from main.
 	// This IS divergence - main has moved forward by deleting the files.
-	hasDiverged := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project1/**"}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project1/**"}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, true, hasDiverged)
 }
 
@@ -1426,11 +1436,13 @@ func TestHasDiverged_MixedPatternsOneDiverged(t *testing.T) {
 
 	// Check with both patterns: project1 (diverged) and project2 (not diverged).
 	// Should return true because at least one pattern has diverged.
-	hasDiverged := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project1/**", "project2/**"}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project1/**", "project2/**"}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, true, hasDiverged)
 
 	// Check with only project2 pattern (not diverged).
-	hasDiverged = wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project2/**"}, pullRequest)
+	hasDiverged, err = wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project2/**"}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, false, hasDiverged)
 }
 
@@ -1501,7 +1513,8 @@ func TestHasDiverged_PRDidNotTouchPattern(t *testing.T) {
 	// first-pr never touched project1, but main has moved forward on it.
 	// This IS considered diverged - the pattern is in autoplanWhenModified,
 	// and we want to ensure plans stay current with main's changes.
-	hasDiverged := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project1/**"}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project1/**"}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, true, hasDiverged)
 }
 
@@ -1578,12 +1591,14 @@ func TestHasDiverged_WithStaleOriginMain(t *testing.T) {
 	// Test 1: Pattern matching project1 should detect divergence.
 	// Even though HEAD has a merge commit, origin/main has a new commit touching project1/**
 	// that isn't in HEAD. The fetch should pick this up.
-	hasDiverged := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project1/**"}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project1/**"}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, true, hasDiverged)
 
 	// Test 2: Pattern matching project2 should NOT detect divergence.
 	// Main has no new commits touching project2/**, so it hasn't diverged for this pattern.
-	hasDiverged = wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project2/**"}, pullRequest)
+	hasDiverged, err = wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{"project2/**"}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, false, hasDiverged)
 }
 
@@ -1665,17 +1680,20 @@ func TestHasDiverged_ProjectInSubdirectory(t *testing.T) {
 	// When adjusted, it should become "modules/**/*.tf" relative to repo root.
 	projectPath := "deployments/staging/app"
 	pattern := "../../../modules/**/*.tf" // 3 levels up from deployments/staging/app
-	hasDiverged := wd.HasDiverged(logger, repoDir+"/repos/0/default", projectPath, []string{pattern}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, repoDir+"/repos/0/default", projectPath, []string{pattern}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, true, hasDiverged) // Should detect that modules/database/main.tf changed
 
 	// Test 2: Pattern that matches files within the project directory itself
 	projectPattern := "*.tf"
-	hasDiverged = wd.HasDiverged(logger, repoDir+"/repos/0/default", projectPath, []string{projectPattern}, pullRequest)
+	hasDiverged, err = wd.HasDiverged(logger, repoDir+"/repos/0/default", projectPath, []string{projectPattern}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, false, hasDiverged) // No .tf files changed in the project directory in divergent commits
 
 	// Test 3: Pattern at repo root should also work
 	absolutePattern := "modules/**/*.tf"
-	hasDiverged = wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{absolutePattern}, pullRequest)
+	hasDiverged, err = wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", []string{absolutePattern}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, true, hasDiverged)
 }
 
@@ -1752,7 +1770,8 @@ func TestHasDiverged_DeepProjectPath(t *testing.T) {
 	projectPath := deepPath
 
 	whenModifiedPattern := "../../../../../../../config/**"
-	hasDiverged := wd.HasDiverged(logger, repoDir+"/repos/0/default", projectPath, []string{whenModifiedPattern}, pullRequest)
+	hasDiverged, err := wd.HasDiverged(logger, repoDir+"/repos/0/default", projectPath, []string{whenModifiedPattern}, pullRequest)
+	assert.NoError(t, err)
 	Equals(t, true, hasDiverged) // Should detect that config/settings.yaml changed
 }
 
@@ -1873,7 +1892,8 @@ func TestHasDiverged_PatternMatching(t *testing.T) {
 				HeadCommit: prHeadCommit,
 			}
 
-			hasDiverged := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", tt.patterns, pullRequest)
+			hasDiverged, err := wd.HasDiverged(logger, repoDir+"/repos/0/default", ".", tt.patterns, pullRequest)
+			assert.NoError(t, err)
 			if hasDiverged != tt.expectDivergence {
 				t.Errorf("expected divergence=%v, got=%v for patterns=%v and changedFiles=%v",
 					tt.expectDivergence, hasDiverged, tt.patterns, tt.changedFiles)

--- a/server/server.go
+++ b/server/server.go
@@ -867,6 +867,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 
 	commentCommandRunnerByCmd := map[command.Name]events.CommentCommandRunner{
 		command.Plan:            planCommandRunner,
+		command.DraftPlan:       planCommandRunner,
 		command.Apply:           applyCommandRunner,
 		command.ApprovePolicies: approvePoliciesCommandRunner,
 		command.Unlock:          unlockCommandRunner,

--- a/server/user_config_test.go
+++ b/server/user_config_test.go
@@ -25,23 +25,23 @@ func TestUserConfig_ToAllowCommandNames(t *testing.T) {
 	}{
 		{
 			name:          "full commands can be parsed by comma",
-			allowCommands: "apply,plan,cancel,unlock,policy_check,approve_policies,version,import,state",
+			allowCommands: "apply,plan,draftplan,cancel,unlock,policy_check,approve_policies,version,import,state",
 			want: []command.Name{
-				command.Apply, command.Plan, command.Cancel, command.Unlock, command.PolicyCheck, command.ApprovePolicies, command.Version, command.Import, command.State,
+				command.Apply, command.Plan, command.DraftPlan, command.Cancel, command.Unlock, command.PolicyCheck, command.ApprovePolicies, command.Version, command.Import, command.State,
 			},
 		},
 		{
 			name:          "all",
 			allowCommands: "all",
 			want: []command.Name{
-				command.Version, command.Plan, command.Apply, command.Cancel, command.Unlock, command.ApprovePolicies, command.Import, command.State,
+				command.Version, command.Plan, command.Apply, command.Cancel, command.Unlock, command.ApprovePolicies, command.Import, command.State, command.DraftPlan,
 			},
 		},
 		{
 			name:          "all with others returns same with all result",
 			allowCommands: "all,plan",
 			want: []command.Name{
-				command.Version, command.Plan, command.Apply, command.Cancel, command.Unlock, command.ApprovePolicies, command.Import, command.State,
+				command.Version, command.Plan, command.Apply, command.Cancel, command.Unlock, command.ApprovePolicies, command.Import, command.State, command.DraftPlan,
 			},
 		},
 		{


### PR DESCRIPTION
## what

Only lock draftplan while the draftplan is running, NOT while policy check is running. 
_Do_ continue preventing policycheck from being retriggered if the lock is held by a running draftplan. 

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## tests

<!--
- [ ] I have tested my changes by ...
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

## architecture decision record

- [ ] I checked the [ADR criteria](https://github.com/runatlantis/atlantis/blob/main/docs/adr/README.md#when-is-an-adr-required).

**ADR:** <!-- Link the ADR, write "This PR", or "Not required". -->
